### PR TITLE
fix: code review fixes — compile blocker, auth safety, SSH crash, perf

### DIFF
--- a/src/chatui/models/mod.rs
+++ b/src/chatui/models/mod.rs
@@ -664,6 +664,11 @@ fn render_expanded_lightbox(area: Rect, buf: &mut Buffer, state: &ModelsModalSta
     let theme = THEME.load();
     let width = area.width.saturating_sub(10).min(110);
     let height = area.height.saturating_sub(6).min(28);
+    // Guard against tiny terminals where popup dimensions collapse to
+    // zero or near-zero, which can panic in layout splits or produce garbage.
+    if width < 20 || height < 6 {
+        return;
+    }
     let x = area.x + area.width.saturating_sub(width) / 2;
     let y = area.y + area.height.saturating_sub(height) / 2;
     let popup = Rect { x, y, width, height };

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -158,19 +158,23 @@ pub async fn run(
     {
         let flag = interrupted.clone();
         tokio::spawn(async move {
-            let mut sigterm = tokio::signal::unix::signal(
-                tokio::signal::unix::SignalKind::terminate(),
-            ).expect("failed to register SIGTERM handler");
-            sigterm.recv().await;
-            flag.store(true, Ordering::Release);
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut sigterm) => {
+                    sigterm.recv().await;
+                    flag.store(true, Ordering::Release);
+                }
+                Err(e) => log(&format!("WARNING: failed to register SIGTERM handler: {e}")),
+            }
         });
         let flag = interrupted.clone();
         tokio::spawn(async move {
-            let mut sighup = tokio::signal::unix::signal(
-                tokio::signal::unix::SignalKind::hangup(),
-            ).expect("failed to register SIGHUP handler");
-            sighup.recv().await;
-            flag.store(true, Ordering::Release);
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup()) {
+                Ok(mut sighup) => {
+                    sighup.recv().await;
+                    flag.store(true, Ordering::Release);
+                }
+                Err(e) => log(&format!("WARNING: failed to register SIGHUP handler: {e}")),
+            }
         });
     }
 

--- a/src/core/auth/storage.rs
+++ b/src/core/auth/storage.rs
@@ -79,6 +79,17 @@ fn save_provider_auth_at(
                     error = %e,
                     "auth.json could not be parsed as a JSON object; replacing with a fresh structure"
                 );
+                // Back up the corrupt file so credentials are potentially recoverable.
+                let ts = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                let backup = path.with_extension(format!("json.corrupt.{}", ts));
+                let _ = std::fs::copy(path, &backup);
+                eprintln!(
+                    "[warn] auth.json was corrupt and has been reset. Backup saved to: {}",
+                    backup.display()
+                );
                 serde_json::Map::new()
             }
         }

--- a/src/core/auth/storage.rs
+++ b/src/core/auth/storage.rs
@@ -57,11 +57,26 @@ fn save_provider_auth_at(
     provider: &str,
     creds: &OAuthCredentials,
 ) -> std::result::Result<(), String> {
+    use fs4::fs_std::FileExt;
+
     // Ensure parent directory exists
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("Failed to create {}: {}", parent.display(), e))?;
     }
+
+    // Hold an exclusive lock for the entire read-modify-write cycle.
+    // Without this, two concurrent `synaps login` processes can race:
+    // both read the same file, each adds their provider, second write
+    // silently drops the first's credential.
+    let lock_path = path.with_extension("json.lock");
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|e| format!("Failed to open lock file {}: {}", lock_path.display(), e))?;
+    FileExt::lock_exclusive(&lock_file)
+        .map_err(|e| format!("Failed to lock {}: {}", lock_path.display(), e))?;
 
     let mut root = if path.exists() {
         let content = std::fs::read_to_string(path)

--- a/src/core/auth/storage.rs
+++ b/src/core/auth/storage.rs
@@ -100,11 +100,20 @@ fn save_provider_auth_at(
                     .map(|d| d.as_secs())
                     .unwrap_or(0);
                 let backup = path.with_extension(format!("json.corrupt.{}", ts));
-                let _ = std::fs::copy(path, &backup);
-                eprintln!(
-                    "[warn] auth.json was corrupt and has been reset. Backup saved to: {}",
-                    backup.display()
-                );
+                match std::fs::copy(path, &backup) {
+                    Ok(_) => {
+                        eprintln!(
+                            "[warn] auth.json was corrupt and has been reset. Backup saved to: {}",
+                            backup.display()
+                        );
+                    }
+                    Err(copy_err) => {
+                        eprintln!(
+                            "[warn] auth.json was corrupt and has been reset, but backup failed: {}",
+                            copy_err
+                        );
+                    }
+                }
                 serde_json::Map::new()
             }
         }
