### PR TITLE
feat: mouse text selection and clipboard copy/paste in TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.59.0",
+ "x11rb",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,10 +282,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -363,6 +395,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "colorchoice"
@@ -476,6 +517,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +613,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,10 +671,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -811,6 +903,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +978,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1180,6 +1293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1553,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1632,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1635,6 +1845,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-pty"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +1920,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -2269,6 +2504,7 @@ name = "synaps-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arboard",
  "arc-swap",
  "async-trait",
  "axum",
@@ -2445,6 +2681,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3055,6 +3305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3424,6 +3680,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3525,3 +3798,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tower = "0.4"
 tower-http = { version = "0.5", features = ["cors"] }
 tokio-tungstenite = "0.21"
 unicode-width = "0.2.0"
+arboard = "3"
 
 # Shell / PTY deps
 portable-pty = "0.9"

--- a/src/chatui/app.rs
+++ b/src/chatui/app.rs
@@ -106,6 +106,20 @@ pub(crate) struct App {
     /// Channel for receiving async ping results.
     pub(crate) ping_tx: tokio::sync::mpsc::UnboundedSender<(String, synaps_cli::runtime::openai::ping::PingStatus, u64)>,
     pub(crate) ping_rx: tokio::sync::mpsc::UnboundedReceiver<(String, synaps_cli::runtime::openai::ping::PingStatus, u64)>,
+    /// Text selection state for the message area.
+    /// Anchor is where the mouse was first pressed (col, row in terminal coords).
+    /// End is the current drag position. Both are absolute terminal coordinates.
+    pub(crate) selection_anchor: Option<(u16, u16)>,
+    pub(crate) selection_end: Option<(u16, u16)>,
+    /// The message area rect from the last draw, used by input.rs to map mouse
+    /// coordinates to message content.
+    pub(crate) msg_area_rect: Option<ratatui::layout::Rect>,
+    /// The visible line range from the last draw: (start_line_index, end_line_index)
+    /// into the line_cache, so we can extract text from screen coordinates.
+    pub(crate) visible_line_range: Option<(usize, usize)>,
+    /// Suppress the next Event::Paste — set after a right-click copy to prevent
+    /// terminals that auto-paste on right-click from inserting into the input box.
+    pub(crate) suppress_next_paste: bool,
 }
 
 pub(crate) const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -172,6 +186,11 @@ impl App {
             ping_pending: 0,
             ping_tx: ping_tx_init,
             ping_rx: ping_rx_init,
+            selection_anchor: None,
+            selection_end: None,
+            msg_area_rect: None,
+            visible_line_range: None,
+            suppress_next_paste: false,
         }
     }
 
@@ -425,6 +444,95 @@ impl App {
             }
             self.cursor_pos = self.input.chars().count();
         }
