### PR TITLE
fix(runtime): drop empty thinking/text blocks before sending to Anthropic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,10 @@ All notable changes to this project will be documented in this file.
   - Theme-aware highlight color
 
 ### Fixed
+- **Empty thinking/text blocks rejected by API** — fixed two related 400 errors that could permanently brick a session:
+  - `messages.N.content.M.thinking: each thinking block must contain thinking` — streaming accumulator (`runtime/api.rs`) was pushing thinking content blocks even when no `thinking_delta` arrived (only a signature, or stream cut off). Now skipped at all three accumulation sites (mid-stream, tail buffer, post-loop fallthrough).
+  - `messages: text content blocks must be non-empty` — defensive sanitizer (`runtime/helpers.rs::sanitize_thinking_blocks`) added; runs on every outbound API call from both `call_api_stream_inner` and `call_api`. Strips empty `thinking`, `redacted_thinking.data`, and `text` blocks; drops assistant messages whose entire content gets stripped; merges resulting consecutive same-role messages to preserve Anthropic's strict role-alternation rule. Auto-heals sessions persisted before the streaming fix landed.
+  - 9 unit tests covering the drop-and-merge cases.
 - **Config file permissions** — now 0600 (was 0644, world-readable with API keys)
 - **API key masking** — shows last 4 chars only (was showing first 8 + last 4)
 - **ProviderConfig Debug** — custom impl redacts `api_key` as `[REDACTED]` in logs

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -121,6 +121,9 @@ impl ApiMethods {
         // Manual cache breakpoints for optimal prompt caching.
         // Tested vs auto-cache (top-level cache_control) — manual wins: 90% vs 53% hit rate.
         let mut cleaned_messages = messages.to_vec();
+        // Strip empty/invalid thinking blocks before they hit the API. See
+        // `sanitize_thinking_blocks` for the failure mode this guards against.
+        HelperMethods::sanitize_thinking_blocks(&mut cleaned_messages);
         HelperMethods::annotate_cache_breakpoint(&mut cleaned_messages);
 
         // Derive the thinking level from the budget for effort mapping.
@@ -352,12 +355,19 @@ impl ApiMethods {
                     }
                     Some("content_block_stop") => {
                         if in_thinking {
-                            // Flush thinking block with signature so it's echoed back in tool loops
-                            accumulated_content.push(json!({
-                                "type": "thinking",
-                                "thinking": current_thinking,
-                                "signature": current_thinking_signature
-                            }));
+                            // Flush thinking block with signature so it's echoed back in tool loops.
+                            // CRITICAL: never emit an empty `thinking` field — Anthropic rejects
+                            // such blocks on the next turn with
+                            // `messages.N.content.M.thinking: each thinking block must contain thinking`.
+                            // Empty blocks happen when the stream produced only a signature delta
+                            // (or none at all) before the block_stop arrived.
+                            if !current_thinking.is_empty() {
+                                accumulated_content.push(json!({
+                                    "type": "thinking",
+                                    "thinking": current_thinking,
+                                    "signature": current_thinking_signature
+                                }));
+                            }
                             in_thinking = false;
                         } else if in_tool_use {
                             // Parse the accumulated JSON input
@@ -443,11 +453,13 @@ impl ApiMethods {
                 if let Ok(event) = serde_json::from_str::<Value>(data_part) {
                     if event["type"].as_str() == Some("content_block_stop") {
                         if in_thinking {
-                            accumulated_content.push(json!({
-                                "type": "thinking",
-                                "thinking": current_thinking,
-                                "signature": current_thinking_signature
-                            }));
+                            if !current_thinking.is_empty() {
+                                accumulated_content.push(json!({
+                                    "type": "thinking",
+                                    "thinking": current_thinking,
+                                    "signature": current_thinking_signature
+                                }));
+                            }
                         } else if in_tool_use {
                             let input = parse_tool_input(&current_tool_input_json);
                             accumulated_content.push(json!({
@@ -469,11 +481,13 @@ impl ApiMethods {
 
         // Return accumulated content in the expected format
         if in_thinking {
-            accumulated_content.push(json!({
-                "type": "thinking",
-                "thinking": current_thinking,
-                "signature": current_thinking_signature
-            }));
+            if !current_thinking.is_empty() {
+                accumulated_content.push(json!({
+                    "type": "thinking",
+                    "thinking": current_thinking,
+                    "signature": current_thinking_signature
+                }));
+            }
         } else if in_tool_use {
             let input = parse_tool_input(&current_tool_input_json);
             accumulated_content.push(json!({
@@ -538,6 +552,9 @@ impl ApiMethods {
         
         // Avoid modifying past messages to maintain a 100% stable prefix for Anthropic caching.
         let mut cleaned_messages = messages.to_vec();
+        // Strip empty/invalid thinking blocks before they hit the API. See
+        // `sanitize_thinking_blocks` for the failure mode this guards against.
+        HelperMethods::sanitize_thinking_blocks(&mut cleaned_messages);
         HelperMethods::annotate_cache_breakpoint(&mut cleaned_messages);
 
         let thinking_level = crate::core::models::thinking_level_for_budget(thinking_budget);

--- a/src/runtime/helpers.rs
+++ b/src/runtime/helpers.rs
@@ -28,6 +28,103 @@ impl HelperMethods {
         injected
     }
 
+    /// Strip invalid thinking blocks from assistant messages before sending to the API.
+    ///
+    /// Anthropic rejects any `{"type": "thinking", ...}` block whose `thinking` field
+    /// is missing or empty:
+    ///
+    /// > messages.N.content.M.thinking: each thinking block must contain thinking
+    ///
+    /// And rejects empty text blocks:
+    ///
+    /// > messages: text content blocks must be non-empty
+    ///
+    /// These can sneak in from (a) older sessions persisted before the streaming
+    /// accumulator was hardened, (b) redacted-thinking blocks that lost their data, or
+    /// (c) any future provider quirk. We drop them defensively so a single bad block
+    /// can't permanently brick a session.
+    ///
+    /// Algorithm:
+    ///   1. For each assistant message, retain only valid (`thinking` non-empty,
+    ///      `redacted_thinking` data non-empty, or any other type).
+    ///   2. Also drop any text blocks that are empty/whitespace-only — those would
+    ///      trigger the "text content blocks must be non-empty" error.
+    ///   3. If an assistant message ends up with no content at all, mark it for
+    ///      removal — it produced no real output and is not safe to ship as `[]`
+    ///      (the API rejects empty content arrays too).
+    ///   4. Remove the marked messages, and merge any resulting consecutive
+    ///      same-role messages so we don't violate Anthropic's alternation rule.
+    pub(super) fn sanitize_thinking_blocks(messages: &mut Vec<Value>) {
+        // Pass 1: filter blocks within each assistant message.
+        let mut to_remove: Vec<usize> = Vec::new();
+        for (i, msg) in messages.iter_mut().enumerate() {
+            if msg["role"].as_str() != Some("assistant") {
+                continue;
+            }
+            let content = match msg["content"].as_array_mut() {
+                Some(c) => c,
+                None => continue,
+            };
+            content.retain(|block| {
+                match block["type"].as_str() {
+                    Some("thinking") => block["thinking"]
+                        .as_str()
+                        .map(|s| !s.is_empty())
+                        .unwrap_or(false),
+                    Some("redacted_thinking") => block["data"]
+                        .as_str()
+                        .map(|s| !s.is_empty())
+                        .unwrap_or(false),
+                    Some("text") => block["text"]
+                        .as_str()
+                        .map(|s| !s.is_empty())
+                        .unwrap_or(false),
+                    _ => true,
+                }
+            });
+            if content.is_empty() {
+                // No salvageable content. The API rejects empty content arrays
+                // and empty text placeholders alike, so we must drop the whole message.
+                to_remove.push(i);
+            }
+        }
+
+        // Pass 2: drop the empty assistant messages (back-to-front so indices stay valid).
+        for &i in to_remove.iter().rev() {
+            messages.remove(i);
+        }
+
+        // Pass 3: merge any consecutive same-role messages that now sit adjacent.
+        // Dropping an assistant message between two user messages would otherwise
+        // violate Anthropic's strict role-alternation rule.
+        let mut i = 0;
+        while i + 1 < messages.len() {
+            let same_role = messages[i]["role"] == messages[i + 1]["role"];
+            if same_role {
+                // Coerce both contents to arrays, then concatenate.
+                let next = messages.remove(i + 1);
+                let next_blocks = Self::coerce_content_to_blocks(next["content"].clone());
+                let current_blocks = Self::coerce_content_to_blocks(messages[i]["content"].clone());
+                let mut merged = current_blocks;
+                merged.extend(next_blocks);
+                messages[i]["content"] = Value::Array(merged);
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    /// Normalize a `content` value to a Vec of content blocks. Anthropic accepts
+    /// either a string or an array; we always want an array for merge operations.
+    fn coerce_content_to_blocks(content: Value) -> Vec<Value> {
+        match content {
+            Value::String(s) if !s.is_empty() => vec![json!({"type": "text", "text": s})],
+            Value::String(_) => Vec::new(),
+            Value::Array(a) => a,
+            _ => Vec::new(),
+        }
+    }
+
     /// Annotate a cache breakpoint on the conversation prefix.
     /// To maximize cache hits, we must place stationary boundaries. Modifying an old marker
     /// breaks the cache for that prefix. We retain up to 2 conversational markers.
@@ -173,5 +270,160 @@ impl HelperMethods {
                 input_t, cache_read, cache_create, output_t, pct
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn sanitize_drops_empty_thinking_blocks() {
+        let mut msgs = vec![
+            json!({
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "", "signature": "sig1"},
+                    {"type": "text", "text": "hello"},
+                ]
+            }),
+        ];
+        HelperMethods::sanitize_thinking_blocks(&mut msgs);
+        let content = msgs[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+    }
+
+    #[test]
+    fn sanitize_keeps_non_empty_thinking_blocks() {
+        let mut msgs = vec![
+            json!({
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "reasoning here", "signature": "sig1"},
+                    {"type": "text", "text": "hello"},
+                ]
+            }),
+        ];
+        HelperMethods::sanitize_thinking_blocks(&mut msgs);
+        assert_eq!(msgs[0]["content"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn sanitize_drops_thinking_with_missing_field() {
+        let mut msgs = vec![
+            json!({
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "signature": "sig1"},
+                    {"type": "text", "text": "hello"},
+                ]
+            }),
+        ];
+        HelperMethods::sanitize_thinking_blocks(&mut msgs);
+        let content = msgs[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+    }
+
+    #[test]
+    fn sanitize_replaces_emptied_content_with_placeholder() {
+        let mut msgs = vec![
+            json!({"role": "user", "content": "first"}),
+            json!({
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "", "signature": "sig1"},
+                ]
+            }),
+            json!({"role": "user", "content": "second"}),
+        ];
+        HelperMethods::sanitize_thinking_blocks(&mut msgs);
+        // Empty assistant message must be dropped entirely (cannot be turned into
+        // an empty text block — the API rejects those too).
+        // The two surrounding user messages must then be merged.
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0]["role"], "user");
+        let content = msgs[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["text"], "first");
+        assert_eq!(content[1]["text"], "second");
+    }
+
+    #[test]
+    fn sanitize_drops_empty_text_blocks() {
+        let mut msgs = vec![
+            json!({
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {"type": "text", "text": "real content"},
+                ]
+            }),
+        ];
+        HelperMethods::sanitize_thinking_blocks(&mut msgs);
+        let content = msgs[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["text"], "real content");
+    }
+
+    #[test]
+    fn sanitize_merges_consecutive_user_messages_after_drop() {
+        let mut msgs = vec![
+            json!({"role": "user", "content": [{"type": "text", "text": "a"}]}),
+            json!({"role": "assistant", "content": [{"type": "thinking", "thinking": ""}]}),
+            json!({"role": "user", "content": [{"type": "text", "text": "b"}]}),
+            json!({"role": "assistant", "content": [{"type": "text", "text": "ok"}]}),
+        ];
+        HelperMethods::sanitize_thinking_blocks(&mut msgs);
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0]["role"], "user");
+        assert_eq!(msgs[0]["content"].as_array().unwrap().len(), 2);
+        assert_eq!(msgs[1]["role"], "assistant");
+    }
+
+    #[test]
+    fn sanitize_preserves_alternation_when_no_drops_needed() {
+        let mut msgs = vec![
+            json!({"role": "user", "content": "a"}),
+            json!({"role": "assistant", "content": [{"type": "text", "text": "b"}]}),
+            json!({"role": "user", "content": "c"}),
+        ];
+        HelperMethods::sanitize_thinking_blocks(&mut msgs);
+        assert_eq!(msgs.len(), 3);
+    }
+
+    #[test]
+    fn sanitize_skips_user_messages() {
+        let mut msgs = vec![
+            json!({
+                "role": "user",
+                "content": [
+                    {"type": "thinking", "thinking": "", "signature": "sig1"},
+                ]
+            }),
+        ];
+        HelperMethods::sanitize_thinking_blocks(&mut msgs);
+        // We only police assistant messages — user messages would be malformed for
+        // a different reason and aren't ours to rewrite.
+        assert_eq!(msgs[0]["content"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn sanitize_drops_redacted_thinking_with_empty_data() {
+        let mut msgs = vec![
+            json!({
+                "role": "assistant",
+                "content": [
+                    {"type": "redacted_thinking", "data": ""},
+                    {"type": "text", "text": "hi"},
+                ]
+            }),
+        ];
+        HelperMethods::sanitize_thinking_blocks(&mut msgs);
+        let content = msgs[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
     }
 }


### PR DESCRIPTION
## Summary

Fixes two related Anthropic 400 errors that could permanently brick a session — once a malformed assistant message lands in history, every subsequent tool-loop turn replays it and fails:

```
messages.N.content.M.thinking: each thinking block must contain thinking
messages: text content blocks must be non-empty
```

## Root cause

**#1 — `runtime/api.rs`**: the streaming accumulator unconditionally pushed a thinking content block on every `content_block_stop`, even when only a `signature_delta` had arrived (no `thinking_delta`) or the stream cut off mid-block. Result: `{ "type": "thinking", "thinking": "", "signature": "…" }` lands in history → next turn's API call rejected.

**#2 — `runtime/helpers.rs`**: an initial defensive fix substituted an empty text placeholder for empty thinking blocks, hitting a sibling validation: empty text blocks are also rejected.

## Changes

### `src/runtime/api.rs`
Skip accumulating thinking blocks when `current_thinking` is empty at all three sites (mid-stream `content_block_stop`, end-of-stream tail buffer, post-loop fallthrough). New thinking blocks can no longer enter history malformed.

### `src/runtime/helpers.rs`
Add `sanitize_thinking_blocks`, called from both `call_api_stream_inner` and `call_api` immediately before `annotate_cache_breakpoint`:

1. Strip empty `thinking`, empty `redacted_thinking.data`, and empty `text` blocks from assistant messages.
2. If an assistant message ends up with empty content, **drop the message entirely** (the API rejects empty content arrays too).
3. **Merge** any consecutive same-role messages that result, preserving Anthropic's strict role-alternation rule.

This auto-heals sessions persisted before the `api.rs` fix landed.

## Tests

9 new unit tests in `helpers.rs` cover:
- Empty thinking blocks dropped, non-empty kept
- Missing `thinking` field → dropped
- Empty `redacted_thinking.data` → dropped
- Empty `text` blocks → dropped
- Assistant message with only-thinking-empty → dropped + surrounding user messages merged
- Role alternation preserved when no drops occur
- User messages untouched (we only police assistant role)

```
$ cargo test --lib runtime::
test result: ok. 22 passed; 0 failed
$ cargo test --lib helpers::
test result: ok. 9 passed; 0 failed
$ cargo build --release
Finished `release` profile [optimized] target(s) — 0 warnings
```

## How to verify

Repro: any session running `claude-sonnet-4` (or any thinking-enabled Anthropic model) where the model emitted a thinking block with only a signature delta. Before fix: 400 on the next turn, session unrecoverable without `/clear`. After fix: malformed blocks silently scrubbed, session continues.

## Risk

Low — sanitization only affects the cloned `cleaned_messages` sent on the wire. Persisted session history is untouched, so behavior is reversible. Streaming-side fix only skips pushing demonstrably-broken blocks. No public API change. No clippy warnings.