@@ -122,18 +131,30 @@ fn save_provider_auth_at(
 
     // Atomic write: write to .tmp then rename. rename(2) is atomic on POSIX.
     // This prevents a crash/kill between truncate and write from zeroing auth.json.
+    // Create with restrictive permissions from the start so credentials are never
+    // world-readable, even briefly.
     let tmp_path = path.with_extension("json.tmp");
-    std::fs::write(&tmp_path, &json)
-        .map_err(|e| format!("Failed to write {}: {}", tmp_path.display(), e))?;
-
-    // Set permissions on tmp file BEFORE rename so there's no window where
-    // the final file is world-readable.
-    #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(&tmp_path, perms)
-            .map_err(|e| format!("Failed to set permissions on {}: {}", tmp_path.display(), e))?;
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp_path)
+            .map_err(|e| format!("Failed to create {}: {}", tmp_path.display(), e))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o600);
+            file.set_permissions(perms)
+                .map_err(|e| format!("Failed to set permissions on {}: {}", tmp_path.display(), e))?;
+        }
+
+        file.write_all(json.as_bytes())
+            .map_err(|e| format!("Failed to write {}: {}", tmp_path.display(), e))?;
+        file.sync_all()
+            .map_err(|e| format!("Failed to fsync {}: {}", tmp_path.display(), e))?;
     }
 
     std::fs::rename(&tmp_path, path)

--- a/src/core/auth/storage.rs
+++ b/src/core/auth/storage.rs
@@ -94,17 +94,24 @@ fn save_provider_auth_at(
     let json = serde_json::to_string_pretty(&root)
         .map_err(|e| format!("Failed to serialize auth: {}", e))?;
 
-    std::fs::write(path, &json)
-        .map_err(|e| format!("Failed to write {}: {}", path.display(), e))?;
+    // Atomic write: write to .tmp then rename. rename(2) is atomic on POSIX.
+    // This prevents a crash/kill between truncate and write from zeroing auth.json.
+    let tmp_path = path.with_extension("json.tmp");
+    std::fs::write(&tmp_path, &json)
+        .map_err(|e| format!("Failed to write {}: {}", tmp_path.display(), e))?;
 
-    // Set file permissions to 600 (owner read/write only)
+    // Set permissions on tmp file BEFORE rename so there's no window where
+    // the final file is world-readable.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(path, perms)
-            .map_err(|e| format!("Failed to set permissions on {}: {}", path.display(), e))?;
+        std::fs::set_permissions(&tmp_path, perms)
+            .map_err(|e| format!("Failed to set permissions on {}: {}", tmp_path.display(), e))?;
     }
+
+    std::fs::rename(&tmp_path, path)
+        .map_err(|e| format!("Failed to atomically replace {}: {}", path.display(), e))?;
 
     Ok(())
 }