+    }
+
+    /// Returns true if there is an active text selection in the message area.
+    pub(crate) fn has_selection(&self) -> bool {
+        self.selection_anchor.is_some() && self.selection_end.is_some()
+    }
+
+    /// Clear the current text selection.
+    pub(crate) fn clear_selection(&mut self) {
+        self.selection_anchor = None;
+        self.selection_end = None;
+    }
+
+    /// Get the normalized selection range: (start_col, start_row, end_col, end_row)
+    /// where start <= end in reading order. Returns None if no selection.
+    pub(crate) fn selection_range(&self) -> Option<(u16, u16, u16, u16)> {
+        let (ac, ar) = self.selection_anchor?;
+        let (ec, er) = self.selection_end?;
+        // Normalize: start is the earlier position in reading order
+        if ar < er || (ar == er && ac <= ec) {
+            Some((ac, ar, ec, er))
+        } else {
+            Some((ec, er, ac, ar))
+        }
+    }
+
+    /// Extract the selected text from the visible line cache.
+    /// Uses msg_area_rect and visible_line_range to map terminal coordinates
+    /// back to line content.
+    pub(crate) fn selected_text(&self) -> Option<String> {
+        let (sc, sr, ec, er) = self.selection_range()?;
+        let rect = self.msg_area_rect?;
+        let (vis_start, vis_end) = self.visible_line_range?;
+        let (_, ref all_lines) = self.line_cache.as_ref()?;
+
+        // The message content area starts at rect.x + 1 (horizontal padding)
+        // and rect.y + 1 (top border)
+        let content_x = rect.x + 1;
+        let content_y = rect.y + 1;
+        let content_h = rect.height.saturating_sub(2) as u16;
+
+        // Convert terminal y-coordinates to line indices
+        let mut result = String::new();
+        for term_y in sr..=er {
+            if term_y < content_y || term_y >= content_y + content_h {
+                continue;
+            }
+            let line_offset = (term_y - content_y) as usize;
+            let line_idx = vis_start + line_offset;
+            if line_idx >= vis_end || line_idx >= all_lines.len() {
+                continue;
+            }
+            let line = &all_lines[line_idx];
+            // Extract text from the line spans
+            let full_text: String = line.spans.iter()
+                .map(|s| s.content.as_ref())
+                .collect();
+
+            // Determine character range on this line
+            let line_start_col = if term_y == sr {
+                (sc.saturating_sub(content_x)) as usize
+            } else {
+                0
+            };
+            let line_end_col = if term_y == er {
+                (ec.saturating_sub(content_x)) as usize
+            } else {
+                full_text.len()
+            };
+
+            let chars: Vec<char> = full_text.chars().collect();
+            let start = line_start_col.min(chars.len());
+            let end = line_end_col.min(chars.len());
+            if start < end {
+                let selected: String = chars[start..end].iter().collect();
+                let trimmed = selected.trim_end();
+                let trimmed = if result.is_empty() {
+                    trimmed.trim_start()
+                } else {
+                    trimmed.strip_prefix("     ").unwrap_or(trimmed)
+                };
+                if !result.is_empty() {
+                    result.push('\n');
+                }
+                result.push_str(trimmed);
+            }
+        }
+
+        if result.is_empty() { None } else { Some(result) }
     }
 
     pub(crate) fn append_or_update_text(&mut self, text: &str) {

--- a/src/chatui/app.rs
+++ b/src/chatui/app.rs
@@ -117,9 +117,11 @@ pub(crate) struct App {
     /// The visible line range from the last draw: (start_line_index, end_line_index)
     /// into the line_cache, so we can extract text from screen coordinates.
     pub(crate) visible_line_range: Option<(usize, usize)>,
-    /// Suppress the next Event::Paste — set after a right-click copy to prevent
-    /// terminals that auto-paste on right-click from inserting into the input box.
-    pub(crate) suppress_next_paste: bool,
+    /// Suppress paste events arriving shortly after a right-click copy/paste.
+    /// Terminals that auto-paste on right-click generate a spurious Event::Paste
+    /// immediately after MouseDown(Right). We suppress only within a short TTL
+    /// window (~150ms) to avoid eating legitimate Ctrl+V pastes.
+    pub(crate) suppress_paste_until: Option<std::time::Instant>,
 }
 
 pub(crate) const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -190,7 +192,7 @@ impl App {
             selection_end: None,
             msg_area_rect: None,
             visible_line_range: None,
-            suppress_next_paste: false,
+            suppress_paste_until: None,
         }
     }
 
@@ -470,20 +472,23 @@ impl App {
         }
     }
 
+    /// Rendering margin used in render.rs for message continuation lines.
+    /// 3-char margin + 2-char content indent = 5 chars total.
+    const MSG_LINE_INDENT: &'static str = "     ";
+
     /// Extract the selected text from the visible line cache.
     /// Uses msg_area_rect and visible_line_range to map terminal coordinates
