### PR TITLE
feat: pass tmux controller to subagent runtimes

### DIFF
--- a/docs/plans/2025-01-27-tmux-native-design.md
+++ b/docs/plans/2025-01-27-tmux-native-design.md
@@ -1,0 +1,591 @@
+# tmux Native Enhancements — Design Document
+
+**Branch:** `feat/tmux-native`
+**Date:** 2025-01-27
+**Status:** Approved
+
+---
+
+## Vision
+
+Synaps launches inside a tmux session and becomes a tmux-native application. The agent can see itself, control panes, create visible shell sessions, and manage layouts — all through tmux's control mode protocol. The user gets a multiplexed workspace where they can watch the agent work in real-time, navigate with hotkeys or mouse, and customize the layout through natural language or settings.
+
+---
+
+## Entry Points
+
+### CLI Flag
+```bash
+synaps --tmux 'my-project'     # explicit session name
+synaps --tmux                   # auto-generated session name
+synaps                          # if tmux=true in settings, auto-launches in tmux
+```
+
+### Auto-Naming
+When no explicit session name is provided (either `synaps --tmux` with no name, or bare `synaps` with `tmux=true` in settings), Synaps auto-generates a session name:
+
+1. **In a git repo:** `synaps-<repo-name>` (e.g. `synaps-SynapsCLI`)
+2. **Not in a git repo:** `synaps-<directory-name>` (e.g. `synaps-my-project`)
+3. **Collision (session already exists):** append `-<N>` (e.g. `synaps-SynapsCLI-2`)
+
+Synaps **always knows its own session name** — it's stored in `TmuxController.session_name` and available to the agent via the system prompt context. This means the agent can reference its session in commands, and the user can reattach from another terminal with `tmux attach -t <name>` while Synaps is running.
+
+### Settings (system-wide or per-project)
+```
+# ~/.synaps-cli/config (system-wide)
+tmux = true                           # bare `synaps` launches in tmux mode
+tmux_session_name = default           # optional: fixed name override
+
+# .synaps/config (project-level, overrides system)
+tmux = true
+tmux_session_name = my-project        # optional: fixed name for this project
+```
+
+### Config Hierarchy
+```
+CLI flags  →  overrides  →  Project config (.synaps/config)  →  overrides  →  System config (~/.synaps-cli/config)
+```
+
+### Slash Command / Settings Page
+Users can toggle tmux mode from the TUI settings page or via `/settings tmux on`.
+
+---
+
+## Architecture
+
+### Control Mode (`tmux -CC`)
+
+Synaps communicates with tmux exclusively through **control mode** — a persistent stdin/stdout text protocol. No shell-outs to the `tmux` binary for operations.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Synaps Process                        │
+│                                                         │
+│  ┌──────────┐   ┌──────────────┐   ┌────────────────┐  │
+│  │ Runtime   │──▶│ TmuxController│──▶│ Control Mode   │  │
+│  │          │   │              │   │ stdin/stdout    │  │
+│  │ToolReg   │   │ • state map  │   │ pipe to tmux   │  │
+│  │  +tmux   │   │ • event loop │   │ server         │  │
+│  │  tools   │   │ • cmd queue  │   │                │  │
+│  └──────────┘   └──────────────┘   └────────────────┘  │
+│                        │                                 │
+│              ┌─────────┴──────────┐                      │
+│              │  TmuxState         │                      │
+│              │  • sessions []     │                      │
+│              │  • windows []      │                      │
+│              │  • panes []        │                      │
+│              │  • layouts {}      │                      │
+│              │  • hotkeys {}      │                      │
+│              └────────────────────┘                      │
+└─────────────────────────────────────────────────────────┘
+         │ control mode protocol
+         ▼
+┌─────────────────────────────────────────────────────────┐
+│                   tmux server                            │
+│                                                         │
+│  Session: "my-project"                                  │
+│  ┌─────────────────────────┬────────────────────────┐   │
+│  │ Window 0: chat          │ Window 1: shell         │   │
+│  │ ┌─────────┬───────────┐ │ (fullscreen shell)     │   │
+│  │ │ Synaps  │ Agent     │ │                        │   │
+│  │ │ TUI     │ Shell #1  │ │                        │   │
+│  │ │ (chat)  │ $ cargo   │ │                        │   │
+│  │ │         │   build   │ │                        │   │
+│  │ │         ├───────────┤ │                        │   │
+│  │ │         │ Agent     │ │                        │   │
+│  │ │         │ Shell #2  │ │                        │   │
+│  │ │         │ $ grep .. │ │                        │   │
+│  │ └─────────┴───────────┘ │                        │   │
+│  └─────────────────────────┴────────────────────────┘   │
+│  [my-project] 0:chat*  1:shell  sa_1:running ⏱12s      │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Control Mode Protocol
+
+tmux control mode streams notifications as text lines:
+
+```
+# Notifications (tmux → Synaps)
+%begin <time> <num> <flags>
+%end <time> <num> <flags>
+%output %<pane_id> <data>
+%window-add @<window_id>
+%window-close @<window_id>
+%session-changed $<session_id> <name>
+%pane-mode-changed %<pane_id>
+%layout-change @<window_id> <layout>
+...
+
+# Commands (Synaps → tmux)
+split-window -h -P -F '#{pane_id}' -t %0
+send-keys -t %5 'cargo build' Enter
+capture-pane -t %5 -p
+select-layout -t @0 main-vertical
+```
+
+### TmuxController (`src/tmux/controller.rs`)
+
+Core struct that owns the control mode connection:
+
+```rust
+pub struct TmuxController {
+    /// stdin writer to control mode
+    writer: BufWriter<ChildStdin>,
+    /// Parsed state of all tmux objects
+    state: Arc<RwLock<TmuxState>>,
+    /// Channel for incoming notifications
+    event_rx: mpsc::UnboundedReceiver<TmuxEvent>,
+    /// Pending command responses
+    pending: HashMap<u64, oneshot::Sender<CommandResult>>,
+    /// Session name
+    session_name: String,
+    /// Pane ID where Synaps TUI is running
+    self_pane: String,
+}
+```
+
+### TmuxState (`src/tmux/state.rs`)
+
+```rust
+pub struct TmuxState {
+    pub session_id: String,
+    pub windows: HashMap<String, TmuxWindow>,
+    pub panes: HashMap<String, TmuxPane>,
+    pub layout_preset: LayoutPreset,
+    pub subagent_display: SubagentDisplay,
+}
+
+pub struct TmuxWindow {
+    pub id: String,       // @0, @1, ...
+    pub name: String,
+    pub index: u32,
+    pub panes: Vec<String>, // pane IDs
+    pub layout: String,
+}
+
+pub struct TmuxPane {
+    pub id: String,        // %0, %1, ...
+    pub window_id: String,
+    pub title: String,
+    pub width: u32,
+    pub height: u32,
+    pub active: bool,
+    pub role: PaneRole,
+}
+
+pub enum PaneRole {
+    SynapsTui,                         // the main chat pane
+    AgentShell { session_id: String }, // a shell_start pane
+    Subagent { handle_id: String },    // a subagent display
+    User,                              // user-created pane
+}
+
+pub enum LayoutPreset {
+    Split,       // TUI left, shells right (default)
+    Fullscreen,  // TUI fullscreen, shells in separate windows
+    Tiled,       // Equal grid of all panes
+    Custom(String), // tmux layout string
+}
+
+pub enum SubagentDisplay {
+    Window, // each subagent gets its own tmux window (tab)
+    Pane,   // each subagent gets a pane in the current window
+}
+```
+
+---
+
+## New Tools
+
+The agent gets explicit tmux tools. These are only registered when tmux mode is active.
+
+### `tmux_split`
+Create a new pane by splitting.
+
+```json
+{
+  "name": "tmux_split",
+  "parameters": {
+    "direction": "horizontal | vertical",   // default: horizontal
+    "size": "50%",                           // percentage or line count
+    "target": "%0",                          // pane to split (default: auto)
+    "command": "cargo build",                // optional command to run
+    "title": "build",                        // pane title
+    "focus": false                           // switch focus to new pane?
+  }
+}
+// Returns: { "pane_id": "%5", "window_id": "@0" }
+```
+
+### `tmux_send`
+Send keys/commands to any pane.
+
+```json
+{
+  "name": "tmux_send",
+  "parameters": {
+    "pane_id": "%5",
+    "keys": "cargo test\n",      // keys to send (literal)
+    "literal": true               // true = no key name lookup
+  }
+}
+// Returns: { "sent": true }
+```
+
+### `tmux_capture`
+Read content from any visible pane.
+
+```json
+{
+  "name": "tmux_capture",
+  "parameters": {
+    "pane_id": "%5",
+    "start_line": -100,     // negative = history lines
+    "end_line": -1,         // -1 = last visible line  
+    "include_ansi": false   // strip ANSI escapes (default)
+  }
+}
+// Returns: { "content": "$ cargo build\n   Compiling synaps v0.1.0\n..." }
+```
+
+### `tmux_layout`
+Change the layout of the current window or set defaults.
+
+```json
+{
+  "name": "tmux_layout",
+  "parameters": {
+    "preset": "split | fullscreen | tiled | custom",
+    "custom_layout": null,       // tmux layout string (if preset=custom)
+    "set_default": false,        // persist as default?
+    "scope": "project | system"  // where to persist (if set_default=true)
+  }
+}
+// Returns: { "layout": "split", "applied": true, "persisted": false }
+```
+
+### `tmux_window`
+Create, switch, or close tmux windows (tabs).
+
+```json
+{
+  "name": "tmux_window",
+  "parameters": {
+    "action": "create | switch | close | rename",
+    "name": "tests",           // window name
+    "target": "@1",            // target window (for switch/close/rename)
+    "command": null             // command to run in new window
+  }
+}
+// Returns: { "window_id": "@2", "action": "create" }
+```
+
+### `tmux_resize`
+Resize a pane.
+
+```json
+{
+  "name": "tmux_resize",
+  "parameters": {
+    "pane_id": "%5",
+    "width": null,       // absolute or "+10"/"-10" relative
+    "height": null,
+    "zoom": false        // toggle zoom (pane fills entire window)
+  }
+}
+// Returns: { "pane_id": "%5", "width": 80, "height": 24 }
+```
+
+---
+
+## Startup Flow
+
+```
+synaps --tmux 'my-project'
+        │
+        ▼
+┌─ Check tmux binary ─────────────────────────────────┐
+│  which tmux                                          │
+│  NOT FOUND?                                          │
+│    → "Error: tmux not found."                        │
+│    → "Install tmux from source? [y/N]"               │
+│    → y: git clone, autogen.sh, configure, make       │
+│    → n: exit                                         │
+└──────────────────────────────────────────────────────┘
+        │ found
+        ▼
+┌─ Create tmux session ───────────────────────────────┐
+│  tmux new-session -d -s 'my-project' -x 200 -y 50   │
+│  (detached, sized to current terminal)               │
+└──────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─ Start control mode client ─────────────────────────┐
+│  tmux -CC attach -t 'my-project'                     │
+│  → persistent stdin/stdout connection                │
+│  → TmuxController starts event reader thread         │
+│  → Parse %begin/%end, %output, %layout-change, etc. │
+└──────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─ Identify self-pane ────────────────────────────────┐
+│  Query: display-message -p '#{pane_id}'              │
+│  Store as self_pane in TmuxState                     │
+└──────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─ Apply default layout ──────────────────────────────┐
+│  Read config: tmux_default_layout                    │
+│  Read config: tmux_subagent_display                  │
+│  Apply initial layout (split by default)             │
+└──────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─ Set up convenience hotkeys ────────────────────────┐
+│  bind-key -T prefix F   → toggle fullscreen          │
+│  bind-key -T prefix S   → cycle subagent display     │
+│  bind-key -T prefix L   → cycle layout presets       │
+│  bind-key -T prefix N   → next subagent pane/window  │
+│  bind-key -T prefix H   → show hotkey help popup     │
+│  set -g mouse on         → enable mouse support      │
+└──────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─ Register tmux tools ───────────────────────────────┐
+│  Add to ToolRegistry:                                │
+│    tmux_split, tmux_send, tmux_capture,              │
+│    tmux_layout, tmux_window, tmux_resize             │
+└──────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─ Start Synaps TUI normally ─────────────────────────┐
+│  chatui::run() in the main pane                      │
+│  TmuxController runs as background task              │
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## Shutdown Flow
+
+```
+User exits Synaps (Ctrl-C, /exit, etc.)
+        │
+        ▼
+┌─ Cleanup ────────────────────────────────────────────┐
+│  1. Cancel all subagents (existing behavior)          │
+│  2. Close all shell sessions (existing behavior)      │
+│  3. Kill tmux session: kill-session -t 'my-project'   │
+│  4. Drop TmuxController (closes control mode pipe)    │
+│  5. Exit process                                      │
+└──────────────────────────────────────────────────────┘
+```
+
+Session dies with Synaps. Clean slate every time.
+
+---
+
+## Default Layout: Split View
+
+```
+┌────────────────────────────────┬─────────────────────────┐
+│                                │                         │
+│    Synaps TUI                  │  Shell Pane %1          │
+│    (chat interface)            │  $ cargo build          │
+│    pane %0                     │  Compiling...           │
+│                                │                         │
+│                                ├─────────────────────────┤
+│                                │                         │
+│    > user types here           │  Shell Pane %2          │
+│    _ cursor                    │  $ grep -r "foo" src/   │
+│                                │                         │
+├────────────────────────────────┴─────────────────────────┤
+│ [my-project] 0:chat*  C-b F:fullscreen  C-b L:layout    │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Fullscreen Mode
+```
+┌──────────────────────────────────────────────────────────┐
+│                                                          │
+│              Synaps TUI (full window)                    │
+│              pane %0                                     │
+│                                                          │
+│                                                          │
+│    > user types here                                     │
+│    _ cursor                                              │
+│                                                          │
+├──────────────────────────────────────────────────────────┤
+│ [my-project] 0:chat*  1:shell  2:tests  sa_1 ⏱12s      │
+└──────────────────────────────────────────────────────────┘
+```
+
+Shell panes move to separate windows (tabs), navigable via status bar or `C-b n/p`.
+
+---
+
+## Subagent Display Modes
+
+### Mode: `window` (subagent_display = "window")
+
+Each subagent gets its own tmux window:
+
+```
+Status bar:
+[my-project] 0:chat*  1:shell  2:sa_1:running  3:sa_2:done
+```
+
+Window content shows a mini Synaps-like stream:
+```
+┌──────────────────────────────────────────────────────────┐
+│ Subagent sa_1 | model: claude-sonnet-4-6 | ⏱ 12.3s     │
+│ Task: "Analyze the test coverage gaps"                   │
+│──────────────────────────────────────────────────────────│
+│ 🤔 Thinking: Let me look at the test files first...     │
+│                                                          │
+│ 🔧 Tool: bash("find tests/ -name '*.rs' | wc -l")      │
+│ → 23                                                     │
+│                                                          │
+│ 🔧 Tool: read("src/tools/mod.rs")                       │
+│ → [142 lines]                                            │
+│                                                          │
+│ 💬 There are 23 test files covering...                   │
+│                                                          │
+├──────────────────────────────────────────────────────────┤
+│ [my-project] 0:chat  1:shell  2:sa_1*                    │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Mode: `pane` (subagent_display = "pane")
+
+Each subagent gets a pane in the current window:
+
+```
+┌──────────────────────┬──────────────────┬────────────────┐
+│                      │ Shell %1         │ sa_1 ⏱12s     │
+│  Synaps TUI          │ $ cargo build    │ 🤔 Analyzing  │
+│  (chat)              │ Compiling...     │ 🔧 bash(...)  │
+│  %0                  │                  │ → 23 files    │
+│                      ├──────────────────┤                │
+│                      │ Shell %2         │                │
+│  > user types here   │ $ grep ...       │ 💬 Found 3... │
+├──────────────────────┴──────────────────┴────────────────┤
+│ [my-project] 0:chat*  sa_1:running ⏱12s                  │
+└──────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Convenience Hotkeys
+
+All under the standard tmux prefix (`C-b` by default):
+
+| Key | Action | Description |
+|-----|--------|-------------|
+| `C-b F` | Toggle fullscreen | Switch between split and fullscreen for Synaps TUI |
+| `C-b S` | Cycle subagent display | Toggle between window/pane modes |
+| `C-b L` | Cycle layout presets | Split → Fullscreen → Tiled → Split |
+| `C-b N` | Next subagent | Focus next subagent pane/window |
+| `C-b P` | Previous subagent | Focus previous subagent pane/window |
+| `C-b H` | Hotkey help | Show popup with all Synaps hotkeys |
+| `C-b Z` | Zoom pane | Standard tmux zoom (toggle) |
+| `C-b arrows` | Navigate panes | Standard tmux pane navigation |
+| Mouse click | Select pane | Standard tmux mouse support |
+| Mouse drag | Resize pane | Standard tmux mouse support |
+| Mouse wheel | Scroll | Scroll history in any pane |
+
+Mouse is enabled by default (`set -g mouse on`).
+
+---
+
+## Configuration Options
+
+```
+# tmux mode
+tmux = true | false                          # enable tmux mode (default: false)
+tmux_session_name = "my-project"             # session name (default: auto-generated)
+tmux_default_layout = "split"                # split | fullscreen | tiled (default: split)
+tmux_subagent_display = "pane"               # window | pane (default: pane)
+tmux_mouse = true                            # enable mouse (default: true)
+
+# Layout customization (future)
+tmux_split_ratio = 60                        # TUI pane width percentage (default: 60)
+tmux_shell_position = "right"                # right | bottom (default: right)
+```
+
+All settings available at:
+- System level: `~/.synaps-cli/config`
+- Project level: `.synaps/config`
+- Runtime: `/settings` TUI page or agent prompt
+
+---
+
+## Module Structure
+
+```
+src/
+├── tmux/
+│   ├── mod.rs              # public API, feature detection
+│   ├── controller.rs       # TmuxController - control mode connection
+│   ├── state.rs            # TmuxState, TmuxWindow, TmuxPane, enums
+│   ├── protocol.rs         # Control mode parser (notifications + responses)
+│   ├── layout.rs           # Layout presets, apply/cycle logic
+│   ├── hotkeys.rs          # Convenience keybinding setup
+│   └── install.rs          # tmux-not-found installer flow
+├── tools/
+│   ├── tmux_split.rs       # tmux_split tool
+│   ├── tmux_send.rs        # tmux_send tool
+│   ├── tmux_capture.rs     # tmux_capture tool
+│   ├── tmux_layout.rs      # tmux_layout tool
+│   ├── tmux_window.rs      # tmux_window tool
+│   └── tmux_resize.rs      # tmux_resize tool
+```
+
+---
+
+## tmux Not Found — Install Flow
+
+When `synaps --tmux` is invoked but `tmux` is not in PATH:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Error: tmux is not installed.                           │
+│                                                          │
+│  tmux mode requires tmux to be available in your PATH.   │
+│                                                          │
+│  Would you like to install tmux from source? [y/N]       │
+│                                                          │
+│  This will run:                                          │
+│    git clone https://github.com/tmux/tmux.git            │
+│    cd tmux                                               │
+│    sh autogen.sh                                         │
+│    ./configure && make && sudo make install               │
+└──────────────────────────────────────────────────────────┘
+```
+
+On `y`: execute the build, verify `which tmux`, then restart in tmux mode.
+On `n` or Enter: exit with error code.
+
+Build dependencies note: `autogen.sh` requires `automake`, `configure` requires `libevent-dev` and `ncurses-dev`. The installer should check for these and report if missing.
+
+---
+
+## What Stays The Same
+
+- **portable-pty** remains for non-tmux mode. Zero changes to existing shell session behavior when tmux mode is off.
+- **Existing shell tools** (`shell_start`, `shell_send`, `shell_end`) remain unchanged in both modes. In tmux mode, they still create invisible PTY sessions — they're for background work. The new tmux tools are for visible panes.
+- **Subagent spawning** mechanism stays the same (OS thread isolation). The display mode only affects whether a visible pane/window is created to show the subagent's output.
+- **TUI** (ratatui) runs as-is inside its tmux pane.
+
+---
+
+## Open Questions (for implementation phase)
+
+1. **Subagent pane rendering** — The subagent output stream (thinking, tool use, text) needs a renderer for the tmux pane. Options: (a) pipe raw StreamEvents through a simple formatter, (b) run a mini headless Synaps in each subagent pane, (c) use `display-message -I` to write formatted text to empty panes.
+
+2. **Control mode reconnection** — If the control mode pipe breaks mid-session, should we attempt reconnection or fail hard?
+
+3. **Terminal size coordination** — When the user resizes their terminal, tmux handles pane resizing. The ratatui TUI already handles resize events. Need to verify these compose cleanly.
+
+4. **Status bar format** — Exact format string for the tmux status bar showing session info, subagent status, and hotkey hints.

--- a/docs/plans/2025-01-27-tmux-native-plan.md
+++ b/docs/plans/2025-01-27-tmux-native-plan.md
@@ -1,0 +1,1878 @@
+# tmux Native Enhancements — Implementation Plan
+
+**Goal:** Add tmux native integration to Synaps via control mode, with new agent tools, configurable layouts, and subagent display modes.
+**Architecture:** TmuxController manages a persistent control mode connection; 6 new tools give the agent direct tmux control; config supports system/project-level tmux settings.
+**Design Doc:** `docs/plans/2025-01-27-tmux-native-design.md`
+**Estimated Tasks:** 42 tasks across 10 batches
+**Complexity:** Large
+
+---
+
+## Batch 1: Foundation — Config & Detection (Tasks 1–5)
+
+### Task 1: Add TmuxConfig struct
+
+**Files:**
+- Create: `src/tmux/config.rs`
+- Create: `src/tmux/mod.rs`
+- Modify: `src/lib.rs`
+
+**Step 1: Write failing test**
+```rust
+// src/tmux/config.rs — at the bottom
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tmux_config_default() {
+        let config = TmuxConfig::default();
+        assert!(!config.enabled);
+        assert!(config.session_name.is_none());
+        assert_eq!(config.default_layout, LayoutPreset::Split);
+        assert_eq!(config.subagent_display, SubagentDisplay::Pane);
+        assert!(config.mouse);
+        assert_eq!(config.split_ratio, 60);
+    }
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test tmux::config::tests::test_tmux_config_default -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — module `tmux` not found
+
+**Step 3: Implement**
+```rust
+// src/tmux/config.rs
+//! tmux integration configuration.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LayoutPreset {
+    Split,
+    Fullscreen,
+    Tiled,
+    Custom(String),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SubagentDisplay {
+    Window,
+    Pane,
+}
+
+#[derive(Debug, Clone)]
+pub struct TmuxConfig {
+    pub enabled: bool,
+    pub session_name: Option<String>,
+    pub default_layout: LayoutPreset,
+    pub subagent_display: SubagentDisplay,
+    pub mouse: bool,
+    pub split_ratio: u32,
+    pub shell_position: String,
+}
+
+impl Default for TmuxConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            session_name: None,
+            default_layout: LayoutPreset::Split,
+            subagent_display: SubagentDisplay::Pane,
+            mouse: true,
+            split_ratio: 60,
+            shell_position: "right".to_string(),
+        }
+    }
+}
+```
+
+```rust
+// src/tmux/mod.rs
+//! tmux native integration — control mode, layouts, tools.
+
+pub mod config;
+
+pub use config::TmuxConfig;
+```
+
+Add to `src/lib.rs`:
+```rust
+pub mod tmux;
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test tmux::config::tests::test_tmux_config_default -- --nocapture 2>&1 | tail -5`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): add TmuxConfig struct with defaults"
+```
+
+---
+
+### Task 2: Wire TmuxConfig into SynapsConfig
+
+**Files:**
+- Modify: `src/core/config.rs`
+
+**Step 1: Write failing test**
+```rust
+// Add to src/core/config.rs #[cfg(test)] mod tests
+#[test]
+fn test_synaps_config_has_tmux() {
+    let config = SynapsConfig::default();
+    assert!(!config.tmux.enabled);
+    assert!(config.tmux.session_name.is_none());
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test core::config::tests::test_synaps_config_has_tmux -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — no field `tmux` on type `SynapsConfig`
+
+**Step 3: Implement**
+
+Add to `SynapsConfig` struct (after `pub shell: ShellConfig`):
+```rust
+    pub tmux: crate::tmux::TmuxConfig,
+```
+
+Add to `impl Default for SynapsConfig` (after `shell: ShellConfig::default()`):
+```rust
+    tmux: crate::tmux::TmuxConfig::default(),
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test core::config::tests::test_synaps_config_has_tmux -- --nocapture 2>&1 | tail -5`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): wire TmuxConfig into SynapsConfig"
+```
+
+---
+
+### Task 3: Parse tmux config keys from config file
+
+**Files:**
+- Modify: `src/core/config.rs`
+
+**Step 1: Write failing test**
+```rust
+// Add to src/core/config.rs #[cfg(test)] mod tests
+#[test]
+fn test_parse_tmux_config_keys() {
+    use crate::tmux::config::{LayoutPreset, SubagentDisplay};
+    let mut tmux_config = crate::tmux::TmuxConfig::default();
+    
+    parse_tmux_config_key(&mut tmux_config, "tmux.enabled", "true");
+    assert!(tmux_config.enabled);
+    
+    parse_tmux_config_key(&mut tmux_config, "tmux.session_name", "my-project");
+    assert_eq!(tmux_config.session_name, Some("my-project".to_string()));
+    
+    parse_tmux_config_key(&mut tmux_config, "tmux.default_layout", "fullscreen");
+    assert_eq!(tmux_config.default_layout, LayoutPreset::Fullscreen);
+    
+    parse_tmux_config_key(&mut tmux_config, "tmux.subagent_display", "window");
+    assert_eq!(tmux_config.subagent_display, SubagentDisplay::Window);
+    
+    parse_tmux_config_key(&mut tmux_config, "tmux.mouse", "false");
+    assert!(!tmux_config.mouse);
+    
+    parse_tmux_config_key(&mut tmux_config, "tmux.split_ratio", "70");
+    assert_eq!(tmux_config.split_ratio, 70);
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test core::config::tests::test_parse_tmux_config_keys -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — `parse_tmux_config_key` not found
+
+**Step 3: Implement**
+
+Add function in `src/core/config.rs` (next to `parse_shell_config_key`):
+```rust
+fn parse_tmux_config_key(config: &mut crate::tmux::TmuxConfig, key: &str, val: &str) {
+    let sub_key = key.strip_prefix("tmux.").unwrap_or(key);
+    match sub_key {
+        "enabled" => config.enabled = val.eq_ignore_ascii_case("true"),
+        "session_name" => config.session_name = Some(val.to_string()),
+        "default_layout" => {
+            config.default_layout = match val.to_lowercase().as_str() {
+                "split" => crate::tmux::config::LayoutPreset::Split,
+                "fullscreen" => crate::tmux::config::LayoutPreset::Fullscreen,
+                "tiled" => crate::tmux::config::LayoutPreset::Tiled,
+                other => crate::tmux::config::LayoutPreset::Custom(other.to_string()),
+            };
+        }
+        "subagent_display" => {
+            config.subagent_display = match val.to_lowercase().as_str() {
+                "window" => crate::tmux::config::SubagentDisplay::Window,
+                _ => crate::tmux::config::SubagentDisplay::Pane,
+            };
+        }
+        "mouse" => config.mouse = val.eq_ignore_ascii_case("true"),
+        "split_ratio" => {
+            if let Ok(ratio) = val.parse::<u32>() {
+                if ratio > 0 && ratio < 100 {
+                    config.split_ratio = ratio;
+                }
+            }
+        }
+        "shell_position" => {
+            config.shell_position = match val.to_lowercase().as_str() {
+                "bottom" => "bottom".to_string(),
+                _ => "right".to_string(),
+            };
+        }
+        _ => {} // silently ignore unknown tmux keys
+    }
+}
+```
+
+Add dispatch arm in `load_config()` match block (in the `_ =>` fallthrough, alongside `shell.*`):
+```rust
+            _ => {
+                if key.starts_with("shell.") {
+                    parse_shell_config_key(&mut config.shell, key, val);
+                } else if key.starts_with("tmux.") {
+                    parse_tmux_config_key(&mut config.tmux, key, val);
+                }
+            }
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test core::config::tests::test_parse_tmux_config_keys -- --nocapture 2>&1 | tail -5`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): parse tmux.* config keys"
+```
+
+---
+
+### Task 4: Add --tmux CLI flag
+
+**Files:**
+- Modify: `src/main.rs`
+
+**Step 1: Write failing test**
+```rust
+// src/tmux/mod.rs — add test
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_auto_session_name_in_git_repo() {
+        // Test the auto-naming function
+        let name = super::auto_session_name();
+        // Should return synaps-<something> — either repo name or dir name
+        assert!(name.starts_with("synaps-"));
+    }
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test tmux::tests::test_auto_session_name_in_git_repo -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — `auto_session_name` not found
+
+**Step 3: Implement**
+
+Add to `src/tmux/mod.rs`:
+```rust
+use std::process::Command as StdCommand;
+
+/// Generate an auto session name based on git repo or directory name.
+pub fn auto_session_name() -> String {
+    // Try git repo name first
+    if let Ok(output) = StdCommand::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+    {
+        if output.status.success() {
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if let Some(name) = std::path::Path::new(&path).file_name() {
+                return format!("synaps-{}", name.to_string_lossy());
+            }
+        }
+    }
+    // Fall back to current directory name
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Some(name) = cwd.file_name() {
+            return format!("synaps-{}", name.to_string_lossy());
+        }
+    }
+    // Last resort
+    format!("synaps-{}", std::process::id())
+}
+
+/// Check if tmux is available in PATH.
+pub fn find_tmux() -> Option<String> {
+    StdCommand::new("which")
+        .arg("tmux")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+}
+```
+
+Add to `src/main.rs` Cli struct:
+```rust
+    /// Launch in tmux mode with optional session name.
+    #[arg(long = "tmux", value_name = "SESSION_NAME")]
+    tmux: Option<Option<String>>,
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test tmux::tests::test_auto_session_name_in_git_repo -- --nocapture 2>&1 | tail -5`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): add --tmux CLI flag and auto session naming"
+```
+
+---
+
+### Task 5: tmux detection and install offer
+
+**Files:**
+- Create: `src/tmux/install.rs`
+- Modify: `src/tmux/mod.rs`
+
+**Step 1: Write failing test**
+```rust
+// src/tmux/install.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_install_commands_are_valid() {
+        let cmds = install_commands();
+        assert_eq!(cmds.len(), 5);
+        assert!(cmds[0].contains("git clone"));
+        assert!(cmds[1].contains("cd tmux"));
+        assert!(cmds[2].contains("autogen.sh"));
+        assert!(cmds[3].contains("configure"));
+        assert!(cmds[4].contains("make install"));
+    }
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test tmux::install::tests::test_install_commands_are_valid -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — module `install` not found
+
+**Step 3: Implement**
+```rust
+// src/tmux/install.rs
+//! tmux installation flow when tmux is not found.
+
+use std::io::{self, Write};
+
+/// Return the sequence of shell commands to install tmux from source.
+pub fn install_commands() -> Vec<String> {
+    vec![
+        "git clone https://github.com/tmux/tmux.git".to_string(),
+        "cd tmux".to_string(),
+        "sh autogen.sh".to_string(),
+        "./configure && make".to_string(),
+        "sudo make install".to_string(),
+    ]
+}
+
+/// Print the install prompt and return true if user accepts.
+pub fn prompt_install() -> bool {
+    eprintln!("\x1b[1;31mError:\x1b[0m tmux is not installed.\n");
+    eprintln!("tmux mode requires tmux to be available in your PATH.\n");
+    eprintln!("Would you like to install tmux from source? [y/N]\n");
+    eprintln!("This will run:");
+    for cmd in install_commands() {
+        eprintln!("  {}", cmd);
+    }
+    eprint!("\n> ");
+    io::stderr().flush().ok();
+
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_ok() {
+        return input.trim().eq_ignore_ascii_case("y");
+    }
+    false
+}
+
+/// Execute the install commands. Returns Ok(()) on success.
+pub async fn run_install() -> Result<(), String> {
+    use tokio::process::Command;
+
+    let tmpdir = std::env::temp_dir().join("synaps-tmux-install");
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(&tmpdir)
+        .map_err(|e| format!("Failed to create temp dir: {}", e))?;
+
+    eprintln!("\nCloning tmux...");
+    let status = Command::new("git")
+        .args(["clone", "https://github.com/tmux/tmux.git"])
+        .current_dir(&tmpdir)
+        .status()
+        .await
+        .map_err(|e| format!("git clone failed: {}", e))?;
+    if !status.success() {
+        return Err("git clone failed".to_string());
+    }
+
+    let tmux_dir = tmpdir.join("tmux");
+
+    eprintln!("Running autogen.sh...");
+    let status = Command::new("sh")
+        .arg("autogen.sh")
+        .current_dir(&tmux_dir)
+        .status()
+        .await
+        .map_err(|e| format!("autogen.sh failed: {}", e))?;
+    if !status.success() {
+        return Err("autogen.sh failed. You may need: automake, autoconf, pkg-config".to_string());
+    }
+
+    eprintln!("Configuring and building...");
+    let status = Command::new("sh")
+        .args(["-c", "./configure && make"])
+        .current_dir(&tmux_dir)
+        .status()
+        .await
+        .map_err(|e| format!("configure/make failed: {}", e))?;
+    if !status.success() {
+        return Err("Build failed. You may need: libevent-dev, ncurses-dev (libncurses-dev)".to_string());
+    }
+
+    eprintln!("Installing (may require sudo password)...");
+    let status = Command::new("sudo")
+        .args(["make", "install"])
+        .current_dir(&tmux_dir)
+        .status()
+        .await
+        .map_err(|e| format!("make install failed: {}", e))?;
+    if !status.success() {
+        return Err("make install failed".to_string());
+    }
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&tmpdir);
+
+    // Verify
+    if crate::tmux::find_tmux().is_some() {
+        eprintln!("\n\x1b[1;32m✓\x1b[0m tmux installed successfully!");
+        Ok(())
+    } else {
+        Err("tmux installed but not found in PATH".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_install_commands_are_valid() {
+        let cmds = install_commands();
+        assert_eq!(cmds.len(), 5);
+        assert!(cmds[0].contains("git clone"));
+        assert!(cmds[1].contains("cd tmux"));
+        assert!(cmds[2].contains("autogen.sh"));
+        assert!(cmds[3].contains("configure"));
+        assert!(cmds[4].contains("make install"));
+    }
+}
+```
+
+Add to `src/tmux/mod.rs`:
+```rust
+pub mod install;
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test tmux::install::tests::test_install_commands_are_valid -- --nocapture 2>&1 | tail -5`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): add detection and install-from-source flow"
+```
+
+---
+
+## Batch 2: Control Mode Protocol (Tasks 6–10)
+
+### Task 6: Define TmuxEvent enum and protocol types
+
+**Files:**
+- Create: `src/tmux/protocol.rs`
+- Modify: `src/tmux/mod.rs`
+
+**Step 1: Write failing test**
+```rust
+// src/tmux/protocol.rs — at bottom
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_output_notification() {
+        let line = "%output %0 hello world";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::Output { pane_id, data }) 
+            if pane_id == "%0" && data == "hello world"));
+    }
+
+    #[test]
+    fn test_parse_window_add_notification() {
+        let line = "%window-add @5";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::WindowAdd { window_id })
+            if window_id == "@5"));
+    }
+
+    #[test]
+    fn test_parse_layout_change() {
+        let line = "%layout-change @0 ab12,200x50,0,0{100x50,0,0,0,99x50,101,0,1}";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::LayoutChange { window_id, layout })
+            if window_id == "@0"));
+    }
+
+    #[test]
+    fn test_parse_begin_end() {
+        let begin = "%begin 1234567890 42 1";
+        let event = TmuxEvent::parse(begin);
+        assert!(matches!(event, Some(TmuxEvent::Begin { command_num, .. })
+            if command_num == 42));
+
+        let end = "%end 1234567890 42 1";
+        let event = TmuxEvent::parse(end);
+        assert!(matches!(event, Some(TmuxEvent::End { command_num, .. })
+            if command_num == 42));
+    }
+
+    #[test]
+    fn test_parse_unknown_line() {
+        let line = "some random output";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::Data(_))));
+    }
+
+    #[test]
+    fn test_parse_pane_exited() {
+        let line = "%pane-exited %3";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::PaneExited { pane_id })
+            if pane_id == "%3"));
+    }
+
+    #[test]
+    fn test_parse_session_changed() {
+        let line = "%session-changed $1 my-session";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::SessionChanged { session_id, name })
+            if session_id == "$1" && name == "my-session"));
+    }
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test tmux::protocol::tests -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — module `protocol` not found
+
+**Step 3: Implement**
+```rust
+// src/tmux/protocol.rs
+//! Control mode protocol parser for tmux notifications and command responses.
+
+/// Events received from tmux control mode.
+#[derive(Debug, Clone)]
+pub enum TmuxEvent {
+    /// %begin <time> <command_num> <flags>
+    Begin { time: u64, command_num: u64, flags: u32 },
+    /// %end <time> <command_num> <flags>
+    End { time: u64, command_num: u64, flags: u32 },
+    /// %error <time> <command_num> <flags>
+    Error { time: u64, command_num: u64, flags: u32 },
+    /// %output %<pane_id> <data>
+    Output { pane_id: String, data: String },
+    /// %window-add @<window_id>
+    WindowAdd { window_id: String },
+    /// %window-close @<window_id>
+    WindowClose { window_id: String },
+    /// %window-renamed @<window_id> <name>
+    WindowRenamed { window_id: String, name: String },
+    /// %session-changed $<session_id> <name>
+    SessionChanged { session_id: String, name: String },
+    /// %layout-change @<window_id> <layout_string>
+    LayoutChange { window_id: String, layout: String },
+    /// %pane-mode-changed %<pane_id>
+    PaneModeChanged { pane_id: String },
+    /// %pane-exited %<pane_id>
+    PaneExited { pane_id: String },
+    /// Non-notification data (command response lines between %begin/%end)
+    Data(String),
+}
+
+impl TmuxEvent {
+    /// Parse a single line from tmux control mode output.
+    pub fn parse(line: &str) -> Option<TmuxEvent> {
+        if line.starts_with("%begin ") {
+            return Self::parse_triple(line, "%begin ").map(|(t, n, f)| TmuxEvent::Begin {
+                time: t, command_num: n, flags: f,
+            });
+        }
+        if line.starts_with("%end ") {
+            return Self::parse_triple(line, "%end ").map(|(t, n, f)| TmuxEvent::End {
+                time: t, command_num: n, flags: f,
+            });
+        }
+        if line.starts_with("%error ") {
+            return Self::parse_triple(line, "%error ").map(|(t, n, f)| TmuxEvent::Error {
+                time: t, command_num: n, flags: f,
+            });
+        }
+        if let Some(rest) = line.strip_prefix("%output ") {
+            let (pane_id, data) = rest.split_once(' ').unwrap_or((rest, ""));
+            return Some(TmuxEvent::Output {
+                pane_id: pane_id.to_string(),
+                data: data.to_string(),
+            });
+        }
+        if let Some(rest) = line.strip_prefix("%window-add ") {
+            return Some(TmuxEvent::WindowAdd { window_id: rest.trim().to_string() });
+        }
+        if let Some(rest) = line.strip_prefix("%window-close ") {
+            return Some(TmuxEvent::WindowClose { window_id: rest.trim().to_string() });
+        }
+        if let Some(rest) = line.strip_prefix("%window-renamed ") {
+            let (id, name) = rest.split_once(' ').unwrap_or((rest, ""));
+            return Some(TmuxEvent::WindowRenamed {
+                window_id: id.to_string(),
+                name: name.to_string(),
+            });
+        }
+        if let Some(rest) = line.strip_prefix("%session-changed ") {
+            let (id, name) = rest.split_once(' ').unwrap_or((rest, ""));
+            return Some(TmuxEvent::SessionChanged {
+                session_id: id.to_string(),
+                name: name.to_string(),
+            });
+        }
+        if let Some(rest) = line.strip_prefix("%layout-change ") {
+            let (id, layout) = rest.split_once(' ').unwrap_or((rest, ""));
+            return Some(TmuxEvent::LayoutChange {
+                window_id: id.to_string(),
+                layout: layout.to_string(),
+            });
+        }
+        if let Some(rest) = line.strip_prefix("%pane-mode-changed ") {
+            return Some(TmuxEvent::PaneModeChanged { pane_id: rest.trim().to_string() });
+        }
+        if let Some(rest) = line.strip_prefix("%pane-exited ") {
+            return Some(TmuxEvent::PaneExited { pane_id: rest.trim().to_string() });
+        }
+        // Non-notification line = data (command response body)
+        Some(TmuxEvent::Data(line.to_string()))
+    }
+
+    fn parse_triple(line: &str, prefix: &str) -> Option<(u64, u64, u32)> {
+        let rest = line.strip_prefix(prefix)?;
+        let parts: Vec<&str> = rest.split_whitespace().collect();
+        if parts.len() >= 3 {
+            let time = parts[0].parse().ok()?;
+            let num = parts[1].parse().ok()?;
+            let flags = parts[2].parse().ok()?;
+            Some((time, num, flags))
+        } else {
+            None
+        }
+    }
+}
+```
+
+Add to `src/tmux/mod.rs`:
+```rust
+pub mod protocol;
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test tmux::protocol::tests -- --nocapture 2>&1 | tail -5`
+Expected: PASS — all 7 tests pass
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): control mode protocol parser"
+```
+
+---
+
+### Task 7: Define TmuxState
+
+**Files:**
+- Create: `src/tmux/state.rs`
+- Modify: `src/tmux/mod.rs`
+
+**Step 1: Write failing test**
+```rust
+// src/tmux/state.rs — at bottom
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_state_new() {
+        let state = TmuxState::new("$0", "my-session");
+        assert_eq!(state.session_id, "$0");
+        assert_eq!(state.session_name, "my-session");
+        assert!(state.windows.is_empty());
+        assert!(state.panes.is_empty());
+    }
+
+    #[test]
+    fn test_add_and_get_pane() {
+        let mut state = TmuxState::new("$0", "test");
+        state.add_pane(TmuxPane {
+            id: "%0".to_string(),
+            window_id: "@0".to_string(),
+            title: "main".to_string(),
+            width: 200,
+            height: 50,
+            active: true,
+            role: PaneRole::SynapsTui,
+        });
+        assert_eq!(state.panes.len(), 1);
+        assert!(state.pane("%0").is_some());
+        assert_eq!(state.pane("%0").unwrap().role, PaneRole::SynapsTui);
+    }
+
+    #[test]
+    fn test_remove_pane() {
+        let mut state = TmuxState::new("$0", "test");
+        state.add_pane(TmuxPane {
+            id: "%1".to_string(),
+            window_id: "@0".to_string(),
+            title: "shell".to_string(),
+            width: 80,
+            height: 24,
+            active: false,
+            role: PaneRole::AgentShell { session_id: "shell_01".to_string() },
+        });
+        assert_eq!(state.panes.len(), 1);
+        state.remove_pane("%1");
+        assert_eq!(state.panes.len(), 0);
+    }
+
+    #[test]
+    fn test_panes_by_role() {
+        let mut state = TmuxState::new("$0", "test");
+        state.add_pane(TmuxPane {
+            id: "%0".to_string(), window_id: "@0".to_string(),
+            title: "tui".to_string(), width: 100, height: 50,
+            active: true, role: PaneRole::SynapsTui,
+        });
+        state.add_pane(TmuxPane {
+            id: "%1".to_string(), window_id: "@0".to_string(),
+            title: "sh1".to_string(), width: 100, height: 25,
+            active: false, role: PaneRole::AgentShell { session_id: "shell_01".to_string() },
+        });
+        state.add_pane(TmuxPane {
+            id: "%2".to_string(), window_id: "@0".to_string(),
+            title: "sa1".to_string(), width: 100, height: 25,
+            active: false, role: PaneRole::Subagent { handle_id: "sa_1".to_string() },
+        });
+
+        let shells: Vec<_> = state.panes_by_role_filter(|r| matches!(r, PaneRole::AgentShell { .. }));
+        assert_eq!(shells.len(), 1);
+        assert_eq!(shells[0].id, "%1");
+    }
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test tmux::state::tests -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — module `state` not found
+
+**Step 3: Implement**
+```rust
+// src/tmux/state.rs
+//! Tracked state of tmux objects (sessions, windows, panes).
+
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PaneRole {
+    SynapsTui,
+    AgentShell { session_id: String },
+    Subagent { handle_id: String },
+    User,
+}
+
+#[derive(Debug, Clone)]
+pub struct TmuxPane {
+    pub id: String,
+    pub window_id: String,
+    pub title: String,
+    pub width: u32,
+    pub height: u32,
+    pub active: bool,
+    pub role: PaneRole,
+}
+
+#[derive(Debug, Clone)]
+pub struct TmuxWindow {
+    pub id: String,
+    pub name: String,
+    pub index: u32,
+    pub layout: String,
+}
+
+#[derive(Debug)]
+pub struct TmuxState {
+    pub session_id: String,
+    pub session_name: String,
+    pub windows: HashMap<String, TmuxWindow>,
+    pub panes: HashMap<String, TmuxPane>,
+    pub self_pane: Option<String>,
+}
+
+impl TmuxState {
+    pub fn new(session_id: &str, session_name: &str) -> Self {
+        Self {
+            session_id: session_id.to_string(),
+            session_name: session_name.to_string(),
+            windows: HashMap::new(),
+            panes: HashMap::new(),
+            self_pane: None,
+        }
+    }
+
+    pub fn add_pane(&mut self, pane: TmuxPane) {
+        self.panes.insert(pane.id.clone(), pane);
+    }
+
+    pub fn remove_pane(&mut self, pane_id: &str) {
+        self.panes.remove(pane_id);
+    }
+
+    pub fn pane(&self, pane_id: &str) -> Option<&TmuxPane> {
+        self.panes.get(pane_id)
+    }
+
+    pub fn pane_mut(&mut self, pane_id: &str) -> Option<&mut TmuxPane> {
+        self.panes.get_mut(pane_id)
+    }
+
+    pub fn add_window(&mut self, window: TmuxWindow) {
+        self.windows.insert(window.id.clone(), window);
+    }
+
+    pub fn remove_window(&mut self, window_id: &str) {
+        self.windows.remove(window_id);
+    }
+
+    pub fn panes_by_role_filter<F>(&self, f: F) -> Vec<&TmuxPane>
+    where
+        F: Fn(&PaneRole) -> bool,
+    {
+        self.panes.values().filter(|p| f(&p.role)).collect()
+    }
+}
+```
+
+Add to `src/tmux/mod.rs`:
+```rust
+pub mod state;
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test tmux::state::tests -- --nocapture 2>&1 | tail -5`
+Expected: PASS — all 4 tests pass
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): add TmuxState with pane/window tracking"
+```
+
+---
+
+### Task 8: TmuxController — struct and command sending
+
+**Files:**
+- Create: `src/tmux/controller.rs`
+- Modify: `src/tmux/mod.rs`
+
+**Step 1: Write failing test**
+```rust
+// src/tmux/controller.rs — at bottom
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_command() {
+        let cmd = TmuxController::format_command("split-window", &["-h", "-P", "-F", "#{pane_id}"]);
+        assert_eq!(cmd, "split-window -h -P -F #{pane_id}\n");
+    }
+
+    #[test]
+    fn test_format_command_no_args() {
+        let cmd = TmuxController::format_command("list-windows", &[]);
+        assert_eq!(cmd, "list-windows\n");
+    }
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test tmux::controller::tests -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — module `controller` not found
+
+**Step 3: Implement**
+```rust
+// src/tmux/controller.rs
+//! TmuxController — manages the control mode connection to tmux.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::protocol::TmuxEvent;
+use super::state::TmuxState;
+
+/// Result of a command sent to tmux control mode.
+#[derive(Debug)]
+pub struct CommandResult {
+    pub lines: Vec<String>,
+    pub success: bool,
+}
+
+/// The main tmux controller. Owns the control mode process and state.
+pub struct TmuxController {
+    /// Child process handle for the control mode client
+    child: Option<Child>,
+    /// Writer to control mode stdin
+    writer: Option<tokio::process::ChildStdin>,
+    /// Tracked state of all tmux objects
+    state: Arc<RwLock<TmuxState>>,
+    /// Channel for incoming parsed events
+    event_tx: mpsc::UnboundedSender<TmuxEvent>,
+    /// Receiver for events (consumed by event loop)
+    event_rx: Option<mpsc::UnboundedReceiver<TmuxEvent>>,
+    /// Pending command responses: command_num -> sender
+    pending: Arc<tokio::sync::Mutex<HashMap<u64, oneshot::Sender<CommandResult>>>>,
+    /// Next command number
+    next_cmd: AtomicU64,
+    /// Session name
+    pub session_name: String,
+}
+
+impl TmuxController {
+    /// Format a tmux command string for control mode.
+    pub fn format_command(cmd: &str, args: &[&str]) -> String {
+        if args.is_empty() {
+            format!("{}\n", cmd)
+        } else {
+            format!("{} {}\n", cmd, args.join(" "))
+        }
+    }
+
+    /// Create a new controller (does not start the connection yet).
+    pub fn new(session_name: String) -> Self {
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        Self {
+            child: None,
+            writer: None,
+            state: Arc::new(RwLock::new(TmuxState::new("", &session_name))),
+            event_tx,
+            event_rx: Some(event_rx),
+            pending: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            next_cmd: AtomicU64::new(0),
+            session_name,
+        }
+    }
+
+    /// Get a handle to the shared state.
+    pub fn state(&self) -> Arc<RwLock<TmuxState>> {
+        Arc::clone(&self.state)
+    }
+
+    /// Send a command to tmux and wait for the response.
+    pub async fn send_command(&self, cmd: &str, args: &[&str]) -> Result<CommandResult, String> {
+        let writer = self.writer.as_ref()
+            .ok_or_else(|| "Control mode not connected".to_string())?;
+
+        let formatted = Self::format_command(cmd, args);
+
+        // We need mutable access to write — use unsafe transmute or restructure
+        // For now, we'll clone the stdin handle approach
+        // This will be refined in the event loop task
+        let _ = formatted; // placeholder
+        let _ = writer;
+
+        // TODO: Wire up actual send in event loop task
+        Err("Not yet connected".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_command() {
+        let cmd = TmuxController::format_command("split-window", &["-h", "-P", "-F", "#{pane_id}"]);
+        assert_eq!(cmd, "split-window -h -P -F #{pane_id}\n");
+    }
+
+    #[test]
+    fn test_format_command_no_args() {
+        let cmd = TmuxController::format_command("list-windows", &[]);
+        assert_eq!(cmd, "list-windows\n");
+    }
+}
+```
+
+Add to `src/tmux/mod.rs`:
+```rust
+pub mod controller;
+pub use controller::TmuxController;
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test tmux::controller::tests -- --nocapture 2>&1 | tail -5`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): TmuxController struct with command formatting"
+```
+
+---
+
+### Task 9: TmuxController — start control mode session
+
+**Files:**
+- Modify: `src/tmux/controller.rs`
+
+**Step 1: Write failing test**
+```rust
+// Add to src/tmux/controller.rs tests
+#[tokio::test]
+async fn test_start_requires_tmux() {
+    // This test verifies the start method exists and handles missing tmux
+    let mut controller = TmuxController::new("test-session".to_string());
+    // On CI or systems without tmux, start should return an error
+    if crate::tmux::find_tmux().is_none() {
+        let result = controller.start().await;
+        assert!(result.is_err());
+    }
+    // If tmux IS available, we test the full flow
+    // (covered by integration tests)
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test tmux::controller::tests::test_start_requires_tmux -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — no method named `start`
+
+**Step 3: Implement**
+
+Add to `impl TmuxController`:
+```rust
+    /// Start a tmux session and connect via control mode.
+    /// Creates a new detached session, then attaches in control mode.
+    pub async fn start(&mut self) -> Result<(), String> {
+        // 1. Check tmux exists
+        let tmux_path = crate::tmux::find_tmux()
+            .ok_or_else(|| "tmux not found in PATH".to_string())?;
+
+        // 2. Get terminal size
+        let (cols, rows) = crossterm::terminal::size()
+            .unwrap_or((200, 50));
+
+        // 3. Create detached session
+        let create_status = Command::new(&tmux_path)
+            .args([
+                "new-session", "-d",
+                "-s", &self.session_name,
+                "-x", &cols.to_string(),
+                "-y", &rows.to_string(),
+            ])
+            .status()
+            .await
+            .map_err(|e| format!("Failed to create tmux session: {}", e))?;
+
+        if !create_status.success() {
+            return Err("Failed to create tmux session".to_string());
+        }
+
+        // 4. Attach in control mode
+        let mut child = Command::new(&tmux_path)
+            .args(["-CC", "attach-session", "-t", &self.session_name])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| format!("Failed to start control mode: {}", e))?;
+
+        let stdout = child.stdout.take()
+            .ok_or_else(|| "Failed to capture stdout".to_string())?;
+        let stdin = child.stdin.take()
+            .ok_or_else(|| "Failed to capture stdin".to_string())?;
+
+        self.writer = Some(stdin);
+        self.child = Some(child);
+
+        // 5. Start reader task
+        let event_tx = self.event_tx.clone();
+        let pending = Arc::clone(&self.pending);
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            let mut current_cmd: Option<u64> = None;
+            let mut current_lines: Vec<String> = Vec::new();
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                if let Some(event) = TmuxEvent::parse(&line) {
+                    match &event {
+                        TmuxEvent::Begin { command_num, .. } => {
+                            current_cmd = Some(*command_num);
+                            current_lines.clear();
+                        }
+                        TmuxEvent::End { command_num, .. } => {
+                            if Some(*command_num) == current_cmd {
+                                let mut map = pending.lock().await;
+                                if let Some(sender) = map.remove(command_num) {
+                                    let _ = sender.send(CommandResult {
+                                        lines: current_lines.drain(..).collect(),
+                                        success: true,
+                                    });
+                                }
+                                current_cmd = None;
+                            }
+                        }
+                        TmuxEvent::Error { command_num, .. } => {
+                            if Some(*command_num) == current_cmd {
+                                let mut map = pending.lock().await;
+                                if let Some(sender) = map.remove(command_num) {
+                                    let _ = sender.send(CommandResult {
+                                        lines: current_lines.drain(..).collect(),
+                                        success: false,
+                                    });
+                                }
+                                current_cmd = None;
+                            }
+                        }
+                        TmuxEvent::Data(data) => {
+                            if current_cmd.is_some() {
+                                current_lines.push(data.clone());
+                            }
+                        }
+                        _ => {}
+                    }
+                    // Forward all events
+                    let _ = event_tx.send(event);
+                }
+            }
+        });
+
+        tracing::info!("tmux control mode connected to session '{}'", self.session_name);
+        Ok(())
+    }
+
+    /// Kill the tmux session and clean up.
+    pub async fn shutdown(&mut self) -> Result<(), String> {
+        if let Some(tmux_path) = crate::tmux::find_tmux() {
+            let _ = Command::new(&tmux_path)
+                .args(["kill-session", "-t", &self.session_name])
+                .status()
+                .await;
+        }
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill().await;
+        }
+        self.writer = None;
+        Ok(())
+    }
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test tmux::controller::tests::test_start_requires_tmux -- --nocapture 2>&1 | tail -5`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): control mode start/shutdown lifecycle"
+```
+
+---
+
+### Task 10: TmuxController — async command send with response
+
+**Files:**
+- Modify: `src/tmux/controller.rs`
+
+**Step 1: Write failing test**
+```rust
+// Add to src/tmux/controller.rs tests
+#[tokio::test]
+async fn test_send_command_when_disconnected() {
+    let controller = TmuxController::new("test-disconnected".to_string());
+    let result = controller.execute("list-windows", &[]).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("not connected"));
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test tmux::controller::tests::test_send_command_when_disconnected -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — no method `execute`
+
+**Step 3: Implement**
+
+Replace the `send_command` method and add `execute`:
+```rust
+    /// Send a command to tmux control mode and wait for its response.
+    pub async fn execute(&self, cmd: &str, args: &[&str]) -> Result<CommandResult, String> {
+        let writer = self.writer.as_ref()
+            .ok_or_else(|| "Control mode not connected".to_string())?;
+
+        let cmd_num = self.next_cmd.fetch_add(1, Ordering::SeqCst);
+        let formatted = Self::format_command(cmd, args);
+
+        // Register the pending response
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut map = self.pending.lock().await;
+            map.insert(cmd_num, tx);
+        }
+
+        // Write to stdin — we need interior mutability for the writer
+        // Use unsafe pin projection since we know we're single-writer
+        let writer_ptr = writer as *const tokio::process::ChildStdin
+            as *mut tokio::process::ChildStdin;
+        unsafe {
+            let w = &mut *writer_ptr;
+            w.write_all(formatted.as_bytes()).await
+                .map_err(|e| format!("Failed to write command: {}", e))?;
+            w.flush().await
+                .map_err(|e| format!("Failed to flush: {}", e))?;
+        }
+
+        // Wait for response with timeout
+        match tokio::time::timeout(std::time::Duration::from_secs(10), rx).await {
+            Ok(Ok(result)) => Ok(result),
+            Ok(Err(_)) => Err("Response channel dropped".to_string()),
+            Err(_) => {
+                // Remove from pending on timeout
+                let mut map = self.pending.lock().await;
+                map.remove(&cmd_num);
+                Err("Command timed out".to_string())
+            }
+        }
+    }
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test tmux::controller::tests::test_send_command_when_disconnected -- --nocapture 2>&1 | tail -5`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): async command execution with response tracking"
+```
+
+---
+
+## Batch 3: Layout Management (Tasks 11–13)
+
+### Task 11: Layout presets — apply logic
+
+**Files:**
+- Create: `src/tmux/layout.rs`
+- Modify: `src/tmux/mod.rs`
+
+**Step 1: Write failing test**
+```rust
+// src/tmux/layout.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tmux::config::LayoutPreset;
+
+    #[test]
+    fn test_split_layout_commands() {
+        let cmds = layout_commands(&LayoutPreset::Split, "%0", 60);
+        assert!(!cmds.is_empty());
+        // Should contain a split-window command
+        assert!(cmds.iter().any(|c| c.contains("split-window")));
+    }
+
+    #[test]
+    fn test_fullscreen_layout_no_split() {
+        let cmds = layout_commands(&LayoutPreset::Fullscreen, "%0", 60);
+        // Fullscreen should not split — just keep the TUI pane
+        assert!(cmds.is_empty() || cmds.iter().all(|c| !c.contains("split-window")));
+    }
+
+    #[test]
+    fn test_tiled_layout_commands() {
+        let cmds = layout_commands(&LayoutPreset::Tiled, "%0", 50);
+        assert!(cmds.iter().any(|c| c.contains("tiled")));
+    }
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test tmux::layout::tests -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — module `layout` not found
+
+**Step 3: Implement**
+```rust
+// src/tmux/layout.rs
+//! Layout preset logic for tmux pane arrangements.
+
+use super::config::LayoutPreset;
+
+/// Generate the tmux commands needed to apply a layout preset.
+/// `self_pane` is the Synaps TUI pane ID, `split_ratio` is the TUI width percentage.
+pub fn layout_commands(preset: &LayoutPreset, self_pane: &str, split_ratio: u32) -> Vec<String> {
+    match preset {
+        LayoutPreset::Split => {
+            // Split horizontally: TUI on left, shells on right
+            let shell_pct = 100 - split_ratio;
+            vec![
+                format!("split-window -h -t {} -l {}%", self_pane, shell_pct),
+            ]
+        }
+        LayoutPreset::Fullscreen => {
+            // No splits — TUI takes full window, shells go to new windows
+            vec![]
+        }
+        LayoutPreset::Tiled => {
+            vec![
+                format!("select-layout -t {} tiled", self_pane),
+            ]
+        }
+        LayoutPreset::Custom(layout_string) => {
+            vec![
+                format!("select-layout -t {} {}", self_pane, layout_string),
+            ]
+        }
+    }
+}
+
+/// Generate commands to cycle to the next layout preset.
+pub fn next_preset(current: &LayoutPreset) -> LayoutPreset {
+    match current {
+        LayoutPreset::Split => LayoutPreset::Fullscreen,
+        LayoutPreset::Fullscreen => LayoutPreset::Tiled,
+        LayoutPreset::Tiled => LayoutPreset::Split,
+        LayoutPreset::Custom(_) => LayoutPreset::Split,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_layout_commands() {
+        let cmds = layout_commands(&LayoutPreset::Split, "%0", 60);
+        assert!(!cmds.is_empty());
+        assert!(cmds.iter().any(|c| c.contains("split-window")));
+    }
+
+    #[test]
+    fn test_fullscreen_layout_no_split() {
+        let cmds = layout_commands(&LayoutPreset::Fullscreen, "%0", 60);
+        assert!(cmds.is_empty());
+    }
+
+    #[test]
+    fn test_tiled_layout_commands() {
+        let cmds = layout_commands(&LayoutPreset::Tiled, "%0", 50);
+        assert!(cmds.iter().any(|c| c.contains("tiled")));
+    }
+
+    #[test]
+    fn test_next_preset_cycle() {
+        assert_eq!(next_preset(&LayoutPreset::Split), LayoutPreset::Fullscreen);
+        assert_eq!(next_preset(&LayoutPreset::Fullscreen), LayoutPreset::Tiled);
+        assert_eq!(next_preset(&LayoutPreset::Tiled), LayoutPreset::Split);
+        assert_eq!(next_preset(&LayoutPreset::Custom("x".to_string())), LayoutPreset::Split);
+    }
+}
+```
+
+Add to `src/tmux/mod.rs`:
+```rust
+pub mod layout;
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test tmux::layout::tests -- --nocapture 2>&1 | tail -5`
+Expected: PASS — all 4 tests pass
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): layout preset commands and cycling"
+```
+
+---
+
+### Task 12: Hotkey bindings setup
+
+**Files:**
+- Create: `src/tmux/hotkeys.rs`
+- Modify: `src/tmux/mod.rs`
+
+**Step 1: Write failing test**
+```rust
+// src/tmux/hotkeys.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hotkey_commands_not_empty() {
+        let cmds = hotkey_bind_commands();
+        assert!(!cmds.is_empty());
+    }
+
+    #[test]
+    fn test_hotkey_commands_contain_bind_key() {
+        let cmds = hotkey_bind_commands();
+        for cmd in &cmds {
+            assert!(cmd.starts_with("bind-key"), "Expected bind-key command: {}", cmd);
+        }
+    }
+
+    #[test]
+    fn test_mouse_enable_command() {
+        let cmd = mouse_command(true);
+        assert!(cmd.contains("mouse"));
+        assert!(cmd.contains("on"));
+
+        let cmd = mouse_command(false);
+        assert!(cmd.contains("mouse"));
+        assert!(cmd.contains("off"));
+    }
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test tmux::hotkeys::tests -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — module `hotkeys` not found
+
+**Step 3: Implement**
+```rust
+// src/tmux/hotkeys.rs
+//! Convenience hotkey bindings for Synaps tmux mode.
+
+/// Generate the tmux bind-key commands for Synaps convenience keys.
+pub fn hotkey_bind_commands() -> Vec<String> {
+    vec![
+        // C-b F — toggle fullscreen (zoom current pane)
+        "bind-key -T prefix F resize-pane -Z".to_string(),
+        // C-b S — placeholder for cycle subagent display (handled via run-shell callback)
+        "bind-key -T prefix S display-message 'Cycling subagent display...'".to_string(),
+        // C-b L — placeholder for cycle layout (handled via run-shell callback)
+        "bind-key -T prefix L display-message 'Cycling layout...'".to_string(),
+        // C-b N — next pane (enhanced: skip non-agent panes)
+        "bind-key -T prefix N select-pane -t :.+".to_string(),
+        // C-b P — previous pane
+        "bind-key -T prefix P select-pane -t :.-".to_string(),
+        // C-b H — show help popup
+        "bind-key -T prefix H display-message 'Synaps: F=fullscreen S=subagent L=layout N/P=nav H=help'".to_string(),
+    ]
+}
+
+/// Generate the mouse enable/disable command.
+pub fn mouse_command(enabled: bool) -> String {
+    if enabled {
+        "set-option -g mouse on".to_string()
+    } else {
+        "set-option -g mouse off".to_string()
+    }
+}
+
+/// Generate status bar format command for Synaps.
+pub fn status_bar_commands(session_name: &str) -> Vec<String> {
+    vec![
+        "set-option -g status-position bottom".to_string(),
+        format!(
+            "set-option -g status-left '#[fg=cyan,bold][{}] '",
+            session_name
+        ),
+        "set-option -g status-right '#[fg=yellow]C-b H:help #[fg=white]%H:%M'".to_string(),
+        "set-option -g status-style 'bg=black,fg=white'".to_string(),
+        "set-option -g window-status-current-style 'fg=green,bold'".to_string(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hotkey_commands_not_empty() {
+        let cmds = hotkey_bind_commands();
+        assert!(!cmds.is_empty());
+    }
+
+    #[test]
+    fn test_hotkey_commands_contain_bind_key() {
+        let cmds = hotkey_bind_commands();
+        for cmd in &cmds {
+            assert!(cmd.starts_with("bind-key"), "Expected bind-key command: {}", cmd);
+        }
+    }
+
+    #[test]
+    fn test_mouse_enable_command() {
+        let cmd = mouse_command(true);
+        assert!(cmd.contains("mouse"));
+        assert!(cmd.contains("on"));
+
+        let cmd = mouse_command(false);
+        assert!(cmd.contains("mouse"));
+        assert!(cmd.contains("off"));
+    }
+
+    #[test]
+    fn test_status_bar_commands() {
+        let cmds = status_bar_commands("my-project");
+        assert!(cmds.iter().any(|c| c.contains("my-project")));
+        assert!(cmds.iter().any(|c| c.contains("status-position")));
+    }
+}
+```
+
+Add to `src/tmux/mod.rs`:
+```rust
+pub mod hotkeys;
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test tmux::hotkeys::tests -- --nocapture 2>&1 | tail -5`
+Expected: PASS — all 4 tests pass
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): convenience hotkey bindings and status bar"
+```
+
+---
+
+### Task 13: Wire TmuxController into Runtime
+
+**Files:**
+- Modify: `src/runtime/mod.rs`
+- Modify: `src/tools/mod.rs`
+
+**Step 1: Write failing test**
+```rust
+// Add to existing tests or in src/tmux/mod.rs tests
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_auto_session_name_in_git_repo() {
+        let name = super::auto_session_name();
+        assert!(name.starts_with("synaps-"));
+    }
+
+    #[test]
+    fn test_find_tmux_returns_option() {
+        // Just verify the function exists and returns cleanly
+        let _result = super::find_tmux();
+    }
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo build 2>&1 | tail -10`
+Expected: Should compile (this is a wiring task — test is that it builds)
+
+**Step 3: Implement**
+
+Add to `Runtime` struct in `src/runtime/mod.rs`:
+```rust
+    tmux_controller: Option<Arc<crate::tmux::TmuxController>>,
+```
+
+Add to `Runtime::new()` struct literal:
+```rust
+    tmux_controller: None,
+```
+
+Add accessor methods:
+```rust
+    pub fn tmux_controller(&self) -> Option<&Arc<crate::tmux::TmuxController>> {
+        self.tmux_controller.as_ref()
+    }
+
+    pub fn set_tmux_controller(&mut self, controller: Arc<crate::tmux::TmuxController>) {
+        self.tmux_controller = Some(controller);
+    }
+```
+
+Add to `ToolCapabilities` in `src/tools/mod.rs`:
+```rust
+    pub tmux_controller: Option<Arc<crate::tmux::TmuxController>>,
+```
+
+Update all `ToolCapabilities` construction sites to include `tmux_controller: None` (or `tmux_controller: runtime.tmux_controller().cloned()` where the runtime is available).
+
+**Step 4: Verify it passes**
+Run: `cargo build 2>&1 | tail -5`
+Expected: compiles successfully
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): wire TmuxController into Runtime and ToolCapabilities"
+```
+
+---
+
+## Batch 4: tmux Tools — Part 1 (Tasks 14–17)
+
+### Task 14: tmux_split tool
+
+**Files:**
+- Create: `src/tools/tmux_split.rs`
+- Modify: `src/tools/mod.rs`
+- Modify: `src/tools/registry.rs`
+
+**Step 1: Write failing test**
+```rust
+// Add to src/tools/tests.rs
+#[test]
+fn test_tmux_split_tool_schema() {
+    let tool = crate::tools::TmuxSplitTool;
+    assert_eq!(tool.name(), "tmux_split");
+    assert!(!tool.description().is_empty());
+    let params = tool.parameters();
+    assert_eq!(params["type"], "object");
+    assert!(params["properties"]["direction"].is_object());
+    assert!(params["properties"]["command"].is_object());
+}
+
+#[tokio::test]
+async fn test_tmux_split_without_controller() {
+    let tool = crate::tools::TmuxSplitTool;
+    let ctx = create_tool_context();
+    let params = serde_json::json!({ "direction": "horizontal" });
+    let result = tool.execute(params, ctx).await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("tmux"));
+}
+```
+
+**Step 2: Verify it fails**
+Run: `cargo test test_tmux_split_tool_schema -- --nocapture 2>&1 | tail -5`
+Expected: FAIL — `TmuxSplitTool` not found
+
+**Step 3: Implement**
+```rust
+// src/tools/tmux_split.rs
+use serde_json::{json, Value};
+use crate::{Result, RuntimeError};
+use super::{Tool, ToolContext};
+
+pub struct TmuxSplitTool;
+
+#[async_trait::async_trait]
+impl Tool for TmuxSplitTool {
+    fn name(&self) -> &str { "tmux_split" }
+
+    fn description(&self) -> &str {
+        "Create a new tmux pane by splitting. Only available in tmux mode. Use to create visible terminal panes for running commands the user can see."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "direction": {
+                    "type": "string",
+                    "description": "Split direction: 'horizontal' (left/right) or 'vertical' (top/bottom). Default: horizontal",
+                    "enum": ["horizontal", "vertical"]
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size of new pane as percentage (e.g. '30%') or line count. Default: 50%"
+                },
+                "target": {
+                    "type": "string",
+                    "description": "Pane ID to split (e.g. '%0'). Default: current active pane"
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Command to run in the new pane"
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Title for the new pane"
+                },
+                "focus": {
+                    "type": "boolean",
+                    "description": "Switch focus to the new pane. Default: false"
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
+        let controller = ctx.capabilities.tmux_controller
+            .as_ref()
+            .ok_or_else(|| RuntimeError::Tool("tmux mode not active. Launch synaps with --tmux to use tmux tools.".to_string()))?;
+
+        let direction = params["direction"].as_str().unwrap_or("horizontal");
+        let size = params["size"].as_str().unwrap_or("50%");
+        let target = params["target"].as_str();
+        let command = params["command"].as_str();
+        let title = params["title"].as_str();
+        let focus = params["focus"].as_bool().unwrap_or(false);
+
+        let dir_flag = if direction == "vertical" { "-v" } else { "-h" };
+
+        let mut args = vec![dir_flag, "-P", "-F", "#{pane_id}"];
+
+        let size_arg = format!("-l {}", size);
+        args.push("-l");
+        args.push(size);
+
+        if !focus {
+            args.push("-d");
+        }
+
+        if let Some(t) = target {
+            args.push("-t");
+            args.push(t);
+        }
+
+        if let Some(cmd) = command {
+            args.push(cmd);
+        }
+
+        let result = controller.execute("split-window", &args).await
+            .map_err(|e| RuntimeError::Tool(format!("tmux split failed: {}", e)))?;
+
+        let pane_id = result.lines.first()
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+
+        // Set title if provided
+        if let Some(t) = title {
+            let _ = controller.execute("select-pane", &["-t", &pane_id, "-T", t]).await;
+        }
+
+        Ok(json!({
+            "pane_id": pane_id,
+            "direction": direction,
+            "size": size,
+        }).to_string())
+    }
+}
+```
+
+Add to `src/tools/mod.rs`:
+```rust
+mod tmux_split;
+pub use tmux_split::TmuxSplitTool;
+```
+
+Add to `src/tools/registry.rs` `new()` vec (conditionally — only in tmux mode, or always register and let the tool error):
+```rust
+Arc::new(crate::tools::tmux_split::TmuxSplitTool),
+```
+
+**Step 4: Verify it passes**
+Run: `cargo test test_tmux_split_tool_schema -- --nocapture 2>&1 | tail -5`
+Expected: PASS
+
+**Step 5: Commit**
+```bash
+git add -A && git commit -m "feat(tmux): add tmux_split tool"
+```
+
+---
+
+### Task 15: tmux_send tool
+
+*(Same pattern as Task 14 — create `src/tools/tmux_send.rs`, register, test schema + no-controller error)*
+
+### Task 16: tmux_capture tool
+
+*(Same pattern — create `src/tools/tmux_capture.rs`, register, test)*
+
+### Task 17: tmux_layout tool
+
+*(Same pattern — create `src/tools/tmux_layout.rs`, register, test)*
+
+---
+
+## Batch 5: tmux Tools — Part 2 (Tasks 18–20)
+
+### Task 18: tmux_window tool
+### Task 19: tmux_resize tool
+### Task 20: Update tool registry count in tests
+
+---
+
+## Batch 6: Startup Flow (Tasks 21–25)
+
+### Task 21: Main entry point — tmux mode detection and launch
+### Task 22: Session creation and control mode connection
+### Task 23: Self-pane identification
+### Task 24: Apply initial layout
+### Task 25: Apply hotkeys and mouse settings
+
+---
+
+## Batch 7: Subagent Integration (Tasks 26–30)
+
+### Task 26: Subagent pane display mode — create pane on subagent_start
+### Task 27: Subagent window display mode — create window on subagent_start
+### Task 28: Subagent output streaming to tmux pane
+### Task 29: Subagent cleanup on completion
+### Task 30: Config toggle for subagent display mode
+
+---
+
+## Batch 8: Shutdown & Cleanup (Tasks 31–34)
+
+### Task 31: Graceful shutdown — kill session on exit
+### Task 32: Signal handling (SIGINT, SIGTERM)
+### Task 33: Cleanup stale sessions on startup
+### Task 34: Error recovery — control mode pipe breaks
+
+---
+
+## Batch 9: Settings Integration (Tasks 35–38)
+
+### Task 35: Project-level config (.synaps/config) loader
+### Task 36: /settings tmux page in TUI
+### Task 37: Agent can change layout via natural language
+### Task 38: Persist layout changes to config
+
+---
+
+## Batch 10: Polish & Testing (Tasks 39–42)
+
+### Task 39: Integration test — full tmux lifecycle (requires tmux)
+### Task 40: System prompt context — inject tmux session info
+### Task 41: Documentation — README section for tmux mode
+### Task 42: Final test suite pass and cleanup

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -1031,27 +1031,7 @@ pub async fn run(
     // Save session on exit
     app.save_session().await;
 
-    // Shut down tmux session (clean slate — session dies with Synaps)
-    if let Some(ctrl) = tmux_controller {
-        // Arc::try_unwrap to get owned value; if other refs exist, force kill via CLI
-        match std::sync::Arc::try_unwrap(ctrl) {
-            Ok(mut owned) => {
-                if let Err(e) = owned.shutdown().await {
-                    tracing::warn!("tmux shutdown error: {}", e);
-                }
-            }
-            Err(arc) => {
-                // Other references still held — fall back to kill-session via CLI
-                tracing::debug!("tmux controller still shared, killing session via CLI");
-                if let Some(tmux_path) = synaps_cli::tmux::find_tmux() {
-                    let _ = tokio::process::Command::new(&tmux_path)
-                        .args(["kill-session", "-t", &arc.session_name])
-                        .status()
-                        .await;
-                }
-            }
-        }
-    }
+    // tmux session cleanup is handled by TmuxSessionGuard in main.rs (Drop on exit)
 
     // Signal the inbox watcher's blocking thread to exit, then abort the async task.
     watcher_shutdown.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -1031,6 +1031,28 @@ pub async fn run(
     // Save session on exit
     app.save_session().await;
 
+    // Shut down tmux session (clean slate — session dies with Synaps)
+    if let Some(ctrl) = tmux_controller {
+        // Arc::try_unwrap to get owned value; if other refs exist, force kill via CLI
+        match std::sync::Arc::try_unwrap(ctrl) {
+            Ok(mut owned) => {
+                if let Err(e) = owned.shutdown().await {
+                    tracing::warn!("tmux shutdown error: {}", e);
+                }
+            }
+            Err(arc) => {
+                // Other references still held — fall back to kill-session via CLI
+                tracing::debug!("tmux controller still shared, killing session via CLI");
+                if let Some(tmux_path) = synaps_cli::tmux::find_tmux() {
+                    let _ = tokio::process::Command::new(&tmux_path)
+                        .args(["kill-session", "-t", &arc.session_name])
+                        .status()
+                        .await;
+                }
+            }
+        }
+    }
+
     // Signal the inbox watcher's blocking thread to exit, then abort the async task.
     watcher_shutdown.store(true, std::sync::atomic::Ordering::Relaxed);
     watcher_task.abort();

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -179,6 +179,7 @@ pub async fn run(
     continue_session: Option<Option<String>>,
     system: Option<String>,
     profile: Option<String>,
+    tmux_controller: Option<std::sync::Arc<synaps_cli::tmux::TmuxController>>,
 ) -> Result<()> {
     if let Some(ref prof) = profile {
         synaps_cli::config::set_profile(Some(prof.clone()));
@@ -190,6 +191,11 @@ pub async fn run(
     // Load config and apply
     let mut config = synaps_cli::config::load_config();
     runtime.apply_config(&config);
+
+    // Wire tmux controller if active
+    if let Some(ref ctrl) = tmux_controller {
+        runtime.set_tmux_controller(std::sync::Arc::clone(ctrl));
+    }
 
     // Load system prompt
     let system_prompt = synaps_cli::config::resolve_system_prompt(system.as_deref());

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -89,6 +89,7 @@ pub struct SynapsConfig {
     pub disabled_plugins: Vec<String>,
     pub disabled_skills: Vec<String>,
     pub shell: ShellConfig,
+    pub tmux: crate::tmux::TmuxConfig,
 }
 
 impl Default for SynapsConfig {
@@ -107,6 +108,7 @@ impl Default for SynapsConfig {
             disabled_plugins: Vec::new(),
             disabled_skills: Vec::new(),
             shell: ShellConfig::default(),
+            tmux: crate::tmux::TmuxConfig::default(),
         }
     }
 }
@@ -192,6 +194,44 @@ fn parse_shell_config_key(shell_config: &mut ShellConfig, key: &str, val: &str) 
     }
 }
 
+/// Parse tmux.* configuration keys and update the TmuxConfig.
+fn parse_tmux_config_key(config: &mut crate::tmux::TmuxConfig, key: &str, val: &str) {
+    let sub_key = key.strip_prefix("tmux.").unwrap_or(key);
+    match sub_key {
+        "enabled" => config.enabled = val.eq_ignore_ascii_case("true"),
+        "session_name" => config.session_name = Some(val.to_string()),
+        "default_layout" => {
+            config.default_layout = match val.to_lowercase().as_str() {
+                "split" => crate::tmux::config::LayoutPreset::Split,
+                "fullscreen" => crate::tmux::config::LayoutPreset::Fullscreen,
+                "tiled" => crate::tmux::config::LayoutPreset::Tiled,
+                other => crate::tmux::config::LayoutPreset::Custom(other.to_string()),
+            };
+        }
+        "subagent_display" => {
+            config.subagent_display = match val.to_lowercase().as_str() {
+                "window" => crate::tmux::config::SubagentDisplay::Window,
+                _ => crate::tmux::config::SubagentDisplay::Pane,
+            };
+        }
+        "mouse" => config.mouse = val.eq_ignore_ascii_case("true"),
+        "split_ratio" => {
+            if let Ok(ratio) = val.parse::<u32>() {
+                if ratio > 0 && ratio < 100 {
+                    config.split_ratio = ratio;
+                }
+            }
+        }
+        "shell_position" => {
+            config.shell_position = match val.to_lowercase().as_str() {
+                "bottom" => "bottom".to_string(),
+                _ => "right".to_string(),
+            };
+        }
+        _ => {} // silently ignore unknown tmux keys
+    }
+}
+
 /// Parse the config file at ~/.synaps-cli/config (or profile variant).
 /// Returns default config if file doesn't exist or can't be read.
 pub fn load_config() -> SynapsConfig {
@@ -262,6 +302,8 @@ pub fn load_config() -> SynapsConfig {
                 // Handle shell.* keys
                 if key.starts_with("shell.") {
                     parse_shell_config_key(&mut config.shell, key, val);
+                } else if key.starts_with("tmux.") {
+                    parse_tmux_config_key(&mut config.tmux, key, val);
                 }
                 // Other unknown keys silently ignored
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod tools;
 pub mod mcp;
 pub mod skills;
 pub mod events;
+pub mod tmux;
 
 // Re-export core modules at crate root for backward compatibility
 pub use core::config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,10 @@ struct Cli {
     #[arg(long = "system", short = 's', value_name = "PROMPT_OR_FILE")]
     system: Option<String>,
 
+    /// Launch in tmux mode with optional session name.
+    #[arg(long = "tmux", value_name = "SESSION_NAME")]
+    tmux: Option<Option<String>>,
+
     #[command(subcommand)]
     command: Option<Command>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,33 @@ mod chatui;
 mod watcher;
 mod cmd;
 
+/// Global tmux session name for cleanup on any exit.
+/// Written once during startup, read by the atexit handler.
+static TMUX_SESSION_NAME: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
+/// Kill the tmux session. Called from atexit and Drop guard.
+/// Uses synchronous std::process::Command — no async runtime needed.
+fn kill_tmux_session() {
+    if let Ok(mut guard) = TMUX_SESSION_NAME.lock() {
+        if let Some(name) = guard.take() {
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &name])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status();
+        }
+    }
+}
+
+/// Guard that kills the tmux session on drop (covers normal exit paths).
+struct TmuxSessionGuard;
+
+impl Drop for TmuxSessionGuard {
+    fn drop(&mut self) {
+        kill_tmux_session();
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "synaps", about = "Neural interface for Claude", version)]
 struct Cli {
@@ -97,6 +124,9 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         None => {
             // Resolve tmux controller if --tmux flag was passed
+            // _tmux_guard lives on the stack — Drop fires on normal exit
+            let _tmux_guard: Option<TmuxSessionGuard>;
+
             let tmux_controller = if cli.tmux.is_some() {
                 // Ensure tmux binary is available
                 if synaps_cli::tmux::find_tmux().is_none() {
@@ -117,13 +147,21 @@ async fn main() -> anyhow::Result<()> {
                     _ => synaps_cli::tmux::auto_session_name(),
                 };
 
-                let mut tmux_ctrl = synaps_cli::tmux::TmuxController::new(session_name);
+                let mut tmux_ctrl = synaps_cli::tmux::TmuxController::new(session_name.clone());
                 if let Err(e) = tmux_ctrl.start().await {
                     eprintln!("error: failed to start tmux session: {}", e);
                     std::process::exit(1);
                 }
+
+                // Arm cleanup: store session name globally + arm drop guard.
+                // The global covers SIGTERM/SIGINT via the atexit handler.
+                // The drop guard covers normal function return.
+                *TMUX_SESSION_NAME.lock().unwrap() = Some(session_name);
+                _tmux_guard = Some(TmuxSessionGuard);
+
                 Some(std::sync::Arc::new(tmux_ctrl))
             } else {
+                _tmux_guard = None;
                 None
             };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,9 @@ mod watcher;
 mod cmd;
 
 /// Global tmux session name for cleanup on any exit.
-/// Written once during startup, read by the atexit handler.
 static TMUX_SESSION_NAME: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
 
-/// Kill the tmux session. Called from atexit and Drop guard.
-/// Uses synchronous std::process::Command — no async runtime needed.
+/// Kill the tmux session. Called from the Drop guard.
 fn kill_tmux_session() {
     if let Ok(mut guard) = TMUX_SESSION_NAME.lock() {
         if let Some(name) = guard.take() {
@@ -22,13 +20,45 @@ fn kill_tmux_session() {
     }
 }
 
-/// Guard that kills the tmux session on drop (covers normal exit paths).
+/// Guard that kills the tmux session on drop.
 struct TmuxSessionGuard;
 
 impl Drop for TmuxSessionGuard {
     fn drop(&mut self) {
         kill_tmux_session();
     }
+}
+
+/// Re-exec the current process inside a new tmux session.
+/// This replaces the current process — does not return on success.
+fn reexec_inside_tmux(session_name: &str, tmux_path: &str) -> ! {
+    use std::os::unix::process::CommandExt;
+
+    // Kill any stale session with the same name
+    let _ = std::process::Command::new(tmux_path)
+        .args(["kill-session", "-t", session_name])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    // Reconstruct the full command line for the inner process.
+    // We pass all original args unchanged — when re-exec'd inside tmux,
+    // $TMUX will be set so we won't re-exec again.
+    let args: Vec<String> = std::env::args().collect();
+    let exe = &args[0];
+
+    // tmux new-session -s <name> -- <exe> <args...>
+    let mut cmd = std::process::Command::new(tmux_path);
+    cmd.args(["new-session", "-s", session_name, "--"]);
+    cmd.arg(exe);
+    for arg in &args[1..] {
+        cmd.arg(arg);
+    }
+
+    // exec replaces this process — never returns
+    let err = cmd.exec();
+    eprintln!("error: failed to exec into tmux: {}", err);
+    std::process::exit(1);
 }
 
 #[derive(Parser)]
@@ -121,45 +151,66 @@ async fn main() -> anyhow::Result<()> {
         synaps_cli::config::set_profile(Some(prof.clone()));
     }
 
+    // ── tmux re-exec gate ──
+    // If --tmux is passed and we're NOT already inside tmux,
+    // re-exec the entire process inside a new tmux session.
+    // On the second run, $TMUX is set so we skip this and proceed normally.
+    if cli.tmux.is_some() && std::env::var("TMUX").is_err() {
+        // Ensure tmux binary is available
+        let tmux_path = match synaps_cli::tmux::find_tmux() {
+            Some(p) => p,
+            None => {
+                if synaps_cli::tmux::install::prompt_install() {
+                    if let Err(e) = synaps_cli::tmux::install::run_install().await {
+                        eprintln!("tmux installation failed: {}", e);
+                        std::process::exit(1);
+                    }
+                    synaps_cli::tmux::find_tmux().unwrap_or_else(|| {
+                        eprintln!("error: tmux still not found after install");
+                        std::process::exit(1);
+                    })
+                } else {
+                    eprintln!("error: tmux is required for --tmux mode but was not found");
+                    std::process::exit(1);
+                }
+            }
+        };
+
+        let session_name = match &cli.tmux {
+            Some(Some(name)) => name.clone(),
+            _ => synaps_cli::tmux::auto_session_name(),
+        };
+
+        // This never returns — replaces the process with tmux
+        reexec_inside_tmux(&session_name, &tmux_path);
+    }
+
     match cli.command {
         None => {
-            // Resolve tmux controller if --tmux flag was passed
-            // _tmux_guard lives on the stack — Drop fires on normal exit
+            // If --tmux was passed and $TMUX is set, we're inside tmux (re-exec'd).
+            // Create the controller for tool access.
             let _tmux_guard: Option<TmuxSessionGuard>;
 
             let tmux_controller = if cli.tmux.is_some() {
-                // Ensure tmux binary is available
-                if synaps_cli::tmux::find_tmux().is_none() {
-                    if synaps_cli::tmux::install::prompt_install() {
-                        if let Err(e) = synaps_cli::tmux::install::run_install().await {
-                            eprintln!("tmux installation failed: {}", e);
-                            std::process::exit(1);
-                        }
-                    } else {
-                        eprintln!("error: tmux is required for --tmux mode but was not found");
-                        std::process::exit(1);
-                    }
-                }
-
-                // Resolve session name: explicit name or auto-generated
-                let session_name = match cli.tmux {
-                    Some(Some(name)) => name,
+                let session_name = match &cli.tmux {
+                    Some(Some(name)) => name.clone(),
                     _ => synaps_cli::tmux::auto_session_name(),
                 };
 
-                let mut tmux_ctrl = synaps_cli::tmux::TmuxController::new(session_name.clone());
-                if let Err(e) = tmux_ctrl.start().await {
-                    eprintln!("error: failed to start tmux session: {}", e);
+                let mut ctrl = synaps_cli::tmux::TmuxController::new(session_name.clone());
+                if let Err(e) = ctrl.start().await {
+                    eprintln!("error: tmux controller failed: {}", e);
                     std::process::exit(1);
                 }
 
-                // Arm cleanup: store session name globally + arm drop guard.
-                // The global covers SIGTERM/SIGINT via the atexit handler.
-                // The drop guard covers normal function return.
+                // Apply tmux session settings: mouse, hotkeys, status bar
+                ctrl.apply_session_defaults().await;
+
+                // Arm cleanup guard
                 *TMUX_SESSION_NAME.lock().unwrap() = Some(session_name);
                 _tmux_guard = Some(TmuxSessionGuard);
 
-                Some(std::sync::Arc::new(tmux_ctrl))
+                Some(std::sync::Arc::new(ctrl))
             } else {
                 _tmux_guard = None;
                 None

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,38 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         None => {
-            chatui::run(cli.continue_session, cli.system, cli.profile).await?;
+            // Resolve tmux controller if --tmux flag was passed
+            let tmux_controller = if cli.tmux.is_some() {
+                // Ensure tmux binary is available
+                if synaps_cli::tmux::find_tmux().is_none() {
+                    if synaps_cli::tmux::install::prompt_install() {
+                        if let Err(e) = synaps_cli::tmux::install::run_install().await {
+                            eprintln!("tmux installation failed: {}", e);
+                            std::process::exit(1);
+                        }
+                    } else {
+                        eprintln!("error: tmux is required for --tmux mode but was not found");
+                        std::process::exit(1);
+                    }
+                }
+
+                // Resolve session name: explicit name or auto-generated
+                let session_name = match cli.tmux {
+                    Some(Some(name)) => name,
+                    _ => synaps_cli::tmux::auto_session_name(),
+                };
+
+                let mut tmux_ctrl = synaps_cli::tmux::TmuxController::new(session_name);
+                if let Err(e) = tmux_ctrl.start().await {
+                    eprintln!("error: failed to start tmux session: {}", e);
+                    std::process::exit(1);
+                }
+                Some(std::sync::Arc::new(tmux_ctrl))
+            } else {
+                None
+            };
+
+            chatui::run(cli.continue_session, cli.system, cli.profile, tmux_controller).await?;
         }
         Some(Command::Run { prompt, agent, system }) => {
             cmd::run::run(prompt, agent, system).await?;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -381,6 +381,7 @@ impl Runtime {
                     let session_mgr = self.session_manager.clone();
                     let cfg_subagent_registry = self.subagent_registry.clone();
                     let cfg_event_queue = self.event_queue.clone();
+                    let cfg_tmux_controller = self.tmux_controller.clone();
                     
                     for tool_use in &tool_uses {
                         if let (Some(tool_name), Some(tool_id)) = (
@@ -393,6 +394,7 @@ impl Runtime {
                             let session_mgr_inner = session_mgr.clone();
                             let registry_inner = cfg_subagent_registry.clone();
                             let event_queue_inner = cfg_event_queue.clone();
+                            let tmux_ctrl_inner = cfg_tmux_controller.clone();
                             
                             join_set.spawn(async move {
                                 let result = match tool {
@@ -408,7 +410,7 @@ impl Runtime {
                                                 session_manager: Some(session_mgr_inner),
                                                 subagent_registry: Some(registry_inner),
                                                 event_queue: Some(event_queue_inner),
-                                                tmux_controller: None,
+                                                tmux_controller: tmux_ctrl_inner,
                                             },
                                             limits: crate::tools::ToolLimits {
                                                 max_tool_output: cfg_max_tool_output,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -54,6 +54,8 @@ pub struct Runtime {
     subagent_timeout: u64,
     api_retries: u32,
     session_manager: std::sync::Arc<crate::tools::shell::SessionManager>,
+    /// tmux controller for tmux-native mode (None when not in tmux mode).
+    tmux_controller: Option<std::sync::Arc<crate::tmux::TmuxController>>,
     // Held to keep the reaper task alive for the Runtime's lifetime; never read directly.
     #[allow(dead_code)]
     reaper_handle: Option<tokio::task::JoinHandle<()>>,
@@ -104,6 +106,7 @@ impl Runtime {
             subagent_timeout: 300,
             api_retries: 3,
             session_manager,
+            tmux_controller: None,
             reaper_handle: Some(reaper_handle),
             reaper_cancel: Some(cancel),
         })
@@ -136,6 +139,16 @@ impl Runtime {
     /// Get a shared reference to the tool registry (for MCP lazy loading).
     pub fn tools_shared(&self) -> Arc<RwLock<ToolRegistry>> {
         Arc::clone(&self.tools)
+    }
+
+    /// Get the tmux controller (if tmux mode is active).
+    pub fn tmux_controller(&self) -> Option<&std::sync::Arc<crate::tmux::TmuxController>> {
+        self.tmux_controller.as_ref()
+    }
+
+    /// Set the tmux controller (activates tmux mode).
+    pub fn set_tmux_controller(&mut self, controller: std::sync::Arc<crate::tmux::TmuxController>) {
+        self.tmux_controller = Some(controller);
     }
 
     pub fn model(&self) -> &str {
@@ -334,6 +347,7 @@ impl Runtime {
                                         session_manager: Some(self.session_manager.clone()),
                                         subagent_registry: Some(self.subagent_registry.clone()),
                                         event_queue: Some(self.event_queue.clone()),
+                                        tmux_controller: self.tmux_controller.clone(),
                                     },
                                     limits: crate::tools::ToolLimits {
                                         max_tool_output: self.max_tool_output,
@@ -394,6 +408,7 @@ impl Runtime {
                                                 session_manager: Some(session_mgr_inner),
                                                 subagent_registry: Some(registry_inner),
                                                 event_queue: Some(event_queue_inner),
+                                                tmux_controller: None,
                                             },
                                             limits: crate::tools::ToolLimits {
                                                 max_tool_output: cfg_max_tool_output,
@@ -543,6 +558,7 @@ impl Clone for Runtime {
             subagent_timeout: self.subagent_timeout,
             api_retries: self.api_retries,
             session_manager: self.session_manager.clone(),
+            tmux_controller: self.tmux_controller.clone(),
             reaper_handle: None,  // Cloned runtimes don't own the reaper
             reaper_cancel: None,  // Cloned runtimes don't own the reaper
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -514,6 +514,7 @@ impl Runtime {
         // Anthropic's claude-code default and gives smarter inference.
         let subagent_registry = self.subagent_registry.clone();
         let event_queue = self.event_queue.clone();
+        let tmux_controller = self.tmux_controller.clone();
         let options = api::ApiOptions {
             use_1m_context: self.context_window_override == Some(1_000_000),
         };
@@ -525,6 +526,7 @@ impl Runtime {
             watcher_exit_path, max_tool_output,
             bash_timeout, bash_max_timeout, subagent_timeout,
             session_manager, subagent_registry, event_queue,
+            tmux_controller,
         };
 
         tokio::spawn(async move {

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -196,7 +196,7 @@ impl StreamMethods {
                                 tokio::select! {
                                     res = tool.execute(input, crate::ToolContext {
                                         channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx.clone()) },
-                                        capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()) },
+                                        capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()), tmux_controller: None },
                                         limits: crate::tools::ToolLimits { max_tool_output, bash_timeout, bash_max_timeout, subagent_timeout },
                                     }) => {
                                         match res {
@@ -277,7 +277,7 @@ impl StreamMethods {
                                     tokio::select! {
                                         res = t.execute(input, crate::ToolContext {
                                             channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx_stream.clone()) },
-                                            capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()) },
+                                            capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()), tmux_controller: None },
                                             limits: crate::tools::ToolLimits { max_tool_output, bash_timeout, bash_max_timeout, subagent_timeout },
                                         }) => {
                                             match res {

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -38,6 +38,7 @@ pub(super) struct StreamSession {
     pub(super) session_manager: std::sync::Arc<crate::tools::shell::SessionManager>,
     pub(super) subagent_registry: Arc<Mutex<crate::runtime::subagent::SubagentRegistry>>,
     pub(super) event_queue: Arc<crate::events::EventQueue>,
+    pub(super) tmux_controller: Option<std::sync::Arc<crate::tmux::TmuxController>>,
 }
 
 pub(super) struct StreamMethods;
@@ -54,6 +55,7 @@ impl StreamMethods {
             watcher_exit_path, max_tool_output,
             bash_timeout, bash_max_timeout, subagent_timeout,
             session_manager, subagent_registry, event_queue,
+            tmux_controller,
         } = session;
         let mut messages = initial_messages;
 
@@ -196,7 +198,7 @@ impl StreamMethods {
                                 tokio::select! {
                                     res = tool.execute(input, crate::ToolContext {
                                         channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx.clone()) },
-                                        capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()), tmux_controller: None },
+                                        capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()), tmux_controller: tmux_controller.clone() },
                                         limits: crate::tools::ToolLimits { max_tool_output, bash_timeout, bash_max_timeout, subagent_timeout },
                                     }) => {
                                         match res {
@@ -258,6 +260,7 @@ impl StreamMethods {
                         let session_mgr = session_manager.clone();
                         let registry_inner = subagent_registry.clone();
                         let eq_inner = event_queue.clone();
+                        let tmux_ctrl_inner = tmux_controller.clone();
 
                         join_set.spawn(async move {
                             let result = match tool {
@@ -277,7 +280,7 @@ impl StreamMethods {
                                     tokio::select! {
                                         res = t.execute(input, crate::ToolContext {
                                             channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx_stream.clone()) },
-                                            capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()), tmux_controller: None },
+                                            capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()), tmux_controller: tmux_ctrl_inner.clone() },
                                             limits: crate::tools::ToolLimits { max_tool_output, bash_timeout, bash_max_timeout, subagent_timeout },
                                         }) => {
                                             match res {

--- a/src/skills/tool.rs
+++ b/src/skills/tool.rs
@@ -92,6 +92,7 @@ mod tests {
                 session_manager: None,
                 subagent_registry: None,
                 event_queue: None,
+                tmux_controller: None,
             },
             limits: crate::tools::ToolLimits {
                 max_tool_output: 30000,

--- a/src/tmux/config.rs
+++ b/src/tmux/config.rs
@@ -1,0 +1,59 @@
+//! tmux integration configuration.
+
+/// Layout preset for tmux pane arrangements.
+#[derive(Debug, Clone, PartialEq)]
+pub enum LayoutPreset {
+    Split,
+    Fullscreen,
+    Tiled,
+    Custom(String),
+}
+
+/// How subagents are displayed in tmux.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SubagentDisplay {
+    Window,
+    Pane,
+}
+
+/// Configuration for tmux integration.
+#[derive(Debug, Clone)]
+pub struct TmuxConfig {
+    pub enabled: bool,
+    pub session_name: Option<String>,
+    pub default_layout: LayoutPreset,
+    pub subagent_display: SubagentDisplay,
+    pub mouse: bool,
+    pub split_ratio: u32,
+    pub shell_position: String,
+}
+
+impl Default for TmuxConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            session_name: None,
+            default_layout: LayoutPreset::Split,
+            subagent_display: SubagentDisplay::Pane,
+            mouse: true,
+            split_ratio: 60,
+            shell_position: "right".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tmux_config_default() {
+        let config = TmuxConfig::default();
+        assert!(!config.enabled);
+        assert!(config.session_name.is_none());
+        assert_eq!(config.default_layout, LayoutPreset::Split);
+        assert_eq!(config.subagent_display, SubagentDisplay::Pane);
+        assert!(config.mouse);
+        assert_eq!(config.split_ratio, 60);
+    }
+}

--- a/src/tmux/controller.rs
+++ b/src/tmux/controller.rs
@@ -64,6 +64,24 @@ impl TmuxController {
         let tmux_path = crate::tmux::find_tmux()
             .ok_or_else(|| "tmux not found in PATH".to_string())?;
 
+        // Kill any stale session with the same name (clean slate model)
+        let has_existing = Command::new(&tmux_path)
+            .args(["has-session", "-t", &self.session_name])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        if has_existing {
+            tracing::info!("killing stale tmux session '{}'", self.session_name);
+            let _ = Command::new(&tmux_path)
+                .args(["kill-session", "-t", &self.session_name])
+                .status()
+                .await;
+        }
+
         // Get terminal size
         let (cols, rows) = crossterm::terminal::size().unwrap_or((200, 50));
 

--- a/src/tmux/controller.rs
+++ b/src/tmux/controller.rs
@@ -1,11 +1,16 @@
 //! TmuxController — manages the control mode connection to tmux.
+//!
+//! tmux requires a real PTY even for control mode (`tmux -CC`).
+//! We use `portable-pty` to provide one, then read/write the master fd
+//! for the control mode protocol.
 
 use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Write};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::{oneshot, RwLock};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, Command};
+
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
 use super::protocol::TmuxEvent;
 use super::state::TmuxState;
@@ -19,19 +24,16 @@ pub struct CommandResult {
 
 /// The main tmux controller. Owns the control mode process and state.
 pub struct TmuxController {
-    /// Child process handle for the control mode client
-    child: Option<Child>,
-    /// Writer to control mode stdin (wrapped in Mutex for interior mutability)
-    writer: Option<Arc<tokio::sync::Mutex<tokio::process::ChildStdin>>>,
+    /// Writer to the PTY master (sends commands to tmux CC stdin)
+    writer: Option<Arc<std::sync::Mutex<Box<dyn Write + Send>>>>,
     /// Tracked state of all tmux objects
     state: Arc<RwLock<TmuxState>>,
     /// FIFO queue of pending command response waiters.
-    /// Commands are serialized through `writer` mutex, so responses arrive
-    /// in the same order. The reader task pops the front waiter on each
-    /// `%begin`, collects data lines, and resolves on `%end`/`%error`.
     response_queue: Arc<tokio::sync::Mutex<VecDeque<oneshot::Sender<CommandResult>>>>,
-    /// Set to true when the reader task detects the control mode pipe has closed.
+    /// Set to false when the reader task detects the control mode pipe has closed.
     alive: Arc<AtomicBool>,
+    /// Child process killer handle
+    child_killer: Option<Box<dyn portable_pty::ChildKiller + Send + Sync>>,
     /// Session name
     pub session_name: String,
 }
@@ -49,11 +51,11 @@ impl TmuxController {
     /// Create a new controller (does not start the connection yet).
     pub fn new(session_name: String) -> Self {
         Self {
-            child: None,
             writer: None,
             state: Arc::new(RwLock::new(TmuxState::new("", &session_name))),
             response_queue: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             alive: Arc::new(AtomicBool::new(false)),
+            child_killer: None,
             session_name,
         }
     }
@@ -70,90 +72,127 @@ impl TmuxController {
 
     /// Start a tmux session and connect via control mode.
     ///
-    /// Uses a single `tmux -CC new-session` call to create the session
-    /// AND connect in control mode atomically.  Waits for the initial
-    /// `%begin`/`%end` handshake before returning to guarantee the pipe
-    /// is live.
+    /// Spawns `tmux -CC new-session` inside a real PTY (tmux requires one
+    /// even for control mode). Waits for the initial `%begin`/`%end`
+    /// handshake before returning.
     pub async fn start(&mut self) -> Result<(), String> {
         let tmux_path = crate::tmux::find_tmux()
             .ok_or_else(|| "tmux not found in PATH".to_string())?;
 
         // Kill any stale session with the same name (clean slate model)
-        let has_existing = Command::new(&tmux_path)
+        let has_existing = std::process::Command::new(&tmux_path)
             .args(["has-session", "-t", &self.session_name])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .status()
-            .await
             .map(|s| s.success())
             .unwrap_or(false);
 
         if has_existing {
             tracing::info!("killing stale tmux session '{}'", self.session_name);
-            let _ = Command::new(&tmux_path)
+            let _ = std::process::Command::new(&tmux_path)
                 .args(["kill-session", "-t", &self.session_name])
-                .status()
-                .await;
+                .status();
         }
 
         // Get terminal size
         let (cols, rows) = crossterm::terminal::size().unwrap_or((200, 50));
 
-        // Single-step: create session AND attach in control mode.
-        // This is the canonical way to use tmux control mode — avoids the
-        // race between create-detached and attach that caused broken pipes.
-        let mut child = Command::new(&tmux_path)
-            .args([
-                "-CC", "new-session",
-                "-s", &self.session_name,
-                "-x", &cols.to_string(),
-                "-y", &rows.to_string(),
-            ])
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .spawn()
-            .map_err(|e| format!("Failed to start tmux control mode: {}", e))?;
+        // Open a PTY pair — tmux needs a real terminal even for -CC mode
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| format!("Failed to open PTY for tmux: {}", e))?;
 
-        let stdout = child.stdout.take()
-            .ok_or_else(|| "Failed to capture stdout".to_string())?;
-        let stdin = child.stdin.take()
-            .ok_or_else(|| "Failed to capture stdin".to_string())?;
-        let stderr = child.stderr.take();
+        // Build the command: tmux -CC new-session -s <name> -x <cols> -y <rows>
+        let mut cmd = CommandBuilder::new(&tmux_path);
+        cmd.args([
+            "-CC", "new-session",
+            "-s", &self.session_name,
+            "-x", &cols.to_string(),
+            "-y", &rows.to_string(),
+        ]);
+        cmd.env("TERM", "xterm-256color");
 
-        // Spawn a task to drain stderr and log it (so we can diagnose failures)
-        if let Some(stderr) = stderr {
-            tokio::spawn(async move {
-                let reader = BufReader::new(stderr);
-                let mut lines = reader.lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    tracing::warn!("tmux stderr: {}", line);
-                }
-            });
-        }
+        // Spawn on the slave side of the PTY
+        let mut child = pair.slave
+            .spawn_command(cmd)
+            .map_err(|e| format!("Failed to spawn tmux control mode: {}", e))?;
 
-        let writer = Arc::new(tokio::sync::Mutex::new(stdin));
-        self.writer = Some(writer);
-        self.child = Some(child);
+        // Drop the slave — the child process owns its end now
+        drop(pair.slave);
+
+        // Get writer (master → child stdin)
+        let writer = pair.master
+            .take_writer()
+            .map_err(|e| format!("Failed to take PTY writer: {}", e))?;
+
+        // Get reader (child stdout → master)
+        let reader = pair.master
+            .try_clone_reader()
+            .map_err(|e| format!("Failed to clone PTY reader: {}", e))?;
+
+        // Keep master alive so the PTY doesn't close
+        // (portable-pty drops the fd when the master is dropped)
+        std::mem::forget(pair.master);
+
+        self.writer = Some(Arc::new(std::sync::Mutex::new(writer)));
+        self.child_killer = Some(child.clone_killer());
         self.alive.store(true, Ordering::Relaxed);
 
-        // Channel for the reader task to signal that the initial handshake
-        // (%begin/%end for the implicit command on connect) has completed.
-        let (ready_tx, ready_rx) = oneshot::channel::<()>();
+        // Channel for readiness signal
+        let (ready_tx, ready_rx) = oneshot::channel::<Result<(), String>>();
 
-        // Start reader task
+        // Spawn blocking reader task — reads control mode output from the PTY
         let response_queue = Arc::clone(&self.response_queue);
         let alive = Arc::clone(&self.alive);
-        tokio::spawn(async move {
-            let reader = BufReader::new(stdout);
-            let mut lines = reader.lines();
+        tokio::task::spawn_blocking(move || {
+            let buf_reader = BufReader::new(reader);
             let mut current_waiter: Option<oneshot::Sender<CommandResult>> = None;
             let mut current_lines: Vec<String> = Vec::new();
             let mut in_command = false;
             let mut ready_tx = Some(ready_tx);
             let mut handshake_done = false;
 
-            while let Ok(Some(line)) = lines.next_line().await {
+            for line_result in buf_reader.lines() {
+                let line = match line_result {
+                    Ok(l) => l,
+                    Err(_) => break,
+                };
+
+                // Strip DCS escape sequences that tmux sends on connect.
+                // The DCS `\x1bP1000p` may be glued to the first real line
+                // (no newline separator), so we strip it rather than skip.
+                let line = if let Some(pos) = line.find("%begin") {
+                    line[pos..].to_string()
+                } else if let Some(pos) = line.find("%end") {
+                    line[pos..].to_string()
+                } else if let Some(pos) = line.find("%error") {
+                    line[pos..].to_string()
+                } else if let Some(pos) = line.find("%output") {
+                    line[pos..].to_string()
+                } else if let Some(pos) = line.find("%window") {
+                    line[pos..].to_string()
+                } else if let Some(pos) = line.find("%session") {
+                    line[pos..].to_string()
+                } else if let Some(pos) = line.find("%layout") {
+                    line[pos..].to_string()
+                } else if let Some(pos) = line.find("%pane") {
+                    line[pos..].to_string()
+                } else if line.starts_with('\x1b') || line.starts_with('\u{1b}') {
+                    // Pure escape sequence with no tmux event — skip
+                    continue;
+                } else if line.is_empty() {
+                    continue;
+                } else {
+                    line
+                };
+
                 if let Some(event) = TmuxEvent::parse(&line) {
                     match &event {
                         TmuxEvent::Begin { .. } => {
@@ -162,20 +201,23 @@ impl TmuxController {
 
                             if handshake_done {
                                 // Normal command — pop waiter from FIFO queue
-                                let mut q = response_queue.lock().await;
-                                current_waiter = q.pop_front();
+                                // Use blocking approach: try_lock in a loop
+                                let rt = tokio::runtime::Handle::current();
+                                if let Ok(mut q) = rt.block_on(async {
+                                    Ok::<_, ()>(response_queue.lock().await)
+                                }) {
+                                    current_waiter = q.pop_front();
+                                }
                             }
-                            // First %begin is the implicit handshake — no waiter
                         }
                         TmuxEvent::End { .. } | TmuxEvent::Error { .. } => {
                             let success = matches!(&event, TmuxEvent::End { .. });
 
                             if in_command {
                                 if !handshake_done {
-                                    // Initial handshake complete — signal readiness
                                     handshake_done = true;
                                     if let Some(tx) = ready_tx.take() {
-                                        let _ = tx.send(());
+                                        let _ = tx.send(Ok(()));
                                     }
                                 } else if let Some(sender) = current_waiter.take() {
                                     let _ = sender.send(CommandResult {
@@ -199,60 +241,58 @@ impl TmuxController {
                 }
             }
 
-            // Stdout closed — control mode process has exited
+            // Reader exited — control mode is dead
             alive.store(false, Ordering::Relaxed);
 
-            // Drain any remaining waiters with an error
-            let mut q = response_queue.lock().await;
-            while let Some(sender) = q.pop_front() {
-                let _ = sender.send(CommandResult {
-                    lines: vec!["control mode disconnected".to_string()],
-                    success: false,
-                });
+            // Drain pending waiters
+            let rt = tokio::runtime::Handle::current();
+            let _ = rt.block_on(async {
+                let mut q = response_queue.lock().await;
+                while let Some(sender) = q.pop_front() {
+                    let _ = sender.send(CommandResult {
+                        lines: vec!["control mode disconnected".to_string()],
+                        success: false,
+                    });
+                }
+            });
+
+            // If we never completed handshake, signal failure
+            if let Some(tx) = ready_tx.take() {
+                let _ = tx.send(Err("tmux control mode exited before handshake completed".to_string()));
             }
 
-            // If we never completed the handshake, unblock start()
-            if let Some(tx) = ready_tx.take() {
-                let _ = tx.send(());
-            }
+            // Wait for child to exit
+            let _ = child.wait();
 
             tracing::debug!("tmux control mode reader exited");
         });
 
-        // Wait for the initial handshake with a timeout.
-        // tmux sends %begin/%end on connect — if we don't see it within 5s,
-        // the process probably died immediately.
+        // Wait for handshake with timeout
         match tokio::time::timeout(std::time::Duration::from_secs(5), ready_rx).await {
-            Ok(Ok(())) if self.alive.load(Ordering::Relaxed) => {
+            Ok(Ok(Ok(()))) => {
                 tracing::info!("tmux control mode connected to session '{}'", self.session_name);
                 Ok(())
             }
-            _ => {
-                // Try to get exit status for a better error message
-                let exit_info = if let Some(ref mut child) = self.child {
-                    match child.try_wait() {
-                        Ok(Some(status)) => format!(" (exit status: {})", status),
-                        _ => String::new(),
-                    }
-                } else {
-                    String::new()
-                };
+            Ok(Ok(Err(e))) => {
+                self.alive.store(false, Ordering::Relaxed);
+                Err(e)
+            }
+            Ok(Err(_)) => {
+                self.alive.store(false, Ordering::Relaxed);
+                Err("tmux control mode channel dropped before handshake".to_string())
+            }
+            Err(_) => {
                 self.alive.store(false, Ordering::Relaxed);
                 Err(format!(
-                    "tmux control mode failed to start{} — check `tmux` version and session name '{}'",
-                    exit_info, self.session_name
+                    "tmux control mode timed out waiting for handshake (5s) — session '{}'",
+                    self.session_name
                 ))
             }
         }
     }
 
     /// Send a command to tmux control mode and wait for its response.
-    ///
-    /// Commands are serialized: the writer mutex ensures only one command
-    /// is in-flight at a time, and the reader task resolves responses in
-    /// FIFO order via the `response_queue`.
     pub async fn execute(&self, cmd: &str, args: &[&str]) -> Result<CommandResult, String> {
-        // Check liveness before attempting to write
         if !self.alive.load(Ordering::Relaxed) {
             return Err("tmux control mode is not running".to_string());
         }
@@ -262,32 +302,30 @@ impl TmuxController {
 
         let formatted = Self::format_command(cmd, args);
 
-        // Create a oneshot channel for this command's response
+        // Create oneshot for response
         let (tx, rx) = oneshot::channel();
 
-        // Enqueue the waiter BEFORE writing the command
+        // Enqueue waiter BEFORE writing
         {
             let mut q = self.response_queue.lock().await;
             q.push_back(tx);
         }
 
-        // Write to stdin (serialized by the mutex)
+        // Write to PTY (synchronous write via std::sync::Mutex)
         {
-            let mut w = writer.lock().await;
-            if let Err(e) = w.write_all(formatted.as_bytes()).await {
-                // Write failed — remove our waiter and report
-                let mut q = self.response_queue.lock().await;
-                q.pop_back(); // best-effort remove (it's the last one we pushed)
-                return Err(format!("Failed to write command: {} — control mode may have exited", e));
-            }
-            if let Err(e) = w.flush().await {
-                let mut q = self.response_queue.lock().await;
-                q.pop_back();
-                return Err(format!("Failed to flush command: {} — control mode may have exited", e));
-            }
+            let mut w = writer.lock()
+                .map_err(|_| "Writer mutex poisoned".to_string())?;
+            w.write_all(formatted.as_bytes())
+                .map_err(|e| {
+                    format!("Failed to write command: {} — control mode may have exited", e)
+                })?;
+            w.flush()
+                .map_err(|e| {
+                    format!("Failed to flush command: {} — control mode may have exited", e)
+                })?;
         }
 
-        // Wait for the reader task to resolve our response
+        // Wait for response
         match tokio::time::timeout(std::time::Duration::from_secs(10), rx).await {
             Ok(Ok(result)) => {
                 if result.success {
@@ -311,13 +349,12 @@ impl TmuxController {
     pub async fn shutdown(&mut self) -> Result<(), String> {
         self.alive.store(false, Ordering::Relaxed);
         if let Some(tmux_path) = crate::tmux::find_tmux() {
-            let _ = Command::new(&tmux_path)
+            let _ = std::process::Command::new(&tmux_path)
                 .args(["kill-session", "-t", &self.session_name])
-                .status()
-                .await;
+                .status();
         }
-        if let Some(mut child) = self.child.take() {
-            let _ = child.kill().await;
+        if let Some(ref mut killer) = self.child_killer {
+            let _ = killer.kill();
         }
         self.writer = None;
         Ok(())
@@ -397,9 +434,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_when_dead() {
-        // Simulate a controller where alive=false but writer exists
         let controller = TmuxController::new("test-dead".to_string());
-        // alive defaults to false, so execute should fail immediately
         let result = controller.execute("list-windows", &[]).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("not running"));

--- a/src/tmux/controller.rs
+++ b/src/tmux/controller.rs
@@ -2,6 +2,7 @@
 
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::{oneshot, RwLock};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
@@ -29,6 +30,8 @@ pub struct TmuxController {
     /// in the same order. The reader task pops the front waiter on each
     /// `%begin`, collects data lines, and resolves on `%end`/`%error`.
     response_queue: Arc<tokio::sync::Mutex<VecDeque<oneshot::Sender<CommandResult>>>>,
+    /// Set to true when the reader task detects the control mode pipe has closed.
+    alive: Arc<AtomicBool>,
     /// Session name
     pub session_name: String,
 }
@@ -50,6 +53,7 @@ impl TmuxController {
             writer: None,
             state: Arc::new(RwLock::new(TmuxState::new("", &session_name))),
             response_queue: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
+            alive: Arc::new(AtomicBool::new(false)),
             session_name,
         }
     }
@@ -59,7 +63,17 @@ impl TmuxController {
         Arc::clone(&self.state)
     }
 
+    /// Check if the control mode connection is alive.
+    pub fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::Relaxed)
+    }
+
     /// Start a tmux session and connect via control mode.
+    ///
+    /// Uses a single `tmux -CC new-session` call to create the session
+    /// AND connect in control mode atomically.  Waits for the initial
+    /// `%begin`/`%end` handshake before returning to guarantee the pipe
+    /// is live.
     pub async fn start(&mut self) -> Result<(), String> {
         let tmux_path = crate::tmux::find_tmux()
             .ok_or_else(|| "tmux not found in PATH".to_string())?;
@@ -85,80 +99,91 @@ impl TmuxController {
         // Get terminal size
         let (cols, rows) = crossterm::terminal::size().unwrap_or((200, 50));
 
-        // Create detached session
-        let create_status = Command::new(&tmux_path)
+        // Single-step: create session AND attach in control mode.
+        // This is the canonical way to use tmux control mode — avoids the
+        // race between create-detached and attach that caused broken pipes.
+        let mut child = Command::new(&tmux_path)
             .args([
-                "new-session", "-d",
+                "-CC", "new-session",
                 "-s", &self.session_name,
                 "-x", &cols.to_string(),
                 "-y", &rows.to_string(),
             ])
-            .status()
-            .await
-            .map_err(|e| format!("Failed to create tmux session: {}", e))?;
-
-        if !create_status.success() {
-            return Err("Failed to create tmux session".to_string());
-        }
-
-        // Attach in control mode
-        let mut child = Command::new(&tmux_path)
-            .args(["-CC", "attach-session", "-t", &self.session_name])
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
             .spawn()
-            .map_err(|e| format!("Failed to start control mode: {}", e))?;
+            .map_err(|e| format!("Failed to start tmux control mode: {}", e))?;
 
         let stdout = child.stdout.take()
             .ok_or_else(|| "Failed to capture stdout".to_string())?;
         let stdin = child.stdin.take()
             .ok_or_else(|| "Failed to capture stdin".to_string())?;
+        let stderr = child.stderr.take();
+
+        // Spawn a task to drain stderr and log it (so we can diagnose failures)
+        if let Some(stderr) = stderr {
+            tokio::spawn(async move {
+                let reader = BufReader::new(stderr);
+                let mut lines = reader.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    tracing::warn!("tmux stderr: {}", line);
+                }
+            });
+        }
 
         let writer = Arc::new(tokio::sync::Mutex::new(stdin));
         self.writer = Some(writer);
         self.child = Some(child);
+        self.alive.store(true, Ordering::Relaxed);
 
-        // Start reader task — reads control mode output lines and dispatches
-        // command responses to the FIFO queue of oneshot senders.
+        // Channel for the reader task to signal that the initial handshake
+        // (%begin/%end for the implicit command on connect) has completed.
+        let (ready_tx, ready_rx) = oneshot::channel::<()>();
+
+        // Start reader task
         let response_queue = Arc::clone(&self.response_queue);
+        let alive = Arc::clone(&self.alive);
         tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
-            // Current waiter being filled (popped from queue on %begin)
             let mut current_waiter: Option<oneshot::Sender<CommandResult>> = None;
             let mut current_lines: Vec<String> = Vec::new();
             let mut in_command = false;
+            let mut ready_tx = Some(ready_tx);
+            let mut handshake_done = false;
 
             while let Ok(Some(line)) = lines.next_line().await {
                 if let Some(event) = TmuxEvent::parse(&line) {
                     match &event {
                         TmuxEvent::Begin { .. } => {
-                            // Pop the next waiter from the FIFO queue
-                            let mut q = response_queue.lock().await;
-                            current_waiter = q.pop_front();
                             current_lines.clear();
                             in_command = true;
-                        }
-                        TmuxEvent::End { .. } => {
-                            if in_command {
-                                if let Some(sender) = current_waiter.take() {
-                                    let _ = sender.send(CommandResult {
-                                        lines: current_lines.drain(..).collect(),
-                                        success: true,
-                                    });
-                                }
-                                in_command = false;
+
+                            if handshake_done {
+                                // Normal command — pop waiter from FIFO queue
+                                let mut q = response_queue.lock().await;
+                                current_waiter = q.pop_front();
                             }
+                            // First %begin is the implicit handshake — no waiter
                         }
-                        TmuxEvent::Error { .. } => {
+                        TmuxEvent::End { .. } | TmuxEvent::Error { .. } => {
+                            let success = matches!(&event, TmuxEvent::End { .. });
+
                             if in_command {
-                                if let Some(sender) = current_waiter.take() {
+                                if !handshake_done {
+                                    // Initial handshake complete — signal readiness
+                                    handshake_done = true;
+                                    if let Some(tx) = ready_tx.take() {
+                                        let _ = tx.send(());
+                                    }
+                                } else if let Some(sender) = current_waiter.take() {
                                     let _ = sender.send(CommandResult {
                                         lines: current_lines.drain(..).collect(),
-                                        success: false,
+                                        success,
                                     });
                                 }
+                                current_lines.clear();
                                 in_command = false;
                             }
                         }
@@ -168,17 +193,57 @@ impl TmuxController {
                             }
                         }
                         _ => {
-                            // Notifications (%output, %window-add, etc.) — log for now
                             tracing::trace!("tmux event: {:?}", event);
                         }
                     }
                 }
             }
+
+            // Stdout closed — control mode process has exited
+            alive.store(false, Ordering::Relaxed);
+
+            // Drain any remaining waiters with an error
+            let mut q = response_queue.lock().await;
+            while let Some(sender) = q.pop_front() {
+                let _ = sender.send(CommandResult {
+                    lines: vec!["control mode disconnected".to_string()],
+                    success: false,
+                });
+            }
+
+            // If we never completed the handshake, unblock start()
+            if let Some(tx) = ready_tx.take() {
+                let _ = tx.send(());
+            }
+
             tracing::debug!("tmux control mode reader exited");
         });
 
-        tracing::info!("tmux control mode connected to session '{}'", self.session_name);
-        Ok(())
+        // Wait for the initial handshake with a timeout.
+        // tmux sends %begin/%end on connect — if we don't see it within 5s,
+        // the process probably died immediately.
+        match tokio::time::timeout(std::time::Duration::from_secs(5), ready_rx).await {
+            Ok(Ok(())) if self.alive.load(Ordering::Relaxed) => {
+                tracing::info!("tmux control mode connected to session '{}'", self.session_name);
+                Ok(())
+            }
+            _ => {
+                // Try to get exit status for a better error message
+                let exit_info = if let Some(ref mut child) = self.child {
+                    match child.try_wait() {
+                        Ok(Some(status)) => format!(" (exit status: {})", status),
+                        _ => String::new(),
+                    }
+                } else {
+                    String::new()
+                };
+                self.alive.store(false, Ordering::Relaxed);
+                Err(format!(
+                    "tmux control mode failed to start{} — check `tmux` version and session name '{}'",
+                    exit_info, self.session_name
+                ))
+            }
+        }
     }
 
     /// Send a command to tmux control mode and wait for its response.
@@ -187,6 +252,11 @@ impl TmuxController {
     /// is in-flight at a time, and the reader task resolves responses in
     /// FIFO order via the `response_queue`.
     pub async fn execute(&self, cmd: &str, args: &[&str]) -> Result<CommandResult, String> {
+        // Check liveness before attempting to write
+        if !self.alive.load(Ordering::Relaxed) {
+            return Err("tmux control mode is not running".to_string());
+        }
+
         let writer = self.writer.as_ref()
             .ok_or_else(|| "Control mode not connected".to_string())?;
 
@@ -195,8 +265,7 @@ impl TmuxController {
         // Create a oneshot channel for this command's response
         let (tx, rx) = oneshot::channel();
 
-        // Enqueue the waiter BEFORE writing the command (so the reader
-        // task can find it when %begin arrives).
+        // Enqueue the waiter BEFORE writing the command
         {
             let mut q = self.response_queue.lock().await;
             q.push_back(tx);
@@ -205,16 +274,29 @@ impl TmuxController {
         // Write to stdin (serialized by the mutex)
         {
             let mut w = writer.lock().await;
-            w.write_all(formatted.as_bytes()).await
-                .map_err(|e| format!("Failed to write command: {}", e))?;
-            w.flush().await
-                .map_err(|e| format!("Failed to flush: {}", e))?;
+            if let Err(e) = w.write_all(formatted.as_bytes()).await {
+                // Write failed — remove our waiter and report
+                let mut q = self.response_queue.lock().await;
+                q.pop_back(); // best-effort remove (it's the last one we pushed)
+                return Err(format!("Failed to write command: {} — control mode may have exited", e));
+            }
+            if let Err(e) = w.flush().await {
+                let mut q = self.response_queue.lock().await;
+                q.pop_back();
+                return Err(format!("Failed to flush command: {} — control mode may have exited", e));
+            }
         }
 
         // Wait for the reader task to resolve our response
         match tokio::time::timeout(std::time::Duration::from_secs(10), rx).await {
-            Ok(Ok(result)) => Ok(result),
-            Ok(Err(_)) => Err("Response channel closed — tmux control mode may have exited".to_string()),
+            Ok(Ok(result)) => {
+                if result.success {
+                    Ok(result)
+                } else {
+                    Err(format!("tmux command failed: {}", result.lines.join("\n")))
+                }
+            }
+            Ok(Err(_)) => Err("Response channel closed — tmux control mode has exited".to_string()),
             Err(_) => Err("Timed out waiting for tmux response (10s)".to_string()),
         }
     }
@@ -227,6 +309,7 @@ impl TmuxController {
 
     /// Kill the tmux session and clean up.
     pub async fn shutdown(&mut self) -> Result<(), String> {
+        self.alive.store(false, Ordering::Relaxed);
         if let Some(tmux_path) = crate::tmux::find_tmux() {
             let _ = Command::new(&tmux_path)
                 .args(["kill-session", "-t", &self.session_name])
@@ -261,6 +344,7 @@ mod tests {
     fn test_new_controller() {
         let controller = TmuxController::new("test-session".to_string());
         assert_eq!(controller.session_name, "test-session");
+        assert!(!controller.is_alive());
     }
 
     #[tokio::test]
@@ -268,7 +352,7 @@ mod tests {
         let controller = TmuxController::new("test-disconnected".to_string());
         let result = controller.execute("list-windows", &[]).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not connected"));
+        assert!(result.unwrap_err().contains("not running"));
     }
 
     #[tokio::test]
@@ -282,7 +366,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_response_queue_ordering() {
-        // Verify that the response queue is FIFO
         let queue: Arc<tokio::sync::Mutex<VecDeque<oneshot::Sender<CommandResult>>>> =
             Arc::new(tokio::sync::Mutex::new(VecDeque::new()));
 
@@ -295,13 +378,11 @@ mod tests {
             q.push_back(tx2);
         }
 
-        // Pop first — should be tx1
         {
             let mut q = queue.lock().await;
             let sender = q.pop_front().unwrap();
             sender.send(CommandResult { lines: vec!["first".to_string()], success: true }).unwrap();
         }
-        // Pop second — should be tx2
         {
             let mut q = queue.lock().await;
             let sender = q.pop_front().unwrap();
@@ -312,5 +393,15 @@ mod tests {
         let r2 = rx2.await.unwrap();
         assert_eq!(r1.lines, vec!["first"]);
         assert_eq!(r2.lines, vec!["second"]);
+    }
+
+    #[tokio::test]
+    async fn test_execute_when_dead() {
+        // Simulate a controller where alive=false but writer exists
+        let controller = TmuxController::new("test-dead".to_string());
+        // alive defaults to false, so execute should fail immediately
+        let result = controller.execute("list-windows", &[]).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not running"));
     }
 }

--- a/src/tmux/controller.rs
+++ b/src/tmux/controller.rs
@@ -1,45 +1,35 @@
-//! TmuxController — manages the control mode connection to tmux.
+//! TmuxController — manages pane/window operations via tmux CLI.
 //!
-//! tmux requires a real PTY even for control mode (`tmux -CC`).
-//! We use `portable-pty` to provide one, then read/write the master fd
-//! for the control mode protocol.
+//! Architecture: Synaps re-execs itself inside a tmux session (handled
+//! in main.rs). Once inside tmux, the controller simply shells out to
+//! `tmux <command> <args>` for all operations — no control mode needed.
+//! Panes are visible and interactive because the user IS in the session.
 
-use std::collections::VecDeque;
-use std::io::{BufRead, BufReader, Write};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::sync::{oneshot, RwLock};
+use std::process::Command as StdCommand;
 
-use portable_pty::{CommandBuilder, PtySize, native_pty_system};
-
-use super::protocol::TmuxEvent;
 use super::state::TmuxState;
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
-/// Result of a command sent to tmux control mode.
+/// Result of a tmux command.
 #[derive(Debug)]
 pub struct CommandResult {
     pub lines: Vec<String>,
     pub success: bool,
 }
 
-/// The main tmux controller. Owns the control mode process and state.
+/// The tmux controller. Shells out to `tmux` for all operations.
 pub struct TmuxController {
-    /// Writer to the PTY master (sends commands to tmux CC stdin)
-    writer: Option<Arc<std::sync::Mutex<Box<dyn Write + Send>>>>,
     /// Tracked state of all tmux objects
     state: Arc<RwLock<TmuxState>>,
-    /// FIFO queue of pending command response waiters.
-    response_queue: Arc<tokio::sync::Mutex<VecDeque<oneshot::Sender<CommandResult>>>>,
-    /// Set to false when the reader task detects the control mode pipe has closed.
-    alive: Arc<AtomicBool>,
-    /// Child process killer handle
-    child_killer: Option<Box<dyn portable_pty::ChildKiller + Send + Sync>>,
+    /// Path to tmux binary
+    tmux_path: String,
     /// Session name
     pub session_name: String,
 }
 
 impl TmuxController {
-    /// Format a tmux command string for control mode.
+    /// Format a tmux command string (for logging/display).
     pub fn format_command(cmd: &str, args: &[&str]) -> String {
         if args.is_empty() {
             format!("{}\n", cmd)
@@ -48,14 +38,13 @@ impl TmuxController {
         }
     }
 
-    /// Create a new controller (does not start the connection yet).
+    /// Create a new controller. Call `start()` to verify we're inside tmux.
     pub fn new(session_name: String) -> Self {
+        let tmux_path = crate::tmux::find_tmux()
+            .unwrap_or_else(|| "tmux".to_string());
         Self {
-            writer: None,
             state: Arc::new(RwLock::new(TmuxState::new("", &session_name))),
-            response_queue: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
-            alive: Arc::new(AtomicBool::new(false)),
-            child_killer: None,
+            tmux_path,
             session_name,
         }
     }
@@ -66,276 +55,109 @@ impl TmuxController {
     }
 
     /// Check if the control mode connection is alive.
+    /// (Always true when inside tmux — the session is the user's terminal.)
     pub fn is_alive(&self) -> bool {
-        self.alive.load(Ordering::Relaxed)
+        std::env::var("TMUX").is_ok()
     }
 
-    /// Start a tmux session and connect via control mode.
-    ///
-    /// Spawns `tmux -CC new-session` inside a real PTY (tmux requires one
-    /// even for control mode). Waits for the initial `%begin`/`%end`
-    /// handshake before returning.
+    /// Verify we're inside the tmux session. No-op if $TMUX is set.
+    /// The actual session creation + re-exec is handled in main.rs.
     pub async fn start(&mut self) -> Result<(), String> {
-        let tmux_path = crate::tmux::find_tmux()
-            .ok_or_else(|| "tmux not found in PATH".to_string())?;
-
-        // Kill any stale session with the same name (clean slate model)
-        let has_existing = std::process::Command::new(&tmux_path)
-            .args(["has-session", "-t", &self.session_name])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-
-        if has_existing {
-            tracing::info!("killing stale tmux session '{}'", self.session_name);
-            let _ = std::process::Command::new(&tmux_path)
-                .args(["kill-session", "-t", &self.session_name])
-                .status();
+        if std::env::var("TMUX").is_err() {
+            return Err(
+                "Not inside a tmux session. The --tmux flag should re-exec into tmux before reaching here.".to_string()
+            );
         }
 
-        // Get terminal size
-        let (cols, rows) = crossterm::terminal::size().unwrap_or((200, 50));
+        tracing::info!("tmux controller active inside session '{}'", self.session_name);
+        Ok(())
+    }
 
-        // Open a PTY pair — tmux needs a real terminal even for -CC mode
-        let pty_system = native_pty_system();
-        let pair = pty_system
-            .openpty(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|e| format!("Failed to open PTY for tmux: {}", e))?;
+    /// Apply default session settings: mouse mode, hotkeys, status bar.
+    /// Called once after start() to configure the tmux session for Synaps.
+    pub async fn apply_session_defaults(&self) {
+        // Enable mouse — click to select panes, scroll, drag to resize
+        if let Err(e) = self.execute("set-option", &["-g", "mouse", "on"]).await {
+            tracing::warn!("failed to enable mouse: {}", e);
+        }
 
-        // Build the command: tmux -CC new-session -s <name> -x <cols> -y <rows>
-        let mut cmd = CommandBuilder::new(&tmux_path);
-        cmd.args([
-            "-CC", "new-session",
-            "-s", &self.session_name,
-            "-x", &cols.to_string(),
-            "-y", &rows.to_string(),
-        ]);
-        cmd.env("TERM", "xterm-256color");
-
-        // Spawn on the slave side of the PTY
-        let mut child = pair.slave
-            .spawn_command(cmd)
-            .map_err(|e| format!("Failed to spawn tmux control mode: {}", e))?;
-
-        // Drop the slave — the child process owns its end now
-        drop(pair.slave);
-
-        // Get writer (master → child stdin)
-        let writer = pair.master
-            .take_writer()
-            .map_err(|e| format!("Failed to take PTY writer: {}", e))?;
-
-        // Get reader (child stdout → master)
-        let reader = pair.master
-            .try_clone_reader()
-            .map_err(|e| format!("Failed to clone PTY reader: {}", e))?;
-
-        // Keep master alive so the PTY doesn't close
-        // (portable-pty drops the fd when the master is dropped)
-        std::mem::forget(pair.master);
-
-        self.writer = Some(Arc::new(std::sync::Mutex::new(writer)));
-        self.child_killer = Some(child.clone_killer());
-        self.alive.store(true, Ordering::Relaxed);
-
-        // Channel for readiness signal
-        let (ready_tx, ready_rx) = oneshot::channel::<Result<(), String>>();
-
-        // Spawn blocking reader task — reads control mode output from the PTY
-        let response_queue = Arc::clone(&self.response_queue);
-        let alive = Arc::clone(&self.alive);
-        tokio::task::spawn_blocking(move || {
-            let buf_reader = BufReader::new(reader);
-            let mut current_waiter: Option<oneshot::Sender<CommandResult>> = None;
-            let mut current_lines: Vec<String> = Vec::new();
-            let mut in_command = false;
-            let mut ready_tx = Some(ready_tx);
-            let mut handshake_done = false;
-
-            for line_result in buf_reader.lines() {
-                let line = match line_result {
-                    Ok(l) => l,
-                    Err(_) => break,
-                };
-
-                // Strip DCS escape sequences that tmux sends on connect.
-                // The DCS `\x1bP1000p` may be glued to the first real line
-                // (no newline separator), so we strip it rather than skip.
-                let line = if let Some(pos) = line.find("%begin") {
-                    line[pos..].to_string()
-                } else if let Some(pos) = line.find("%end") {
-                    line[pos..].to_string()
-                } else if let Some(pos) = line.find("%error") {
-                    line[pos..].to_string()
-                } else if let Some(pos) = line.find("%output") {
-                    line[pos..].to_string()
-                } else if let Some(pos) = line.find("%window") {
-                    line[pos..].to_string()
-                } else if let Some(pos) = line.find("%session") {
-                    line[pos..].to_string()
-                } else if let Some(pos) = line.find("%layout") {
-                    line[pos..].to_string()
-                } else if let Some(pos) = line.find("%pane") {
-                    line[pos..].to_string()
-                } else if line.starts_with('\x1b') || line.starts_with('\u{1b}') {
-                    // Pure escape sequence with no tmux event — skip
-                    continue;
-                } else if line.is_empty() {
-                    continue;
-                } else {
-                    line
-                };
-
-                if let Some(event) = TmuxEvent::parse(&line) {
-                    match &event {
-                        TmuxEvent::Begin { .. } => {
-                            current_lines.clear();
-                            in_command = true;
-
-                            if handshake_done {
-                                // Normal command — pop waiter from FIFO queue
-                                // Use blocking approach: try_lock in a loop
-                                let rt = tokio::runtime::Handle::current();
-                                if let Ok(mut q) = rt.block_on(async {
-                                    Ok::<_, ()>(response_queue.lock().await)
-                                }) {
-                                    current_waiter = q.pop_front();
-                                }
-                            }
-                        }
-                        TmuxEvent::End { .. } | TmuxEvent::Error { .. } => {
-                            let success = matches!(&event, TmuxEvent::End { .. });
-
-                            if in_command {
-                                if !handshake_done {
-                                    handshake_done = true;
-                                    if let Some(tx) = ready_tx.take() {
-                                        let _ = tx.send(Ok(()));
-                                    }
-                                } else if let Some(sender) = current_waiter.take() {
-                                    let _ = sender.send(CommandResult {
-                                        lines: current_lines.drain(..).collect(),
-                                        success,
-                                    });
-                                }
-                                current_lines.clear();
-                                in_command = false;
-                            }
-                        }
-                        TmuxEvent::Data(data) => {
-                            if in_command {
-                                current_lines.push(data.clone());
-                            }
-                        }
-                        _ => {
-                            tracing::trace!("tmux event: {:?}", event);
-                        }
-                    }
-                }
+        // Apply hotkey bindings
+        for cmd_str in crate::tmux::hotkeys::hotkey_bind_commands() {
+            if let Err(e) = self.execute_raw(&cmd_str).await {
+                tracing::warn!("failed to apply hotkey: {}", e);
             }
+        }
 
-            // Reader exited — control mode is dead
-            alive.store(false, Ordering::Relaxed);
-
-            // Drain pending waiters
-            let rt = tokio::runtime::Handle::current();
-            let _ = rt.block_on(async {
-                let mut q = response_queue.lock().await;
-                while let Some(sender) = q.pop_front() {
-                    let _ = sender.send(CommandResult {
-                        lines: vec!["control mode disconnected".to_string()],
-                        success: false,
-                    });
-                }
-            });
-
-            // If we never completed handshake, signal failure
-            if let Some(tx) = ready_tx.take() {
-                let _ = tx.send(Err("tmux control mode exited before handshake completed".to_string()));
+        // Apply status bar
+        for cmd_str in crate::tmux::hotkeys::status_bar_commands(&self.session_name) {
+            if let Err(e) = self.execute_raw(&cmd_str).await {
+                tracing::warn!("failed to apply status bar setting: {}", e);
             }
+        }
 
-            // Wait for child to exit
-            let _ = child.wait();
+        tracing::info!("tmux session defaults applied (mouse, hotkeys, status bar)");
+    }
 
-            tracing::debug!("tmux control mode reader exited");
-        });
+    /// Execute a raw tmux command string (the full command as you'd type it
+    /// after `tmux`). Handles quoting properly by letting the shell parse it.
+    pub async fn execute_raw(&self, cmd_str: &str) -> Result<CommandResult, String> {
+        let full = format!("tmux {}", cmd_str);
+        tracing::debug!("tmux raw exec: {}", cmd_str);
 
-        // Wait for handshake with timeout
-        match tokio::time::timeout(std::time::Duration::from_secs(5), ready_rx).await {
-            Ok(Ok(Ok(()))) => {
-                tracing::info!("tmux control mode connected to session '{}'", self.session_name);
-                Ok(())
-            }
-            Ok(Ok(Err(e))) => {
-                self.alive.store(false, Ordering::Relaxed);
-                Err(e)
-            }
-            Ok(Err(_)) => {
-                self.alive.store(false, Ordering::Relaxed);
-                Err("tmux control mode channel dropped before handshake".to_string())
-            }
-            Err(_) => {
-                self.alive.store(false, Ordering::Relaxed);
-                Err(format!(
-                    "tmux control mode timed out waiting for handshake (5s) — session '{}'",
-                    self.session_name
-                ))
-            }
+        let output = StdCommand::new("sh")
+            .args(["-c", &full])
+            .output()
+            .map_err(|e| format!("Failed to run tmux command: {}", e))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        let lines: Vec<String> = stdout.lines().map(|l| l.to_string()).collect();
+
+        if output.status.success() {
+            Ok(CommandResult { lines, success: true })
+        } else {
+            let err_msg = if stderr.is_empty() {
+                format!("tmux command failed: {}", cmd_str)
+            } else {
+                format!("tmux command failed: {}", stderr.trim())
+            };
+            Err(err_msg)
         }
     }
 
-    /// Send a command to tmux control mode and wait for its response.
+    /// Execute a tmux command by shelling out to the tmux binary.
+    /// Captures stdout and returns the output lines.
     pub async fn execute(&self, cmd: &str, args: &[&str]) -> Result<CommandResult, String> {
-        if !self.alive.load(Ordering::Relaxed) {
-            return Err("tmux control mode is not running".to_string());
+        let mut command = StdCommand::new(&self.tmux_path);
+        command.arg(cmd);
+        for arg in args {
+            command.arg(arg);
         }
 
-        let writer = self.writer.as_ref()
-            .ok_or_else(|| "Control mode not connected".to_string())?;
+        tracing::debug!("tmux exec: {} {}", cmd, args.join(" "));
 
-        let formatted = Self::format_command(cmd, args);
+        let output = command
+            .output()
+            .map_err(|e| format!("Failed to run tmux {}: {}", cmd, e))?;
 
-        // Create oneshot for response
-        let (tx, rx) = oneshot::channel();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
 
-        // Enqueue waiter BEFORE writing
-        {
-            let mut q = self.response_queue.lock().await;
-            q.push_back(tx);
-        }
+        let lines: Vec<String> = stdout
+            .lines()
+            .map(|l| l.to_string())
+            .collect();
 
-        // Write to PTY (synchronous write via std::sync::Mutex)
-        {
-            let mut w = writer.lock()
-                .map_err(|_| "Writer mutex poisoned".to_string())?;
-            w.write_all(formatted.as_bytes())
-                .map_err(|e| {
-                    format!("Failed to write command: {} — control mode may have exited", e)
-                })?;
-            w.flush()
-                .map_err(|e| {
-                    format!("Failed to flush command: {} — control mode may have exited", e)
-                })?;
-        }
-
-        // Wait for response
-        match tokio::time::timeout(std::time::Duration::from_secs(10), rx).await {
-            Ok(Ok(result)) => {
-                if result.success {
-                    Ok(result)
-                } else {
-                    Err(format!("tmux command failed: {}", result.lines.join("\n")))
-                }
-            }
-            Ok(Err(_)) => Err("Response channel closed — tmux control mode has exited".to_string()),
-            Err(_) => Err("Timed out waiting for tmux response (10s)".to_string()),
+        if output.status.success() {
+            Ok(CommandResult { lines, success: true })
+        } else {
+            let err_msg = if stderr.is_empty() {
+                format!("tmux {} failed with exit code {:?}", cmd, output.status.code())
+            } else {
+                format!("tmux {} failed: {}", cmd, stderr.trim())
+            };
+            Err(err_msg)
         }
     }
 
@@ -347,16 +169,9 @@ impl TmuxController {
 
     /// Kill the tmux session and clean up.
     pub async fn shutdown(&mut self) -> Result<(), String> {
-        self.alive.store(false, Ordering::Relaxed);
-        if let Some(tmux_path) = crate::tmux::find_tmux() {
-            let _ = std::process::Command::new(&tmux_path)
-                .args(["kill-session", "-t", &self.session_name])
-                .status();
-        }
-        if let Some(ref mut killer) = self.child_killer {
-            let _ = killer.kill();
-        }
-        self.writer = None;
+        let _ = StdCommand::new(&self.tmux_path)
+            .args(["kill-session", "-t", &self.session_name])
+            .output();
         Ok(())
     }
 }
@@ -381,62 +196,34 @@ mod tests {
     fn test_new_controller() {
         let controller = TmuxController::new("test-session".to_string());
         assert_eq!(controller.session_name, "test-session");
-        assert!(!controller.is_alive());
     }
 
     #[tokio::test]
-    async fn test_execute_when_disconnected() {
-        let controller = TmuxController::new("test-disconnected".to_string());
-        let result = controller.execute("list-windows", &[]).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not running"));
-    }
-
-    #[tokio::test]
-    async fn test_start_requires_tmux() {
-        let mut controller = TmuxController::new("test-start".to_string());
-        if crate::tmux::find_tmux().is_none() {
+    async fn test_execute_when_not_in_tmux() {
+        // If we're not inside tmux, start() should fail
+        if std::env::var("TMUX").is_err() {
+            let mut controller = TmuxController::new("test-start".to_string());
             let result = controller.start().await;
             assert!(result.is_err());
         }
     }
 
     #[tokio::test]
-    async fn test_response_queue_ordering() {
-        let queue: Arc<tokio::sync::Mutex<VecDeque<oneshot::Sender<CommandResult>>>> =
-            Arc::new(tokio::sync::Mutex::new(VecDeque::new()));
-
-        let (tx1, rx1) = oneshot::channel();
-        let (tx2, rx2) = oneshot::channel();
-
-        {
-            let mut q = queue.lock().await;
-            q.push_back(tx1);
-            q.push_back(tx2);
-        }
-
-        {
-            let mut q = queue.lock().await;
-            let sender = q.pop_front().unwrap();
-            sender.send(CommandResult { lines: vec!["first".to_string()], success: true }).unwrap();
-        }
-        {
-            let mut q = queue.lock().await;
-            let sender = q.pop_front().unwrap();
-            sender.send(CommandResult { lines: vec!["second".to_string()], success: true }).unwrap();
-        }
-
-        let r1 = rx1.await.unwrap();
-        let r2 = rx2.await.unwrap();
-        assert_eq!(r1.lines, vec!["first"]);
-        assert_eq!(r2.lines, vec!["second"]);
+    async fn test_execute_valid_command() {
+        // tmux list-sessions works even outside tmux (if tmux server is running)
+        // We just test that execute doesn't panic
+        let controller = TmuxController::new("test-exec".to_string());
+        let _result = controller.execute("list-sessions", &[]).await;
+        // Don't assert success — tmux server may not be running
     }
 
     #[tokio::test]
-    async fn test_execute_when_dead() {
-        let controller = TmuxController::new("test-dead".to_string());
-        let result = controller.execute("list-windows", &[]).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not running"));
+    async fn test_response_queue_ordering() {
+        // This test verified the old FIFO queue — keep as a basic sanity check
+        // that CommandResult can be constructed
+        let r1 = CommandResult { lines: vec!["first".to_string()], success: true };
+        let r2 = CommandResult { lines: vec!["second".to_string()], success: true };
+        assert_eq!(r1.lines, vec!["first"]);
+        assert_eq!(r2.lines, vec!["second"]);
     }
 }

--- a/src/tmux/controller.rs
+++ b/src/tmux/controller.rs
@@ -1,0 +1,260 @@
+//! TmuxController — manages the control mode connection to tmux.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use std::sync::atomic::AtomicU64;
+
+use super::protocol::TmuxEvent;
+use super::state::TmuxState;
+
+/// Result of a command sent to tmux control mode.
+#[derive(Debug)]
+pub struct CommandResult {
+    pub lines: Vec<String>,
+    pub success: bool,
+}
+
+/// The main tmux controller. Owns the control mode process and state.
+pub struct TmuxController {
+    /// Child process handle for the control mode client
+    child: Option<Child>,
+    /// Writer to control mode stdin (wrapped in Mutex for interior mutability)
+    writer: Option<Arc<tokio::sync::Mutex<tokio::process::ChildStdin>>>,
+    /// Tracked state of all tmux objects
+    state: Arc<RwLock<TmuxState>>,
+    /// Channel for incoming parsed events
+    event_tx: mpsc::UnboundedSender<TmuxEvent>,
+    /// Receiver for events (consumed by event loop)
+    event_rx: Option<mpsc::UnboundedReceiver<TmuxEvent>>,
+    /// Pending command responses: command_num -> sender
+    pending: Arc<tokio::sync::Mutex<HashMap<u64, oneshot::Sender<CommandResult>>>>,
+    /// Next command number
+    #[allow(dead_code)]
+    next_cmd: AtomicU64,
+    /// Session name
+    pub session_name: String,
+}
+
+impl TmuxController {
+    /// Format a tmux command string for control mode.
+    pub fn format_command(cmd: &str, args: &[&str]) -> String {
+        if args.is_empty() {
+            format!("{}\n", cmd)
+        } else {
+            format!("{} {}\n", cmd, args.join(" "))
+        }
+    }
+
+    /// Create a new controller (does not start the connection yet).
+    pub fn new(session_name: String) -> Self {
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        Self {
+            child: None,
+            writer: None,
+            state: Arc::new(RwLock::new(TmuxState::new("", &session_name))),
+            event_tx,
+            event_rx: Some(event_rx),
+            pending: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            next_cmd: AtomicU64::new(0),
+            session_name,
+        }
+    }
+
+    /// Get a handle to the shared state.
+    pub fn state(&self) -> Arc<RwLock<TmuxState>> {
+        Arc::clone(&self.state)
+    }
+
+    /// Take the event receiver (can only be called once).
+    pub fn take_event_rx(&mut self) -> Option<mpsc::UnboundedReceiver<TmuxEvent>> {
+        self.event_rx.take()
+    }
+
+    /// Start a tmux session and connect via control mode.
+    pub async fn start(&mut self) -> Result<(), String> {
+        let tmux_path = crate::tmux::find_tmux()
+            .ok_or_else(|| "tmux not found in PATH".to_string())?;
+
+        // Get terminal size
+        let (cols, rows) = crossterm::terminal::size().unwrap_or((200, 50));
+
+        // Create detached session
+        let create_status = Command::new(&tmux_path)
+            .args([
+                "new-session", "-d",
+                "-s", &self.session_name,
+                "-x", &cols.to_string(),
+                "-y", &rows.to_string(),
+            ])
+            .status()
+            .await
+            .map_err(|e| format!("Failed to create tmux session: {}", e))?;
+
+        if !create_status.success() {
+            return Err("Failed to create tmux session".to_string());
+        }
+
+        // Attach in control mode
+        let mut child = Command::new(&tmux_path)
+            .args(["-CC", "attach-session", "-t", &self.session_name])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| format!("Failed to start control mode: {}", e))?;
+
+        let stdout = child.stdout.take()
+            .ok_or_else(|| "Failed to capture stdout".to_string())?;
+        let stdin = child.stdin.take()
+            .ok_or_else(|| "Failed to capture stdin".to_string())?;
+
+        let writer = Arc::new(tokio::sync::Mutex::new(stdin));
+        self.writer = Some(writer);
+        self.child = Some(child);
+
+        // Start reader task
+        let event_tx = self.event_tx.clone();
+        let pending = Arc::clone(&self.pending);
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            let mut current_cmd: Option<u64> = None;
+            let mut current_lines: Vec<String> = Vec::new();
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                if let Some(event) = TmuxEvent::parse(&line) {
+                    match &event {
+                        TmuxEvent::Begin { command_num, .. } => {
+                            current_cmd = Some(*command_num);
+                            current_lines.clear();
+                        }
+                        TmuxEvent::End { command_num, .. } => {
+                            if Some(*command_num) == current_cmd {
+                                let mut map = pending.lock().await;
+                                if let Some(sender) = map.remove(command_num) {
+                                    let _ = sender.send(CommandResult {
+                                        lines: current_lines.drain(..).collect(),
+                                        success: true,
+                                    });
+                                }
+                                current_cmd = None;
+                            }
+                        }
+                        TmuxEvent::Error { command_num, .. } => {
+                            if Some(*command_num) == current_cmd {
+                                let mut map = pending.lock().await;
+                                if let Some(sender) = map.remove(command_num) {
+                                    let _ = sender.send(CommandResult {
+                                        lines: current_lines.drain(..).collect(),
+                                        success: false,
+                                    });
+                                }
+                                current_cmd = None;
+                            }
+                        }
+                        TmuxEvent::Data(data) => {
+                            if current_cmd.is_some() {
+                                current_lines.push(data.clone());
+                            }
+                        }
+                        _ => {}
+                    }
+                    let _ = event_tx.send(event);
+                }
+            }
+        });
+
+        tracing::info!("tmux control mode connected to session '{}'", self.session_name);
+        Ok(())
+    }
+
+    /// Send a command to tmux control mode and wait for its response.
+    pub async fn execute(&self, cmd: &str, args: &[&str]) -> Result<CommandResult, String> {
+        let writer = self.writer.as_ref()
+            .ok_or_else(|| "Control mode not connected".to_string())?;
+
+        let formatted = Self::format_command(cmd, args);
+
+        // Write to stdin
+        {
+            let mut w = writer.lock().await;
+            w.write_all(formatted.as_bytes()).await
+                .map_err(|e| format!("Failed to write command: {}", e))?;
+            w.flush().await
+                .map_err(|e| format!("Failed to flush: {}", e))?;
+        }
+
+        // For now, commands are fire-and-forget since control mode
+        // command numbering needs the server to assign numbers.
+        // We return a synthetic success. Full request-response tracking
+        // will be wired when we process %begin/%end with server-assigned numbers.
+        Ok(CommandResult {
+            lines: vec![],
+            success: true,
+        })
+    }
+
+    /// Execute a command and return the first line of output.
+    pub async fn execute_single(&self, cmd: &str, args: &[&str]) -> Result<String, String> {
+        let result = self.execute(cmd, args).await?;
+        Ok(result.lines.into_iter().next().unwrap_or_default())
+    }
+
+    /// Kill the tmux session and clean up.
+    pub async fn shutdown(&mut self) -> Result<(), String> {
+        if let Some(tmux_path) = crate::tmux::find_tmux() {
+            let _ = Command::new(&tmux_path)
+                .args(["kill-session", "-t", &self.session_name])
+                .status()
+                .await;
+        }
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill().await;
+        }
+        self.writer = None;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_command() {
+        let cmd = TmuxController::format_command("split-window", &["-h", "-P", "-F", "#{pane_id}"]);
+        assert_eq!(cmd, "split-window -h -P -F #{pane_id}\n");
+    }
+
+    #[test]
+    fn test_format_command_no_args() {
+        let cmd = TmuxController::format_command("list-windows", &[]);
+        assert_eq!(cmd, "list-windows\n");
+    }
+
+    #[test]
+    fn test_new_controller() {
+        let controller = TmuxController::new("test-session".to_string());
+        assert_eq!(controller.session_name, "test-session");
+    }
+
+    #[tokio::test]
+    async fn test_execute_when_disconnected() {
+        let controller = TmuxController::new("test-disconnected".to_string());
+        let result = controller.execute("list-windows", &[]).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not connected"));
+    }
+
+    #[tokio::test]
+    async fn test_start_requires_tmux() {
+        let mut controller = TmuxController::new("test-start".to_string());
+        if crate::tmux::find_tmux().is_none() {
+            let result = controller.start().await;
+            assert!(result.is_err());
+        }
+    }
+}

--- a/src/tmux/controller.rs
+++ b/src/tmux/controller.rs
@@ -1,11 +1,10 @@
 //! TmuxController — manages the control mode connection to tmux.
 
-use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::sync::{oneshot, RwLock};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
-use std::sync::atomic::AtomicU64;
 
 use super::protocol::TmuxEvent;
 use super::state::TmuxState;
@@ -25,15 +24,11 @@ pub struct TmuxController {
     writer: Option<Arc<tokio::sync::Mutex<tokio::process::ChildStdin>>>,
     /// Tracked state of all tmux objects
     state: Arc<RwLock<TmuxState>>,
-    /// Channel for incoming parsed events
-    event_tx: mpsc::UnboundedSender<TmuxEvent>,
-    /// Receiver for events (consumed by event loop)
-    event_rx: Option<mpsc::UnboundedReceiver<TmuxEvent>>,
-    /// Pending command responses: command_num -> sender
-    pending: Arc<tokio::sync::Mutex<HashMap<u64, oneshot::Sender<CommandResult>>>>,
-    /// Next command number
-    #[allow(dead_code)]
-    next_cmd: AtomicU64,
+    /// FIFO queue of pending command response waiters.
+    /// Commands are serialized through `writer` mutex, so responses arrive
+    /// in the same order. The reader task pops the front waiter on each
+    /// `%begin`, collects data lines, and resolves on `%end`/`%error`.
+    response_queue: Arc<tokio::sync::Mutex<VecDeque<oneshot::Sender<CommandResult>>>>,
     /// Session name
     pub session_name: String,
 }
@@ -50,15 +45,11 @@ impl TmuxController {
 
     /// Create a new controller (does not start the connection yet).
     pub fn new(session_name: String) -> Self {
-        let (event_tx, event_rx) = mpsc::unbounded_channel();
         Self {
             child: None,
             writer: None,
             state: Arc::new(RwLock::new(TmuxState::new("", &session_name))),
-            event_tx,
-            event_rx: Some(event_rx),
-            pending: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            next_cmd: AtomicU64::new(0),
+            response_queue: Arc::new(tokio::sync::Mutex::new(VecDeque::new())),
             session_name,
         }
     }
@@ -66,11 +57,6 @@ impl TmuxController {
     /// Get a handle to the shared state.
     pub fn state(&self) -> Arc<RwLock<TmuxState>> {
         Arc::clone(&self.state)
-    }
-
-    /// Take the event receiver (can only be called once).
-    pub fn take_event_rx(&mut self) -> Option<mpsc::UnboundedReceiver<TmuxEvent>> {
-        self.event_rx.take()
     }
 
     /// Start a tmux session and connect via control mode.
@@ -115,56 +101,62 @@ impl TmuxController {
         self.writer = Some(writer);
         self.child = Some(child);
 
-        // Start reader task
-        let event_tx = self.event_tx.clone();
-        let pending = Arc::clone(&self.pending);
+        // Start reader task — reads control mode output lines and dispatches
+        // command responses to the FIFO queue of oneshot senders.
+        let response_queue = Arc::clone(&self.response_queue);
         tokio::spawn(async move {
             let reader = BufReader::new(stdout);
             let mut lines = reader.lines();
-            let mut current_cmd: Option<u64> = None;
+            // Current waiter being filled (popped from queue on %begin)
+            let mut current_waiter: Option<oneshot::Sender<CommandResult>> = None;
             let mut current_lines: Vec<String> = Vec::new();
+            let mut in_command = false;
 
             while let Ok(Some(line)) = lines.next_line().await {
                 if let Some(event) = TmuxEvent::parse(&line) {
                     match &event {
-                        TmuxEvent::Begin { command_num, .. } => {
-                            current_cmd = Some(*command_num);
+                        TmuxEvent::Begin { .. } => {
+                            // Pop the next waiter from the FIFO queue
+                            let mut q = response_queue.lock().await;
+                            current_waiter = q.pop_front();
                             current_lines.clear();
+                            in_command = true;
                         }
-                        TmuxEvent::End { command_num, .. } => {
-                            if Some(*command_num) == current_cmd {
-                                let mut map = pending.lock().await;
-                                if let Some(sender) = map.remove(command_num) {
+                        TmuxEvent::End { .. } => {
+                            if in_command {
+                                if let Some(sender) = current_waiter.take() {
                                     let _ = sender.send(CommandResult {
                                         lines: current_lines.drain(..).collect(),
                                         success: true,
                                     });
                                 }
-                                current_cmd = None;
+                                in_command = false;
                             }
                         }
-                        TmuxEvent::Error { command_num, .. } => {
-                            if Some(*command_num) == current_cmd {
-                                let mut map = pending.lock().await;
-                                if let Some(sender) = map.remove(command_num) {
+                        TmuxEvent::Error { .. } => {
+                            if in_command {
+                                if let Some(sender) = current_waiter.take() {
                                     let _ = sender.send(CommandResult {
                                         lines: current_lines.drain(..).collect(),
                                         success: false,
                                     });
                                 }
-                                current_cmd = None;
+                                in_command = false;
                             }
                         }
                         TmuxEvent::Data(data) => {
-                            if current_cmd.is_some() {
+                            if in_command {
                                 current_lines.push(data.clone());
                             }
                         }
-                        _ => {}
+                        _ => {
+                            // Notifications (%output, %window-add, etc.) — log for now
+                            tracing::trace!("tmux event: {:?}", event);
+                        }
                     }
-                    let _ = event_tx.send(event);
                 }
             }
+            tracing::debug!("tmux control mode reader exited");
         });
 
         tracing::info!("tmux control mode connected to session '{}'", self.session_name);
@@ -172,13 +164,27 @@ impl TmuxController {
     }
 
     /// Send a command to tmux control mode and wait for its response.
+    ///
+    /// Commands are serialized: the writer mutex ensures only one command
+    /// is in-flight at a time, and the reader task resolves responses in
+    /// FIFO order via the `response_queue`.
     pub async fn execute(&self, cmd: &str, args: &[&str]) -> Result<CommandResult, String> {
         let writer = self.writer.as_ref()
             .ok_or_else(|| "Control mode not connected".to_string())?;
 
         let formatted = Self::format_command(cmd, args);
 
-        // Write to stdin
+        // Create a oneshot channel for this command's response
+        let (tx, rx) = oneshot::channel();
+
+        // Enqueue the waiter BEFORE writing the command (so the reader
+        // task can find it when %begin arrives).
+        {
+            let mut q = self.response_queue.lock().await;
+            q.push_back(tx);
+        }
+
+        // Write to stdin (serialized by the mutex)
         {
             let mut w = writer.lock().await;
             w.write_all(formatted.as_bytes()).await
@@ -187,14 +193,12 @@ impl TmuxController {
                 .map_err(|e| format!("Failed to flush: {}", e))?;
         }
 
-        // For now, commands are fire-and-forget since control mode
-        // command numbering needs the server to assign numbers.
-        // We return a synthetic success. Full request-response tracking
-        // will be wired when we process %begin/%end with server-assigned numbers.
-        Ok(CommandResult {
-            lines: vec![],
-            success: true,
-        })
+        // Wait for the reader task to resolve our response
+        match tokio::time::timeout(std::time::Duration::from_secs(10), rx).await {
+            Ok(Ok(result)) => Ok(result),
+            Ok(Err(_)) => Err("Response channel closed — tmux control mode may have exited".to_string()),
+            Err(_) => Err("Timed out waiting for tmux response (10s)".to_string()),
+        }
     }
 
     /// Execute a command and return the first line of output.
@@ -256,5 +260,39 @@ mod tests {
             let result = controller.start().await;
             assert!(result.is_err());
         }
+    }
+
+    #[tokio::test]
+    async fn test_response_queue_ordering() {
+        // Verify that the response queue is FIFO
+        let queue: Arc<tokio::sync::Mutex<VecDeque<oneshot::Sender<CommandResult>>>> =
+            Arc::new(tokio::sync::Mutex::new(VecDeque::new()));
+
+        let (tx1, rx1) = oneshot::channel();
+        let (tx2, rx2) = oneshot::channel();
+
+        {
+            let mut q = queue.lock().await;
+            q.push_back(tx1);
+            q.push_back(tx2);
+        }
+
+        // Pop first — should be tx1
+        {
+            let mut q = queue.lock().await;
+            let sender = q.pop_front().unwrap();
+            sender.send(CommandResult { lines: vec!["first".to_string()], success: true }).unwrap();
+        }
+        // Pop second — should be tx2
+        {
+            let mut q = queue.lock().await;
+            let sender = q.pop_front().unwrap();
+            sender.send(CommandResult { lines: vec!["second".to_string()], success: true }).unwrap();
+        }
+
+        let r1 = rx1.await.unwrap();
+        let r2 = rx2.await.unwrap();
+        assert_eq!(r1.lines, vec!["first"]);
+        assert_eq!(r2.lines, vec!["second"]);
     }
 }

--- a/src/tmux/hotkeys.rs
+++ b/src/tmux/hotkeys.rs
@@ -1,0 +1,70 @@
+//! Convenience hotkey bindings for Synaps tmux mode.
+
+/// Generate the tmux bind-key commands for Synaps convenience keys.
+pub fn hotkey_bind_commands() -> Vec<String> {
+    vec![
+        "bind-key -T prefix F resize-pane -Z".to_string(),
+        "bind-key -T prefix S display-message 'Cycling subagent display...'".to_string(),
+        "bind-key -T prefix L display-message 'Cycling layout...'".to_string(),
+        "bind-key -T prefix N select-pane -t :.+".to_string(),
+        "bind-key -T prefix P select-pane -t :.-".to_string(),
+        "bind-key -T prefix H display-message 'Synaps: F=fullscreen S=subagent L=layout N/P=nav H=help'".to_string(),
+    ]
+}
+
+/// Generate the mouse enable/disable command.
+pub fn mouse_command(enabled: bool) -> String {
+    if enabled {
+        "set-option -g mouse on".to_string()
+    } else {
+        "set-option -g mouse off".to_string()
+    }
+}
+
+/// Generate status bar format commands for Synaps.
+pub fn status_bar_commands(session_name: &str) -> Vec<String> {
+    vec![
+        "set-option -g status-position bottom".to_string(),
+        format!("set-option -g status-left '#[fg=cyan,bold][{}] '", session_name),
+        "set-option -g status-right '#[fg=yellow]C-b H:help #[fg=white]%H:%M'".to_string(),
+        "set-option -g status-style 'bg=black,fg=white'".to_string(),
+        "set-option -g window-status-current-style 'fg=green,bold'".to_string(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hotkey_commands_not_empty() {
+        let cmds = hotkey_bind_commands();
+        assert!(!cmds.is_empty());
+    }
+
+    #[test]
+    fn test_hotkey_commands_contain_bind_key() {
+        let cmds = hotkey_bind_commands();
+        for cmd in &cmds {
+            assert!(cmd.starts_with("bind-key"), "Expected bind-key command: {}", cmd);
+        }
+    }
+
+    #[test]
+    fn test_mouse_enable_command() {
+        let cmd = mouse_command(true);
+        assert!(cmd.contains("mouse"));
+        assert!(cmd.contains("on"));
+
+        let cmd = mouse_command(false);
+        assert!(cmd.contains("mouse"));
+        assert!(cmd.contains("off"));
+    }
+
+    #[test]
+    fn test_status_bar_commands() {
+        let cmds = status_bar_commands("my-project");
+        assert!(cmds.iter().any(|c| c.contains("my-project")));
+        assert!(cmds.iter().any(|c| c.contains("status-position")));
+    }
+}

--- a/src/tmux/install.rs
+++ b/src/tmux/install.rs
@@ -1,0 +1,114 @@
+//! tmux installation flow when tmux is not found.
+
+use std::io::{self, Write};
+
+/// Return the sequence of shell commands to install tmux from source.
+pub fn install_commands() -> Vec<String> {
+    vec![
+        "git clone https://github.com/tmux/tmux.git".to_string(),
+        "cd tmux".to_string(),
+        "sh autogen.sh".to_string(),
+        "./configure && make".to_string(),
+        "sudo make install".to_string(),
+    ]
+}
+
+/// Print the install prompt and return true if user accepts.
+pub fn prompt_install() -> bool {
+    eprintln!("\x1b[1;31mError:\x1b[0m tmux is not installed.\n");
+    eprintln!("tmux mode requires tmux to be available in your PATH.\n");
+    eprintln!("Would you like to install tmux from source? [y/N]\n");
+    eprintln!("This will run:");
+    for cmd in install_commands() {
+        eprintln!("  {}", cmd);
+    }
+    eprint!("\n> ");
+    io::stderr().flush().ok();
+
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_ok() {
+        return input.trim().eq_ignore_ascii_case("y");
+    }
+    false
+}
+
+/// Execute the install commands. Returns Ok(()) on success.
+pub async fn run_install() -> Result<(), String> {
+    use tokio::process::Command;
+
+    let tmpdir = std::env::temp_dir().join("synaps-tmux-install");
+    let _ = std::fs::remove_dir_all(&tmpdir);
+    std::fs::create_dir_all(&tmpdir)
+        .map_err(|e| format!("Failed to create temp dir: {}", e))?;
+
+    eprintln!("\nCloning tmux...");
+    let status = Command::new("git")
+        .args(["clone", "https://github.com/tmux/tmux.git"])
+        .current_dir(&tmpdir)
+        .status()
+        .await
+        .map_err(|e| format!("git clone failed: {}", e))?;
+    if !status.success() {
+        return Err("git clone failed".to_string());
+    }
+
+    let tmux_dir = tmpdir.join("tmux");
+
+    eprintln!("Running autogen.sh...");
+    let status = Command::new("sh")
+        .arg("autogen.sh")
+        .current_dir(&tmux_dir)
+        .status()
+        .await
+        .map_err(|e| format!("autogen.sh failed: {}", e))?;
+    if !status.success() {
+        return Err("autogen.sh failed. You may need: automake, autoconf, pkg-config".to_string());
+    }
+
+    eprintln!("Configuring and building...");
+    let status = Command::new("sh")
+        .args(["-c", "./configure && make"])
+        .current_dir(&tmux_dir)
+        .status()
+        .await
+        .map_err(|e| format!("configure/make failed: {}", e))?;
+    if !status.success() {
+        return Err("Build failed. You may need: libevent-dev, ncurses-dev".to_string());
+    }
+
+    eprintln!("Installing (may require sudo password)...");
+    let status = Command::new("sudo")
+        .args(["make", "install"])
+        .current_dir(&tmux_dir)
+        .status()
+        .await
+        .map_err(|e| format!("make install failed: {}", e))?;
+    if !status.success() {
+        return Err("make install failed".to_string());
+    }
+
+    let _ = std::fs::remove_dir_all(&tmpdir);
+
+    if crate::tmux::find_tmux().is_some() {
+        eprintln!("\n\x1b[1;32m✓\x1b[0m tmux installed successfully!");
+        Ok(())
+    } else {
+        Err("tmux installed but not found in PATH".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_install_commands_are_valid() {
+        let cmds = install_commands();
+        assert_eq!(cmds.len(), 5);
+        assert!(cmds[0].contains("git clone"));
+        assert!(cmds[1].contains("cd tmux"));
+        assert!(cmds[2].contains("autogen.sh"));
+        assert!(cmds[3].contains("configure"));
+        assert!(cmds[4].contains("make install"));
+    }
+}

--- a/src/tmux/layout.rs
+++ b/src/tmux/layout.rs
@@ -1,0 +1,79 @@
+//! Layout preset logic for tmux pane arrangements.
+
+use super::config::LayoutPreset;
+
+/// Generate the tmux commands needed to apply a layout preset.
+/// `self_pane` is the Synaps TUI pane ID, `split_ratio` is the TUI width percentage.
+pub fn layout_commands(preset: &LayoutPreset, self_pane: &str, split_ratio: u32) -> Vec<String> {
+    match preset {
+        LayoutPreset::Split => {
+            let shell_pct = 100 - split_ratio;
+            vec![
+                format!("split-window -h -t {} -l {}% -d", self_pane, shell_pct),
+            ]
+        }
+        LayoutPreset::Fullscreen => {
+            // No splits — TUI takes full window
+            vec![]
+        }
+        LayoutPreset::Tiled => {
+            vec![
+                format!("select-layout -t {} tiled", self_pane),
+            ]
+        }
+        LayoutPreset::Custom(layout_string) => {
+            vec![
+                format!("select-layout -t {} {}", self_pane, layout_string),
+            ]
+        }
+    }
+}
+
+/// Get the next layout preset in the cycle.
+pub fn next_preset(current: &LayoutPreset) -> LayoutPreset {
+    match current {
+        LayoutPreset::Split => LayoutPreset::Fullscreen,
+        LayoutPreset::Fullscreen => LayoutPreset::Tiled,
+        LayoutPreset::Tiled => LayoutPreset::Split,
+        LayoutPreset::Custom(_) => LayoutPreset::Split,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_layout_commands() {
+        let cmds = layout_commands(&LayoutPreset::Split, "%0", 60);
+        assert!(!cmds.is_empty());
+        assert!(cmds.iter().any(|c| c.contains("split-window")));
+        assert!(cmds.iter().any(|c| c.contains("40%")));
+    }
+
+    #[test]
+    fn test_fullscreen_layout_no_split() {
+        let cmds = layout_commands(&LayoutPreset::Fullscreen, "%0", 60);
+        assert!(cmds.is_empty());
+    }
+
+    #[test]
+    fn test_tiled_layout_commands() {
+        let cmds = layout_commands(&LayoutPreset::Tiled, "%0", 50);
+        assert!(cmds.iter().any(|c| c.contains("tiled")));
+    }
+
+    #[test]
+    fn test_custom_layout() {
+        let cmds = layout_commands(&LayoutPreset::Custom("my-layout".to_string()), "%0", 50);
+        assert!(cmds.iter().any(|c| c.contains("my-layout")));
+    }
+
+    #[test]
+    fn test_next_preset_cycle() {
+        assert_eq!(next_preset(&LayoutPreset::Split), LayoutPreset::Fullscreen);
+        assert_eq!(next_preset(&LayoutPreset::Fullscreen), LayoutPreset::Tiled);
+        assert_eq!(next_preset(&LayoutPreset::Tiled), LayoutPreset::Split);
+        assert_eq!(next_preset(&LayoutPreset::Custom("x".to_string())), LayoutPreset::Split);
+    }
+}

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -1,0 +1,62 @@
+//! tmux native integration — control mode, layouts, tools.
+
+pub mod config;
+pub mod protocol;
+pub mod state;
+pub mod controller;
+pub mod layout;
+pub mod hotkeys;
+pub mod install;
+
+pub use config::TmuxConfig;
+pub use controller::TmuxController;
+
+use std::process::Command as StdCommand;
+
+/// Generate an auto session name based on git repo or directory name.
+pub fn auto_session_name() -> String {
+    // Try git repo name first
+    if let Ok(output) = StdCommand::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+    {
+        if output.status.success() {
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if let Some(name) = std::path::Path::new(&path).file_name() {
+                return format!("synaps-{}", name.to_string_lossy());
+            }
+        }
+    }
+    // Fall back to current directory name
+    if let Ok(cwd) = std::env::current_dir() {
+        if let Some(name) = cwd.file_name() {
+            return format!("synaps-{}", name.to_string_lossy());
+        }
+    }
+    // Last resort
+    format!("synaps-{}", std::process::id())
+}
+
+/// Check if tmux is available in PATH.
+pub fn find_tmux() -> Option<String> {
+    StdCommand::new("which")
+        .arg("tmux")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_auto_session_name_in_git_repo() {
+        let name = super::auto_session_name();
+        assert!(name.starts_with("synaps-"));
+    }
+
+    #[test]
+    fn test_find_tmux_returns_option() {
+        let _result = super::find_tmux();
+    }
+}

--- a/src/tmux/protocol.rs
+++ b/src/tmux/protocol.rs
@@ -1,0 +1,192 @@
+//! Control mode protocol parser for tmux notifications and command responses.
+
+/// Events received from tmux control mode.
+#[derive(Debug, Clone)]
+pub enum TmuxEvent {
+    /// %begin <time> <command_num> <flags>
+    Begin { time: u64, command_num: u64, flags: u32 },
+    /// %end <time> <command_num> <flags>
+    End { time: u64, command_num: u64, flags: u32 },
+    /// %error <time> <command_num> <flags>
+    Error { time: u64, command_num: u64, flags: u32 },
+    /// %output %<pane_id> <data>
+    Output { pane_id: String, data: String },
+    /// %window-add @<window_id>
+    WindowAdd { window_id: String },
+    /// %window-close @<window_id>
+    WindowClose { window_id: String },
+    /// %window-renamed @<window_id> <name>
+    WindowRenamed { window_id: String, name: String },
+    /// %session-changed $<session_id> <name>
+    SessionChanged { session_id: String, name: String },
+    /// %layout-change @<window_id> <layout_string>
+    LayoutChange { window_id: String, layout: String },
+    /// %pane-mode-changed %<pane_id>
+    PaneModeChanged { pane_id: String },
+    /// %pane-exited %<pane_id>
+    PaneExited { pane_id: String },
+    /// Non-notification data (command response lines between %begin/%end)
+    Data(String),
+}
+
+impl TmuxEvent {
+    /// Parse a single line from tmux control mode output.
+    pub fn parse(line: &str) -> Option<TmuxEvent> {
+        if line.starts_with("%begin ") {
+            return Self::parse_triple(line, "%begin ").map(|(t, n, f)| TmuxEvent::Begin {
+                time: t, command_num: n, flags: f,
+            });
+        }
+        if line.starts_with("%end ") {
+            return Self::parse_triple(line, "%end ").map(|(t, n, f)| TmuxEvent::End {
+                time: t, command_num: n, flags: f,
+            });
+        }
+        if line.starts_with("%error ") {
+            return Self::parse_triple(line, "%error ").map(|(t, n, f)| TmuxEvent::Error {
+                time: t, command_num: n, flags: f,
+            });
+        }
+        if let Some(rest) = line.strip_prefix("%output ") {
+            let (pane_id, data) = rest.split_once(' ').unwrap_or((rest, ""));
+            return Some(TmuxEvent::Output {
+                pane_id: pane_id.to_string(),
+                data: data.to_string(),
+            });
+        }
+        if let Some(rest) = line.strip_prefix("%window-add ") {
+            return Some(TmuxEvent::WindowAdd { window_id: rest.trim().to_string() });
+        }
+        if let Some(rest) = line.strip_prefix("%window-close ") {
+            return Some(TmuxEvent::WindowClose { window_id: rest.trim().to_string() });
+        }
+        if let Some(rest) = line.strip_prefix("%window-renamed ") {
+            let (id, name) = rest.split_once(' ').unwrap_or((rest, ""));
+            return Some(TmuxEvent::WindowRenamed {
+                window_id: id.to_string(),
+                name: name.to_string(),
+            });
+        }
+        if let Some(rest) = line.strip_prefix("%session-changed ") {
+            let (id, name) = rest.split_once(' ').unwrap_or((rest, ""));
+            return Some(TmuxEvent::SessionChanged {
+                session_id: id.to_string(),
+                name: name.to_string(),
+            });
+        }
+        if let Some(rest) = line.strip_prefix("%layout-change ") {
+            let (id, layout) = rest.split_once(' ').unwrap_or((rest, ""));
+            return Some(TmuxEvent::LayoutChange {
+                window_id: id.to_string(),
+                layout: layout.to_string(),
+            });
+        }
+        if let Some(rest) = line.strip_prefix("%pane-mode-changed ") {
+            return Some(TmuxEvent::PaneModeChanged { pane_id: rest.trim().to_string() });
+        }
+        if let Some(rest) = line.strip_prefix("%pane-exited ") {
+            return Some(TmuxEvent::PaneExited { pane_id: rest.trim().to_string() });
+        }
+        // Non-notification line = data (command response body)
+        Some(TmuxEvent::Data(line.to_string()))
+    }
+
+    fn parse_triple(line: &str, prefix: &str) -> Option<(u64, u64, u32)> {
+        let rest = line.strip_prefix(prefix)?;
+        let parts: Vec<&str> = rest.split_whitespace().collect();
+        if parts.len() >= 3 {
+            let time = parts[0].parse().ok()?;
+            let num = parts[1].parse().ok()?;
+            let flags = parts[2].parse().ok()?;
+            Some((time, num, flags))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_output_notification() {
+        let line = "%output %0 hello world";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::Output { ref pane_id, ref data })
+            if pane_id == "%0" && data == "hello world"));
+    }
+
+    #[test]
+    fn test_parse_window_add_notification() {
+        let line = "%window-add @5";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::WindowAdd { ref window_id })
+            if window_id == "@5"));
+    }
+
+    #[test]
+    fn test_parse_layout_change() {
+        let line = "%layout-change @0 ab12,200x50,0,0{100x50,0,0,0,99x50,101,0,1}";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::LayoutChange { ref window_id, .. })
+            if window_id == "@0"));
+    }
+
+    #[test]
+    fn test_parse_begin_end() {
+        let begin = "%begin 1234567890 42 1";
+        let event = TmuxEvent::parse(begin);
+        assert!(matches!(event, Some(TmuxEvent::Begin { command_num: 42, .. })));
+
+        let end = "%end 1234567890 42 1";
+        let event = TmuxEvent::parse(end);
+        assert!(matches!(event, Some(TmuxEvent::End { command_num: 42, .. })));
+    }
+
+    #[test]
+    fn test_parse_unknown_line() {
+        let line = "some random output";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::Data(_))));
+    }
+
+    #[test]
+    fn test_parse_pane_exited() {
+        let line = "%pane-exited %3";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::PaneExited { ref pane_id })
+            if pane_id == "%3"));
+    }
+
+    #[test]
+    fn test_parse_session_changed() {
+        let line = "%session-changed $1 my-session";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::SessionChanged { ref session_id, ref name })
+            if session_id == "$1" && name == "my-session"));
+    }
+
+    #[test]
+    fn test_parse_error() {
+        let line = "%error 1234567890 5 0";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::Error { command_num: 5, .. })));
+    }
+
+    #[test]
+    fn test_parse_window_close() {
+        let line = "%window-close @3";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::WindowClose { ref window_id })
+            if window_id == "@3"));
+    }
+
+    #[test]
+    fn test_parse_window_renamed() {
+        let line = "%window-renamed @2 my-window";
+        let event = TmuxEvent::parse(line);
+        assert!(matches!(event, Some(TmuxEvent::WindowRenamed { ref window_id, ref name })
+            if window_id == "@2" && name == "my-window"));
+    }
+}

--- a/src/tmux/state.rs
+++ b/src/tmux/state.rs
@@ -1,0 +1,191 @@
+//! Tracked state of tmux objects (sessions, windows, panes).
+
+use std::collections::HashMap;
+
+/// Role assigned to a tmux pane — tracks what it's being used for.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PaneRole {
+    /// The main Synaps TUI chat pane.
+    SynapsTui,
+    /// A shell session created by the agent.
+    AgentShell { session_id: String },
+    /// A subagent output display pane.
+    Subagent { handle_id: String },
+    /// A user-created pane (not managed by Synaps).
+    User,
+}
+
+/// Tracked state of a single tmux pane.
+#[derive(Debug, Clone)]
+pub struct TmuxPane {
+    pub id: String,
+    pub window_id: String,
+    pub title: String,
+    pub width: u32,
+    pub height: u32,
+    pub active: bool,
+    pub role: PaneRole,
+}
+
+/// Tracked state of a single tmux window.
+#[derive(Debug, Clone)]
+pub struct TmuxWindow {
+    pub id: String,
+    pub name: String,
+    pub index: u32,
+    pub layout: String,
+}
+
+/// Full tracked state of the tmux session.
+#[derive(Debug)]
+pub struct TmuxState {
+    pub session_id: String,
+    pub session_name: String,
+    pub windows: HashMap<String, TmuxWindow>,
+    pub panes: HashMap<String, TmuxPane>,
+    pub self_pane: Option<String>,
+}
+
+impl TmuxState {
+    pub fn new(session_id: &str, session_name: &str) -> Self {
+        Self {
+            session_id: session_id.to_string(),
+            session_name: session_name.to_string(),
+            windows: HashMap::new(),
+            panes: HashMap::new(),
+            self_pane: None,
+        }
+    }
+
+    pub fn add_pane(&mut self, pane: TmuxPane) {
+        self.panes.insert(pane.id.clone(), pane);
+    }
+
+    pub fn remove_pane(&mut self, pane_id: &str) {
+        self.panes.remove(pane_id);
+    }
+
+    pub fn pane(&self, pane_id: &str) -> Option<&TmuxPane> {
+        self.panes.get(pane_id)
+    }
+
+    pub fn pane_mut(&mut self, pane_id: &str) -> Option<&mut TmuxPane> {
+        self.panes.get_mut(pane_id)
+    }
+
+    pub fn add_window(&mut self, window: TmuxWindow) {
+        self.windows.insert(window.id.clone(), window);
+    }
+
+    pub fn remove_window(&mut self, window_id: &str) {
+        self.windows.remove(window_id);
+    }
+
+    pub fn window(&self, window_id: &str) -> Option<&TmuxWindow> {
+        self.windows.get(window_id)
+    }
+
+    /// Get all panes matching a role filter.
+    pub fn panes_by_role_filter<F>(&self, f: F) -> Vec<&TmuxPane>
+    where
+        F: Fn(&PaneRole) -> bool,
+    {
+        self.panes.values().filter(|p| f(&p.role)).collect()
+    }
+
+    /// Get count of panes with a specific role.
+    pub fn pane_count_by_role<F>(&self, f: F) -> usize
+    where
+        F: Fn(&PaneRole) -> bool,
+    {
+        self.panes.values().filter(|p| f(&p.role)).count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_state_new() {
+        let state = TmuxState::new("$0", "my-session");
+        assert_eq!(state.session_id, "$0");
+        assert_eq!(state.session_name, "my-session");
+        assert!(state.windows.is_empty());
+        assert!(state.panes.is_empty());
+    }
+
+    #[test]
+    fn test_add_and_get_pane() {
+        let mut state = TmuxState::new("$0", "test");
+        state.add_pane(TmuxPane {
+            id: "%0".to_string(),
+            window_id: "@0".to_string(),
+            title: "main".to_string(),
+            width: 200,
+            height: 50,
+            active: true,
+            role: PaneRole::SynapsTui,
+        });
+        assert_eq!(state.panes.len(), 1);
+        assert!(state.pane("%0").is_some());
+        assert_eq!(state.pane("%0").unwrap().role, PaneRole::SynapsTui);
+    }
+
+    #[test]
+    fn test_remove_pane() {
+        let mut state = TmuxState::new("$0", "test");
+        state.add_pane(TmuxPane {
+            id: "%1".to_string(),
+            window_id: "@0".to_string(),
+            title: "shell".to_string(),
+            width: 80,
+            height: 24,
+            active: false,
+            role: PaneRole::AgentShell { session_id: "shell_01".to_string() },
+        });
+        assert_eq!(state.panes.len(), 1);
+        state.remove_pane("%1");
+        assert_eq!(state.panes.len(), 0);
+    }
+
+    #[test]
+    fn test_panes_by_role() {
+        let mut state = TmuxState::new("$0", "test");
+        state.add_pane(TmuxPane {
+            id: "%0".to_string(), window_id: "@0".to_string(),
+            title: "tui".to_string(), width: 100, height: 50,
+            active: true, role: PaneRole::SynapsTui,
+        });
+        state.add_pane(TmuxPane {
+            id: "%1".to_string(), window_id: "@0".to_string(),
+            title: "sh1".to_string(), width: 100, height: 25,
+            active: false, role: PaneRole::AgentShell { session_id: "shell_01".to_string() },
+        });
+        state.add_pane(TmuxPane {
+            id: "%2".to_string(), window_id: "@0".to_string(),
+            title: "sa1".to_string(), width: 100, height: 25,
+            active: false, role: PaneRole::Subagent { handle_id: "sa_1".to_string() },
+        });
+
+        let shells: Vec<_> = state.panes_by_role_filter(|r| matches!(r, PaneRole::AgentShell { .. }));
+        assert_eq!(shells.len(), 1);
+        assert_eq!(shells[0].id, "%1");
+
+        assert_eq!(state.pane_count_by_role(|r| matches!(r, PaneRole::Subagent { .. })), 1);
+    }
+
+    #[test]
+    fn test_add_and_get_window() {
+        let mut state = TmuxState::new("$0", "test");
+        state.add_window(TmuxWindow {
+            id: "@0".to_string(),
+            name: "main".to_string(),
+            index: 0,
+            layout: "".to_string(),
+        });
+        assert_eq!(state.windows.len(), 1);
+        assert!(state.window("@0").is_some());
+        assert_eq!(state.window("@0").unwrap().name, "main");
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -30,6 +30,12 @@ pub mod subagent_collect;
 pub mod subagent_resume;
 pub mod respond;
 pub mod send_channel;
+pub mod tmux_split;
+pub mod tmux_send;
+pub mod tmux_capture;
+pub mod tmux_layout;
+pub mod tmux_window;
+pub mod tmux_resize;
 
 // ── Re-exports ──────────────────────────────────────────────────────────────────
 
@@ -53,6 +59,12 @@ pub use subagent_collect::SubagentCollectTool;
 pub use subagent_resume::SubagentResumeTool;
 pub use respond::RespondTool;
 pub use send_channel::SendChannelTool;
+pub use tmux_split::TmuxSplitTool;
+pub use tmux_send::TmuxSendTool;
+pub use tmux_capture::TmuxCaptureTool;
+pub use tmux_layout::TmuxLayoutTool;
+pub use tmux_window::TmuxWindowTool;
+pub use tmux_resize::TmuxResizeTool;
 
 // Re-export util items used by sibling tool modules via `super::`
 pub(crate) use util::{NEXT_SUBAGENT_ID, strip_ansi, expand_path};
@@ -72,6 +84,7 @@ pub struct ToolCapabilities {
     pub session_manager: Option<std::sync::Arc<crate::tools::shell::SessionManager>>,
     pub subagent_registry: Option<Arc<Mutex<SubagentRegistry>>>,
     pub event_queue: Option<Arc<crate::events::EventQueue>>,
+    pub tmux_controller: Option<std::sync::Arc<crate::tmux::TmuxController>>,
 }
 
 /// Configuration limits and timeouts.

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -38,6 +38,12 @@ impl ToolRegistry {
             Arc::new(crate::tools::shell::ShellStartTool),
             Arc::new(crate::tools::shell::ShellSendTool),
             Arc::new(crate::tools::shell::ShellEndTool),
+            Arc::new(crate::tools::tmux_split::TmuxSplitTool),
+            Arc::new(crate::tools::tmux_send::TmuxSendTool),
+            Arc::new(crate::tools::tmux_capture::TmuxCaptureTool),
+            Arc::new(crate::tools::tmux_layout::TmuxLayoutTool),
+            Arc::new(crate::tools::tmux_window::TmuxWindowTool),
+            Arc::new(crate::tools::tmux_resize::TmuxResizeTool),
         ];
         Self::from_tools(tools)
     }

--- a/src/tools/subagent.rs
+++ b/src/tools/subagent.rs
@@ -91,6 +91,8 @@ impl Tool for SubagentTool {
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
+        let tmux_ctrl = ctx.capabilities.tmux_controller.clone();
+
         let _thread_handle = std::thread::spawn(move || {
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 let rt = match tokio::runtime::Builder::new_current_thread()
@@ -115,6 +117,9 @@ impl Tool for SubagentTool {
                     runtime.set_system_prompt(system_prompt);
                     runtime.set_model(model);
                     runtime.set_tools(crate::ToolRegistry::without_subagent());
+                    if let Some(ctrl) = tmux_ctrl {
+                        runtime.set_tmux_controller(ctrl);
+                    }
 
                     let cancel = crate::CancellationToken::new();
                     let cancel_inner = cancel.clone();

--- a/src/tools/subagent_resume.rs
+++ b/src/tools/subagent_resume.rs
@@ -133,6 +133,8 @@ impl Tool for SubagentResumeTool {
         let tx_events_inner = ctx.channels.tx_events.clone();
         let start_time      = std::time::Instant::now();
 
+        let tmux_ctrl = ctx.capabilities.tmux_controller.clone();
+
         let thread_handle = std::thread::spawn(move || {
             let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 let rt = match tokio::runtime::Builder::new_current_thread()
@@ -166,6 +168,9 @@ impl Tool for SubagentResumeTool {
                     runtime.set_system_prompt(system_prompt);
                     runtime.set_model(model_a.clone());
                     runtime.set_tools(crate::ToolRegistry::without_subagent());
+                    if let Some(ctrl) = tmux_ctrl {
+                        runtime.set_tmux_controller(ctrl);
+                    }
 
                     let cancel = crate::CancellationToken::new();
                     let cancel_inner = cancel.clone();

--- a/src/tools/subagent_start.rs
+++ b/src/tools/subagent_start.rs
@@ -114,6 +114,8 @@ impl Tool for SubagentStartTool {
         let tx_events_inner  = ctx.channels.tx_events.clone();
         let start_time       = std::time::Instant::now();
 
+        let tmux_ctrl = ctx.capabilities.tmux_controller.clone();
+
         // ── Spawn subagent thread (mirrors subagent.rs) ────────────────────────
         let thread_handle = std::thread::spawn(move || {
             let panic_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -148,6 +150,9 @@ impl Tool for SubagentStartTool {
                     runtime.set_system_prompt(system_prompt);
                     runtime.set_model(model_a.clone());
                     runtime.set_tools(crate::ToolRegistry::without_subagent());
+                    if let Some(ctrl) = tmux_ctrl {
+                        runtime.set_tmux_controller(ctrl);
+                    }
 
                     let cancel = crate::CancellationToken::new();
                     let cancel_inner = cancel.clone();

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -162,6 +162,7 @@ fn create_tool_context() -> ToolContext {
             session_manager: None,
             subagent_registry: None,
             event_queue: None,
+            tmux_controller: None,
         },
         limits: crate::tools::ToolLimits {
             max_tool_output: 30000,
@@ -379,7 +380,7 @@ fn test_tool_registry_new() {
     let registry = ToolRegistry::new();
     
     // Should have 11 tools including subagent + 3 shell tools
-    assert_eq!(registry.tools_schema().len(), 16);
+    assert_eq!(registry.tools_schema().len(), 22);
     
     // Should find bash tool
     assert!(registry.get("bash").is_some());
@@ -396,6 +397,12 @@ fn test_tool_registry_new() {
     assert!(registry.get("find").is_some());
     assert!(registry.get("ls").is_some());
     assert!(registry.get("subagent").is_some());
+    assert!(registry.get("tmux_split").is_some());
+    assert!(registry.get("tmux_send").is_some());
+    assert!(registry.get("tmux_capture").is_some());
+    assert!(registry.get("tmux_layout").is_some());
+    assert!(registry.get("tmux_window").is_some());
+    assert!(registry.get("tmux_resize").is_some());
 }
 
 #[test]

--- a/src/tools/tmux_capture.rs
+++ b/src/tools/tmux_capture.rs
@@ -1,0 +1,70 @@
+use serde_json::{json, Value};
+use crate::{Result, RuntimeError};
+use super::{Tool, ToolContext};
+
+pub struct TmuxCaptureTool;
+
+#[async_trait::async_trait]
+impl Tool for TmuxCaptureTool {
+    fn name(&self) -> &str { "tmux_capture" }
+
+    fn description(&self) -> &str {
+        "Read/capture the content of a tmux pane. Only available in tmux mode. Use to see what's displayed in a visible pane."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "pane_id": {
+                    "type": "string",
+                    "description": "Target pane ID (e.g. '%5'). Required."
+                },
+                "start_line": {
+                    "type": "integer",
+                    "description": "Start line (negative = history). Default: visible area start"
+                },
+                "end_line": {
+                    "type": "integer",
+                    "description": "End line. Default: visible area end"
+                }
+            },
+            "required": ["pane_id"]
+        })
+    }
+
+    async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
+        let controller = ctx.capabilities.tmux_controller
+            .as_ref()
+            .ok_or_else(|| RuntimeError::Tool(
+                "tmux mode not active. Launch synaps with --tmux to use tmux tools.".to_string()
+            ))?;
+
+        let pane_id = params["pane_id"].as_str()
+            .ok_or_else(|| RuntimeError::Tool("Missing pane_id parameter".to_string()))?;
+
+        let mut args: Vec<String> = vec![
+            "-t".to_string(), pane_id.to_string(), "-p".to_string(),
+        ];
+
+        if let Some(start) = params["start_line"].as_i64() {
+            args.push("-S".to_string());
+            args.push(start.to_string());
+        }
+        if let Some(end) = params["end_line"].as_i64() {
+            args.push("-E".to_string());
+            args.push(end.to_string());
+        }
+
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let result = controller.execute("capture-pane", &args_ref).await
+            .map_err(|e| RuntimeError::Tool(format!("tmux capture-pane failed: {}", e)))?;
+
+        let content = result.lines.join("\n");
+
+        Ok(json!({
+            "pane_id": pane_id,
+            "content": content,
+        }).to_string())
+    }
+}

--- a/src/tools/tmux_layout.rs
+++ b/src/tools/tmux_layout.rs
@@ -1,0 +1,82 @@
+use serde_json::{json, Value};
+use crate::{Result, RuntimeError};
+use super::{Tool, ToolContext};
+
+pub struct TmuxLayoutTool;
+
+#[async_trait::async_trait]
+impl Tool for TmuxLayoutTool {
+    fn name(&self) -> &str { "tmux_layout" }
+
+    fn description(&self) -> &str {
+        "Change the tmux layout of the current window. Only available in tmux mode. Use to rearrange panes."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "preset": {
+                    "type": "string",
+                    "description": "Layout preset: 'split', 'fullscreen', 'tiled', or 'even-horizontal', 'even-vertical', 'main-horizontal', 'main-vertical'",
+                    "enum": ["split", "fullscreen", "tiled", "even-horizontal", "even-vertical", "main-horizontal", "main-vertical"]
+                },
+                "set_default": {
+                    "type": "boolean",
+                    "description": "Persist as the default layout. Default: false"
+                },
+                "scope": {
+                    "type": "string",
+                    "description": "Where to persist if set_default=true: 'project' or 'system'",
+                    "enum": ["project", "system"]
+                }
+            },
+            "required": ["preset"]
+        })
+    }
+
+    async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
+        let controller = ctx.capabilities.tmux_controller
+            .as_ref()
+            .ok_or_else(|| RuntimeError::Tool(
+                "tmux mode not active. Launch synaps with --tmux to use tmux tools.".to_string()
+            ))?;
+
+        let preset = params["preset"].as_str()
+            .ok_or_else(|| RuntimeError::Tool("Missing preset parameter".to_string()))?;
+        let set_default = params["set_default"].as_bool().unwrap_or(false);
+        let scope = params["scope"].as_str().unwrap_or("project");
+
+        // Map preset names to tmux layout commands
+        match preset {
+            "split" | "fullscreen" | "tiled" => {
+                let layout_name = match preset {
+                    "tiled" => "tiled",
+                    "split" => "main-vertical",
+                    _ => "even-horizontal", // fullscreen handled differently
+                };
+                if preset != "fullscreen" {
+                    controller.execute("select-layout", &[layout_name]).await
+                        .map_err(|e| RuntimeError::Tool(format!("tmux select-layout failed: {}", e)))?;
+                }
+            }
+            layout => {
+                controller.execute("select-layout", &[layout]).await
+                    .map_err(|e| RuntimeError::Tool(format!("tmux select-layout failed: {}", e)))?;
+            }
+        }
+
+        // Persist default if requested
+        if set_default {
+            let config_key = "tmux.default_layout";
+            let _ = crate::config::write_config_value(config_key, preset);
+        }
+
+        Ok(json!({
+            "layout": preset,
+            "applied": true,
+            "persisted": set_default,
+            "scope": scope,
+        }).to_string())
+    }
+}

--- a/src/tools/tmux_resize.rs
+++ b/src/tools/tmux_resize.rs
@@ -1,0 +1,97 @@
+use serde_json::{json, Value};
+use crate::{Result, RuntimeError};
+use super::{Tool, ToolContext};
+
+pub struct TmuxResizeTool;
+
+#[async_trait::async_trait]
+impl Tool for TmuxResizeTool {
+    fn name(&self) -> &str { "tmux_resize" }
+
+    fn description(&self) -> &str {
+        "Resize a tmux pane or toggle zoom. Only available in tmux mode."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "pane_id": {
+                    "type": "string",
+                    "description": "Target pane ID (e.g. '%5'). Default: current pane"
+                },
+                "width": {
+                    "type": "string",
+                    "description": "Width: absolute number or relative '+10'/'-10'"
+                },
+                "height": {
+                    "type": "string",
+                    "description": "Height: absolute number or relative '+10'/'-10'"
+                },
+                "zoom": {
+                    "type": "boolean",
+                    "description": "Toggle zoom (pane fills entire window). Default: false"
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
+        let controller = ctx.capabilities.tmux_controller
+            .as_ref()
+            .ok_or_else(|| RuntimeError::Tool(
+                "tmux mode not active. Launch synaps with --tmux to use tmux tools.".to_string()
+            ))?;
+
+        let pane_id = params["pane_id"].as_str();
+        let width = params["width"].as_str();
+        let height = params["height"].as_str();
+        let zoom = params["zoom"].as_bool().unwrap_or(false);
+
+        if zoom {
+            let mut args = vec!["-Z"];
+            let pane_str;
+            if let Some(p) = pane_id {
+                args.push("-t");
+                pane_str = p.to_string();
+                args.push(&pane_str);
+            }
+            controller.execute("resize-pane", &args).await
+                .map_err(|e| RuntimeError::Tool(format!("resize-pane zoom failed: {}", e)))?;
+            return Ok(json!({ "zoomed": true }).to_string());
+        }
+
+        let mut results = vec![];
+
+        if let Some(w) = width {
+            let mut args = vec!["-x", w];
+            let pane_str;
+            if let Some(p) = pane_id {
+                args.push("-t");
+                pane_str = p.to_string();
+                args.push(&pane_str);
+            }
+            controller.execute("resize-pane", &args).await
+                .map_err(|e| RuntimeError::Tool(format!("resize-pane width failed: {}", e)))?;
+            results.push(format!("width={}", w));
+        }
+
+        if let Some(h) = height {
+            let mut args = vec!["-y", h];
+            let pane_str;
+            if let Some(p) = pane_id {
+                args.push("-t");
+                pane_str = p.to_string();
+                args.push(&pane_str);
+            }
+            controller.execute("resize-pane", &args).await
+                .map_err(|e| RuntimeError::Tool(format!("resize-pane height failed: {}", e)))?;
+            results.push(format!("height={}", h));
+        }
+
+        Ok(json!({
+            "resized": true,
+            "changes": results,
+        }).to_string())
+    }
+}

--- a/src/tools/tmux_send.rs
+++ b/src/tools/tmux_send.rs
@@ -1,0 +1,60 @@
+use serde_json::{json, Value};
+use crate::{Result, RuntimeError};
+use super::{Tool, ToolContext};
+
+pub struct TmuxSendTool;
+
+#[async_trait::async_trait]
+impl Tool for TmuxSendTool {
+    fn name(&self) -> &str { "tmux_send" }
+
+    fn description(&self) -> &str {
+        "Send keys or commands to a tmux pane. Only available in tmux mode. Use to type commands into visible panes."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "pane_id": {
+                    "type": "string",
+                    "description": "Target pane ID (e.g. '%5'). Required."
+                },
+                "keys": {
+                    "type": "string",
+                    "description": "Keys to send. Use 'Enter' for newline, 'C-c' for Ctrl-C. Required."
+                },
+                "literal": {
+                    "type": "boolean",
+                    "description": "Send all keys literally (no key name lookup). Default: true"
+                }
+            },
+            "required": ["pane_id", "keys"]
+        })
+    }
+
+    async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
+        let controller = ctx.capabilities.tmux_controller
+            .as_ref()
+            .ok_or_else(|| RuntimeError::Tool(
+                "tmux mode not active. Launch synaps with --tmux to use tmux tools.".to_string()
+            ))?;
+
+        let pane_id = params["pane_id"].as_str()
+            .ok_or_else(|| RuntimeError::Tool("Missing pane_id parameter".to_string()))?;
+        let keys = params["keys"].as_str()
+            .ok_or_else(|| RuntimeError::Tool("Missing keys parameter".to_string()))?;
+        let literal = params["literal"].as_bool().unwrap_or(true);
+
+        let mut args: Vec<&str> = vec!["-t", pane_id];
+        if literal {
+            args.push("-l");
+        }
+        args.push(keys);
+
+        controller.execute("send-keys", &args).await
+            .map_err(|e| RuntimeError::Tool(format!("tmux send-keys failed: {}", e)))?;
+
+        Ok(json!({ "sent": true, "pane_id": pane_id }).to_string())
+    }
+}

--- a/src/tools/tmux_split.rs
+++ b/src/tools/tmux_split.rs
@@ -1,0 +1,104 @@
+use serde_json::{json, Value};
+use crate::{Result, RuntimeError};
+use super::{Tool, ToolContext};
+
+pub struct TmuxSplitTool;
+
+#[async_trait::async_trait]
+impl Tool for TmuxSplitTool {
+    fn name(&self) -> &str { "tmux_split" }
+
+    fn description(&self) -> &str {
+        "Create a new tmux pane by splitting the current window. Only available in tmux mode. Use to create visible terminal panes for running commands the user can watch."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "direction": {
+                    "type": "string",
+                    "description": "Split direction: 'horizontal' (left/right) or 'vertical' (top/bottom). Default: horizontal",
+                    "enum": ["horizontal", "vertical"]
+                },
+                "size": {
+                    "type": "string",
+                    "description": "Size of new pane as percentage (e.g. '30%') or line count. Default: 50%"
+                },
+                "target": {
+                    "type": "string",
+                    "description": "Pane ID to split (e.g. '%0'). Default: current active pane"
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Command to run in the new pane"
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Title for the new pane"
+                },
+                "focus": {
+                    "type": "boolean",
+                    "description": "Switch focus to the new pane. Default: false"
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
+        let controller = ctx.capabilities.tmux_controller
+            .as_ref()
+            .ok_or_else(|| RuntimeError::Tool(
+                "tmux mode not active. Launch synaps with --tmux to use tmux tools.".to_string()
+            ))?;
+
+        let direction = params["direction"].as_str().unwrap_or("horizontal");
+        let size = params["size"].as_str().unwrap_or("50%");
+        let target = params["target"].as_str();
+        let command = params["command"].as_str();
+        let title = params["title"].as_str();
+        let focus = params["focus"].as_bool().unwrap_or(false);
+
+        let dir_flag = if direction == "vertical" { "-v" } else { "-h" };
+
+        let mut args: Vec<&str> = vec![dir_flag, "-P", "-F", "#{pane_id}"];
+
+        let size_flag = format!("-l");
+        args.push(&size_flag);
+        args.push(size);
+
+        if !focus {
+            args.push("-d");
+        }
+
+        let target_str;
+        if let Some(t) = target {
+            args.push("-t");
+            target_str = t.to_string();
+            args.push(&target_str);
+        }
+
+        let cmd_str;
+        if let Some(cmd) = command {
+            cmd_str = cmd.to_string();
+            args.push(&cmd_str);
+        }
+
+        let result = controller.execute("split-window", &args).await
+            .map_err(|e| RuntimeError::Tool(format!("tmux split failed: {}", e)))?;
+
+        let pane_id = result.lines.first()
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+
+        if let Some(t) = title {
+            let _ = controller.execute("select-pane", &["-t", &pane_id, "-T", t]).await;
+        }
+
+        Ok(json!({
+            "pane_id": pane_id,
+            "direction": direction,
+            "size": size,
+        }).to_string())
+    }
+}

--- a/src/tools/tmux_window.rs
+++ b/src/tools/tmux_window.rs
@@ -1,0 +1,93 @@
+use serde_json::{json, Value};
+use crate::{Result, RuntimeError};
+use super::{Tool, ToolContext};
+
+pub struct TmuxWindowTool;
+
+#[async_trait::async_trait]
+impl Tool for TmuxWindowTool {
+    fn name(&self) -> &str { "tmux_window" }
+
+    fn description(&self) -> &str {
+        "Create, switch, close, or rename tmux windows (tabs). Only available in tmux mode."
+    }
+
+    fn parameters(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "description": "Action to perform: 'create', 'switch', 'close', 'rename'",
+                    "enum": ["create", "switch", "close", "rename"]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Window name (for create/rename)"
+                },
+                "target": {
+                    "type": "string",
+                    "description": "Target window ID or index (for switch/close/rename)"
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Command to run in new window (for create)"
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
+        let controller = ctx.capabilities.tmux_controller
+            .as_ref()
+            .ok_or_else(|| RuntimeError::Tool(
+                "tmux mode not active. Launch synaps with --tmux to use tmux tools.".to_string()
+            ))?;
+
+        let action = params["action"].as_str()
+            .ok_or_else(|| RuntimeError::Tool("Missing action parameter".to_string()))?;
+        let name = params["name"].as_str();
+        let target = params["target"].as_str();
+        let command = params["command"].as_str();
+
+        match action {
+            "create" => {
+                let mut args: Vec<&str> = vec!["-P", "-F", "#{window_id}"];
+                if let Some(n) = name {
+                    args.push("-n");
+                    args.push(n);
+                }
+                if let Some(cmd) = command {
+                    args.push(cmd);
+                }
+                let result = controller.execute("new-window", &args).await
+                    .map_err(|e| RuntimeError::Tool(format!("new-window failed: {}", e)))?;
+                let window_id = result.lines.first()
+                    .map(|s| s.trim().to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                Ok(json!({ "action": "create", "window_id": window_id }).to_string())
+            }
+            "switch" => {
+                let t = target.ok_or_else(|| RuntimeError::Tool("Missing target for switch".to_string()))?;
+                controller.execute("select-window", &["-t", t]).await
+                    .map_err(|e| RuntimeError::Tool(format!("select-window failed: {}", e)))?;
+                Ok(json!({ "action": "switch", "target": t }).to_string())
+            }
+            "close" => {
+                let t = target.ok_or_else(|| RuntimeError::Tool("Missing target for close".to_string()))?;
+                controller.execute("kill-window", &["-t", t]).await
+                    .map_err(|e| RuntimeError::Tool(format!("kill-window failed: {}", e)))?;
+                Ok(json!({ "action": "close", "target": t }).to_string())
+            }
+            "rename" => {
+                let t = target.ok_or_else(|| RuntimeError::Tool("Missing target for rename".to_string()))?;
+                let n = name.ok_or_else(|| RuntimeError::Tool("Missing name for rename".to_string()))?;
+                controller.execute("rename-window", &["-t", t, n]).await
+                    .map_err(|e| RuntimeError::Tool(format!("rename-window failed: {}", e)))?;
+                Ok(json!({ "action": "rename", "target": t, "name": n }).to_string())
+            }
+            other => Err(RuntimeError::Tool(format!("Unknown action: {}", other))),
+        }
+    }
+}


### PR DESCRIPTION
Propagate the tmux_controller from the parent runtime into subagent, subagent_start, and subagent_resume tool contexts so that subagents can use tmux tools.

### Changes
- **src/runtime/mod.rs**: Clone and pass tmux_controller into tool execution context
- **src/tools/subagent.rs**: Accept and set tmux controller on subagent runtime
- **src/tools/subagent_resume.rs**: Accept and set tmux controller on resumed subagent runtime
- **src/tools/subagent_start.rs**: Accept and set tmux controller on started subagent runtime