--- a/src/events/registry.rs
+++ b/src/events/registry.rs
@@ -31,10 +31,13 @@ pub fn registry_dir() -> PathBuf {
 /// Rejects path separators, `..`, and non-printable characters.
 /// Returns the sanitized string (replaces unsafe chars with `_`).
 pub fn sanitize_session_id(raw: &str) -> String {
+    // Only allow alphanumeric, hyphens, and underscores. Dots are not needed
+    // in session IDs (format is {name}-{timestamp}-{pid}) and allowing them
+    // complicates path traversal prevention (single-pass ".." replace is
+    // incomplete for "..." inputs).
     raw.chars()
-        .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' { c } else { '_' })
+        .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
         .collect::<String>()
-        .replace("..", "_")
 }
 
 /// Returns the Unix domain socket path for a session.

--- a/src/runtime/openai/reasoning.rs
+++ b/src/runtime/openai/reasoning.rs
@@ -30,6 +30,12 @@ pub fn apply_openai_reasoning_params(
     model: &str,
     thinking_budget: u32,
 ) {
+    // Don't inject reasoning params when thinking is disabled.
+    // Without this guard, non-reasoning models (e.g. llama-3.3) get
+    // unsupported fields that cause request failures.
+    if thinking_budget == 0 {
+        return;
+    }
     let level = thinking_level_for_budget(thinking_budget);
     match provider {
         OpenAiReasoningProvider::OpenRouter => {
@@ -89,5 +95,15 @@ mod tests {
         assert!(body.is_empty());
         apply_openai_reasoning_params(&mut body, OpenAiReasoningProvider::Generic, "some/model", 4096);
         assert!(body.is_empty());
+    }
+
+    #[test]
+    fn zero_budget_skips_all_reasoning_params() {
+        let mut body = Map::new();
+        apply_openai_reasoning_params(&mut body, OpenAiReasoningProvider::OpenRouter, "deepseek/deepseek-r1", 0);
+        assert!(body.is_empty(), "OpenRouter should not inject reasoning when budget is 0");
+
+        apply_openai_reasoning_params(&mut body, OpenAiReasoningProvider::Groq, "openai/gpt-oss-120b", 0);
+        assert!(body.is_empty(), "Groq should not inject reasoning when budget is 0");
     }
 }

--- a/src/runtime/openai/stream.rs
+++ b/src/runtime/openai/stream.rs
@@ -294,11 +294,15 @@ fn codex_input_messages(messages: Vec<ChatMessage>) -> Vec<Value> {
             continue;
         }
         if msg.role == "tool" {
-            out.push(json!({
-                "type": "function_call_output",
-                "call_id": msg.tool_call_id.unwrap_or_default(),
-                "output": msg.content.unwrap_or_default(),
-            }));
+            // Skip tool results with no call_id — sending an empty call_id
+            // to the Codex API would cause a 400 with a confusing error.
+            if let Some(call_id) = msg.tool_call_id {
+                out.push(json!({
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": msg.content.unwrap_or_default(),
+                }));
+            }
             continue;
         }
         out.push(json!({

--- a/src/runtime/openai/stream.rs
+++ b/src/runtime/openai/stream.rs
@@ -173,8 +173,8 @@ pub(crate) async fn call_codex_stream_inner(
         .or_else(|| crate::auth::extract_codex_account_id(&creds.access))
         .ok_or("Failed to extract ChatGPT account id from Codex token")?;
 
-    let oai_messages = translate::messages_to_oai(messages, system_prompt);
-    let oai_tools = translate::tools_to_oai(tools_schema);
+    let (oai_tools, name_map) = translate::tools_to_oai(tools_schema);
+    let oai_messages = translate::messages_to_oai(messages, system_prompt, &name_map);
     let tools: Vec<Value> = oai_tools
         .into_iter()
         .map(|tool| {
@@ -261,7 +261,7 @@ pub(crate) async fn call_codex_stream_inner(
     if !accumulated_text.is_empty() {
         content.push(json!({"type": "text", "text": accumulated_text}));
     }
-    content.extend(translate::tool_calls_to_content_blocks(&parser.completed_tools));
+    content.extend(translate::tool_calls_to_content_blocks(&parser.completed_tools, &name_map));
 
     Ok(json!({
         "role": "assistant",

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -173,9 +173,11 @@ impl ToolRegistry {
                 let mut out = serde_json::Map::new();
                 for (api_name, value) in obj {
                     let runtime_name = map.api_to_runtime.get(&api_name).cloned().unwrap_or_else(|| api_name.clone());
-                    let value = map.children.get(&api_name)
-                        .map(|child| Self::translate_input_names(value.clone(), child))
-                        .unwrap_or(value);
+                    let value = if let Some(child) = map.children.get(&api_name) {
+                        Self::translate_input_names(value, child)
+                    } else {
+                        value
+                    };
                     out.insert(runtime_name, value);
                 }
                 Value::Object(out)
@@ -228,9 +230,11 @@ impl ToolRegistry {
     }
 
     pub fn translate_input_for_api_tool(&self, tool_name: &str, input: Value) -> Value {
-        self.input_name_maps.get(tool_name)
-            .map(|map| Self::translate_input_names(input.clone(), map))
-            .unwrap_or(input)
+        if let Some(map) = self.input_name_maps.get(tool_name) {
+            Self::translate_input_names(input, map)
+        } else {
+            input
+        }
     }
 
     pub fn tools_schema(&self) -> Arc<Vec<Value>> {

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -76,9 +76,14 @@ impl ToolRegistry {
             api_to_runtime_names: HashMap::new(),
             input_name_maps: HashMap::new(),
         };
+        // Insert all tools first, then rebuild schema once.
+        // Calling register() in a loop would rebuild_schema() on every
+        // iteration, making initialization O(n²) with MCP tool counts.
         for tool in tool_list {
-            registry.register(tool);
+            let name = tool.name().to_string();
+            registry.tools.insert(name, tool);
         }
+        registry.rebuild_schema();
         registry
     }
 

--- a/src/tools/shell/readiness.rs
+++ b/src/tools/shell/readiness.rs
@@ -181,8 +181,14 @@ impl ReadinessDetector {
         }
 
         // Grab the tail to avoid scanning megabytes of scrollback.
+        // Walk forward to the next UTF-8 char boundary to avoid panicking
+        // when multi-byte glyphs (●, ❯, box-drawing, emoji) straddle the cut.
         let tail = if output.len() > PROMPT_TAIL_LEN {
-            &output[output.len() - PROMPT_TAIL_LEN..]
+            let mut start = output.len() - PROMPT_TAIL_LEN;
+            while start < output.len() && !output.is_char_boundary(start) {
+                start += 1;
+            }
+            &output[start..]
         } else {
             output
         };
@@ -424,5 +430,39 @@ mod tests {
         assert!(!det.matches_prompt("user@host:~$ \nstill running..."));
         // Prompt at the end
         assert!(det.matches_prompt("still running...\nuser@host:~$ "));
+    }
+
+    // Regression: multi-byte UTF-8 glyphs at the tail boundary must not panic.
+    // See BUG_REPORT_synaps_ssh_crash.md — starship/powerline prompts with
+    // ●/❯/box-drawing glyphs caused SIGABRT when the byte-offset slice landed
+    // inside a multi-byte sequence.
+    #[test]
+    fn matches_prompt_handles_multibyte_glyph_at_tail_boundary() {
+        let det = hybrid_detector();
+
+        // Build output where a 3-byte char straddles the tail-window cut.
+        // prefix_len puts the start of '●' (3 bytes) exactly 1 byte before
+        // the PROMPT_TAIL_LEN boundary, so a naive slice would land inside it.
+        let prefix_len = PROMPT_TAIL_LEN - 1;
+        let mut output = "x".repeat(prefix_len);
+        output.push('●'); // 3-byte: E2 97 8F
+        output.push_str("\n~/repo on  main\nuser@host:~$ ");
+
+        // Must not panic, and should still detect the prompt.
+        assert!(det.matches_prompt(&output));
+    }
+
+    #[test]
+    fn matches_prompt_handles_4byte_emoji_at_tail_boundary() {
+        let det = hybrid_detector();
+
+        // 4-byte emoji right at the boundary edge
+        for offset in 0..4 {
+            let prefix_len = PROMPT_TAIL_LEN - offset;
+            let mut output = "a".repeat(prefix_len);
+            output.push('🔥'); // 4-byte: F0 9F 94 A5
+            output.push_str("\nuser@host:~$ ");
+            assert!(det.matches_prompt(&output), "panicked at offset {}", offset);
+        }
     }
 }


### PR DESCRIPTION
## Summary

12 fixes from a 3-agent parallel code review of the `dev` branch (PRs #7-#9).

**Reviewers:** Chrollo (runtime/events), Shady (auth/security), Spike (UI/tools)

## Changes

### Compilation Blocker (P0)
- **Codex stream path** — updated `call_codex_stream_inner` to match refactored `translate` signatures (`tools_to_oai` tuple return, `messages_to_oai` 3-arg, `tool_calls_to_content_blocks` name_map)

### Critical Fixes
- **Atomic auth.json writes** — replaced `std::fs::write` (truncate→write, crash-vulnerable) with write-to-tmp + rename pattern
- **Exclusive file lock on auth.json** — `fs4::lock_exclusive` over the full read-modify-write cycle prevents concurrent `synaps login` from silently dropping credentials
- **Corrupt file backup** — copies corrupt auth.json to `.corrupt.<timestamp>` before resetting, with visible `eprintln!` warning
- **Reasoning params guard** — `apply_openai_reasoning_params` now returns early when `thinking_budget == 0`, preventing broken requests to non-reasoning models (llama-3.3, etc) on OpenRouter
- **O(n²) tool registration** — `from_tools()` now inserts all tools first, calls `rebuild_schema()` once instead of per-tool
- **Tiny terminal popup guard** — expanded lightbox returns early when dimensions collapse below 20×6

### Bug Fixes
- **SIGABRT on SSH** — `readiness.rs` prompt tail slice now walks to UTF-8 char boundary, preventing panic on multi-byte glyphs (●, ❯, emoji) from starship/powerline prompts
- **Codex tool_call_id** — skips tool results with `None` call_id instead of sending empty string (400 from API)
- **Session ID sanitization** — dropped dots from allowed chars, eliminating incomplete `..` replace
- **Daemon signal handlers** — replaced `.expect()` with match + warning log for graceful degradation in containers

### Performance
- **Removed unnecessary Value clones** in `translate_input_names` and `translate_input_for_api_tool`

## Testing
- All targeted test suites pass (auth/storage, reasoning, registry, readiness, codex)
- 2 new regression tests for UTF-8 boundary handling (3-byte and 4-byte glyphs)
- 1 new test for zero-budget reasoning guard
- Pre-existing flaky tests (chain, config favorites) are test-isolation issues, unrelated

## Still Open (non-blocking, needs input)
- C6: `extract_account_id` JWT decode naming (JR)
- C9: Favorites re-sync in expanded mode (JR)
- W4: High severity priority queue change — intentional? (JR)
- W12: `clamp_line` unicode width vs char count
- W13-W17: Minor UX/code quality items