-    /// back to line content.
+    /// back to line content. msg_area_rect stores the inner content rect
+    /// (after borders/padding), so no offset arithmetic is needed here.
     pub(crate) fn selected_text(&self) -> Option<String> {
         let (sc, sr, ec, er) = self.selection_range()?;
         let rect = self.msg_area_rect?;
         let (vis_start, vis_end) = self.visible_line_range?;
         let (_, ref all_lines) = self.line_cache.as_ref()?;
 
-        // The message content area starts at rect.x + 1 (horizontal padding)
-        // and rect.y + 1 (top border)
-        let content_x = rect.x + 1;
-        let content_y = rect.y + 1;
-        let content_h = rect.height.saturating_sub(2) as u16;
+        let content_x = rect.x;
+        let content_y = rect.y;
+        let content_h = rect.height;
 
         // Convert terminal y-coordinates to line indices
         let mut result = String::new();
@@ -523,7 +528,7 @@ impl App {
                 let trimmed = if result.is_empty() {
                     trimmed.trim_start()
                 } else {
-                    trimmed.strip_prefix("     ").unwrap_or(trimmed)
+                    trimmed.strip_prefix(Self::MSG_LINE_INDENT).unwrap_or(trimmed)
                 };
                 if !result.is_empty() {
                     result.push('\n');

--- a/src/chatui/draw.rs
+++ b/src/chatui/draw.rs
@@ -208,6 +208,41 @@ pub(crate) fn draw(
         frame.render_widget(Clear, msg_area);
         frame.render_widget(messages_widget, msg_area);
 
+        // Save message area geometry so input.rs can map mouse coordinates
+        app.msg_area_rect = Some(msg_area);
+        app.visible_line_range = Some((start, end));
+
+        // Render text selection highlight overlay
+        if let Some((sc, sr, ec, er)) = app.selection_range() {
+            let content_x = msg_area.x + 1; // horizontal padding
+            let content_y = msg_area.y + 1; // top border
+            let content_h = msg_area.height.saturating_sub(2);
+            let content_w = msg_area.width.saturating_sub(2);
+
+            for y in sr..=er {
+                if y < content_y || y >= content_y + content_h {
+                    continue;
+                }
+                let row_start = if y == sr { sc.max(content_x) } else { content_x };
+                let row_end = if y == er { ec.min(content_x + content_w) } else { content_x + content_w };
+
+                for x in row_start..row_end {
+                    if x >= content_x && x < content_x + content_w {
+                        if let Some(cell) = frame.buffer_mut().cell_mut((x, y)) {
+                            // Invert colors for selection highlight
+                            let fg = cell.fg;
+                            let bg = cell.bg;
+                            cell.set_fg(bg);
+                            cell.set_bg(match fg {
+                                Color::Reset => Color::Rgb(100, 140, 180),
+                                other => other,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
         // Empty state: SYNAPS with CRT dismiss animation
         let show_logo = app.messages.is_empty() || app.logo_dismiss_t.is_some();
         if show_logo && visible.is_empty() {

--- a/src/chatui/draw.rs
+++ b/src/chatui/draw.rs
@@ -204,20 +204,23 @@ pub(crate) fn draw(
             .border_type(BorderType::Plain)
             .border_style(Style::default().fg(THEME.load().border))
             .padding(Padding::horizontal(1));
+        // Compute inner rect before block is consumed by Paragraph
+        let msg_inner = msg_block.inner(msg_area);
         let messages_widget = Paragraph::new(visible.clone()).block(msg_block);
         frame.render_widget(Clear, msg_area);
         frame.render_widget(messages_widget, msg_area);
 
-        // Save message area geometry so input.rs can map mouse coordinates
-        app.msg_area_rect = Some(msg_area);
+        // Save inner content rect (after borders + padding) so input.rs can
+        // map mouse coordinates without hardcoded offsets.
+        app.msg_area_rect = Some(msg_inner);
         app.visible_line_range = Some((start, end));
 
         // Render text selection highlight overlay
         if let Some((sc, sr, ec, er)) = app.selection_range() {
-            let content_x = msg_area.x + 1; // horizontal padding
-            let content_y = msg_area.y + 1; // top border
-            let content_h = msg_area.height.saturating_sub(2);
-            let content_w = msg_area.width.saturating_sub(2);
+            let content_x = msg_inner.x;
+            let content_y = msg_inner.y;
+            let content_h = msg_inner.height;
+            let content_w = msg_inner.width;
 
             for y in sr..=er {
                 if y < content_y || y >= content_y + content_h {
@@ -234,7 +237,7 @@ pub(crate) fn draw(
                             let bg = cell.bg;
                             cell.set_fg(bg);
                             cell.set_bg(match fg {
-                                Color::Reset => Color::Rgb(100, 140, 180),
+                                Color::Reset => THEME.load().border_active,
                                 other => other,
                             });
                         }

--- a/src/chatui/input.rs
+++ b/src/chatui/input.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crossterm::event::{KeyCode, KeyModifiers, MouseEventKind, Event};
+use crossterm::event::{KeyCode, KeyModifiers, MouseEventKind, MouseButton, Event};
 use synaps_cli::skills::registry::CommandRegistry;
 use super::app::{App, ChatMessage};
 
@@ -129,22 +129,16 @@ pub(super) fn handle_event(
     match event {
         Event::Key(key) => handle_key(key.code, key.modifiers, app, streaming, registry),
         Event::Mouse(mouse) => {
-            match mouse.kind {
-                MouseEventKind::ScrollUp => {
-                    app.scroll_back = app.scroll_back.saturating_add(3);
-                    app.scroll_pinned = false;
-                }
-                MouseEventKind::ScrollDown => {
-                    app.scroll_back = app.scroll_back.saturating_sub(3);
-                    if app.scroll_back == 0 {
-                        app.scroll_pinned = true;
-                    }
-                }
-                _ => {}
-            }
-            InputAction::None
+            handle_mouse(mouse, app)
         }
         Event::Paste(text) => {
+            // Suppress paste events that fire immediately after a right-click copy.
+            // Some terminals send both a Mouse(Down(Right)) AND an Event::Paste
+            // when the user right-clicks, causing unintended paste into the input box.
+            if app.suppress_next_paste {
+                app.suppress_next_paste = false;
+                return InputAction::None;
+            }
             const MAX_PASTE_CHARS: usize = 100_000;
             if !streaming || !app.input.is_empty() {
                 let text = if text.chars().count() > MAX_PASTE_CHARS {
@@ -170,6 +164,124 @@ pub(super) fn handle_event(
     }
 }
 
+/// Handle mouse events: scroll, text selection (left drag), right-click copy/paste.
+fn handle_mouse(mouse: crossterm::event::MouseEvent, app: &mut App) -> InputAction {
+    match mouse.kind {
+        MouseEventKind::ScrollUp => {
+            app.clear_selection();
+            app.scroll_back = app.scroll_back.saturating_add(3);
+            app.scroll_pinned = false;
+        }
+        MouseEventKind::ScrollDown => {
+            app.clear_selection();
+            app.scroll_back = app.scroll_back.saturating_sub(3);
+            if app.scroll_back == 0 {
+                app.scroll_pinned = true;
+            }
+        }
+
+        // Left-click starts a new selection (clears any existing one)
+        MouseEventKind::Down(MouseButton::Left) => {
+            // Only start selection if click is inside the message area
+            if is_in_msg_area(app, mouse.column, mouse.row) {
+                app.selection_anchor = Some((mouse.column, mouse.row));
+                app.selection_end = None;
+            } else {
+                app.clear_selection();
+            }
+        }
+
+        // Left-drag extends the selection
+        MouseEventKind::Drag(MouseButton::Left) => {
+            if app.selection_anchor.is_some() {
+                app.selection_end = Some((mouse.column, mouse.row));
+            }
+        }
+
+        // Left-release finalizes the selection
+        MouseEventKind::Up(MouseButton::Left) => {
+            if let Some(anchor) = app.selection_anchor {
+                let end = (mouse.column, mouse.row);
+                // If start == end, it was a click not a drag — clear selection
+                if anchor == end {
+                    app.clear_selection();
+                } else {
+                    app.selection_end = Some(end);
+                }
+            }
+        }
+
+        // Right-click: copy if selection exists, paste if not
+        MouseEventKind::Down(MouseButton::Right) => {
+            if app.has_selection() {
+                // Copy selected text to clipboard — right-click with selection is COPY ONLY
+                if let Some(text) = app.selected_text() {
+                    copy_to_clipboard(&text);
+                    app.push_msg(ChatMessage::System(format!("Copied {} chars", text.chars().count())));
+                }
+                // Suppress any terminal-generated paste event that follows this right-click
+                app.suppress_next_paste = true;
+                // Clear selection after copy
+                app.clear_selection();
+            } else {
+                // No selection — paste from clipboard at cursor position
+                if let Some(text) = paste_from_clipboard() {
+                    if !text.is_empty() {
+                        if app.input_before_paste.is_none() {
+                            app.input_before_paste = Some(app.input.clone());
+                        }
+                        let byte_pos = app.cursor_byte_pos();
+                        app.input.insert_str(byte_pos, &text);
+                        app.cursor_pos += text.chars().count();
+                        app.pasted_char_count += text.chars().count();
+                    }
+                }
+                // Suppress the terminal-generated paste event that follows this right-click
+                app.suppress_next_paste = true;
+            }
+        }
+
+        _ => {}
+    }
+    InputAction::None
+}
+
+/// Check if a terminal coordinate is inside the message area.
+fn is_in_msg_area(app: &App, col: u16, row: u16) -> bool {
+    if let Some(rect) = app.msg_area_rect {
+        col >= rect.x && col < rect.x + rect.width
+            && row >= rect.y + 1 && row < rect.y + rect.height.saturating_sub(1)
+    } else {
+        false
+    }
+}
+
+/// Copy text to system clipboard. Spawns a background thread to hold
+/// clipboard ownership long enough for clipboard managers to read it
+/// (X11/Wayland require the owner process to serve selection requests).
+fn copy_to_clipboard(text: &str) {
+    let text = text.to_string();
+    std::thread::spawn(move || {
+        if let Ok(mut clipboard) = arboard::Clipboard::new() {
+            let _ = clipboard.set_text(&text);
+            // Hold ownership so clipboard managers / other apps can read it
+            std::thread::sleep(std::time::Duration::from_secs(5));
+        }
+    });
+}
+
+/// Read text from system clipboard. Returns None if clipboard is empty or inaccessible.
+fn paste_from_clipboard() -> Option<String> {
+    if let Ok(mut clipboard) = arboard::Clipboard::new() {
+        if let Ok(text) = clipboard.get_text() {
+            if !text.is_empty() {
+                return Some(text);
+            }
+        }
+    }
+    None
+}
+
 /// Handle a key event.
 fn handle_key(
     code: KeyCode,
@@ -178,6 +290,8 @@ fn handle_key(
     streaming: bool,
     registry: &Arc<CommandRegistry>,
 ) -> InputAction {
+    // Clear text selection on any keypress (typing dismisses selection)
+    app.clear_selection();
     // Any non-Tab key resets the tab-completion cycle state. (Tab handler
     // below returns early after setting its own cycle state.)
     if !matches!(code, KeyCode::Tab) {

--- a/src/chatui/input.rs
+++ b/src/chatui/input.rs
@@ -135,9 +135,12 @@ pub(super) fn handle_event(
             // Suppress paste events that fire immediately after a right-click copy.
             // Some terminals send both a Mouse(Down(Right)) AND an Event::Paste
             // when the user right-clicks, causing unintended paste into the input box.
-            if app.suppress_next_paste {
-                app.suppress_next_paste = false;
-                return InputAction::None;
+            if let Some(deadline) = app.suppress_paste_until {
+                if std::time::Instant::now() < deadline {
+                    app.suppress_paste_until = None;
+                    return InputAction::None;
+                }
+                app.suppress_paste_until = None;
             }
             const MAX_PASTE_CHARS: usize = 100_000;
             if !streaming || !app.input.is_empty() {
@@ -220,7 +223,7 @@ fn handle_mouse(mouse: crossterm::event::MouseEvent, app: &mut App) -> InputActi
                     app.push_msg(ChatMessage::System(format!("Copied {} chars", text.chars().count())));
                 }
                 // Suppress any terminal-generated paste event that follows this right-click
-                app.suppress_next_paste = true;
+                app.suppress_paste_until = Some(std::time::Instant::now() + std::time::Duration::from_millis(150));
                 // Clear selection after copy
                 app.clear_selection();
             } else {
@@ -237,7 +240,7 @@ fn handle_mouse(mouse: crossterm::event::MouseEvent, app: &mut App) -> InputActi
                     }
                 }
                 // Suppress the terminal-generated paste event that follows this right-click
-                app.suppress_next_paste = true;
+                app.suppress_paste_until = Some(std::time::Instant::now() + std::time::Duration::from_millis(150));
             }
         }
 
@@ -246,28 +249,34 @@ fn handle_mouse(mouse: crossterm::event::MouseEvent, app: &mut App) -> InputActi
     InputAction::None
 }
 
-/// Check if a terminal coordinate is inside the message area.
+/// Check if a terminal coordinate is inside the message content area.
+/// msg_area_rect stores the inner rect (after borders/padding), so no offset needed.
 fn is_in_msg_area(app: &App, col: u16, row: u16) -> bool {
     if let Some(rect) = app.msg_area_rect {
         col >= rect.x && col < rect.x + rect.width
-            && row >= rect.y + 1 && row < rect.y + rect.height.saturating_sub(1)
+            && row >= rect.y && row < rect.y + rect.height
     } else {
         false
     }
 }
 
-/// Copy text to system clipboard. Spawns a background thread to hold
-/// clipboard ownership long enough for clipboard managers to read it
-/// (X11/Wayland require the owner process to serve selection requests).
+/// Copy text to system clipboard. Uses a singleton background thread that
+/// holds one clipboard handle for the lifetime of the app. New copies replace
+/// the previous content atomically — no thread accumulation, no races.
 fn copy_to_clipboard(text: &str) {
-    let text = text.to_string();
-    std::thread::spawn(move || {
-        if let Ok(mut clipboard) = arboard::Clipboard::new() {
-            let _ = clipboard.set_text(&text);
-            // Hold ownership so clipboard managers / other apps can read it
-            std::thread::sleep(std::time::Duration::from_secs(5));
-        }
+    use std::sync::{OnceLock, mpsc};
+    static TX: OnceLock<mpsc::Sender<String>> = OnceLock::new();
+    let sender = TX.get_or_init(|| {
+        let (tx, rx) = mpsc::channel::<String>();
+        std::thread::spawn(move || {
+            let Ok(mut clipboard) = arboard::Clipboard::new() else { return };
+            while let Ok(text) = rx.recv() {
+                let _ = clipboard.set_text(&text);
+            }
+        });
+        tx
     });
+    let _ = sender.send(text.to_string());
 }
 
 /// Read text from system clipboard. Returns None if clipboard is empty or inaccessible.


### PR DESCRIPTION
Adds mouse-driven text selection and clipboard integration to the chat UI.

## Changes
- **arboard** crate for cross-platform clipboard (macOS/Linux/Windows)
- **Left-click + drag** to select text in the message area
- **Right-click with selection** → copy to clipboard
- **Right-click without selection** → paste from clipboard into input
- Selection rendered as **inverted colors** overlay
- Suppresses spurious paste events after right-click copy
- Selection clears on any keypress or scroll

## Files
- `Cargo.toml` / `Cargo.lock` — add `arboard = "3"`
- `src/chatui/app.rs` — selection state + extraction logic
- `src/chatui/draw.rs` — highlight overlay rendering
- `src/chatui/input.rs` — mouse handler + clipboard functions