### PR TITLE
fix: sanitize API tool schemas

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -339,6 +339,7 @@ impl Runtime {
                         let input = &tool_use["input"];
                         let result = match self.tools.read().await.get(tool_name).cloned() {
                             Some(tool) => {
+                                let input = self.tools.read().await.translate_input_for_api_tool(tool_name, input.clone());
                                 let ctx = crate::ToolContext {
                                     channels: crate::tools::ToolChannels {
                                         tx_delta: None,
@@ -358,7 +359,7 @@ impl Runtime {
                                         subagent_timeout: self.subagent_timeout,
                                     },
                                 };
-                                match tool.execute(input.clone(), ctx).await {
+                                match tool.execute(input, ctx).await {
                                     Ok(output) => output,
                                     Err(e) => format!("Tool execution failed: {}", e),
                                 }
@@ -390,7 +391,10 @@ impl Runtime {
                             tool_use["id"].as_str().map(|s| s.to_string()),
                         ) {
                             let input = tool_use["input"].clone();
-                            let tool = self.tools.read().await.get(&tool_name).cloned();
+                            let tools_snapshot = self.tools.read().await;
+                            let input = tools_snapshot.translate_input_for_api_tool(&tool_name, input);
+                            let tool = tools_snapshot.get(&tool_name).cloned();
+                            drop(tools_snapshot);
                             let exit_path = self.watcher_exit_path.clone();
                             let session_mgr_inner = session_mgr.clone();
                             let registry_inner = cfg_subagent_registry.clone();

--- a/src/runtime/openai/stream.rs
+++ b/src/runtime/openai/stream.rs
@@ -27,8 +27,8 @@ pub(crate) async fn call_oai_stream_inner(
     max_tokens: Option<u32>,
     cancel: &tokio_util::sync::CancellationToken,
 ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
-    let oai_messages = translate::messages_to_oai(messages, system_prompt);
-    let oai_tools = translate::tools_to_oai(tools_schema);
+    let (oai_tools, name_map) = translate::tools_to_oai(tools_schema);
+    let oai_messages = translate::messages_to_oai(messages, system_prompt, &name_map);
     let tools_opt = if oai_tools.is_empty() { None } else { Some(oai_tools) };
 
     // Google's OpenAI-compat endpoint rejects stream_options
@@ -103,7 +103,7 @@ pub(crate) async fn call_oai_stream_inner(
 
             sink.clear();
             decoder.push_line(line, &mut sink);
-            handle_events(&sink, tx, &mut accumulated_text, &mut tool_use_blocks);
+            handle_events(&sink, tx, &mut accumulated_text, &mut tool_use_blocks, &name_map);
         }
     }
 
@@ -112,11 +112,11 @@ pub(crate) async fn call_oai_stream_inner(
         let line = std::str::from_utf8(&buf).unwrap_or("");
         sink.clear();
         decoder.push_line(line, &mut sink);
-        handle_events(&sink, tx, &mut accumulated_text, &mut tool_use_blocks);
+        handle_events(&sink, tx, &mut accumulated_text, &mut tool_use_blocks, &name_map);
     }
     sink.clear();
     decoder.finish(&mut sink);
-    handle_events(&sink, tx, &mut accumulated_text, &mut tool_use_blocks);
+    handle_events(&sink, tx, &mut accumulated_text, &mut tool_use_blocks, &name_map);
 
     // Build Anthropic-shaped final response
     let mut content: Vec<Value> = Vec::new();
@@ -136,13 +136,14 @@ fn handle_events(
     tx: &mpsc::UnboundedSender<StreamEvent>,
     text_acc: &mut String,
     tool_blocks: &mut Vec<Value>,
+    name_map: &translate::ToolNameMap,
 ) {
     for ev in events {
         if let OaiEvent::TextDelta(t) = ev {
             text_acc.push_str(t);
         }
         if let OaiEvent::ToolCallsComplete { calls, .. } = ev {
-            tool_blocks.extend(translate::tool_calls_to_content_blocks(calls));
+            tool_blocks.extend(translate::tool_calls_to_content_blocks(calls, name_map));
         }
         if let Some(se) = translate::oai_event_to_llm(ev) {
             let _ = tx.send(se);

--- a/src/runtime/openai/translate.rs
+++ b/src/runtime/openai/translate.rs
@@ -3,13 +3,62 @@
 use super::types::{ChatMessage, FunctionCall, FunctionDefinition, OaiEvent, ToolCall, ToolDefinition};
 use crate::runtime::types::{LlmEvent, SessionEvent, StreamEvent};
 use serde_json::{json, Value};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Default)]
+pub struct ToolNameMap {
+    original_to_oai: HashMap<String, String>,
+    oai_to_original: HashMap<String, String>,
+}
+
+impl ToolNameMap {
+    pub fn to_oai<'a>(&'a self, name: &'a str) -> &'a str {
+        self.original_to_oai.get(name).map(String::as_str).unwrap_or(name)
+    }
+
+    pub fn to_original<'a>(&'a self, name: &'a str) -> &'a str {
+        self.oai_to_original.get(name).map(String::as_str).unwrap_or(name)
+    }
+
+    fn insert(&mut self, original: &str, oai: &str) {
+        if original != oai {
+            self.original_to_oai.insert(original.to_string(), oai.to_string());
+            self.oai_to_original.insert(oai.to_string(), original.to_string());
+        }
+    }
+}
+
+/// OpenAI function names must match `^[a-zA-Z0-9_-]+$`. Synaps/MCP names may
+/// contain namespace separators like `:` or `.`, so sanitize only for the
+/// OpenAI wire format and map back before tool execution.
+fn sanitize_oai_tool_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        "tool".to_string()
+    } else {
+        if out.len() > 128 {
+            out.truncate(128);
+        }
+        out
+    }
+}
 
 /// Convert Anthropic tool schema entries to OpenAI ToolDefinitions.
 ///
 /// Anthropic shape: `{"name", "description", "input_schema", optional cache_control}`.
 /// OpenAI shape:    `{"type": "function", "function": {"name", "description", "parameters"}}`.
-pub fn tools_to_oai(schema: &[Value]) -> Vec<ToolDefinition> {
-    schema
+pub fn tools_to_oai(schema: &[Value]) -> (Vec<ToolDefinition>, ToolNameMap) {
+    let mut name_map = ToolNameMap::default();
+    let mut used_names: HashMap<String, String> = HashMap::new();
+
+    let tools = schema
         .iter()
         .filter_map(|t| {
             let name = t.get("name")?.as_str()?.to_string();
@@ -17,6 +66,20 @@ pub fn tools_to_oai(schema: &[Value]) -> Vec<ToolDefinition> {
             if name.is_empty() || name == "respond" || name == "send_channel" || name == "watcher_exit" {
                 return None;
             }
+            let mut oai_name = sanitize_oai_tool_name(&name);
+            if let Some(existing) = used_names.get(&oai_name) {
+                if existing != &name {
+                    let base = oai_name.clone();
+                    let mut suffix = 2;
+                    while used_names.contains_key(&oai_name) {
+                        oai_name = format!("{base}_{suffix}");
+                        suffix += 1;
+                    }
+                }
+            }
+            used_names.insert(oai_name.clone(), name.clone());
+            name_map.insert(&name, &oai_name);
+
             let description = t
                 .get("description")
                 .and_then(|d| d.as_str())
@@ -28,13 +91,15 @@ pub fn tools_to_oai(schema: &[Value]) -> Vec<ToolDefinition> {
             Some(ToolDefinition {
                 kind: "function".to_string(),
                 function: FunctionDefinition {
-                    name,
+                    name: oai_name,
                     description,
                     parameters,
                 },
             })
         })
-        .collect()
+        .collect();
+
+    (tools, name_map)
 }
 
 /// Convert Anthropic-shaped message list + optional system prompt into
@@ -42,6 +107,7 @@ pub fn tools_to_oai(schema: &[Value]) -> Vec<ToolDefinition> {
 pub fn messages_to_oai(
     anthropic_messages: &[Value],
     system_prompt: &Option<String>,
+    name_map: &ToolNameMap,
 ) -> Vec<ChatMessage> {
     let mut out: Vec<ChatMessage> = Vec::new();
 
@@ -63,7 +129,7 @@ pub fn messages_to_oai(
                             block.get("id").and_then(|v| v.as_str()),
                             block.get("name").and_then(|v| v.as_str()),
                         ) {
-                            tool_name_map.insert(id.to_string(), name.to_string());
+                            tool_name_map.insert(id.to_string(), name_map.to_oai(name).to_string());
                         }
                     }
                 }
@@ -146,8 +212,8 @@ pub fn messages_to_oai(
                                 let name = block
                                     .get("name")
                                     .and_then(|v| v.as_str())
-                                    .unwrap_or("")
-                                    .to_string();
+                                    .map(|n| name_map.to_oai(n).to_string())
+                                    .unwrap_or_default();
                                 let arguments = block
                                     .get("input")
                                     .map(|v| v.to_string())
@@ -231,7 +297,7 @@ pub fn oai_event_to_llm(event: &OaiEvent) -> Option<StreamEvent> {
 }
 
 /// Convert an OpenAI tool-call list into Anthropic-shaped `tool_use` content blocks.
-pub fn tool_calls_to_content_blocks(calls: &[ToolCall]) -> Vec<Value> {
+pub fn tool_calls_to_content_blocks(calls: &[ToolCall], name_map: &ToolNameMap) -> Vec<Value> {
     calls
         .iter()
         .map(|c| {
@@ -239,7 +305,7 @@ pub fn tool_calls_to_content_blocks(calls: &[ToolCall]) -> Vec<Value> {
             json!({
                 "type": "tool_use",
                 "id": c.id,
-                "name": c.function.name,
+                "name": name_map.to_original(&c.function.name),
                 "input": input,
             })
         })

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -181,6 +181,7 @@ impl StreamMethods {
                     } else if !tool_id.is_empty() && !tool_name.is_empty() {
                         let result = match tools.read().await.get(&tool_name).cloned() {
                             Some(tool) => {
+                                let input = tools.read().await.translate_input_for_api_tool(&tool_name, input);
                                 let (tx_d, mut rx_d) = tokio::sync::mpsc::unbounded_channel::<String>();
                                 let tx_k = tx.clone();
                                 let t_id = tool_id.clone();
@@ -250,7 +251,10 @@ impl StreamMethods {
                             continue;
                         }
 
-                        let tool = tools.read().await.get(&tool_name).cloned();
+                        let tools_snapshot = tools.read().await;
+                        let input = tools_snapshot.translate_input_for_api_tool(&tool_name, input);
+                        let tool = tools_snapshot.get(&tool_name).cloned();
+                        drop(tools_snapshot);
                         let tx_stream = tx.clone();
                         let cancel_token = cancel.clone();
                         let exit_path = watcher_exit_path.clone();

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -1,7 +1,7 @@
 //! Tool registry — maintains name→tool map and cached JSON schema for the API.
 use std::sync::Arc;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use crate::tools::Tool;
 
 /// Registry of available tools. Maintains a name→tool map and a cached JSON schema
@@ -9,8 +9,18 @@ use crate::tools::Tool;
 #[derive(Clone)]
 pub struct ToolRegistry {
     tools: HashMap<String, Arc<dyn Tool>>,
-    /// Cached schema — rebuilt on register(), shared via Arc for zero-copy reads.
+    /// Cached Anthropic-compatible schema — rebuilt on register(), shared via Arc for zero-copy reads.
     cached_schema: Arc<Vec<Value>>,
+    /// Mapping from API-safe tool names back to their runtime names.
+    api_to_runtime_names: HashMap<String, String>,
+    /// Per-tool mapping from API-safe input property names back to runtime names.
+    input_name_maps: HashMap<String, SchemaNameMap>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SchemaNameMap {
+    api_to_runtime: HashMap<String, String>,
+    children: HashMap<String, SchemaNameMap>,
 }
 
 impl Default for ToolRegistry {
@@ -60,48 +70,277 @@ impl ToolRegistry {
     }
 
     fn from_tools(tool_list: Vec<Arc<dyn Tool>>) -> Self {
-        let mut tools = HashMap::new();
-        for tool in &tool_list {
-            tools.insert(tool.name().to_string(), Arc::clone(tool));
+        let mut registry = ToolRegistry {
+            tools: HashMap::new(),
+            cached_schema: Arc::new(Vec::new()),
+            api_to_runtime_names: HashMap::new(),
+            input_name_maps: HashMap::new(),
+        };
+        for tool in tool_list {
+            registry.register(tool);
+        }
+        registry
+    }
+
+    fn api_safe_name(name: &str, used: &HashSet<String>) -> String {
+        Self::api_safe_identifier(name, used, 128, false)
+    }
+
+    fn api_safe_property_name(name: &str, used: &HashSet<String>) -> String {
+        Self::api_safe_identifier(name, used, 64, true)
+    }
+
+    fn api_safe_identifier(name: &str, used: &HashSet<String>, max_len: usize, allow_dot: bool) -> String {
+        let mut sanitized = String::with_capacity(name.len());
+        for ch in name.chars() {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || (allow_dot && ch == '.') {
+                sanitized.push(ch);
+            } else {
+                sanitized.push('_');
+            }
+        }
+        if sanitized.is_empty() {
+            sanitized.push_str("field");
+        }
+        if sanitized.len() > max_len {
+            sanitized.truncate(max_len);
         }
 
-        let cached_schema = tool_list.iter().map(|tool| {
-            serde_json::json!({
-                "name": tool.name(),
-                "description": tool.description(),
-                "input_schema": tool.parameters()
-            })
-        }).collect();
+        let base = sanitized.clone();
+        let mut suffix = 2;
+        while used.contains(&sanitized) {
+            let suffix_str = format!("_{suffix}");
+            let keep = max_len.saturating_sub(suffix_str.len());
+            sanitized = format!("{}{}", &base[..base.len().min(keep)], suffix_str);
+            suffix += 1;
+        }
+        sanitized
+    }
 
-        ToolRegistry { tools, cached_schema: Arc::new(cached_schema) }
+    fn sanitize_schema(mut schema: Value) -> (Value, SchemaNameMap) {
+        let mut map = SchemaNameMap::default();
+        let Some(obj) = schema.as_object_mut() else {
+            return (schema, map);
+        };
+
+        let mut required_name_map = HashMap::new();
+        if let Some(props_value) = obj.get_mut("properties") {
+            if let Some(props) = props_value.as_object_mut() {
+                let original = std::mem::take(props);
+                let mut used = HashSet::new();
+                for (runtime_name, child_schema) in original {
+                    let api_name = Self::api_safe_property_name(&runtime_name, &used);
+                    used.insert(api_name.clone());
+                    required_name_map.insert(runtime_name.clone(), api_name.clone());
+                    map.api_to_runtime.insert(api_name.clone(), runtime_name);
+
+                    let (sanitized_child, child_map) = Self::sanitize_schema(child_schema);
+                    if !child_map.api_to_runtime.is_empty() || !child_map.children.is_empty() {
+                        map.children.insert(api_name.clone(), child_map);
+                    }
+                    props.insert(api_name, sanitized_child);
+                }
+            }
+        }
+
+        if let Some(required) = obj.get_mut("required").and_then(Value::as_array_mut) {
+            for item in required.iter_mut() {
+                if let Some(name) = item.as_str() {
+                    if let Some(api_name) = required_name_map.get(name) {
+                        *item = Value::String(api_name.clone());
+                    }
+                }
+            }
+        }
+
+        // Recurse into array item schemas too; no direct key mapping is needed at this level.
+        if let Some(items) = obj.get_mut("items") {
+            let (sanitized_items, _) = Self::sanitize_schema(std::mem::take(items));
+            *items = sanitized_items;
+        }
+
+        (schema, map)
+    }
+
+    fn translate_input_names(input: Value, map: &SchemaNameMap) -> Value {
+        match input {
+            Value::Object(obj) => {
+                let mut out = serde_json::Map::new();
+                for (api_name, value) in obj {
+                    let runtime_name = map.api_to_runtime.get(&api_name).cloned().unwrap_or_else(|| api_name.clone());
+                    let value = map.children.get(&api_name)
+                        .map(|child| Self::translate_input_names(value.clone(), child))
+                        .unwrap_or(value);
+                    out.insert(runtime_name, value);
+                }
+                Value::Object(out)
+            }
+            Value::Array(arr) => Value::Array(arr.into_iter().map(|v| Self::translate_input_names(v, map)).collect()),
+            other => other,
+        }
+    }
+
+    fn rebuild_schema(&mut self) {
+        let mut used = HashSet::new();
+        let mut api_to_runtime_names = HashMap::new();
+        let mut input_name_maps = HashMap::new();
+        let mut schema = Vec::with_capacity(self.tools.len());
+
+        for tool in self.tools.values() {
+            let runtime_name = tool.name();
+            let api_name = Self::api_safe_name(runtime_name, &used);
+            used.insert(api_name.clone());
+            api_to_runtime_names.insert(api_name.clone(), runtime_name.to_string());
+            let (input_schema, input_map) = Self::sanitize_schema(tool.parameters());
+            input_name_maps.insert(api_name.clone(), input_map);
+            schema.push(serde_json::json!({
+                "name": api_name,
+                "description": tool.description(),
+                "input_schema": input_schema
+            }));
+        }
+
+        self.api_to_runtime_names = api_to_runtime_names;
+        self.input_name_maps = input_name_maps;
+        self.cached_schema = Arc::new(schema);
     }
 
     /// Register an additional tool at runtime (e.g. MCP tools, custom tools).
     /// If a tool with the same name exists, it is replaced.
     pub fn register(&mut self, tool: Arc<dyn Tool>) {
         let name = tool.name().to_string();
-
-        // Get mutable access to schema (Arc::make_mut clones only if shared)
-        let schema = Arc::make_mut(&mut self.cached_schema);
-
-        // Remove existing schema entry if replacing
-        if self.tools.contains_key(&name) {
-            schema.retain(|s| s["name"].as_str() != Some(&name));
-        }
-
-        schema.push(serde_json::json!({
-            "name": tool.name(),
-            "description": tool.description(),
-            "input_schema": tool.parameters()
-        }));
         self.tools.insert(name, tool);
+        self.rebuild_schema();
     }
 
     pub fn get(&self, name: &str) -> Option<&Arc<dyn Tool>> {
-        self.tools.get(name)
+        let runtime_name = self.api_to_runtime_names.get(name).map(String::as_str).unwrap_or(name);
+        self.tools.get(runtime_name)
+    }
+
+    pub fn runtime_name_for_api<'a>(&'a self, name: &'a str) -> &'a str {
+        self.api_to_runtime_names.get(name).map(String::as_str).unwrap_or(name)
+    }
+
+    pub fn translate_input_for_api_tool(&self, tool_name: &str, input: Value) -> Value {
+        self.input_name_maps.get(tool_name)
+            .map(|map| Self::translate_input_names(input.clone(), map))
+            .unwrap_or(input)
     }
 
     pub fn tools_schema(&self) -> Arc<Vec<Value>> {
         Arc::clone(&self.cached_schema)
     }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Result, ToolContext};
+    use serde_json::json;
+
+    struct NamedTool(&'static str);
+
+    #[async_trait::async_trait]
+    impl Tool for NamedTool {
+        fn name(&self) -> &str { self.0 }
+        fn description(&self) -> &str { "test tool" }
+        fn parameters(&self) -> Value { json!({"type": "object"}) }
+        async fn execute(&self, _params: Value, _ctx: ToolContext) -> Result<String> {
+            Ok("ok".to_string())
+        }
+    }
+
+
+
+    struct SchemaTool;
+
+    #[async_trait::async_trait]
+    impl Tool for SchemaTool {
+        fn name(&self) -> &str { "schema_tool" }
+        fn description(&self) -> &str { "schema tool" }
+        fn parameters(&self) -> Value {
+            json!({
+                "type": "object",
+                "properties": {
+                    "bad:key/that/is/far/too/long/for/anthropic/property/names/and/keeps/going": {"type": "string"},
+                    "nested:obj": {
+                        "type": "object",
+                        "properties": {"inner/key": {"type": "string"}},
+                        "required": ["inner/key"]
+                    }
+                },
+                "required": [
+                    "bad:key/that/is/far/too/long/for/anthropic/property/names/and/keeps/going",
+                    "nested:obj"
+                ]
+            })
+        }
+        async fn execute(&self, _params: Value, _ctx: ToolContext) -> Result<String> {
+            Ok("ok".to_string())
+        }
+    }
+
+    #[test]
+    fn tool_schema_uses_api_safe_names_and_maps_back() {
+        let registry = ToolRegistry::from_tools(vec![Arc::new(NamedTool("plugin:skill.tool"))]);
+
+        assert_eq!(registry.tools_schema()[0]["name"], "plugin_skill_tool");
+        assert!(registry.get("plugin:skill.tool").is_some());
+        assert!(registry.get("plugin_skill_tool").is_some());
+        assert_eq!(registry.runtime_name_for_api("plugin_skill_tool"), "plugin:skill.tool");
+    }
+
+    #[test]
+    fn tool_schema_disambiguates_sanitized_name_collisions() {
+        let registry = ToolRegistry::from_tools(vec![
+            Arc::new(NamedTool("a:b")),
+            Arc::new(NamedTool("a.b")),
+        ]);
+        let names: HashSet<String> = registry.tools_schema().iter()
+            .filter_map(|s| s["name"].as_str().map(str::to_string))
+            .collect();
+
+        assert_eq!(names.len(), 2);
+        assert!(names.contains("a_b"));
+        assert!(names.contains("a_b_2"));
+        assert!(registry.get("a_b").is_some());
+        assert!(registry.get("a_b_2").is_some());
+    }
+
+    #[test]
+    fn tool_schema_truncates_long_names_to_anthropic_limit() {
+        let long = "x".repeat(140);
+        let leaked: &'static str = Box::leak(long.into_boxed_str());
+        let registry = ToolRegistry::from_tools(vec![Arc::new(NamedTool(leaked))]);
+        let schema = registry.tools_schema();
+        let name = schema[0]["name"].as_str().unwrap();
+
+        assert_eq!(name.len(), 128);
+        assert!(name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'));
+        assert!(registry.get(name).is_some());
+    }
+
+    #[test]
+    fn tool_schema_sanitizes_input_property_names_and_translates_inputs_back() {
+        let registry = ToolRegistry::from_tools(vec![Arc::new(SchemaTool)]);
+        let schema = registry.tools_schema();
+        let input_schema = &schema[0]["input_schema"];
+        let props = input_schema["properties"].as_object().unwrap();
+
+        assert!(props.keys().all(|k| k.len() <= 64 && k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')));
+        assert_eq!(input_schema["required"].as_array().unwrap()[0].as_str().unwrap().len(), 64);
+        assert_eq!(input_schema["required"][1], "nested_obj");
+        assert!(props["nested_obj"]["properties"].as_object().unwrap().contains_key("inner_key"));
+        assert_eq!(props["nested_obj"]["required"][0], "inner_key");
+
+        let first_required = input_schema["required"][0].as_str().unwrap();
+        let translated = registry.translate_input_for_api_tool("schema_tool", json!({
+            first_required: "value",
+            "nested_obj": {"inner_key": "nested"}
+        }));
+
+        assert_eq!(translated["bad:key/that/is/far/too/long/for/anthropic/property/names/and/keeps/going"], "value");
+        assert_eq!(translated["nested:obj"]["inner/key"], "nested");
+    }
+
 }


### PR DESCRIPTION
## Summary
- sanitize tool names before sending schemas to Anthropic/OpenAI-compatible APIs
- sanitize input schema property keys and required entries to meet provider validation rules
- map sanitized tool names and input properties back to runtime names before execution
- keep OpenAI wire-format tool names sanitized across message history and tool-call translation

## Verification
- cargo test --lib tools::registry::tests -- --nocapture
- cargo check --lib