### PR TITLE
fix(subagent): allow blank agent with inline system prompt

### DIFF
--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -19,6 +19,17 @@ fn is_valid_name(s: &str) -> bool {
 
 /// Resolve an agent name to a system prompt.
 pub fn resolve_agent_prompt(name: &str) -> std::result::Result<String, String> {
+    // Defense-in-depth: callers should already filter blank names to None, but if
+    // one slips through we must not search `~/.synaps-cli/agents/.md` — that path
+    // looks valid on disk and produces a confusing error that models retry forever.
+    // Reject names that are empty or entirely whitespace/control chars (incl. NUL).
+    if name.chars().all(|c| c.is_whitespace() || c.is_control()) {
+        return Err(
+            "Empty 'agent' parameter. Pass a non-empty agent name, omit the field entirely, \
+             or provide 'system_prompt' inline instead.".to_string()
+        );
+    }
+
     // 1. File path — name contains '/'
     if name.contains('/') {
         let path = expand_path(name);
@@ -236,5 +247,27 @@ mod tests {
         assert!(is_valid_name("sage"));
         assert!(is_valid_name("my_agent_123"));
         assert!(is_valid_name("BBE"));
+    }
+
+    #[test]
+    fn resolve_agent_prompt_rejects_blank_name() {
+        // Empty string, whitespace, and NUL must all error early — never search disk.
+        for name in ["", " ", "  \t  ", "\n", "\u{0}"] {
+            let err = resolve_agent_prompt(name).unwrap_err();
+            assert!(
+                err.contains("Empty 'agent' parameter"),
+                "blank name {:?} should produce the empty-agent error, got: {}",
+                name,
+                err,
+            );
+            // Critical: the error must NOT mention `agents/.md` — that's the bug
+            // signature that caused models to loop with sentinel agent values.
+            assert!(
+                !err.contains("agents/.md"),
+                "blank name {:?} leaked path-search error: {}",
+                name,
+                err,
+            );
+        }
     }
 }

--- a/src/tools/subagent.rs
+++ b/src/tools/subagent.rs
@@ -49,8 +49,20 @@ impl Tool for SubagentTool {
             .ok_or_else(|| RuntimeError::Tool("Missing 'task' parameter".to_string()))?
             .to_string();
 
-        let agent_name = params["agent"].as_str().map(|s| s.to_string());
-        let inline_prompt = params["system_prompt"].as_str().map(|s| s.to_string());
+        // Treat blank / whitespace / control-char strings as absent — see
+        // subagent_start.rs for full rationale. Models occasionally pass `agent: ""`
+        // (or "\u{0}", or " ") alongside a real `system_prompt`; without this filter
+        // we'd try to resolve an empty agent name and fail, instead of falling
+        // through to the inline prompt.
+        let is_blank = |s: &String| s.chars().all(|c| c.is_whitespace() || c.is_control());
+        let agent_name = params["agent"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
+        let inline_prompt = params["system_prompt"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
         let model_override = params["model"].as_str().map(|s| s.to_string());
         let timeout_secs = params["timeout"].as_u64().unwrap_or(ctx.limits.subagent_timeout);
 

--- a/src/tools/subagent_start.rs
+++ b/src/tools/subagent_start.rs
@@ -65,8 +65,20 @@ impl Tool for SubagentStartTool {
             .ok_or_else(|| RuntimeError::Tool("Missing 'task' parameter".to_string()))?
             .to_string();
 
-        let agent_name    = params["agent"].as_str().map(|s| s.to_string());
-        let inline_prompt = params["system_prompt"].as_str().map(|s| s.to_string());
+        // Treat blank / whitespace / control-char strings as absent.
+        // Some model providers serialize "unset" as "" rather than omitting the field,
+        // and we must not try to resolve "" (or " ", or "\u{0}") as an agent name —
+        // doing so produces a hard "Agent '' not found" error that the model then
+        // retries forever with sentinel values instead of falling back to system_prompt.
+        let is_blank = |s: &String| s.chars().all(|c| c.is_whitespace() || c.is_control());
+        let agent_name = params["agent"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
+        let inline_prompt = params["system_prompt"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
         let model_override = params["model"].as_str().map(|s| s.to_string());
         let timeout_secs   = params["timeout"].as_u64().unwrap_or(ctx.limits.subagent_timeout);
 

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -463,6 +463,54 @@ fn test_resolve_agent_prompt_path_not_found() {
     assert!(error.contains("Failed to read agent file"));
 }
 
+#[test]
+fn test_resolve_agent_prompt_blank_rejected_without_agent_lookup() {
+    let result = resolve_agent_prompt("");
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert!(error.contains("Empty 'agent' parameter"));
+    assert!(!error.contains("agents/.md"));
+}
+
+#[tokio::test]
+async fn test_subagent_start_blank_agent_uses_system_prompt() {
+    use std::sync::{Arc, Mutex};
+
+    let tool = SubagentStartTool;
+    let mut ctx = create_tool_context();
+    ctx.capabilities.subagent_registry = Some(Arc::new(Mutex::new(SubagentRegistry::new())));
+
+    let params = json!({
+        "agent": "",
+        "system_prompt": "You are a concise test subagent. Reply with only: ok",
+        "task": "Say ok",
+        "model": "claude-sonnet-4-6",
+        "timeout": 1
+    });
+
+    let result = tool.execute(params, ctx).await;
+    assert!(result.is_ok(), "blank agent should not be resolved as ~/.synaps-cli/agents/.md: {result:?}");
+    let body: serde_json::Value = serde_json::from_str(&result.unwrap()).unwrap();
+    assert_eq!(body["agent_name"], "inline");
+    assert!(body["handle_id"].as_str().unwrap_or_default().starts_with("sa_"));
+}
+
+#[tokio::test]
+async fn test_subagent_blank_agent_uses_system_prompt() {
+    let tool = SubagentTool;
+    let ctx = create_tool_context();
+    let params = json!({
+        "agent": "",
+        "system_prompt": "You are a concise test subagent. Reply with only: ok",
+        "task": "Say ok",
+        "model": "claude-sonnet-4-6",
+        "timeout": 1
+    });
+
+    let result = tool.execute(params, ctx).await;
+    assert!(result.is_ok(), "blank agent should not be resolved as ~/.synaps-cli/agents/.md: {result:?}");
+}
+
 #[tokio::test]
 async fn test_grep_tool_execution() {
     let temp_dir = std::env::temp_dir();


### PR DESCRIPTION
## Summary
- Treat blank/whitespace/control-char `agent` parameters as absent for subagent tools.
- Fall back to inline `system_prompt` instead of resolving `~/.synaps-cli/agents/.md`.
- Add regression tests for `subagent_start`, one-shot `subagent`, and defensive agent resolution.

## Verification
- `cargo test test_subagent_start_blank_agent_uses_system_prompt --lib -- --nocapture`
- `cargo test test_subagent_blank_agent_uses_system_prompt --lib -- --nocapture`
- `cargo test test_resolve_agent_prompt_blank_rejected_without_agent_lookup --lib -- --nocapture`
- `cargo build`
- Manual tmux/Synaps check: `subagent_start { agent: "", system_prompt: ... }` returned `agent_name: inline`, then `subagent_collect` returned `ok`.