### PR TITLE
feat: Extension system — hooks, permissions, JSON-RPC runtime, Synaps Hub

### DIFF
--- a/examples/extensions/hub/hub.py
+++ b/examples/extensions/hub/hub.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""
+Synaps Hub — Live agent dashboard extension.
+
+Runs a web dashboard showing subagent activity in real-time.
+Hooks into before/after_tool_call:subagent to track agent states.
+
+Usage: spawned by SynapsCLI extension system, serves on :3456
+"""
+
+import asyncio
+import json
+import sys
+import threading
+import time
+from datetime import datetime
+from typing import Dict, List, Optional
+
+try:
+    from aiohttp import web
+    HAS_AIOHTTP = True
+except ImportError:
+    HAS_AIOHTTP = False
+
+# ── State ─────────────────────────────────────────────────────────────
+
+class AgentTask:
+    def __init__(self, task_id: str, description: str):
+        self.task_id = task_id
+        self.description = description
+        self.started = time.time()
+        self.status = "working"  # working, done, failed
+
+class AgentState:
+    def __init__(self, name: str):
+        self.name = name
+        self.tasks: Dict[str, AgentTask] = {}
+        self.completed_count = 0
+        self.last_active: Optional[float] = None
+
+    @property
+    def status(self):
+        active = [t for t in self.tasks.values() if t.status == "working"]
+        if len(active) > 1:
+            return "multitasking"
+        elif len(active) == 1:
+            return "working"
+        return "idle"
+
+    @property
+    def active_tasks(self):
+        return [t for t in self.tasks.values() if t.status == "working"]
+
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "status": self.status,
+            "active_tasks": [
+                {
+                    "id": t.task_id,
+                    "description": t.description[:80],
+                    "elapsed": round(time.time() - t.started, 1),
+                }
+                for t in self.active_tasks
+            ],
+            "active_count": len(self.active_tasks),
+            "completed": self.completed_count,
+            "last_active": self.last_active,
+        }
+
+class HubState:
+    def __init__(self):
+        self.agents: Dict[str, AgentState] = {}
+        self.total_dispatched = 0
+        self.total_completed = 0
+        self.session_start = time.time()
+        self.websockets: List[web.WebSocketResponse] = []
+        self._lock = threading.Lock()
+
+    def get_or_create(self, name: str) -> AgentState:
+        if name not in self.agents:
+            self.agents[name] = AgentState(name)
+        return self.agents[name]
+
+    def dispatch(self, agent_name: str, task_id: str, description: str):
+        with self._lock:
+            agent = self.get_or_create(agent_name)
+            agent.tasks[task_id] = AgentTask(task_id, description)
+            agent.last_active = time.time()
+            self.total_dispatched += 1
+
+    def complete(self, agent_name: str, task_id: str):
+        with self._lock:
+            agent = self.get_or_create(agent_name)
+            if task_id in agent.tasks:
+                agent.tasks[task_id].status = "done"
+                del agent.tasks[task_id]
+                agent.completed_count += 1
+                agent.last_active = time.time()
+                self.total_completed += 1
+
+    def snapshot(self):
+        with self._lock:
+            agents = []
+            for name in sorted(self.agents.keys()):
+                agents.append(self.agents[name].to_dict())
+            
+            active = sum(1 for a in self.agents.values() if a.status != "idle")
+            return {
+                "agents": agents,
+                "stats": {
+                    "active": active,
+                    "total": len(self.agents),
+                    "dispatched": self.total_dispatched,
+                    "completed": self.total_completed,
+                    "uptime": round(time.time() - self.session_start, 1),
+                },
+                "timestamp": datetime.now().isoformat(),
+            }
+
+state = HubState()
+
+# ── JSON-RPC stdin reader ─────────────────────────────────────────────
+
+def read_jsonrpc():
+    """Read Content-Length framed JSON-RPC from stdin (blocking)."""
+    header = sys.stdin.readline()
+    if not header:
+        return None
+    if not header.startswith("Content-Length:"):
+        return None
+    length = int(header.split(":")[1].strip())
+    sys.stdin.readline()  # blank separator
+    body = sys.stdin.read(length)
+    return json.loads(body)
+
+def write_jsonrpc(msg):
+    """Write Content-Length framed JSON-RPC to stdout."""
+    body = json.dumps(msg)
+    sys.stdout.write(f"Content-Length: {len(body)}\r\n\r\n{body}")
+    sys.stdout.flush()
+
+_task_counter = 0
+
+def handle_hook(params):
+    """Handle a hook event from SynapsCLI."""
+    global _task_counter
+    kind = params.get("kind", "")
+    tool_name = params.get("tool_name", "")
+    tool_input = params.get("tool_input", {})
+    tool_output = params.get("tool_output", "")
+
+    if kind == "before_tool_call" and tool_name in ("subagent", "subagent_start"):
+        # Extract agent name and task
+        if isinstance(tool_input, dict):
+            agent_name = tool_input.get("agent", tool_input.get("agent_name", "unknown"))
+            task_desc = tool_input.get("task", "")[:120]
+        else:
+            agent_name = "unknown"
+            task_desc = str(tool_input)[:120]
+
+        _task_counter += 1
+        task_id = f"task_{_task_counter}"
+        state.dispatch(agent_name, task_id, task_desc)
+        broadcast_state()
+        return {"action": "continue"}
+
+    elif kind == "after_tool_call" and tool_name in ("subagent", "subagent_start", "subagent_collect"):
+        # Try to figure out which agent completed
+        if isinstance(tool_input, dict):
+            agent_name = tool_input.get("agent", tool_input.get("agent_name", ""))
+        else:
+            agent_name = ""
+
+        if agent_name and agent_name in state.agents:
+            # Complete the oldest active task for this agent
+            agent = state.agents[agent_name]
+            active = [t for t in agent.tasks.values() if t.status == "working"]
+            if active:
+                oldest = min(active, key=lambda t: t.started)
+                state.complete(agent_name, oldest.task_id)
+                broadcast_state()
+        return {"action": "continue"}
+
+    return {"action": "continue"}
+
+def stdin_loop():
+    """Blocking stdin reader loop (runs in a thread)."""
+    while True:
+        try:
+            request = read_jsonrpc()
+            if request is None:
+                break
+
+            method = request.get("method", "")
+            req_id = request.get("id", 0)
+
+            if method == "hook.handle":
+                result = handle_hook(request.get("params", {}))
+            elif method == "shutdown":
+                write_jsonrpc({"jsonrpc": "2.0", "result": None, "id": req_id})
+                break
+            else:
+                result = {"action": "continue"}
+
+            write_jsonrpc({"jsonrpc": "2.0", "result": result, "id": req_id})
+
+        except Exception as e:
+            sys.stderr.write(f"[hub] stdin error: {e}\n")
+            sys.stderr.flush()
+            break
+
+    # Shutdown the web server
+    sys.stderr.write("[hub] stdin loop ended, shutting down\n")
+    sys.stderr.flush()
+
+# ── WebSocket broadcast ───────────────────────────────────────────────
+
+_loop = None
+
+def broadcast_state():
+    """Push state to all connected WebSocket clients."""
+    if _loop is None:
+        return
+    snapshot = state.snapshot()
+    msg = json.dumps(snapshot)
+    # Schedule the broadcast on the async loop
+    asyncio.run_coroutine_threadsafe(_broadcast(msg), _loop)
+
+async def _broadcast(msg):
+    dead = []
+    for ws in state.websockets:
+        try:
+            await ws.send_str(msg)
+        except Exception:
+            dead.append(ws)
+    for ws in dead:
+        state.websockets.remove(ws)
+
+# ── Web server ────────────────────────────────────────────────────────
+
+async def handle_index(request):
+    return web.Response(text=DASHBOARD_HTML, content_type="text/html")
+
+async def handle_ws(request):
+    ws = web.WebSocketResponse()
+    await ws.prepare(request)
+    state.websockets.append(ws)
+
+    # Send initial state
+    await ws.send_str(json.dumps(state.snapshot()))
+
+    async for msg in ws:
+        pass  # We don't expect messages from the client
+
+    state.websockets.remove(ws)
+    return ws
+
+async def handle_api(request):
+    return web.json_response(state.snapshot())
+
+async def tick_loop():
+    """Periodic state broadcast for elapsed time updates."""
+    while True:
+        await asyncio.sleep(1)
+        if state.websockets:
+            msg = json.dumps(state.snapshot())
+            await _broadcast(msg)
+
+async def start_server():
+    global _loop
+    _loop = asyncio.get_event_loop()
+
+    app = web.Application()
+    app.router.add_get("/", handle_index)
+    app.router.add_get("/ws", handle_ws)
+    app.router.add_get("/api/state", handle_api)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 3456)
+    await site.start()
+
+    sys.stderr.write("[hub] Dashboard running at http://localhost:3456\n")
+    sys.stderr.flush()
+
+    # Start tick loop for elapsed time updates
+    asyncio.create_task(tick_loop())
+
+    # Block forever (stdin thread handles shutdown)
+    while True:
+        await asyncio.sleep(3600)
+
+# ── Dashboard HTML ────────────────────────────────────────────────────
+
+DASHBOARD_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Synaps Hub</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #0a0a0f;
+    color: #e0e0e0;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+    min-height: 100vh;
+  }
+  .header {
+    text-align: center;
+    padding: 24px;
+    border-bottom: 1px solid #1a1a2e;
+  }
+  .header h1 {
+    font-size: 28px;
+    background: linear-gradient(135deg, #00d4ff, #7b2fef);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    letter-spacing: 4px;
+  }
+  .stats {
+    display: flex;
+    justify-content: center;
+    gap: 32px;
+    margin-top: 12px;
+    font-size: 13px;
+    color: #666;
+  }
+  .stats .val { color: #00d4ff; font-weight: bold; }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 16px;
+    padding: 24px;
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+  .agent-card {
+    background: #12121f;
+    border: 1px solid #1e1e35;
+    border-radius: 12px;
+    padding: 20px;
+    transition: all 0.3s ease;
+    position: relative;
+    overflow: hidden;
+  }
+  .agent-card.working {
+    border-color: #00d4ff44;
+    box-shadow: 0 0 20px rgba(0, 212, 255, 0.08);
+  }
+  .agent-card.multitasking {
+    border-color: #ffa50066;
+    box-shadow: 0 0 20px rgba(255, 165, 0, 0.12);
+  }
+  .agent-card.idle {
+    opacity: 0.5;
+  }
+  .agent-name {
+    font-size: 18px;
+    font-weight: bold;
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+  }
+  .status-dot.working { background: #00d4ff; animation: pulse 1.5s infinite; }
+  .status-dot.multitasking { background: #ffa500; animation: pulse 0.8s infinite; }
+  .status-dot.idle { background: #333; }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.5; transform: scale(0.8); }
+  }
+  .status-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    margin-bottom: 12px;
+  }
+  .status-label.working { color: #00d4ff; }
+  .status-label.multitasking { color: #ffa500; }
+  .status-label.idle { color: #444; }
+  .task {
+    background: #0a0a14;
+    border-left: 3px solid #00d4ff;
+    padding: 8px 12px;
+    margin-bottom: 6px;
+    border-radius: 0 6px 6px 0;
+    font-size: 12px;
+  }
+  .task.multi { border-left-color: #ffa500; }
+  .task-desc {
+    color: #aaa;
+    line-height: 1.4;
+    word-break: break-word;
+  }
+  .task-time {
+    color: #555;
+    font-size: 11px;
+    margin-top: 4px;
+  }
+  .completed {
+    font-size: 11px;
+    color: #333;
+    margin-top: 8px;
+  }
+  .multi-badge {
+    background: #ffa500;
+    color: #000;
+    font-size: 10px;
+    font-weight: bold;
+    padding: 2px 6px;
+    border-radius: 4px;
+    margin-left: auto;
+  }
+  .empty-state {
+    text-align: center;
+    color: #333;
+    padding: 60px;
+    font-size: 16px;
+  }
+  .empty-state .hint {
+    font-size: 12px;
+    margin-top: 8px;
+    color: #222;
+  }
+</style>
+</head>
+<body>
+<div class="header">
+  <h1>⚡ SYNAPS HUB</h1>
+  <div class="stats">
+    <span>Active: <span class="val" id="stat-active">0</span>/<span id="stat-total">0</span></span>
+    <span>Dispatched: <span class="val" id="stat-dispatched">0</span></span>
+    <span>Completed: <span class="val" id="stat-completed">0</span></span>
+    <span>Uptime: <span class="val" id="stat-uptime">0s</span></span>
+  </div>
+</div>
+<div class="grid" id="grid"></div>
+<div class="empty-state" id="empty">
+  Waiting for agents...<br>
+  <span class="hint">Dispatch subagents in SynapsCLI to see them here</span>
+</div>
+
+<script>
+const ws = new WebSocket(`ws://${location.host}/ws`);
+const grid = document.getElementById('grid');
+const empty = document.getElementById('empty');
+
+function formatTime(secs) {
+  if (secs < 60) return Math.round(secs) + 's';
+  if (secs < 3600) return Math.round(secs / 60) + 'm ' + Math.round(secs % 60) + 's';
+  return Math.round(secs / 3600) + 'h ' + Math.round((secs % 3600) / 60) + 'm';
+}
+
+function render(data) {
+  // Stats
+  document.getElementById('stat-active').textContent = data.stats.active;
+  document.getElementById('stat-total').textContent = data.stats.total;
+  document.getElementById('stat-dispatched').textContent = data.stats.dispatched;
+  document.getElementById('stat-completed').textContent = data.stats.completed;
+  document.getElementById('stat-uptime').textContent = formatTime(data.stats.uptime);
+
+  if (data.agents.length === 0) {
+    grid.innerHTML = '';
+    empty.style.display = 'block';
+    return;
+  }
+  empty.style.display = 'none';
+
+  grid.innerHTML = data.agents.map(agent => {
+    const isMulti = agent.status === 'multitasking';
+    const taskClass = isMulti ? 'task multi' : 'task';
+    const tasks = agent.active_tasks.map(t => `
+      <div class="${taskClass}">
+        <div class="task-desc">${escHtml(t.description)}</div>
+        <div class="task-time">${formatTime(t.elapsed)}</div>
+      </div>
+    `).join('');
+
+    const multiBadge = isMulti 
+      ? `<span class="multi-badge">×${agent.active_count}</span>` 
+      : '';
+
+    return `
+      <div class="agent-card ${agent.status}">
+        <div class="agent-name">
+          <span class="status-dot ${agent.status}"></span>
+          ${escHtml(agent.name)}
+          ${multiBadge}
+        </div>
+        <div class="status-label ${agent.status}">${agent.status}</div>
+        ${tasks}
+        ${agent.completed > 0 ? `<div class="completed">${agent.completed} completed</div>` : ''}
+      </div>
+    `;
+  }).join('');
+}
+
+function escHtml(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+ws.onmessage = (e) => render(JSON.parse(e.data));
+ws.onclose = () => {
+  empty.innerHTML = 'Connection lost. Refresh to reconnect.';
+  empty.style.display = 'block';
+};
+</script>
+</body>
+</html>
+"""
+
+# ── Main ──────────────────────────────────────────────────────────────
+
+def main():
+    if not HAS_AIOHTTP:
+        sys.stderr.write("[hub] ERROR: aiohttp not installed. Run: pip install aiohttp\n")
+        sys.stderr.flush()
+        # Fall back to just responding to hooks without web UI
+        stdin_loop()
+        return
+
+    # Start stdin reader in a background thread
+    stdin_thread = threading.Thread(target=stdin_loop, daemon=True)
+    stdin_thread.start()
+
+    # Run the web server on the main thread
+    try:
+        asyncio.run(start_server())
+    except KeyboardInterrupt:
+        pass
+
+if __name__ == "__main__":
+    main()

--- a/examples/extensions/hub/hub.py
+++ b/examples/extensions/hub/hub.py
@@ -172,7 +172,11 @@ def handle_hook(params):
         else:
             agent_name = ""
 
-        if agent_name and agent_name in state.agents:
+        # For inline subagents (no agent name), use "unknown"
+        if not agent_name:
+            agent_name = "unknown"
+
+        if agent_name in state.agents:
             # Complete the oldest active task for this agent
             agent = state.agents[agent_name]
             active = [t for t in agent.tasks.values() if t.status == "working"]

--- a/examples/extensions/hub/hub.py
+++ b/examples/extensions/hub/hub.py
@@ -74,6 +74,7 @@ class HubState:
         self.agents: Dict[str, AgentState] = {}
         self.total_dispatched = 0
         self.total_completed = 0
+        self.next_task_id = 0
         self.session_start = time.time()
         self.websockets: List[web.WebSocketResponse] = []
         self._lock = threading.Lock()
@@ -83,12 +84,24 @@ class HubState:
             self.agents[name] = AgentState(name)
         return self.agents[name]
 
-    def dispatch(self, agent_name: str, task_id: str, description: str):
+    def dispatch(self, agent_name: str, description: str) -> str:
         with self._lock:
+            self.next_task_id += 1
+            task_id = f"task_{self.next_task_id}"
             agent = self.get_or_create(agent_name)
             agent.tasks[task_id] = AgentTask(task_id, description)
             agent.last_active = time.time()
             self.total_dispatched += 1
+            return task_id
+
+    def prune_idle(self):
+        with self._lock:
+            cutoff = time.time() - 300  # 5 minutes
+            to_remove = [name for name, agent in self.agents.items()
+                         if agent.status == "idle" and agent.last_active
+                         and agent.last_active < cutoff]
+            for name in to_remove:
+                del self.agents[name]
 
     def complete(self, agent_name: str, task_id: str):
         with self._lock:
@@ -144,11 +157,8 @@ def write_jsonrpc(msg):
     sys.stdout.buffer.write(body_bytes)
     sys.stdout.buffer.flush()
 
-_task_counter = 0
-
 def handle_hook(params):
     """Handle a hook event from SynapsCLI."""
-    global _task_counter
     kind = params.get("kind", "")
     tool_name = params.get("tool_name", "")
     tool_input = params.get("tool_input", {})
@@ -163,9 +173,12 @@ def handle_hook(params):
             agent_name = "unknown"
             task_desc = str(tool_input)[:120]
 
-        _task_counter += 1
-        task_id = f"task_{_task_counter}"
-        state.dispatch(agent_name, task_id, task_desc)
+        if not agent_name or agent_name == "unknown":
+            # Use first few words of task description
+            words = task_desc.strip().split()[:3]
+            agent_name = " ".join(words).lower() if words else "inline"
+
+        task_id = state.dispatch(agent_name, task_desc)
         broadcast_state()
         return {"action": "continue"}
 
@@ -273,15 +286,19 @@ async def handle_api(request):
 
 async def tick_loop():
     """Periodic state broadcast for elapsed time updates."""
+    ticks = 0
     while True:
         await asyncio.sleep(1)
+        ticks += 1
         if state.websockets:
             msg = json.dumps(state.snapshot())
             await _broadcast(msg)
+        if ticks % 60 == 0:
+            state.prune_idle()
 
 async def start_server():
     global _loop
-    _loop = asyncio.get_event_loop()
+    _loop = asyncio.get_running_loop()
 
     app = web.Application()
     app.router.add_get("/", handle_index)
@@ -466,7 +483,6 @@ DASHBOARD_HTML = """<!DOCTYPE html>
 </div>
 
 <script>
-const ws = new WebSocket(`ws://${location.host}/ws`);
 const grid = document.getElementById('grid');
 const empty = document.getElementById('empty');
 
@@ -526,11 +542,13 @@ function escHtml(s) {
   return d.innerHTML;
 }
 
-ws.onmessage = (e) => render(JSON.parse(e.data));
-ws.onclose = () => {
-  empty.innerHTML = 'Connection lost. Refresh to reconnect.';
-  empty.style.display = 'block';
-};
+function connect() {
+  const ws = new WebSocket(`ws://${location.host}/ws`);
+  ws.onmessage = (e) => render(JSON.parse(e.data));
+  ws.onclose = () => setTimeout(connect, 2000);
+  ws.onerror = () => ws.close();
+}
+connect();
 </script>
 </body>
 </html>

--- a/examples/extensions/hub/hub.py
+++ b/examples/extensions/hub/hub.py
@@ -125,21 +125,24 @@ state = HubState()
 
 def read_jsonrpc():
     """Read Content-Length framed JSON-RPC from stdin (blocking)."""
-    header = sys.stdin.readline()
+    header = sys.stdin.buffer.readline().decode('utf-8')
     if not header:
         return None
     if not header.startswith("Content-Length:"):
         return None
     length = int(header.split(":")[1].strip())
-    sys.stdin.readline()  # blank separator
-    body = sys.stdin.read(length)
+    sys.stdin.buffer.readline()  # blank line
+    body = sys.stdin.buffer.read(length)
     return json.loads(body)
 
 def write_jsonrpc(msg):
     """Write Content-Length framed JSON-RPC to stdout."""
     body = json.dumps(msg)
-    sys.stdout.write(f"Content-Length: {len(body)}\r\n\r\n{body}")
-    sys.stdout.flush()
+    body_bytes = body.encode('utf-8')
+    header = f"Content-Length: {len(body_bytes)}\r\n\r\n"
+    sys.stdout.buffer.write(header.encode('utf-8'))
+    sys.stdout.buffer.write(body_bytes)
+    sys.stdout.buffer.flush()
 
 _task_counter = 0
 

--- a/examples/extensions/hub/hub.py
+++ b/examples/extensions/hub/hub.py
@@ -9,6 +9,7 @@ Usage: spawned by SynapsCLI extension system, serves on :3456
 """
 
 import asyncio
+import os
 import json
 import sys
 import threading
@@ -214,9 +215,10 @@ def stdin_loop():
             sys.stderr.flush()
             break
 
-    # Shutdown the web server
-    sys.stderr.write("[hub] stdin loop ended, shutting down\n")
+    # Parent process (synaps) exited — kill the whole process
+    sys.stderr.write("[hub] stdin closed, exiting\n")
     sys.stderr.flush()
+    os._exit(0)
 
 # ── WebSocket broadcast ───────────────────────────────────────────────
 

--- a/examples/extensions/hub/hub.py
+++ b/examples/extensions/hub/hub.py
@@ -166,7 +166,10 @@ def handle_hook(params):
         broadcast_state()
         return {"action": "continue"}
 
-    elif kind == "after_tool_call" and tool_name in ("subagent", "subagent_start", "subagent_collect"):
+    elif kind == "after_tool_call" and tool_name in ("subagent", "subagent_collect"):
+        # subagent = blocking (done when it returns)
+        # subagent_collect = reactive (done when collected)
+        # subagent_start = NOT here — it returns immediately, agent still running
         # Try to figure out which agent completed
         if isinstance(tool_input, dict):
             agent_name = tool_input.get("agent", tool_input.get("agent_name", ""))

--- a/examples/extensions/hub/hub.py
+++ b/examples/extensions/hub/hub.py
@@ -290,10 +290,15 @@ async def start_server():
 
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", 3456)
+    port = int(os.environ.get("HUB_PORT", "3456"))
+    try:
+        site = web.TCPSite(runner, "127.0.0.1", port)
+    except Exception:
+        port += 1
+        site = web.TCPSite(runner, "127.0.0.1", port)
     await site.start()
 
-    sys.stderr.write("[hub] Dashboard running at http://localhost:3456\n")
+    sys.stderr.write(f"[hub] Dashboard running at http://localhost:{port}\n")
     sys.stderr.flush()
 
     # Start tick loop for elapsed time updates

--- a/examples/extensions/hub/test_hub.py
+++ b/examples/extensions/hub/test_hub.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Test harness for Synaps Hub — simulates subagent dispatch events
+without needing SynapsCLI running.
+
+Run hub.py first, then run this script to simulate agents working.
+"""
+
+import json
+import subprocess
+import sys
+import time
+import threading
+
+def send_rpc(proc, method, params, req_id):
+    """Send a JSON-RPC message to the hub process."""
+    request = {"jsonrpc": "2.0", "method": method, "params": params, "id": req_id}
+    body = json.dumps(request)
+    frame = f"Content-Length: {len(body)}\r\n\r\n{body}"
+    proc.stdin.write(frame.encode())
+    proc.stdin.flush()
+
+def read_rpc(proc):
+    """Read a JSON-RPC response."""
+    header = b""
+    while not header.endswith(b"\r\n"):
+        header += proc.stdout.read(1)
+    length = int(header.decode().split(":")[1].strip())
+    proc.stdout.read(2)  # \r\n separator
+    body = proc.stdout.read(length)
+    return json.loads(body)
+
+def dispatch_agent(proc, agent_name, task, req_id):
+    """Simulate dispatching a subagent."""
+    send_rpc(proc, "hook.handle", {
+        "kind": "before_tool_call",
+        "tool_name": "subagent",
+        "tool_input": {"agent": agent_name, "task": task},
+        "tool_output": None,
+        "message": None,
+        "session_id": None,
+        "data": None,
+    }, req_id)
+    return read_rpc(proc)
+
+def complete_agent(proc, agent_name, req_id):
+    """Simulate a subagent completing."""
+    send_rpc(proc, "hook.handle", {
+        "kind": "after_tool_call",
+        "tool_name": "subagent",
+        "tool_input": {"agent": agent_name},
+        "tool_output": "done",
+        "message": None,
+        "session_id": None,
+        "data": None,
+    }, req_id)
+    return read_rpc(proc)
+
+def main():
+    print("Starting hub process...")
+    proc = subprocess.Popen(
+        [sys.executable, "hub.py"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=sys.stderr,
+        cwd=str(__import__('pathlib').Path(__file__).parent),
+    )
+    
+    time.sleep(1)  # Let web server start
+    print("Hub started. Open http://localhost:3456 in your browser.\n")
+    
+    req_id = 1
+    
+    # Simulate a realistic session
+    scenarios = [
+        ("spike",    "Fixing the auth module in storage.rs"),
+        ("chrollo",  "Analyzing the codebase architecture for review"),
+        ("shady",    "Reviewing PR #10 for security issues"),
+    ]
+    
+    print("Dispatching 3 agents...")
+    for agent, task in scenarios:
+        resp = dispatch_agent(proc, agent, task, req_id)
+        print(f"  → {agent}: {task[:50]}... (resp: {resp['result']['action']})")
+        req_id += 1
+        time.sleep(0.5)
+    
+    time.sleep(3)
+    
+    # Dispatch more Chrollos (multitasking!)
+    print("\nDispatching 2 more Chrollos (multitasking)...")
+    dispatch_agent(proc, "chrollo", "Deep dive on velocirag search pipeline", req_id)
+    req_id += 1
+    time.sleep(0.3)
+    dispatch_agent(proc, "chrollo", "Analyzing memkoshi memory patterns", req_id)
+    req_id += 1
+    
+    time.sleep(4)
+    
+    # Complete some tasks
+    print("\nSpike finished!")
+    complete_agent(proc, "spike", req_id)
+    req_id += 1
+    
+    time.sleep(2)
+    
+    print("Shady finished!")
+    complete_agent(proc, "shady", req_id)
+    req_id += 1
+    
+    time.sleep(2)
+    
+    # Dispatch Yoru
+    print("\nDispatching Yoru...")
+    dispatch_agent(proc, "yoru", "Optimizing search query performance", req_id)
+    req_id += 1
+    
+    time.sleep(3)
+    
+    # Complete Chrollo tasks one by one
+    print("\nChrollo finishing tasks...")
+    complete_agent(proc, "chrollo", req_id)
+    req_id += 1
+    time.sleep(1)
+    complete_agent(proc, "chrollo", req_id)
+    req_id += 1
+    time.sleep(1)
+    complete_agent(proc, "chrollo", req_id)
+    req_id += 1
+    
+    print("\n✓ Simulation complete. Dashboard still live at http://localhost:3456")
+    print("Press Ctrl+C to stop.\n")
+    
+    try:
+        proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+
+if __name__ == "__main__":
+    main()

--- a/examples/extensions/time-ext.py
+++ b/examples/extensions/time-ext.py
@@ -13,25 +13,24 @@ from datetime import datetime
 
 def read_message():
     """Read a Content-Length framed JSON-RPC message from stdin."""
-    header = sys.stdin.readline()
+    header = sys.stdin.buffer.readline().decode('utf-8')
     if not header:
         return None
-    
-    # Parse Content-Length
     if not header.startswith("Content-Length:"):
         return None
-    
     length = int(header.split(":")[1].strip())
-    sys.stdin.readline()  # blank line separator
-    body = sys.stdin.read(length)
+    sys.stdin.buffer.readline()  # blank line
+    body = sys.stdin.buffer.read(length)
     return json.loads(body)
 
 def write_message(msg):
     """Write a Content-Length framed JSON-RPC message to stdout."""
     body = json.dumps(msg)
-    frame = f"Content-Length: {len(body)}\r\n\r\n{body}"
-    sys.stdout.write(frame)
-    sys.stdout.flush()
+    body_bytes = body.encode('utf-8')
+    header = f"Content-Length: {len(body_bytes)}\r\n\r\n"
+    sys.stdout.buffer.write(header.encode('utf-8'))
+    sys.stdout.buffer.write(body_bytes)
+    sys.stdout.buffer.flush()
 
 def handle_hook(request):
     """Handle a hook.handle call."""

--- a/examples/extensions/time-ext.py
+++ b/examples/extensions/time-ext.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Time extension for SynapsCLI — injects current date/time into every message.
+
+Speaks JSON-RPC 2.0 over stdio with Content-Length framing.
+Subscribes to before_message hook and returns an Inject result
+with the current timestamp.
+"""
+
+import json
+import sys
+from datetime import datetime
+
+def read_message():
+    """Read a Content-Length framed JSON-RPC message from stdin."""
+    header = sys.stdin.readline()
+    if not header:
+        return None
+    
+    # Parse Content-Length
+    if not header.startswith("Content-Length:"):
+        return None
+    
+    length = int(header.split(":")[1].strip())
+    sys.stdin.readline()  # blank line separator
+    body = sys.stdin.read(length)
+    return json.loads(body)
+
+def write_message(msg):
+    """Write a Content-Length framed JSON-RPC message to stdout."""
+    body = json.dumps(msg)
+    frame = f"Content-Length: {len(body)}\r\n\r\n{body}"
+    sys.stdout.write(frame)
+    sys.stdout.flush()
+
+def handle_hook(request):
+    """Handle a hook.handle call."""
+    params = request.get("params", {})
+    kind = params.get("kind", "")
+    
+    if kind == "before_message":
+        now = datetime.now().strftime("%A, %B %d, %Y at %I:%M %p")
+        return {
+            "action": "inject",
+            "content": f"[Current date and time: {now}]"
+        }
+    
+    return {"action": "continue"}
+
+def main():
+    sys.stderr.write("[time-ext] Started\n")
+    sys.stderr.flush()
+    
+    while True:
+        try:
+            request = read_message()
+            if request is None:
+                break
+            
+            method = request.get("method", "")
+            req_id = request.get("id", 0)
+            
+            if method == "hook.handle":
+                result = handle_hook(request)
+            elif method == "shutdown":
+                sys.stderr.write("[time-ext] Shutting down\n")
+                sys.stderr.flush()
+                write_message({"jsonrpc": "2.0", "result": None, "id": req_id})
+                break
+            else:
+                result = {"action": "continue"}
+            
+            write_message({
+                "jsonrpc": "2.0",
+                "result": result,
+                "id": req_id
+            })
+            
+        except Exception as e:
+            sys.stderr.write(f"[time-ext] Error: {e}\n")
+            sys.stderr.flush()
+            break
+
+if __name__ == "__main__":
+    main()

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -306,6 +306,23 @@ pub async fn run(
     }
 
 
+    // ═══ Extension Discovery ═══
+    // Scan ~/.synaps-cli/plugins/ for extensions and load them
+    {
+        let mut ext_mgr = synaps_cli::extensions::manager::ExtensionManager::new(
+            std::sync::Arc::clone(runtime.hook_bus()),
+        );
+        let loaded = ext_mgr.discover_and_load().await;
+        if !loaded.is_empty() {
+            app.push_msg(ChatMessage::System(format!(
+                "Extensions loaded: {}", loaded.join(", ")
+            )));
+        }
+        // Leak the manager so extensions stay alive for the session
+        // (proper ownership will come with the extension lifecycle refactor)
+        std::mem::forget(ext_mgr);
+    }
+
     // ═══ HOOK: on_session_start ═══
     {
         let hook_event = synaps_cli::extensions::hooks::events::HookEvent::on_session_start(&app.session.id);

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -180,6 +180,7 @@ pub async fn run(
     continue_session: Option<Option<String>>,
     system: Option<String>,
     profile: Option<String>,
+    no_extensions: bool,
 ) -> Result<()> {
     if let Some(ref prof) = profile {
         synaps_cli::config::set_profile(Some(prof.clone()));
@@ -311,13 +312,18 @@ pub async fn run(
     let mut ext_mgr = synaps_cli::extensions::manager::ExtensionManager::new(
         std::sync::Arc::clone(runtime.hook_bus()),
     );
-    {
-        let loaded = ext_mgr.discover_and_load().await;
+    if !no_extensions {
+        let (loaded, failed) = ext_mgr.discover_and_load().await;
         let handler_count = runtime.hook_bus().handler_count().await;
         tracing::info!(extensions = loaded.len(), handlers = handler_count, "Extension discovery complete");
         if !loaded.is_empty() {
             app.push_msg(ChatMessage::System(format!(
                 "Extensions loaded: {} ({} hooks)", loaded.join(", "), handler_count
+            )));
+        }
+        for (name, error) in &failed {
+            app.push_msg(ChatMessage::System(format!(
+                "⚠ Extension '{}' failed: {}", name, error
             )));
         }
     }

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -308,20 +308,18 @@ pub async fn run(
 
     // ═══ Extension Discovery ═══
     // Scan ~/.synaps-cli/plugins/ for extensions and load them
+    let mut ext_mgr = synaps_cli::extensions::manager::ExtensionManager::new(
+        std::sync::Arc::clone(runtime.hook_bus()),
+    );
     {
-        let mut ext_mgr = synaps_cli::extensions::manager::ExtensionManager::new(
-            std::sync::Arc::clone(runtime.hook_bus()),
-        );
         let loaded = ext_mgr.discover_and_load().await;
         let handler_count = runtime.hook_bus().handler_count().await;
-        eprintln!("[ext-debug] discovered {} extensions, {} handlers registered", loaded.len(), handler_count);
+        tracing::info!(extensions = loaded.len(), handlers = handler_count, "Extension discovery complete");
         if !loaded.is_empty() {
             app.push_msg(ChatMessage::System(format!(
                 "Extensions loaded: {} ({} hooks)", loaded.join(", "), handler_count
             )));
         }
-        // Leak the manager so extensions stay alive for the session
-        std::mem::forget(ext_mgr);
     }
 
     // ═══ HOOK: on_session_start ═══
@@ -1169,6 +1167,9 @@ pub async fn run(
         let hook_event = synaps_cli::extensions::hooks::events::HookEvent::on_session_end(&app.session.id);
         let _ = runtime.hook_bus().emit(&hook_event).await;
     }
+
+    // Gracefully shut down all extensions
+    ext_mgr.shutdown_all().await;
 
     // Signal the inbox watcher's blocking thread to exit, then abort the async task.
     watcher_shutdown.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -1170,7 +1170,8 @@ pub async fn run(
 
     // ═══ HOOK: on_session_end ═══
     {
-        let hook_event = synaps_cli::extensions::hooks::events::HookEvent::on_session_end(&app.session.id);
+        let transcript = Some(app.api_messages.clone());
+        let hook_event = synaps_cli::extensions::hooks::events::HookEvent::on_session_end(&app.session.id, transcript);
         let _ = runtime.hook_bus().emit(&hook_event).await;
     }
 

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -313,13 +313,14 @@ pub async fn run(
             std::sync::Arc::clone(runtime.hook_bus()),
         );
         let loaded = ext_mgr.discover_and_load().await;
+        let handler_count = runtime.hook_bus().handler_count().await;
+        eprintln!("[ext-debug] discovered {} extensions, {} handlers registered", loaded.len(), handler_count);
         if !loaded.is_empty() {
             app.push_msg(ChatMessage::System(format!(
-                "Extensions loaded: {}", loaded.join(", ")
+                "Extensions loaded: {} ({} hooks)", loaded.join(", "), handler_count
             )));
         }
         // Leak the manager so extensions stay alive for the session
-        // (proper ownership will come with the extension lifecycle refactor)
         std::mem::forget(ext_mgr);
     }
 

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -306,6 +306,12 @@ pub async fn run(
     }
 
 
+    // ═══ HOOK: on_session_start ═══
+    {
+        let hook_event = synaps_cli::extensions::hooks::events::HookEvent::on_session_start(&app.session.id);
+        let _ = runtime.hook_bus().emit(&hook_event).await;
+    }
+
     // ── Event loop ──
     loop {
         let elapsed = last_frame.elapsed();
@@ -1139,6 +1145,12 @@ pub async fn run(
 
     // Save session on exit
     app.save_session().await;
+
+    // ═══ HOOK: on_session_end ═══
+    {
+        let hook_event = synaps_cli::extensions::hooks::events::HookEvent::on_session_end(&app.session.id);
+        let _ = runtime.hook_bus().emit(&hook_event).await;
+    }
 
     // Signal the inbox watcher's blocking thread to exit, then abort the async task.
     watcher_shutdown.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/src/extensions/hooks/events.rs
+++ b/src/extensions/hooks/events.rs
@@ -184,7 +184,6 @@ impl HookEvent {
 ///
 /// The runtime resolves multiple handlers by precedence:
 /// - Any `Block` from any handler prevents the operation.
-/// - `Modify` signals that the handler mutated the event's fields in-place
 ///   and the runtime should re-read them before proceeding.
 /// - `Continue` is the no-op default — processing continues normally.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -194,12 +193,13 @@ pub enum HookResult {
     Continue,
     /// Prevent the hooked operation. The `reason` is surfaced to the user.
     Block { reason: String },
-    /// The handler mutated the event payload; the runtime should re-read
-    /// the affected fields (e.g. `tool_input`, `message`) before continuing.
-    Modify,
     /// Inject context — the extension provides text to prepend to the
     /// system prompt or conversation. Used by before_message hooks.
     Inject { content: String },
+    // NOTE: `Modify` was removed in the review pass. Process-based extensions
+    // can't mutate events in-place (they get a serialized copy). If mutation
+    // support is needed, add a `ModifyWith { fields: Value }` variant that
+    // carries the modified data back.
 }
 
 impl Default for HookResult {
@@ -382,12 +382,5 @@ mod tests {
     fn hook_result_continue_serde() {
         let json = serde_json::to_string(&HookResult::Continue).unwrap();
         assert_eq!(json, r#"{"action":"continue"}"#);
-    }
-
-    /// Modify serialises as {"action":"modify"}.
-    #[test]
-    fn hook_result_modify_serde() {
-        let json = serde_json::to_string(&HookResult::Modify).unwrap();
-        assert_eq!(json, r#"{"action":"modify"}"#);
     }
 }

--- a/src/extensions/hooks/events.rs
+++ b/src/extensions/hooks/events.rs
@@ -1,0 +1,390 @@
+//! Hook events — typed payloads for each extension point.
+//!
+//! Each [`HookKind`] maps to a discrete phase of SynapsCLI's execution loop.
+//! [`HookEvent`] is the concrete payload dispatched to subscribers at that
+//! phase; [`HookResult`] is what a handler returns to control execution flow.
+//!
+//! Permission enforcement lives in [`crate::extensions::permissions`]:
+//! every `HookKind` declares a [`required_permission`][HookKind::required_permission]
+//! so the runtime can gate subscriptions before any payload is delivered.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::extensions::permissions::Permission;
+
+// ── HookKind ──────────────────────────────────────────────────────────────────
+
+/// All hook event kinds in the phase-1 catalog.
+///
+/// Each variant identifies a well-defined extension point in the agent loop.
+/// The set is intentionally closed; new kinds are added via a breaking version
+/// bump so existing permission grants stay coherent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HookKind {
+    /// Fires immediately before a tool is invoked. Handlers may block the call.
+    BeforeToolCall,
+    /// Fires immediately after a tool returns. Handlers receive the output.
+    AfterToolCall,
+    /// Fires before an LLM message is sent. Handlers may inspect or block.
+    BeforeMessage,
+    /// Fires when a new session is created.
+    OnSessionStart,
+    /// Fires when a session is torn down.
+    OnSessionEnd,
+}
+
+impl HookKind {
+    /// Canonical string identifier for this kind, suitable for serialization
+    /// keys, log output, and manifest declarations.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::BeforeToolCall => "before_tool_call",
+            Self::AfterToolCall => "after_tool_call",
+            Self::BeforeMessage => "before_message",
+            Self::OnSessionStart => "on_session_start",
+            Self::OnSessionEnd => "on_session_end",
+        }
+    }
+
+    /// Parse from the canonical string representation.
+    ///
+    /// Returns `None` for unrecognised strings so callers can surface
+    /// a manifest validation error rather than silently dropping hooks.
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "before_tool_call" => Some(Self::BeforeToolCall),
+            "after_tool_call" => Some(Self::AfterToolCall),
+            "before_message" => Some(Self::BeforeMessage),
+            "on_session_start" => Some(Self::OnSessionStart),
+            "on_session_end" => Some(Self::OnSessionEnd),
+            _ => None,
+        }
+    }
+
+    /// The [`Permission`] an extension must hold to subscribe to this hook.
+    ///
+    /// Called by the permission gate before delivering any event; if the
+    /// extension's [`PermissionSet`][crate::extensions::permissions::PermissionSet]
+    /// does not include this permission the subscription is silently dropped.
+    pub fn required_permission(&self) -> Permission {
+        match self {
+            Self::BeforeToolCall | Self::AfterToolCall => Permission::ToolsIntercept,
+            Self::BeforeMessage => Permission::LlmContent,
+            Self::OnSessionStart | Self::OnSessionEnd => Permission::SessionLifecycle,
+        }
+    }
+}
+
+// ── HookEvent ─────────────────────────────────────────────────────────────────
+
+/// A hook event payload dispatched to extension handlers.
+///
+/// Fields are optional and populated only when relevant to the hook kind:
+///
+/// | Kind              | tool_name | tool_input | tool_output | message | session_id |
+/// |-------------------|-----------|------------|-------------|---------|------------|
+/// | `before_tool_call`| ✓         | ✓          |             |         |            |
+/// | `after_tool_call` | ✓         | ✓          | ✓           |         |            |
+/// | `before_message`  |           |            |             | ✓       |            |
+/// | `on_session_start`|           |            |             |         | ✓          |
+/// | `on_session_end`  |           |            |             |         | ✓          |
+///
+/// The `data` field is available on all events for extensions that need to
+/// attach arbitrary structured context when constructing synthetic events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookEvent {
+    /// Which hook fired.
+    pub kind: HookKind,
+    /// Tool name for tool-specific hooks; `None` for general hooks.
+    pub tool_name: Option<String>,
+    /// Tool input arguments for `before_tool_call` and `after_tool_call`.
+    pub tool_input: Option<Value>,
+    /// Tool output for `after_tool_call`.
+    pub tool_output: Option<String>,
+    /// LLM message content for `before_message`.
+    pub message: Option<String>,
+    /// Session identifier for session lifecycle hooks.
+    pub session_id: Option<String>,
+    /// Arbitrary extension-defined data, passed through without inspection.
+    pub data: Value,
+}
+
+impl HookEvent {
+    /// Construct a `before_tool_call` event.
+    pub fn before_tool_call(tool_name: &str, input: Value) -> Self {
+        Self {
+            kind: HookKind::BeforeToolCall,
+            tool_name: Some(tool_name.to_string()),
+            tool_input: Some(input),
+            tool_output: None,
+            message: None,
+            session_id: None,
+            data: Value::Null,
+        }
+    }
+
+    /// Construct an `after_tool_call` event carrying both input and output.
+    pub fn after_tool_call(tool_name: &str, input: Value, output: String) -> Self {
+        Self {
+            kind: HookKind::AfterToolCall,
+            tool_name: Some(tool_name.to_string()),
+            tool_input: Some(input),
+            tool_output: Some(output),
+            message: None,
+            session_id: None,
+            data: Value::Null,
+        }
+    }
+
+    /// Construct a `before_message` event.
+    pub fn before_message(message: &str) -> Self {
+        Self {
+            kind: HookKind::BeforeMessage,
+            tool_name: None,
+            tool_input: None,
+            tool_output: None,
+            message: Some(message.to_string()),
+            session_id: None,
+            data: Value::Null,
+        }
+    }
+
+    /// Construct an `on_session_start` event.
+    pub fn on_session_start(session_id: &str) -> Self {
+        Self {
+            kind: HookKind::OnSessionStart,
+            tool_name: None,
+            tool_input: None,
+            tool_output: None,
+            message: None,
+            session_id: Some(session_id.to_string()),
+            data: Value::Null,
+        }
+    }
+
+    /// Construct an `on_session_end` event.
+    pub fn on_session_end(session_id: &str) -> Self {
+        Self {
+            kind: HookKind::OnSessionEnd,
+            tool_name: None,
+            tool_input: None,
+            tool_output: None,
+            message: None,
+            session_id: Some(session_id.to_string()),
+            data: Value::Null,
+        }
+    }
+}
+
+// ── HookResult ────────────────────────────────────────────────────────────────
+
+/// What an extension handler returns after processing a hook event.
+///
+/// The runtime resolves multiple handlers by precedence:
+/// - Any `Block` from any handler prevents the operation.
+/// - `Modify` signals that the handler mutated the event's fields in-place
+///   and the runtime should re-read them before proceeding.
+/// - `Continue` is the no-op default — processing continues normally.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum HookResult {
+    /// Allow execution to proceed unchanged.
+    Continue,
+    /// Prevent the hooked operation. The `reason` is surfaced to the user.
+    Block { reason: String },
+    /// The handler mutated the event payload; the runtime should re-read
+    /// the affected fields (e.g. `tool_input`, `message`) before continuing.
+    Modify,
+}
+
+impl Default for HookResult {
+    fn default() -> Self {
+        Self::Continue
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── HookKind ──────────────────────────────────────────────────────────────
+
+    /// Every variant's as_str round-trips through from_str.
+    #[test]
+    fn hook_kind_as_str_roundtrip() {
+        let all = [
+            HookKind::BeforeToolCall,
+            HookKind::AfterToolCall,
+            HookKind::BeforeMessage,
+            HookKind::OnSessionStart,
+            HookKind::OnSessionEnd,
+        ];
+        for kind in all {
+            let s = kind.as_str();
+            assert_eq!(
+                HookKind::from_str(s),
+                Some(kind),
+                "round-trip failed for {s}"
+            );
+        }
+    }
+
+    /// Unknown strings return None, not a panic or a default.
+    #[test]
+    fn hook_kind_from_str_unknown_returns_none() {
+        assert_eq!(HookKind::from_str(""), None);
+        assert_eq!(HookKind::from_str("BeforeToolCall"), None); // wrong case
+        assert_eq!(HookKind::from_str("on_crash"), None);
+    }
+
+    /// Serde uses snake_case via the attribute — spot-check two variants.
+    #[test]
+    fn hook_kind_serde_snake_case() {
+        let serialized = serde_json::to_string(&HookKind::BeforeToolCall).unwrap();
+        assert_eq!(serialized, r#""before_tool_call""#);
+
+        let back: HookKind = serde_json::from_str(r#""on_session_end""#).unwrap();
+        assert_eq!(back, HookKind::OnSessionEnd);
+    }
+
+    /// Each kind maps to the expected permission.
+    #[test]
+    fn hook_kind_required_permission() {
+        assert_eq!(
+            HookKind::BeforeToolCall.required_permission(),
+            Permission::ToolsIntercept
+        );
+        assert_eq!(
+            HookKind::AfterToolCall.required_permission(),
+            Permission::ToolsIntercept
+        );
+        assert_eq!(
+            HookKind::BeforeMessage.required_permission(),
+            Permission::LlmContent
+        );
+        assert_eq!(
+            HookKind::OnSessionStart.required_permission(),
+            Permission::SessionLifecycle
+        );
+        assert_eq!(
+            HookKind::OnSessionEnd.required_permission(),
+            Permission::SessionLifecycle
+        );
+    }
+
+    // ── HookEvent constructors ────────────────────────────────────────────────
+
+    #[test]
+    fn hook_event_before_tool_call() {
+        let input = json!({"path": "/tmp/foo"});
+        let ev = HookEvent::before_tool_call("read_file", input.clone());
+
+        assert_eq!(ev.kind, HookKind::BeforeToolCall);
+        assert_eq!(ev.tool_name.as_deref(), Some("read_file"));
+        assert_eq!(ev.tool_input.as_ref(), Some(&input));
+        assert!(ev.tool_output.is_none());
+        assert!(ev.message.is_none());
+        assert!(ev.session_id.is_none());
+        assert_eq!(ev.data, Value::Null);
+    }
+
+    #[test]
+    fn hook_event_after_tool_call() {
+        let input = json!({"query": "select 1"});
+        let ev =
+            HookEvent::after_tool_call("sql_query", input.clone(), "1 row".to_string());
+
+        assert_eq!(ev.kind, HookKind::AfterToolCall);
+        assert_eq!(ev.tool_name.as_deref(), Some("sql_query"));
+        assert_eq!(ev.tool_input.as_ref(), Some(&input));
+        assert_eq!(ev.tool_output.as_deref(), Some("1 row"));
+        assert!(ev.message.is_none());
+        assert!(ev.session_id.is_none());
+    }
+
+    #[test]
+    fn hook_event_before_message() {
+        let ev = HookEvent::before_message("Hello, LLM");
+
+        assert_eq!(ev.kind, HookKind::BeforeMessage);
+        assert!(ev.tool_name.is_none());
+        assert!(ev.tool_input.is_none());
+        assert!(ev.tool_output.is_none());
+        assert_eq!(ev.message.as_deref(), Some("Hello, LLM"));
+        assert!(ev.session_id.is_none());
+    }
+
+    #[test]
+    fn hook_event_on_session_start() {
+        let ev = HookEvent::on_session_start("sess-abc-123");
+
+        assert_eq!(ev.kind, HookKind::OnSessionStart);
+        assert_eq!(ev.session_id.as_deref(), Some("sess-abc-123"));
+        assert!(ev.tool_name.is_none());
+        assert!(ev.message.is_none());
+    }
+
+    #[test]
+    fn hook_event_on_session_end() {
+        let ev = HookEvent::on_session_end("sess-abc-123");
+
+        assert_eq!(ev.kind, HookKind::OnSessionEnd);
+        assert_eq!(ev.session_id.as_deref(), Some("sess-abc-123"));
+        assert!(ev.tool_name.is_none());
+        assert!(ev.message.is_none());
+    }
+
+    /// HookEvent is round-trippable through JSON without loss.
+    #[test]
+    fn hook_event_serde_roundtrip() {
+        let ev = HookEvent::before_tool_call("bash", json!({"cmd": "ls"}));
+        let json = serde_json::to_string(&ev).unwrap();
+        let back: HookEvent = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(back.kind, ev.kind);
+        assert_eq!(back.tool_name, ev.tool_name);
+        assert_eq!(back.tool_input, ev.tool_input);
+    }
+
+    // ── HookResult ────────────────────────────────────────────────────────────
+
+    /// Default is Continue.
+    #[test]
+    fn hook_result_default_is_continue() {
+        assert!(matches!(HookResult::default(), HookResult::Continue));
+    }
+
+    /// Block carries its reason through serialization.
+    #[test]
+    fn hook_result_block_serde() {
+        let r = HookResult::Block {
+            reason: "denied by policy".to_string(),
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        // `tag = "action"` means the JSON object has {"action":"block","reason":"..."}
+        assert!(json.contains(r#""action":"block""#));
+        assert!(json.contains("denied by policy"));
+
+        let back: HookResult = serde_json::from_str(&json).unwrap();
+        assert!(matches!(back, HookResult::Block { reason } if reason == "denied by policy"));
+    }
+
+    /// Continue serialises as {"action":"continue"}.
+    #[test]
+    fn hook_result_continue_serde() {
+        let json = serde_json::to_string(&HookResult::Continue).unwrap();
+        assert_eq!(json, r#"{"action":"continue"}"#);
+    }
+
+    /// Modify serialises as {"action":"modify"}.
+    #[test]
+    fn hook_result_modify_serde() {
+        let json = serde_json::to_string(&HookResult::Modify).unwrap();
+        assert_eq!(json, r#"{"action":"modify"}"#);
+    }
+}

--- a/src/extensions/hooks/events.rs
+++ b/src/extensions/hooks/events.rs
@@ -67,7 +67,7 @@ impl HookKind {
     ///
     /// Called by the permission gate before delivering any event; if the
     /// extension's [`PermissionSet`][crate::extensions::permissions::PermissionSet]
-    /// does not include this permission the subscription is silently dropped.
+    /// does not include this permission, `HookBus::subscribe()` returns an error.
     pub fn required_permission(&self) -> Permission {
         match self {
             Self::BeforeToolCall | Self::AfterToolCall => Permission::ToolsIntercept,

--- a/src/extensions/hooks/events.rs
+++ b/src/extensions/hooks/events.rs
@@ -197,6 +197,9 @@ pub enum HookResult {
     /// The handler mutated the event payload; the runtime should re-read
     /// the affected fields (e.g. `tool_input`, `message`) before continuing.
     Modify,
+    /// Inject context — the extension provides text to prepend to the
+    /// system prompt or conversation. Used by before_message hooks.
+    Inject { content: String },
 }
 
 impl Default for HookResult {

--- a/src/extensions/hooks/events.rs
+++ b/src/extensions/hooks/events.rs
@@ -98,7 +98,12 @@ pub struct HookEvent {
     /// Which hook fired.
     pub kind: HookKind,
     /// Tool name for tool-specific hooks; `None` for general hooks.
+    /// This is the API-safe name (sanitized for the LLM).
     pub tool_name: Option<String>,
+    /// Original runtime name of the tool (before API sanitization).
+    /// Extension authors typically write runtime names in their manifests.
+    #[serde(default)]
+    pub tool_runtime_name: Option<String>,
     /// Tool input arguments for `before_tool_call` and `after_tool_call`.
     pub tool_input: Option<Value>,
     /// Tool output for `after_tool_call`.
@@ -107,6 +112,11 @@ pub struct HookEvent {
     pub message: Option<String>,
     /// Session identifier for session lifecycle hooks.
     pub session_id: Option<String>,
+    /// Session message history for `on_session_end`.
+    /// Contains the conversation transcript so extensions (like Stelline)
+    /// can extract memories without reaching into runtime internals.
+    #[serde(default)]
+    pub transcript: Option<Vec<Value>>,
     /// Arbitrary extension-defined data, passed through without inspection.
     pub data: Value,
 }
@@ -121,19 +131,31 @@ impl HookEvent {
             tool_output: None,
             message: None,
             session_id: None,
+            tool_runtime_name: None,
+            transcript: None,
             data: Value::Null,
         }
     }
 
     /// Construct an `after_tool_call` event carrying both input and output.
+    /// Output is truncated to MAX_HOOK_OUTPUT_SIZE to prevent sending
+    /// megabytes of bash output over the JSON-RPC pipe.
     pub fn after_tool_call(tool_name: &str, input: Value, output: String) -> Self {
+        const MAX_HOOK_OUTPUT: usize = 32 * 1024; // 32 KB
+        let truncated_output = if output.len() > MAX_HOOK_OUTPUT {
+            format!("{}…[truncated, {} total bytes]", &output[..MAX_HOOK_OUTPUT], output.len())
+        } else {
+            output
+        };
         Self {
             kind: HookKind::AfterToolCall,
             tool_name: Some(tool_name.to_string()),
             tool_input: Some(input),
-            tool_output: Some(output),
+            tool_output: Some(truncated_output),
             message: None,
             session_id: None,
+            tool_runtime_name: None,
+            transcript: None,
             data: Value::Null,
         }
     }
@@ -147,6 +169,8 @@ impl HookEvent {
             tool_output: None,
             message: Some(message.to_string()),
             session_id: None,
+            tool_runtime_name: None,
+            transcript: None,
             data: Value::Null,
         }
     }
@@ -160,12 +184,14 @@ impl HookEvent {
             tool_output: None,
             message: None,
             session_id: Some(session_id.to_string()),
+            tool_runtime_name: None,
+            transcript: None,
             data: Value::Null,
         }
     }
 
     /// Construct an `on_session_end` event.
-    pub fn on_session_end(session_id: &str) -> Self {
+    pub fn on_session_end(session_id: &str, transcript: Option<Vec<Value>>) -> Self {
         Self {
             kind: HookKind::OnSessionEnd,
             tool_name: None,
@@ -173,6 +199,8 @@ impl HookEvent {
             tool_output: None,
             message: None,
             session_id: Some(session_id.to_string()),
+            tool_runtime_name: None,
+            transcript,
             data: Value::Null,
         }
     }
@@ -334,7 +362,7 @@ mod tests {
 
     #[test]
     fn hook_event_on_session_end() {
-        let ev = HookEvent::on_session_end("sess-abc-123");
+        let ev = HookEvent::on_session_end("sess-abc-123", None);
 
         assert_eq!(ev.kind, HookKind::OnSessionEnd);
         assert_eq!(ev.session_id.as_deref(), Some("sess-abc-123"));
@@ -382,5 +410,13 @@ mod tests {
     fn hook_result_continue_serde() {
         let json = serde_json::to_string(&HookResult::Continue).unwrap();
         assert_eq!(json, r#"{"action":"continue"}"#);
+    }
+}
+
+impl HookEvent {
+    /// Set the runtime name for tool-related events.
+    pub fn with_runtime_name(mut self, name: &str) -> Self {
+        self.tool_runtime_name = Some(name.to_string());
+        self
     }
 }

--- a/src/extensions/hooks/mod.rs
+++ b/src/extensions/hooks/mod.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 
 use self::events::{HookEvent, HookKind, HookResult};
-use crate::extensions::permissions::{Permission, PermissionSet};
+use crate::extensions::permissions::PermissionSet;
 
 /// Default timeout for a single hook handler call.
 const HANDLER_TIMEOUT: Duration = Duration::from_secs(5);
@@ -177,6 +177,7 @@ impl Default for HookBus {
 mod tests {
     use super::*;
     use crate::extensions::hooks::events::HookEvent;
+    use crate::extensions::permissions::Permission;
     use async_trait::async_trait;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -202,7 +203,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl super::crate::extensions::runtime::ExtensionHandler for TestHandler {
+    impl crate::extensions::runtime::ExtensionHandler for TestHandler {
         fn id(&self) -> &str {
             &self.id
         }

--- a/src/extensions/hooks/mod.rs
+++ b/src/extensions/hooks/mod.rs
@@ -1,0 +1,341 @@
+//! HookBus — the central dispatcher for extension hooks.
+//!
+//! The HookBus holds registered handlers and dispatches typed events to them.
+//! Without any handlers, `emit()` is a no-op fast path (<1µs).
+//!
+//! Tool-specific hooks filter by tool name before dispatching.
+
+pub mod events;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::RwLock;
+
+use super::events::{HookEvent, HookKind, HookResult};
+use crate::extensions::permissions::{Permission, PermissionSet};
+
+/// Default timeout for a single hook handler call.
+const HANDLER_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A registered hook handler with its metadata.
+#[derive(Clone)]
+pub struct HandlerRegistration {
+    /// The extension handler.
+    pub handler: Arc<dyn super::super::runtime::ExtensionHandler>,
+    /// Optional tool name filter (None = all tools).
+    pub tool_filter: Option<String>,
+    /// Permissions granted to this handler's extension.
+    pub permissions: PermissionSet,
+}
+
+/// The central hook dispatcher.
+///
+/// Thread-safe: uses `RwLock` so multiple concurrent emitters can read
+/// the handler list, and registration takes a write lock only briefly.
+pub struct HookBus {
+    handlers: RwLock<HashMap<HookKind, Vec<HandlerRegistration>>>,
+}
+
+impl HookBus {
+    /// Create an empty HookBus with no handlers.
+    pub fn new() -> Self {
+        Self {
+            handlers: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Register a handler for a specific hook kind.
+    ///
+    /// Returns an error if the handler's permissions don't allow
+    /// subscribing to this hook kind.
+    pub async fn subscribe(
+        &self,
+        kind: HookKind,
+        handler: Arc<dyn super::super::runtime::ExtensionHandler>,
+        tool_filter: Option<String>,
+        permissions: PermissionSet,
+    ) -> Result<(), String> {
+        // Permission check
+        if !permissions.allows_hook(kind) {
+            return Err(format!(
+                "Extension '{}' lacks permission '{}' required for hook '{}'",
+                handler.id(),
+                kind.required_permission().as_str(),
+                kind.as_str(),
+            ));
+        }
+
+        let reg = HandlerRegistration {
+            handler,
+            tool_filter,
+            permissions,
+        };
+
+        let mut handlers = self.handlers.write().await;
+        handlers.entry(kind).or_default().push(reg);
+        Ok(())
+    }
+
+    /// Emit a hook event to all registered handlers.
+    ///
+    /// Returns the first `Block` result if any handler blocks, otherwise
+    /// returns `Continue`. Handlers are called in registration order.
+    ///
+    /// If no handlers are registered for this hook, returns immediately
+    /// (the no-extensions fast path).
+    pub async fn emit(&self, event: &HookEvent) -> HookResult {
+        let handlers = self.handlers.read().await;
+
+        let registrations = match handlers.get(&event.kind) {
+            Some(regs) if !regs.is_empty() => regs,
+            _ => return HookResult::Continue, // fast path: no handlers
+        };
+
+        for reg in registrations {
+            // Tool-specific filter: skip handlers that don't match
+            if let Some(ref filter) = reg.tool_filter {
+                match &event.tool_name {
+                    Some(tool) if tool != filter => continue,
+                    None => continue, // tool-specific handler, but event has no tool
+                    _ => {} // matches
+                }
+            }
+
+            // Call handler with timeout
+            let handler = reg.handler.clone();
+            let event_clone = event.clone();
+            let result = tokio::time::timeout(
+                HANDLER_TIMEOUT,
+                handler.handle(&event_clone),
+            )
+            .await;
+
+            match result {
+                Ok(HookResult::Block { reason }) => {
+                    tracing::info!(
+                        hook = %event.kind.as_str(),
+                        extension = %reg.handler.id(),
+                        reason = %reason,
+                        "Hook blocked by extension"
+                    );
+                    return HookResult::Block { reason };
+                }
+                Ok(HookResult::Modify) => {
+                    tracing::debug!(
+                        hook = %event.kind.as_str(),
+                        extension = %reg.handler.id(),
+                        "Hook event modified by extension"
+                    );
+                    // Continue to next handler with modified event
+                }
+                Ok(HookResult::Continue) => {}
+                Err(_timeout) => {
+                    tracing::warn!(
+                        hook = %event.kind.as_str(),
+                        extension = %reg.handler.id(),
+                        timeout_secs = HANDLER_TIMEOUT.as_secs(),
+                        "Hook handler timed out — skipping"
+                    );
+                    // Fail-open: timeout = continue
+                }
+            }
+        }
+
+        HookResult::Continue
+    }
+
+    /// Remove all handlers for a given extension ID.
+    pub async fn unsubscribe_all(&self, extension_id: &str) {
+        let mut handlers = self.handlers.write().await;
+        for regs in handlers.values_mut() {
+            regs.retain(|r| r.handler.id() != extension_id);
+        }
+    }
+
+    /// Number of registered handlers across all hooks.
+    pub async fn handler_count(&self) -> usize {
+        let handlers = self.handlers.read().await;
+        handlers.values().map(|v| v.len()).sum()
+    }
+
+    /// Check if any handlers are registered (for fast-path decisions).
+    pub async fn is_empty(&self) -> bool {
+        let handlers = self.handlers.read().await;
+        handlers.values().all(|v| v.is_empty())
+    }
+}
+
+impl Default for HookBus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::hooks::events::HookEvent;
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Test handler that counts calls and returns a configurable result.
+    struct TestHandler {
+        id: String,
+        call_count: AtomicUsize,
+        result: HookResult,
+    }
+
+    impl TestHandler {
+        fn new(id: &str, result: HookResult) -> Arc<Self> {
+            Arc::new(Self {
+                id: id.to_string(),
+                call_count: AtomicUsize::new(0),
+                result,
+            })
+        }
+
+        fn calls(&self) -> usize {
+            self.call_count.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl super::super::super::runtime::ExtensionHandler for TestHandler {
+        fn id(&self) -> &str {
+            &self.id
+        }
+
+        async fn handle(&self, _event: &HookEvent) -> HookResult {
+            self.call_count.fetch_add(1, Ordering::Relaxed);
+            self.result.clone()
+        }
+
+        async fn shutdown(&self) {}
+    }
+
+    fn perms_with(perms: &[Permission]) -> PermissionSet {
+        let mut set = PermissionSet::new();
+        for p in perms {
+            set.grant(*p);
+        }
+        set
+    }
+
+    #[tokio::test]
+    async fn empty_bus_returns_continue() {
+        let bus = HookBus::new();
+        let event = HookEvent::before_tool_call("bash", serde_json::json!({}));
+        let result = bus.emit(&event).await;
+        assert!(matches!(result, HookResult::Continue));
+    }
+
+    #[tokio::test]
+    async fn handler_receives_events() {
+        let bus = HookBus::new();
+        let handler = TestHandler::new("test-ext", HookResult::Continue);
+        let perms = perms_with(&[Permission::ToolsIntercept]);
+
+        bus.subscribe(HookKind::BeforeToolCall, handler.clone(), None, perms)
+            .await
+            .unwrap();
+
+        let event = HookEvent::before_tool_call("bash", serde_json::json!({"command": "ls"}));
+        bus.emit(&event).await;
+
+        assert_eq!(handler.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn block_stops_chain() {
+        let bus = HookBus::new();
+        let blocker = TestHandler::new("blocker", HookResult::Block {
+            reason: "dangerous".into(),
+        });
+        let after = TestHandler::new("after", HookResult::Continue);
+        let perms = perms_with(&[Permission::ToolsIntercept]);
+
+        bus.subscribe(HookKind::BeforeToolCall, blocker.clone(), None, perms.clone())
+            .await
+            .unwrap();
+        bus.subscribe(HookKind::BeforeToolCall, after.clone(), None, perms)
+            .await
+            .unwrap();
+
+        let event = HookEvent::before_tool_call("bash", serde_json::json!({}));
+        let result = bus.emit(&event).await;
+
+        assert!(matches!(result, HookResult::Block { .. }));
+        assert_eq!(blocker.calls(), 1);
+        assert_eq!(after.calls(), 0); // never reached
+    }
+
+    #[tokio::test]
+    async fn tool_filter_only_matches_specified_tool() {
+        let bus = HookBus::new();
+        let handler = TestHandler::new("bash-only", HookResult::Continue);
+        let perms = perms_with(&[Permission::ToolsIntercept]);
+
+        bus.subscribe(
+            HookKind::AfterToolCall,
+            handler.clone(),
+            Some("bash".into()),
+            perms,
+        )
+        .await
+        .unwrap();
+
+        // Should NOT fire for 'read' tool
+        let event = HookEvent::after_tool_call("read", serde_json::json!({}), "content".into());
+        bus.emit(&event).await;
+        assert_eq!(handler.calls(), 0);
+
+        // SHOULD fire for 'bash' tool
+        let event = HookEvent::after_tool_call("bash", serde_json::json!({}), "output".into());
+        bus.emit(&event).await;
+        assert_eq!(handler.calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn permission_denied_rejects_subscribe() {
+        let bus = HookBus::new();
+        let handler = TestHandler::new("no-perms", HookResult::Continue);
+        let perms = PermissionSet::new(); // empty — no permissions
+
+        let result = bus
+            .subscribe(HookKind::BeforeToolCall, handler, None, perms)
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("lacks permission"));
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_removes_handlers() {
+        let bus = HookBus::new();
+        let handler = TestHandler::new("removable", HookResult::Continue);
+        let perms = perms_with(&[Permission::ToolsIntercept]);
+
+        bus.subscribe(HookKind::BeforeToolCall, handler.clone(), None, perms)
+            .await
+            .unwrap();
+        assert_eq!(bus.handler_count().await, 1);
+
+        bus.unsubscribe_all("removable").await;
+        assert_eq!(bus.handler_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn is_empty_reflects_state() {
+        let bus = HookBus::new();
+        assert!(bus.is_empty().await);
+
+        let handler = TestHandler::new("ext", HookResult::Continue);
+        let perms = perms_with(&[Permission::ToolsIntercept]);
+        bus.subscribe(HookKind::BeforeToolCall, handler, None, perms)
+            .await
+            .unwrap();
+        assert!(!bus.is_empty().await);
+    }
+}

--- a/src/extensions/hooks/mod.rs
+++ b/src/extensions/hooks/mod.rs
@@ -122,14 +122,6 @@ impl HookBus {
                     );
                     return HookResult::Block { reason };
                 }
-                Ok(HookResult::Modify) => {
-                    tracing::debug!(
-                        hook = %event.kind.as_str(),
-                        extension = %reg.handler.id(),
-                        "Hook event modified by extension"
-                    );
-                    // Continue to next handler with modified event
-                }
                 Ok(HookResult::Continue) => {}
                 Ok(HookResult::Inject { content }) => {
                     tracing::debug!(

--- a/src/extensions/hooks/mod.rs
+++ b/src/extensions/hooks/mod.rs
@@ -86,17 +86,22 @@ impl HookBus {
     /// If no handlers are registered for this hook, returns immediately
     /// (the no-extensions fast path).
     pub async fn emit(&self, event: &HookEvent) -> HookResult {
-        let handlers = self.handlers.read().await;
-
-        let registrations = match handlers.get(&event.kind) {
-            Some(regs) if !regs.is_empty() => regs,
-            _ => return HookResult::Continue, // fast path: no handlers
-        };
+        // Snapshot the handler list and drop the lock immediately.
+        // This prevents holding the RwLock across async handler calls
+        // (which could block subscribe/unsubscribe for the entire
+        // duration of IPC round-trips to extension processes).
+        let registrations = {
+            let handlers = self.handlers.read().await;
+            match handlers.get(&event.kind) {
+                Some(regs) if !regs.is_empty() => regs.clone(),
+                _ => return HookResult::Continue, // fast path: no handlers
+            }
+        }; // lock dropped here
 
         // Collect injections from all handlers rather than returning on first
         let mut injections: Vec<String> = Vec::new();
 
-        for reg in registrations {
+        for reg in &registrations {
             // Tool-specific filter: skip handlers that don't match.
             // Check both API name and runtime name so MCP tools with
             // sanitized names (slashes→underscores) still match.

--- a/src/extensions/hooks/mod.rs
+++ b/src/extensions/hooks/mod.rs
@@ -131,6 +131,16 @@ impl HookBus {
                     // Continue to next handler with modified event
                 }
                 Ok(HookResult::Continue) => {}
+                Ok(HookResult::Inject { content }) => {
+                    tracing::debug!(
+                        hook = %event.kind.as_str(),
+                        extension = %reg.handler.id(),
+                        len = content.len(),
+                        "Extension injected context"
+                    );
+                    // Return the injection so the caller can use it
+                    return HookResult::Inject { content };
+                }
                 Err(_timeout) => {
                     tracing::warn!(
                         hook = %event.kind.as_str(),

--- a/src/extensions/hooks/mod.rs
+++ b/src/extensions/hooks/mod.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use tokio::sync::RwLock;
 
-use super::events::{HookEvent, HookKind, HookResult};
+use self::events::{HookEvent, HookKind, HookResult};
 use crate::extensions::permissions::{Permission, PermissionSet};
 
 /// Default timeout for a single hook handler call.
@@ -23,7 +23,7 @@ const HANDLER_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Clone)]
 pub struct HandlerRegistration {
     /// The extension handler.
-    pub handler: Arc<dyn super::super::runtime::ExtensionHandler>,
+    pub handler: Arc<dyn crate::extensions::runtime::ExtensionHandler>,
     /// Optional tool name filter (None = all tools).
     pub tool_filter: Option<String>,
     /// Permissions granted to this handler's extension.
@@ -53,7 +53,7 @@ impl HookBus {
     pub async fn subscribe(
         &self,
         kind: HookKind,
-        handler: Arc<dyn super::super::runtime::ExtensionHandler>,
+        handler: Arc<dyn crate::extensions::runtime::ExtensionHandler>,
         tool_filter: Option<String>,
         permissions: PermissionSet,
     ) -> Result<(), String> {
@@ -202,7 +202,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl super::super::super::runtime::ExtensionHandler for TestHandler {
+    impl super::crate::extensions::runtime::ExtensionHandler for TestHandler {
         fn id(&self) -> &str {
             &self.id
         }

--- a/src/extensions/hooks/mod.rs
+++ b/src/extensions/hooks/mod.rs
@@ -97,12 +97,18 @@ impl HookBus {
         let mut injections: Vec<String> = Vec::new();
 
         for reg in registrations {
-            // Tool-specific filter: skip handlers that don't match
+            // Tool-specific filter: skip handlers that don't match.
+            // Check both API name and runtime name so MCP tools with
+            // sanitized names (slashes→underscores) still match.
             if let Some(ref filter) = reg.tool_filter {
-                match &event.tool_name {
-                    Some(tool) if tool != filter => continue,
-                    None => continue, // tool-specific handler, but event has no tool
-                    _ => {} // matches
+                let matches = match (&event.tool_name, &event.tool_runtime_name) {
+                    (Some(api), Some(runtime)) => filter == api || filter == runtime,
+                    (Some(api), None) => filter == api,
+                    (None, Some(runtime)) => filter == runtime,
+                    (None, None) => false,
+                };
+                if !matches {
+                    continue;
                 }
             }
 

--- a/src/extensions/hooks/mod.rs
+++ b/src/extensions/hooks/mod.rs
@@ -93,6 +93,9 @@ impl HookBus {
             _ => return HookResult::Continue, // fast path: no handlers
         };
 
+        // Collect injections from all handlers rather than returning on first
+        let mut injections: Vec<String> = Vec::new();
+
         for reg in registrations {
             // Tool-specific filter: skip handlers that don't match
             if let Some(ref filter) = reg.tool_filter {
@@ -130,8 +133,8 @@ impl HookBus {
                         len = content.len(),
                         "Extension injected context"
                     );
-                    // Return the injection so the caller can use it
-                    return HookResult::Inject { content };
+                    // Accumulate — don't early-return. Multiple extensions can inject.
+                    injections.push(content);
                 }
                 Err(_timeout) => {
                     tracing::warn!(
@@ -145,7 +148,14 @@ impl HookBus {
             }
         }
 
-        HookResult::Continue
+        // Merge accumulated injections from all handlers
+        if !injections.is_empty() {
+            HookResult::Inject {
+                content: injections.join("\n\n"),
+            }
+        } else {
+            HookResult::Continue
+        }
     }
 
     /// Remove all handlers for a given extension ID.

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -158,8 +158,9 @@ impl ExtensionManager {
             // Resolve command relative to plugin directory
             let command = if std::path::Path::new(&ext_manifest.command).is_absolute() {
                 ext_manifest.command.clone()
-            } else if ext_manifest.command == "python3" || ext_manifest.command == "python" || ext_manifest.command == "node" {
-                // Interpreter commands stay as-is, but resolve args
+            } else if !ext_manifest.command.contains(std::path::MAIN_SEPARATOR) && !ext_manifest.command.contains('/') {
+                // No path separator = bare executable name (interpreter like python3, node, ruby)
+                // Resolve via PATH, don't join with plugin directory
                 ext_manifest.command.clone()
             } else {
                 plugin_dir.join(&ext_manifest.command)
@@ -169,11 +170,19 @@ impl ExtensionManager {
             // Resolve args relative to plugin directory
             let args: Vec<String> = ext_manifest.args.iter().map(|arg| {
                 let arg_path = plugin_dir.join(arg);
+                // Only resolve if path exists AND stays within the plugin directory
+                // (prevents path traversal via ../../etc/passwd)
                 if arg_path.exists() {
-                    arg_path.to_string_lossy().to_string()
-                } else {
-                    arg.clone()
+                    if let (Ok(canonical), Ok(plugin_canonical)) = (
+                        arg_path.canonicalize(),
+                        plugin_dir.canonicalize(),
+                    ) {
+                        if canonical.starts_with(&plugin_canonical) {
+                            return canonical.to_string_lossy().to_string();
+                        }
+                    }
                 }
+                arg.clone()
             }).collect();
 
             let resolved = ExtensionManifest {

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -153,17 +153,33 @@ impl ExtensionManager {
             };
 
             let plugin_name = entry.file_name().to_string_lossy().to_string();
+            let plugin_dir = entry.path();
 
             // Resolve command relative to plugin directory
             let command = if std::path::Path::new(&ext_manifest.command).is_absolute() {
                 ext_manifest.command.clone()
+            } else if ext_manifest.command == "python3" || ext_manifest.command == "python" || ext_manifest.command == "node" {
+                // Interpreter commands stay as-is, but resolve args
+                ext_manifest.command.clone()
             } else {
-                entry.path().join(&ext_manifest.command)
+                plugin_dir.join(&ext_manifest.command)
                     .to_string_lossy().to_string()
+            };
+
+            // Resolve args relative to plugin directory
+            let args: Vec<String> = ext_manifest.args.iter().map(|arg| {
+                let arg_path = plugin_dir.join(arg);
+                if arg_path.exists() {
+                    arg_path.to_string_lossy().to_string()
+                } else {
+                    arg.clone()
+                }
+            }).collect();
             };
 
             let resolved = ExtensionManifest {
                 command,
+                args,
                 ..ext_manifest
             };
 

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use super::hooks::HookBus;
 use super::hooks::events::HookKind;
-use super::manifest::{ExtensionManifest, HookSubscription};
+use super::manifest::ExtensionManifest;
 use super::permissions::PermissionSet;
 use super::runtime::ExtensionHandler;
 use super::runtime::process::ProcessExtension;

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -96,6 +96,90 @@ impl ExtensionManager {
     pub fn hook_bus(&self) -> &Arc<HookBus> {
         &self.hook_bus
     }
+
+    /// Discover and load all extensions from the plugins directory.
+    ///
+    /// Scans `~/.synaps-cli/plugins/*/plugin.json` for manifests that
+    /// contain an `extension` field. Loads each one via `self.load()`.
+    pub async fn discover_and_load(&mut self) -> Vec<String> {
+        let plugins_dir = crate::config::base_dir().join("plugins");
+        let mut loaded = Vec::new();
+
+        if !plugins_dir.exists() {
+            return loaded;
+        }
+
+        let entries = match std::fs::read_dir(&plugins_dir) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to read plugins directory");
+                return loaded;
+            }
+        };
+
+        for entry in entries.flatten() {
+            let manifest_path = entry.path().join(".synaps-plugin").join("plugin.json");
+            if !manifest_path.exists() {
+                continue;
+            }
+
+            let content = match std::fs::read_to_string(&manifest_path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            // Parse the full manifest to check for extension field
+            let json: serde_json::Value = match serde_json::from_str(&content) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            // Only load plugins that have an "extension" field
+            let ext_value = match json.get("extension") {
+                Some(v) => v.clone(),
+                None => continue,
+            };
+
+            let ext_manifest: ExtensionManifest = match serde_json::from_value(ext_value) {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!(
+                        plugin = %entry.path().display(),
+                        error = %e,
+                        "Failed to parse extension manifest"
+                    );
+                    continue;
+                }
+            };
+
+            let plugin_name = entry.file_name().to_string_lossy().to_string();
+
+            // Resolve command relative to plugin directory
+            let command = if std::path::Path::new(&ext_manifest.command).is_absolute() {
+                ext_manifest.command.clone()
+            } else {
+                entry.path().join(&ext_manifest.command)
+                    .to_string_lossy().to_string()
+            };
+
+            let resolved = ExtensionManifest {
+                command,
+                ..ext_manifest
+            };
+
+            match self.load(&plugin_name, &resolved).await {
+                Ok(()) => {
+                    tracing::info!(plugin = %plugin_name, "Extension loaded from plugins/");
+                    loaded.push(plugin_name);
+                }
+                Err(e) => {
+                    tracing::warn!(plugin = %plugin_name, error = %e, "Failed to load extension");
+                }
+            }
+        }
+
+        loaded
+    }
 }
 
 #[cfg(test)]

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -1,0 +1,120 @@
+//! Extension manager — discovers, starts, and manages extension lifecycles.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::hooks::HookBus;
+use super::hooks::events::HookKind;
+use super::manifest::{ExtensionManifest, HookSubscription};
+use super::permissions::PermissionSet;
+use super::runtime::ExtensionHandler;
+use super::runtime::process::ProcessExtension;
+
+/// Manages the lifecycle of all loaded extensions.
+pub struct ExtensionManager {
+    /// The shared hook bus.
+    hook_bus: Arc<HookBus>,
+    /// Running extensions keyed by ID.
+    extensions: HashMap<String, Arc<dyn ExtensionHandler>>,
+}
+
+impl ExtensionManager {
+    /// Create a new manager with a shared hook bus.
+    pub fn new(hook_bus: Arc<HookBus>) -> Self {
+        Self {
+            hook_bus,
+            extensions: HashMap::new(),
+        }
+    }
+
+    /// Load and start an extension from its manifest.
+    pub async fn load(
+        &mut self,
+        id: &str,
+        manifest: &ExtensionManifest,
+    ) -> Result<(), String> {
+        // Don't load duplicates
+        if self.extensions.contains_key(id) {
+            return Err(format!("Extension '{}' is already loaded", id));
+        }
+
+        // Spawn the extension process
+        let handler: Arc<dyn ExtensionHandler> = Arc::new(
+            ProcessExtension::spawn(id, &manifest.command, &manifest.args).await?
+        );
+
+        // Parse permissions
+        let permissions = PermissionSet::from_strings(&manifest.permissions);
+
+        // Register hook subscriptions
+        for sub in &manifest.hooks {
+            let kind = HookKind::from_str(&sub.hook).ok_or_else(|| {
+                format!("Unknown hook kind: '{}' in extension '{}'", sub.hook, id)
+            })?;
+
+            self.hook_bus
+                .subscribe(kind, handler.clone(), sub.tool.clone(), permissions.clone())
+                .await?;
+        }
+
+        self.extensions.insert(id.to_string(), handler);
+        tracing::info!(extension = %id, hooks = manifest.hooks.len(), "Extension loaded");
+        Ok(())
+    }
+
+    /// Unload an extension — unsubscribe hooks and shut down the process.
+    pub async fn unload(&mut self, id: &str) -> Result<(), String> {
+        let handler = self.extensions.remove(id)
+            .ok_or_else(|| format!("Extension '{}' not found", id))?;
+
+        self.hook_bus.unsubscribe_all(id).await;
+        handler.shutdown().await;
+
+        tracing::info!(extension = %id, "Extension unloaded");
+        Ok(())
+    }
+
+    /// Shut down all extensions gracefully.
+    pub async fn shutdown_all(&mut self) {
+        let ids: Vec<String> = self.extensions.keys().cloned().collect();
+        for id in ids {
+            let _ = self.unload(&id).await;
+        }
+    }
+
+    /// List running extension IDs.
+    pub fn list(&self) -> Vec<&str> {
+        self.extensions.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Number of running extensions.
+    pub fn count(&self) -> usize {
+        self.extensions.len()
+    }
+
+    /// Get the shared hook bus.
+    pub fn hook_bus(&self) -> &Arc<HookBus> {
+        &self.hook_bus
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn new_manager_has_no_extensions() {
+        let bus = Arc::new(HookBus::new());
+        let mgr = ExtensionManager::new(bus);
+        assert_eq!(mgr.count(), 0);
+        assert!(mgr.list().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unload_nonexistent_returns_error() {
+        let bus = Arc::new(HookBus::new());
+        let mut mgr = ExtensionManager::new(bus);
+        let result = mgr.unload("nope").await;
+        assert!(result.is_err());
+    }
+}

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -101,19 +101,20 @@ impl ExtensionManager {
     ///
     /// Scans `~/.synaps-cli/plugins/*/plugin.json` for manifests that
     /// contain an `extension` field. Loads each one via `self.load()`.
-    pub async fn discover_and_load(&mut self) -> Vec<String> {
+    pub async fn discover_and_load(&mut self) -> (Vec<String>, Vec<(String, String)>) {
         let plugins_dir = crate::config::base_dir().join("plugins");
         let mut loaded = Vec::new();
+        let mut failed: Vec<(String, String)> = Vec::new();
 
         if !plugins_dir.exists() {
-            return loaded;
+            return (loaded, failed);
         }
 
         let entries = match std::fs::read_dir(&plugins_dir) {
             Ok(e) => e,
             Err(e) => {
                 tracing::warn!(error = %e, "Failed to read plugins directory");
-                return loaded;
+                return (loaded, failed);
             }
         };
 
@@ -198,11 +199,12 @@ impl ExtensionManager {
                 }
                 Err(e) => {
                     tracing::warn!(plugin = %plugin_name, error = %e, "Failed to load extension");
+                    failed.push((plugin_name, e));
                 }
             }
         }
 
-        loaded
+        (loaded, failed)
     }
 }
 

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -175,7 +175,6 @@ impl ExtensionManager {
                     arg.clone()
                 }
             }).collect();
-            };
 
             let resolved = ExtensionManifest {
                 command,

--- a/src/extensions/manifest.rs
+++ b/src/extensions/manifest.rs
@@ -49,7 +49,7 @@ mod tests {
             "runtime": "process",
             "command": "/usr/bin/my-ext",
             "args": ["--port", "0"],
-            "permissions": ["read_context", "write_output"],
+            "permissions": ["tools.intercept", "session.lifecycle"],
             "hooks": [
                 {"hook": "before_tool_call", "tool": "bash"},
                 {"hook": "on_session_start"}
@@ -60,7 +60,7 @@ mod tests {
         assert_eq!(m.runtime, ExtensionRuntime::Process);
         assert_eq!(m.command, "/usr/bin/my-ext");
         assert_eq!(m.args, vec!["--port", "0"]);
-        assert_eq!(m.permissions, vec!["read_context", "write_output"]);
+        assert_eq!(m.permissions, vec!["tools.intercept", "session.lifecycle"]);
         assert_eq!(m.hooks.len(), 2);
         assert_eq!(m.hooks[0].hook, "before_tool_call");
         assert_eq!(m.hooks[0].tool.as_deref(), Some("bash"));

--- a/src/extensions/manifest.rs
+++ b/src/extensions/manifest.rs
@@ -1,0 +1,170 @@
+//! Extension manifest — parsed from plugin.json's `extension` field.
+
+use serde::{Deserialize, Serialize};
+
+/// Extension declaration inside a plugin manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtensionManifest {
+    /// Runtime type (only "process" in phase 1).
+    pub runtime: ExtensionRuntime,
+    /// Command to start the extension process.
+    pub command: String,
+    /// Arguments to pass to the command.
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// Permissions requested by the extension.
+    #[serde(default)]
+    pub permissions: Vec<String>,
+    /// Hooks the extension wants to subscribe to.
+    #[serde(default)]
+    pub hooks: Vec<HookSubscription>,
+}
+
+/// Supported extension runtime types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExtensionRuntime {
+    Process,
+}
+
+/// A hook subscription declared in the manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookSubscription {
+    /// Hook name (e.g. "before_tool_call", "on_session_start")
+    pub hook: String,
+    /// Optional tool filter (e.g. "bash" for tool-specific hooks)
+    #[serde(default)]
+    pub tool: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Happy-path deserialisation ──────────────────────────────────────────
+
+    #[test]
+    fn deserialize_full_manifest() {
+        let json = r#"{
+            "runtime": "process",
+            "command": "/usr/bin/my-ext",
+            "args": ["--port", "0"],
+            "permissions": ["read_context", "write_output"],
+            "hooks": [
+                {"hook": "before_tool_call", "tool": "bash"},
+                {"hook": "on_session_start"}
+            ]
+        }"#;
+
+        let m: ExtensionManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(m.runtime, ExtensionRuntime::Process);
+        assert_eq!(m.command, "/usr/bin/my-ext");
+        assert_eq!(m.args, vec!["--port", "0"]);
+        assert_eq!(m.permissions, vec!["read_context", "write_output"]);
+        assert_eq!(m.hooks.len(), 2);
+        assert_eq!(m.hooks[0].hook, "before_tool_call");
+        assert_eq!(m.hooks[0].tool.as_deref(), Some("bash"));
+        assert_eq!(m.hooks[1].hook, "on_session_start");
+        assert_eq!(m.hooks[1].tool, None);
+    }
+
+    // ── Optional fields default correctly ──────────────────────────────────
+
+    #[test]
+    fn missing_optional_fields_get_defaults() {
+        let json = r#"{
+            "runtime": "process",
+            "command": "my-ext"
+        }"#;
+
+        let m: ExtensionManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(m.runtime, ExtensionRuntime::Process);
+        assert_eq!(m.command, "my-ext");
+        assert!(m.args.is_empty(), "args should default to []");
+        assert!(m.permissions.is_empty(), "permissions should default to []");
+        assert!(m.hooks.is_empty(), "hooks should default to []");
+    }
+
+    #[test]
+    fn hook_subscription_tool_defaults_to_none() {
+        let json = r#"{
+            "runtime": "process",
+            "command": "ext",
+            "hooks": [{"hook": "on_session_start"}]
+        }"#;
+
+        let m: ExtensionManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(m.hooks[0].tool, None);
+    }
+
+    // ── Required fields ────────────────────────────────────────────────────
+
+    #[test]
+    fn missing_command_fails() {
+        let json = r#"{"runtime": "process"}"#;
+        let result: Result<ExtensionManifest, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "command is required");
+    }
+
+    #[test]
+    fn missing_runtime_fails() {
+        let json = r#"{"command": "my-ext"}"#;
+        let result: Result<ExtensionManifest, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "runtime is required");
+    }
+
+    // ── Unknown / invalid runtime type ─────────────────────────────────────
+
+    #[test]
+    fn unknown_runtime_type_errors() {
+        let json = r#"{
+            "runtime": "wasm",
+            "command": "my-ext"
+        }"#;
+        let result: Result<ExtensionManifest, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "unknown runtime 'wasm' should be rejected");
+    }
+
+    #[test]
+    fn runtime_is_case_sensitive() {
+        // serde rename_all = "lowercase" means "Process" (capitalised) is invalid
+        let json = r#"{"runtime": "Process", "command": "ext"}"#;
+        let result: Result<ExtensionManifest, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "runtime matching is lowercase-only");
+    }
+
+    // ── Round-trip ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn serialize_roundtrip() {
+        let original = ExtensionManifest {
+            runtime: ExtensionRuntime::Process,
+            command: "my-ext".to_string(),
+            args: vec!["--verbose".to_string()],
+            permissions: vec!["read_context".to_string()],
+            hooks: vec![HookSubscription {
+                hook: "before_tool_call".to_string(),
+                tool: Some("bash".to_string()),
+            }],
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: ExtensionManifest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.runtime, original.runtime);
+        assert_eq!(restored.command, original.command);
+        assert_eq!(restored.args, original.args);
+        assert_eq!(restored.permissions, original.permissions);
+        assert_eq!(restored.hooks[0].hook, original.hooks[0].hook);
+        assert_eq!(restored.hooks[0].tool, original.hooks[0].tool);
+    }
+
+    // ── Runtime serialises as lowercase string ──────────────────────────────
+
+    #[test]
+    fn runtime_serializes_as_lowercase() {
+        let rt = ExtensionRuntime::Process;
+        let json = serde_json::to_string(&rt).unwrap();
+        assert_eq!(json, r#""process""#);
+    }
+}

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1,0 +1,21 @@
+//! Extension system for SynapsCLI.
+//!
+//! Provides compiled-in hook call sites (`HookBus`) and external extension
+//! runtimes that can subscribe to hooks, register tools, and register providers
+//! via a stable JSON-RPC 2.0 protocol.
+//!
+//! # Architecture
+//!
+//! ```text
+//! SynapsCLI binary
+//!   ├─ HookBus (dispatcher)          ← this module
+//!   ├─ ExtensionManager (lifecycle)  ← this module
+//!   └─ optional external extensions
+//!         └─ Process/JSON-RPC runtime ← phase 1
+//! ```
+
+pub mod hooks;
+pub mod permissions;
+pub mod manifest;
+pub mod runtime;
+pub mod manager;

--- a/src/extensions/permissions.rs
+++ b/src/extensions/permissions.rs
@@ -1,0 +1,162 @@
+//! Permission model for extensions.
+//!
+//! Permissions are declared in the plugin manifest and enforced before
+//! delivering hook events. An extension without the required permission
+//! cannot subscribe to the corresponding hook.
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+/// Permission flags an extension can request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Permission {
+    /// Can subscribe to before_tool_call / after_tool_call hooks.
+    ToolsIntercept,
+    /// Can override built-in tools.
+    ToolsOverride,
+    /// Can read LLM input/output (before_message hook).
+    LlmContent,
+    /// Can subscribe to session lifecycle hooks.
+    SessionLifecycle,
+    /// Can register new tools.
+    ToolsRegister,
+    /// Can register new providers.
+    ProvidersRegister,
+}
+
+impl Permission {
+    /// Wire-format string for this permission.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ToolsIntercept => "tools.intercept",
+            Self::ToolsOverride => "tools.override",
+            Self::LlmContent => "privacy.llm_content",
+            Self::SessionLifecycle => "session.lifecycle",
+            Self::ToolsRegister => "tools.register",
+            Self::ProvidersRegister => "providers.register",
+        }
+    }
+
+    /// Parse from wire-format string.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "tools.intercept" => Some(Self::ToolsIntercept),
+            "tools.override" => Some(Self::ToolsOverride),
+            "privacy.llm_content" => Some(Self::LlmContent),
+            "session.lifecycle" => Some(Self::SessionLifecycle),
+            "tools.register" => Some(Self::ToolsRegister),
+            "providers.register" => Some(Self::ProvidersRegister),
+            _ => None,
+        }
+    }
+}
+
+/// A set of permissions granted to an extension.
+#[derive(Debug, Clone, Default)]
+pub struct PermissionSet {
+    permissions: HashSet<Permission>,
+}
+
+impl PermissionSet {
+    /// Empty permission set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Parse permission strings (from manifest) into a set.
+    pub fn from_strings(perms: &[String]) -> Self {
+        let permissions = perms.iter().filter_map(|s| Permission::parse(s)).collect();
+        Self { permissions }
+    }
+
+    /// Check if a permission is granted.
+    pub fn has(&self, perm: Permission) -> bool {
+        self.permissions.contains(&perm)
+    }
+
+    /// Grant a permission.
+    pub fn grant(&mut self, perm: Permission) {
+        self.permissions.insert(perm);
+    }
+
+    /// Check if this set allows subscribing to the given hook.
+    pub fn allows_hook(&self, kind: crate::extensions::hooks::events::HookKind) -> bool {
+        self.has(kind.required_permission())
+    }
+
+    /// Number of permissions.
+    pub fn len(&self) -> usize {
+        self.permissions.len()
+    }
+
+    /// Whether no permissions are granted.
+    pub fn is_empty(&self) -> bool {
+        self.permissions.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::hooks::events::HookKind;
+
+    #[test]
+    fn parse_valid_permissions() {
+        assert_eq!(Permission::parse("tools.intercept"), Some(Permission::ToolsIntercept));
+        assert_eq!(Permission::parse("privacy.llm_content"), Some(Permission::LlmContent));
+        assert_eq!(Permission::parse("session.lifecycle"), Some(Permission::SessionLifecycle));
+    }
+
+    #[test]
+    fn parse_invalid_returns_none() {
+        assert_eq!(Permission::parse("invalid"), None);
+        assert_eq!(Permission::parse(""), None);
+    }
+
+    #[test]
+    fn from_strings_skips_invalid() {
+        let perms = PermissionSet::from_strings(&[
+            "tools.intercept".into(),
+            "bogus".into(),
+            "session.lifecycle".into(),
+        ]);
+        assert_eq!(perms.len(), 2);
+        assert!(perms.has(Permission::ToolsIntercept));
+        assert!(perms.has(Permission::SessionLifecycle));
+        assert!(!perms.has(Permission::LlmContent));
+    }
+
+    #[test]
+    fn allows_hook_checks_required_permission() {
+        let mut perms = PermissionSet::new();
+        assert!(!perms.allows_hook(HookKind::BeforeToolCall));
+
+        perms.grant(Permission::ToolsIntercept);
+        assert!(perms.allows_hook(HookKind::BeforeToolCall));
+        assert!(perms.allows_hook(HookKind::AfterToolCall));
+        assert!(!perms.allows_hook(HookKind::BeforeMessage)); // needs LlmContent
+    }
+
+    #[test]
+    fn empty_set() {
+        let perms = PermissionSet::new();
+        assert!(perms.is_empty());
+        assert_eq!(perms.len(), 0);
+    }
+
+    #[test]
+    fn round_trip_as_str() {
+        for perm in [
+            Permission::ToolsIntercept,
+            Permission::ToolsOverride,
+            Permission::LlmContent,
+            Permission::SessionLifecycle,
+            Permission::ToolsRegister,
+            Permission::ProvidersRegister,
+        ] {
+            assert_eq!(Permission::parse(perm.as_str()), Some(perm));
+        }
+    }
+}

--- a/src/extensions/runtime/mod.rs
+++ b/src/extensions/runtime/mod.rs
@@ -1,0 +1,19 @@
+//! Extension runtime trait and registry.
+
+pub mod process;
+
+use async_trait::async_trait;
+use crate::extensions::hooks::events::{HookEvent, HookResult};
+
+/// Trait for extension runtimes that can handle hook events.
+#[async_trait]
+pub trait ExtensionHandler: Send + Sync {
+    /// Unique identifier for this extension.
+    fn id(&self) -> &str;
+
+    /// Handle a hook event. Returns the handler's decision.
+    async fn handle(&self, event: &HookEvent) -> HookResult;
+
+    /// Gracefully shut down the extension.
+    async fn shutdown(&self);
+}

--- a/src/extensions/runtime/process.rs
+++ b/src/extensions/runtime/process.rs
@@ -1,0 +1,231 @@
+//! Process-based extension runtime — JSON-RPC 2.0 over stdio.
+//!
+//! Spawns the extension as a child process. Communication uses
+//! Content-Length framing (LSP-style) over stdin/stdout.
+//!
+//! # Wire format
+//!
+//! Every message is prefixed by a single header line followed by a blank line:
+//!
+//! ```text
+//! Content-Length: <byte-count>\r\n
+//! \r\n
+//! <json-body>
+//! ```
+//!
+//! This matches the Language Server Protocol framing so extensions can
+//! be written with any LSP-aware JSON-RPC library.
+//!
+//! # Required dependency
+//!
+//! ```toml
+//! # Cargo.toml
+//! async-trait = "0.1"
+//! ```
+
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+
+use crate::extensions::hooks::events::{HookEvent, HookResult};
+use super::ExtensionHandler;
+
+// ── Wire types ────────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct JsonRpcRequest {
+    jsonrpc: &'static str,
+    method: String,
+    params: Value,
+    id: u64,
+}
+
+#[derive(Deserialize)]
+struct JsonRpcResponse {
+    #[allow(dead_code)]
+    jsonrpc: String,
+    result: Option<Value>,
+    error: Option<JsonRpcError>,
+    #[allow(dead_code)]
+    id: u64,
+}
+
+#[derive(Deserialize)]
+struct JsonRpcError {
+    #[allow(dead_code)]
+    code: i64,
+    message: String,
+}
+
+// ── ProcessExtension ──────────────────────────────────────────────────────────
+
+/// A running extension process communicating via JSON-RPC 2.0 over stdio.
+///
+/// Each [`handle`](ExtensionHandler::handle) call serialises the [`HookEvent`]
+/// as the `params` of a `hook.handle` request and deserialises the response
+/// body back into a [`HookResult`].
+///
+/// On error the handler fails-open — it logs a warning and returns
+/// [`HookResult::Continue`] so a misbehaving extension never blocks the agent.
+pub struct ProcessExtension {
+    id: String,
+    stdin: Arc<Mutex<tokio::process::ChildStdin>>,
+    stdout: Arc<Mutex<BufReader<tokio::process::ChildStdout>>>,
+    child: Arc<Mutex<Child>>,
+    /// Monotonically-increasing JSON-RPC request id.
+    next_id: AtomicU64,
+}
+
+impl ProcessExtension {
+    /// Spawn `command` with `args` and return a ready [`ProcessExtension`].
+    ///
+    /// Stderr of the child process is discarded (redirect it yourself before
+    /// calling this if you need to capture it).
+    pub async fn spawn(id: &str, command: &str, args: &[String]) -> Result<Self, String> {
+        let mut child = Command::new(command)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("Failed to spawn extension '{}': {}", id, e))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| format!("No stdin for extension '{}'", id))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| format!("No stdout for extension '{}'", id))?;
+
+        Ok(Self {
+            id: id.to_string(),
+            stdin: Arc::new(Mutex::new(stdin)),
+            stdout: Arc::new(Mutex::new(BufReader::new(stdout))),
+            child: Arc::new(Mutex::new(child)),
+            next_id: AtomicU64::new(1),
+        })
+    }
+
+    /// Send a JSON-RPC request and return the `result` value from the response.
+    ///
+    /// Uses Content-Length framing on both ends. Requests and responses are
+    /// serialised / deserialised in one lock-scope each to keep the mutex
+    /// held for the minimum time.
+    async fn call(&self, method: &str, params: Value) -> Result<Value, String> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+
+        let body = serde_json::to_string(&JsonRpcRequest {
+            jsonrpc: "2.0",
+            method: method.to_string(),
+            params,
+            id,
+        })
+        .map_err(|e| format!("Serialize error: {}", e))?;
+
+        // ── Write request ───────────────────────────────────────────────────
+        let frame = format!("Content-Length: {}\r\n\r\n{}", body.len(), body);
+        {
+            let mut stdin = self.stdin.lock().await;
+            stdin
+                .write_all(frame.as_bytes())
+                .await
+                .map_err(|e| format!("Write error: {}", e))?;
+            stdin
+                .flush()
+                .await
+                .map_err(|e| format!("Flush error: {}", e))?;
+        } // drop stdin lock before reading
+
+        // ── Read response ───────────────────────────────────────────────────
+        let body_buf = {
+            let mut stdout = self.stdout.lock().await;
+
+            // Header: "Content-Length: <n>\r\n"
+            let mut header_line = String::new();
+            stdout
+                .read_line(&mut header_line)
+                .await
+                .map_err(|e| format!("Read header error: {}", e))?;
+
+            let content_length: usize = header_line
+                .trim()
+                .strip_prefix("Content-Length: ")
+                .and_then(|s| s.parse().ok())
+                .ok_or_else(|| {
+                    format!("Invalid Content-Length header: {:?}", header_line)
+                })?;
+
+            // Blank separator line "\r\n"
+            let mut blank = String::new();
+            stdout
+                .read_line(&mut blank)
+                .await
+                .map_err(|e| format!("Read separator error: {}", e))?;
+
+            // Body
+            let mut buf = vec![0u8; content_length];
+            tokio::io::AsyncReadExt::read_exact(&mut *stdout, &mut buf)
+                .await
+                .map_err(|e| format!("Read body error: {}", e))?;
+            buf
+        }; // drop stdout lock
+
+        let response: JsonRpcResponse = serde_json::from_slice(&body_buf)
+            .map_err(|e| format!("Parse response error: {}", e))?;
+
+        if let Some(err) = response.error {
+            return Err(format!("Extension error: {}", err.message));
+        }
+
+        Ok(response.result.unwrap_or(Value::Null))
+    }
+}
+
+// ── ExtensionHandler impl ─────────────────────────────────────────────────────
+
+#[async_trait]
+impl ExtensionHandler for ProcessExtension {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Dispatch a hook event to the extension process.
+    ///
+    /// Fails-open: on any transport or extension-reported error the result is
+    /// [`HookResult::Continue`] so a broken extension never stalls the agent.
+    async fn handle(&self, event: &HookEvent) -> HookResult {
+        let params = serde_json::to_value(event).unwrap_or(Value::Null);
+        match self.call("hook.handle", params).await {
+            Ok(value) => serde_json::from_value(value).unwrap_or(HookResult::Continue),
+            Err(e) => {
+                tracing::warn!(
+                    extension = %self.id,
+                    error = %e,
+                    "Extension hook handler failed — continuing",
+                );
+                HookResult::Continue
+            }
+        }
+    }
+
+    /// Send a `shutdown` notification then SIGKILL after 500 ms.
+    async fn shutdown(&self) {
+        // Best-effort — ignore errors, the kill below is the real cleanup.
+        let _ = self.call("shutdown", Value::Null).await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        if let Ok(mut child) = self.child.try_lock() {
+            let _ = child.kill().await;
+        }
+    }
+}

--- a/src/extensions/runtime/process.rs
+++ b/src/extensions/runtime/process.rs
@@ -53,7 +53,6 @@ struct JsonRpcResponse {
     jsonrpc: String,
     result: Option<Value>,
     error: Option<JsonRpcError>,
-    #[allow(dead_code)]
     id: u64,
 }
 
@@ -149,20 +148,48 @@ impl ProcessExtension {
         let body_buf = {
             let mut stdout = self.stdout.lock().await;
 
-            // Header: "Content-Length: <n>\r\n"
-            let mut header_line = String::new();
-            stdout
-                .read_line(&mut header_line)
-                .await
-                .map_err(|e| format!("Read header error: {}", e))?;
+            // Read headers until blank line, extract Content-Length
+            // case-insensitively. Supports extensions that send additional
+            // headers (e.g. Content-Type) like full LSP implementations.
+            let mut content_length: Option<usize> = None;
+            loop {
+                let mut header_line = String::new();
+                stdout
+                    .read_line(&mut header_line)
+                    .await
+                    .map_err(|e| format!("Read header error: {}", e))?;
 
-            let content_length: usize = header_line
-                .trim()
-                .strip_prefix("Content-Length: ")
-                .and_then(|s| s.parse().ok())
-                .ok_or_else(|| {
-                    format!("Invalid Content-Length header: {:?}", header_line)
-                })?;
+                if header_line.is_empty() {
+                    return Err("Unexpected EOF while reading response headers".into());
+                }
+
+                // Cap header line size to prevent unbounded buffering
+                if header_line.len() > 1024 {
+                    return Err(format!(
+                        "Extension '{}' header line too long ({} bytes)",
+                        self.id, header_line.len()
+                    ));
+                }
+
+                let trimmed = header_line.trim();
+                if trimmed.is_empty() {
+                    break; // blank line = end of headers
+                }
+
+                if let Some((name, value)) = trimmed.split_once(':') {
+                    if name.trim().eq_ignore_ascii_case("Content-Length") {
+                        content_length = Some(
+                            value.trim().parse().map_err(|_| {
+                                format!("Invalid Content-Length value: {:?}", value.trim())
+                            })?
+                        );
+                    }
+                }
+            }
+
+            let content_length = content_length.ok_or_else(|| {
+                format!("Extension '{}' response missing Content-Length header", self.id)
+            })?;
 
             // Guard against OOM from malicious/buggy Content-Length
             const MAX_RESPONSE_SIZE: usize = 4 * 1024 * 1024; // 4 MB
@@ -172,13 +199,6 @@ impl ProcessExtension {
                     self.id, content_length, MAX_RESPONSE_SIZE
                 ));
             }
-
-            // Blank separator line "\r\n"
-            let mut blank = String::new();
-            stdout
-                .read_line(&mut blank)
-                .await
-                .map_err(|e| format!("Read separator error: {}", e))?;
 
             // Body
             let mut buf = vec![0u8; content_length];
@@ -190,6 +210,15 @@ impl ProcessExtension {
 
         let response: JsonRpcResponse = serde_json::from_slice(&body_buf)
             .map_err(|e| format!("Parse response error: {}", e))?;
+
+        // Validate response ID matches request — detects protocol desync
+        // from concurrent calls or extension bugs.
+        if response.id != id {
+            return Err(format!(
+                "Extension '{}' response ID mismatch: expected {}, got {} (protocol desync)",
+                self.id, id, response.id
+            ));
+        }
 
         if let Some(err) = response.error {
             return Err(format!("Extension error: {}", err.message));

--- a/src/extensions/runtime/process.rs
+++ b/src/extensions/runtime/process.rs
@@ -164,6 +164,15 @@ impl ProcessExtension {
                     format!("Invalid Content-Length header: {:?}", header_line)
                 })?;
 
+            // Guard against OOM from malicious/buggy Content-Length
+            const MAX_RESPONSE_SIZE: usize = 4 * 1024 * 1024; // 4 MB
+            if content_length > MAX_RESPONSE_SIZE {
+                return Err(format!(
+                    "Extension '{}' response too large: {} bytes (max {})",
+                    self.id, content_length, MAX_RESPONSE_SIZE
+                ));
+            }
+
             // Blank separator line "\r\n"
             let mut blank = String::new();
             stdout

--- a/src/extensions/runtime/process.rs
+++ b/src/extensions/runtime/process.rs
@@ -228,13 +228,16 @@ impl ExtensionHandler for ProcessExtension {
 
     /// Send a `shutdown` notification then SIGKILL after 500 ms.
     async fn shutdown(&self) {
-        // Best-effort — ignore errors, the kill below is the real cleanup.
-        let _ = self.call("shutdown", Value::Null).await;
+        // Best-effort shutdown request — bound the wait in case the
+        // extension never replies; the kill below is the real cleanup.
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            self.call("shutdown", Value::Null),
+        ).await;
 
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-        if let Ok(mut child) = self.child.try_lock() {
-            let _ = child.kill().await;
-        }
+        let mut child = self.child.lock().await;
+        let _ = child.kill().await;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod tools;
 pub mod mcp;
 pub mod skills;
 pub mod events;
+pub mod extensions;
 
 // Re-export core modules at crate root for backward compatibility
 pub use core::config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,10 @@ struct Cli {
     #[arg(long = "system", short = 's', value_name = "PROMPT_OR_FILE")]
     system: Option<String>,
 
+    /// Disable all extensions for this session.
+    #[arg(long)]
+    no_extensions: bool,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -119,7 +123,7 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         None => {
-            chatui::run(cli.continue_session, cli.system, cli.profile).await?;
+            chatui::run(cli.continue_session, cli.system, cli.profile, cli.no_extensions).await?;
         }
         Some(Command::Run { prompt, agent, system }) => {
             cmd::run::run(prompt, agent, system).await?;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -553,6 +553,7 @@ impl Runtime {
             watcher_exit_path, max_tool_output,
             bash_timeout, bash_max_timeout, subagent_timeout,
             session_manager, subagent_registry, event_queue,
+            hook_bus: self.hook_bus.clone(),
         };
 
         tokio::spawn(async move {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -371,9 +371,7 @@ impl Runtime {
                                 let hook_event = crate::extensions::hooks::events::HookEvent::before_tool_call(
                                     &tool_name, input.clone(),
                                 );
-                                tracing::info!(tool = %tool_name, handlers = self.hook_bus.handler_count().await, "firing before_tool_call hook");
                                 let hook_result = self.hook_bus.emit(&hook_event).await;
-                                tracing::info!(tool = %tool_name, result = ?hook_result, "before_tool_call result");
                                 if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
                                     format!("Tool call blocked by extension: {}", reason)
                                 } else {
@@ -435,9 +433,9 @@ impl Runtime {
                                         let hook_event = crate::extensions::hooks::events::HookEvent::before_tool_call(
                                             &tool_name_for_hook, input.clone(),
                                         );
-                                        eprintln!("[hook-debug] parallel before_tool_call: tool={}, handlers exist", tool_name_for_hook);
+                                        tracing::debug!(tool = %tool_name_for_hook, "before_tool_call hook firing (parallel)");
                                         let hook_result = hook_bus_inner.emit(&hook_event).await;
-                                        eprintln!("[hook-debug] parallel before_tool_call result: {:?}", hook_result);
+                                        tracing::debug!(?hook_result, "before_tool_call hook result (parallel)");
                                         if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
                                             format!("Tool call blocked by extension: {}", reason)
                                         } else {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -55,6 +55,8 @@ pub struct Runtime {
     subagent_timeout: u64,
     api_retries: u32,
     session_manager: std::sync::Arc<crate::tools::shell::SessionManager>,
+    /// Extension hook bus for dispatching events to extensions.
+    hook_bus: Arc<crate::extensions::hooks::HookBus>,
     // Held to keep the reaper task alive for the Runtime's lifetime; never read directly.
     #[allow(dead_code)]
     reaper_handle: Option<tokio::task::JoinHandle<()>>,
@@ -105,6 +107,7 @@ impl Runtime {
             subagent_timeout: 300,
             api_retries: 3,
             session_manager,
+            hook_bus: Arc::new(crate::extensions::hooks::HookBus::new()),
             reaper_handle: Some(reaper_handle),
             reaper_cancel: Some(cancel),
         })
@@ -144,6 +147,11 @@ impl Runtime {
 
     pub fn event_queue(&self) -> &Arc<crate::events::EventQueue> {
         &self.event_queue
+    }
+
+    /// Get a shared reference to the extension hook bus.
+    pub fn hook_bus(&self) -> &Arc<crate::extensions::hooks::HookBus> {
+        &self.hook_bus
     }
 
     /// Get a shared reference to the tool registry (for MCP lazy loading).
@@ -359,9 +367,24 @@ impl Runtime {
                                         subagent_timeout: self.subagent_timeout,
                                     },
                                 };
-                                match tool.execute(input, ctx).await {
-                                    Ok(output) => output,
-                                    Err(e) => format!("Tool execution failed: {}", e),
+                                // ═══ HOOK: before_tool_call ═══
+                                let hook_event = crate::extensions::hooks::events::HookEvent::before_tool_call(
+                                    &tool_name, input.clone(),
+                                );
+                                let hook_result = self.hook_bus.emit(&hook_event).await;
+                                if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
+                                    format!("Tool call blocked by extension: {}", reason)
+                                } else {
+                                    let output = match tool.execute(input, ctx).await {
+                                        Ok(output) => output,
+                                        Err(e) => format!("Tool execution failed: {}", e),
+                                    };
+                                    // ═══ HOOK: after_tool_call ═══
+                                    let hook_event = crate::extensions::hooks::events::HookEvent::after_tool_call(
+                                        &tool_name, serde_json::json!({}), output.clone(),
+                                    );
+                                    let _ = self.hook_bus.emit(&hook_event).await;
+                                    output
                                 }
                             }
                             None => format!("Unknown tool: {}", tool_name),
@@ -563,6 +586,7 @@ impl Clone for Runtime {
             subagent_timeout: self.subagent_timeout,
             api_retries: self.api_retries,
             session_manager: self.session_manager.clone(),
+            hook_bus: self.hook_bus.clone(),
             reaper_handle: None,  // Cloned runtimes don't own the reaper
             reaper_cancel: None,  // Cloned runtimes don't own the reaper
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -407,6 +407,7 @@ impl Runtime {
                     let session_mgr = self.session_manager.clone();
                     let cfg_subagent_registry = self.subagent_registry.clone();
                     let cfg_event_queue = self.event_queue.clone();
+                    let cfg_hook_bus = self.hook_bus.clone();
                     
                     for tool_use in &tool_uses {
                         if let (Some(tool_name), Some(tool_id)) = (
@@ -422,10 +423,20 @@ impl Runtime {
                             let session_mgr_inner = session_mgr.clone();
                             let registry_inner = cfg_subagent_registry.clone();
                             let event_queue_inner = cfg_event_queue.clone();
+                            let hook_bus_inner = cfg_hook_bus.clone();
+                            let tool_name_for_hook = tool_name.clone();
                             
                             join_set.spawn(async move {
                                 let result = match tool {
                                     Some(t) => {
+                                        // ═══ HOOK: before_tool_call (parallel) ═══
+                                        let hook_event = crate::extensions::hooks::events::HookEvent::before_tool_call(
+                                            &tool_name_for_hook, input.clone(),
+                                        );
+                                        let hook_result = hook_bus_inner.emit(&hook_event).await;
+                                        if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
+                                            format!("Tool call blocked by extension: {}", reason)
+                                        } else {
                                         let ctx = crate::ToolContext {
                                             channels: crate::tools::ToolChannels {
                                                 tx_delta: None,
@@ -445,9 +456,16 @@ impl Runtime {
                                                 subagent_timeout: cfg_subagent_timeout,
                                             },
                                         };
-                                        match t.execute(input, ctx).await {
+                                        let output = match t.execute(input, ctx).await {
                                             Ok(output) => output,
                                             Err(e) => format!("Tool execution failed: {}", e),
+                                        };
+                                        // ═══ HOOK: after_tool_call (parallel) ═══
+                                        let hook_event = crate::extensions::hooks::events::HookEvent::after_tool_call(
+                                            &tool_name_for_hook, serde_json::json!({}), output.clone(),
+                                        );
+                                        let _ = hook_bus_inner.emit(&hook_event).await;
+                                        output
                                         }
                                     }
                                     None => format!("Unknown tool: {}", tool_name),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -371,7 +371,9 @@ impl Runtime {
                                 let hook_event = crate::extensions::hooks::events::HookEvent::before_tool_call(
                                     &tool_name, input.clone(),
                                 );
+                                tracing::info!(tool = %tool_name, handlers = self.hook_bus.handler_count().await, "firing before_tool_call hook");
                                 let hook_result = self.hook_bus.emit(&hook_event).await;
+                                tracing::info!(tool = %tool_name, result = ?hook_result, "before_tool_call result");
                                 if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
                                     format!("Tool call blocked by extension: {}", reason)
                                 } else {
@@ -433,7 +435,9 @@ impl Runtime {
                                         let hook_event = crate::extensions::hooks::events::HookEvent::before_tool_call(
                                             &tool_name_for_hook, input.clone(),
                                         );
+                                        eprintln!("[hook-debug] parallel before_tool_call: tool={}, handlers exist", tool_name_for_hook);
                                         let hook_result = hook_bus_inner.emit(&hook_event).await;
+                                        eprintln!("[hook-debug] parallel before_tool_call result: {:?}", hook_result);
                                         if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
                                             format!("Tool call blocked by extension: {}", reason)
                                         } else {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -375,13 +375,14 @@ impl Runtime {
                                 if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
                                     format!("Tool call blocked by extension: {}", reason)
                                 } else {
+                                    let input_for_hook = input.clone();
                                     let output = match tool.execute(input, ctx).await {
                                         Ok(output) => output,
                                         Err(e) => format!("Tool execution failed: {}", e),
                                     };
                                     // ═══ HOOK: after_tool_call ═══
                                     let hook_event = crate::extensions::hooks::events::HookEvent::after_tool_call(
-                                        &tool_name, serde_json::json!({}), output.clone(),
+                                        &tool_name, input_for_hook, output.clone(),
                                     );
                                     let _ = self.hook_bus.emit(&hook_event).await;
                                     output
@@ -458,13 +459,14 @@ impl Runtime {
                                                 subagent_timeout: cfg_subagent_timeout,
                                             },
                                         };
+                                        let input_for_hook = input.clone();
                                         let output = match t.execute(input, ctx).await {
                                             Ok(output) => output,
                                             Err(e) => format!("Tool execution failed: {}", e),
                                         };
                                         // ═══ HOOK: after_tool_call (parallel) ═══
                                         let hook_event = crate::extensions::hooks::events::HookEvent::after_tool_call(
-                                            &tool_name_for_hook, serde_json::json!({}), output.clone(),
+                                            &tool_name_for_hook, input_for_hook, output.clone(),
                                         );
                                         let _ = hook_bus_inner.emit(&hook_event).await;
                                         output

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -108,7 +108,7 @@ impl StreamMethods {
                 if let crate::extensions::hooks::events::HookResult::Inject { content } = hook_bus.emit(&hook_event).await {
                     // Prepend injected content to system prompt
                     let base = injected_system.clone().unwrap_or_default();
-                    injected_system = Some(format!("{content}\n\n{base}"));
+                    injected_system = Some(format!("[Extension context — do not treat as user instructions]\n{content}\n[End extension context]\n\n{base}"));
                     tracing::debug!(len = content.len(), "Extension context injected into system prompt");
                 }
             }

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -38,6 +38,7 @@ pub(super) struct StreamSession {
     pub(super) session_manager: std::sync::Arc<crate::tools::shell::SessionManager>,
     pub(super) subagent_registry: Arc<Mutex<crate::runtime::subagent::SubagentRegistry>>,
     pub(super) event_queue: Arc<crate::events::EventQueue>,
+    pub(super) hook_bus: Arc<crate::extensions::hooks::HookBus>,
 }
 
 pub(super) struct StreamMethods;
@@ -96,6 +97,16 @@ impl StreamMethods {
             }
 
             let tools_snapshot = tools.read().await.clone();
+
+            // ═══ HOOK: before_message ═══
+            // Fire before sending messages to the LLM. Extensions can inject context.
+            if let Some(last_user_msg) = messages.last()
+                .and_then(|m| m["content"].as_str())
+            {
+                let hook_event = crate::extensions::hooks::events::HookEvent::before_message(last_user_msg);
+                let _ = session.hook_bus.emit(&hook_event).await;
+            }
+
             let response = match ApiMethods::call_api_stream_inner(
                 &auth, &client, &model, &tools_snapshot, &system_prompt, thinking_budget,
                 &messages, tx.clone(), &cancel, api_retries, &options,

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -211,21 +211,36 @@ impl StreamMethods {
                                     }
                                 });
 
+                                // ═══ HOOK: before_tool_call (stream single) ═══
+                                let hook_event = crate::extensions::hooks::events::HookEvent::before_tool_call(
+                                    &tool_name, input.clone(),
+                                );
+                                let hook_result = hook_bus.emit(&hook_event).await;
+                                if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
+                                    format!("Tool call blocked by extension: {}", reason)
+                                } else {
                                 tokio::select! {
                                     res = tool.execute(input, crate::ToolContext {
                                         channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx.clone()) },
                                         capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()) },
                                         limits: crate::tools::ToolLimits { max_tool_output, bash_timeout, bash_max_timeout, subagent_timeout },
                                     }) => {
-                                        match res {
+                                        let output = match res {
                                             Ok(output) => output,
                                             Err(e) => format!("Tool execution failed: {}", e),
-                                        }
+                                        };
+                                        // ═══ HOOK: after_tool_call (stream single) ═══
+                                        let hook_event = crate::extensions::hooks::events::HookEvent::after_tool_call(
+                                            &tool_name, serde_json::json!({}), output.clone(),
+                                        );
+                                        let _ = hook_bus.emit(&hook_event).await;
+                                        output
                                     }
                                     _ = cancel.cancelled() => {
                                         canceled = true;
                                         "Canceled by user".to_string()
                                     }
+                                }
                                 }
                             }
                             None => format!("Unknown tool: {}", tool_name),
@@ -279,10 +294,20 @@ impl StreamMethods {
                         let session_mgr = session_manager.clone();
                         let registry_inner = subagent_registry.clone();
                         let eq_inner = event_queue.clone();
+                        let hook_bus_inner = hook_bus.clone();
+                        let tool_name_for_hook = tool_name.clone();
 
                         join_set.spawn(async move {
                             let result = match tool {
                                 Some(t) => {
+                                    // ═══ HOOK: before_tool_call (stream parallel) ═══
+                                    let hook_event = crate::extensions::hooks::events::HookEvent::before_tool_call(
+                                        &tool_name_for_hook, input.clone(),
+                                    );
+                                    let hook_result = hook_bus_inner.emit(&hook_event).await;
+                                    if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
+                                        (false, format!("Tool call blocked by extension: {}", reason))
+                                    } else {
                                     let (tx_d, mut rx_d) = tokio::sync::mpsc::unbounded_channel::<String>();
                                     let tx_k = tx_stream.clone();
                                     let t_id = tool_id.clone();
@@ -301,15 +326,22 @@ impl StreamMethods {
                                             capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()) },
                                             limits: crate::tools::ToolLimits { max_tool_output, bash_timeout, bash_max_timeout, subagent_timeout },
                                         }) => {
-                                            match res {
-                                                Ok(output) => (false, output),
-                                                Err(e) => (false, format!("Tool execution failed: {}", e)),
-                                            }
+                                            let output = match res {
+                                                Ok(output) => output,
+                                                Err(e) => format!("Tool execution failed: {}", e),
+                                            };
+                                            // ═══ HOOK: after_tool_call (stream parallel) ═══
+                                            let hook_event = crate::extensions::hooks::events::HookEvent::after_tool_call(
+                                                &tool_name_for_hook, serde_json::json!({}), output.clone(),
+                                            );
+                                            let _ = hook_bus_inner.emit(&hook_event).await;
+                                            (false, output)
                                         }
                                         _ = cancel_token.cancelled() => {
                                             (true, "Canceled by user".to_string())
                                         }
                                     }
+                                    } // close else from Block check
                                 }
                                 None => (false, format!("Unknown tool: {}", tool_name)),
                             };

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -212,9 +212,11 @@ impl StreamMethods {
                                 });
 
                                 // ═══ HOOK: before_tool_call (stream single) ═══
-                                let hook_event = crate::extensions::hooks::events::HookEvent::before_tool_call(
+                                let runtime_name = tools.read().await.runtime_name_for_api(&tool_name).to_string();
+                                let mut hook_event = crate::extensions::hooks::events::HookEvent::before_tool_call(
                                     &tool_name, input.clone(),
                                 );
+                                hook_event.tool_runtime_name = Some(runtime_name.clone());
                                 let hook_result = hook_bus.emit(&hook_event).await;
                                 if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
                                     format!("Tool call blocked by extension: {}", reason)

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -100,11 +100,27 @@ impl StreamMethods {
 
             // ═══ HOOK: before_message ═══
             // Fire before sending messages to the LLM. Extensions can inject context.
+            // Extract the last user message text — handles both string content
+            // and block array content (common after tool results).
             let mut injected_system = system_prompt.clone();
-            if let Some(last_user_msg) = messages.last()
-                .and_then(|m| m["content"].as_str())
-            {
-                let hook_event = crate::extensions::hooks::events::HookEvent::before_message(last_user_msg);
+            let last_user_msg: Option<String> = messages.iter().rev()
+                .find(|m| m["role"].as_str() == Some("user"))
+                .and_then(|m| {
+                    // Try string content first
+                    if let Some(s) = m["content"].as_str() {
+                        return Some(s.to_string());
+                    }
+                    // Try block array content
+                    if let Some(arr) = m["content"].as_array() {
+                        return arr.iter()
+                            .find(|b| b["type"].as_str() == Some("text"))
+                            .and_then(|b| b["text"].as_str())
+                            .map(String::from);
+                    }
+                    None
+                });
+            if let Some(ref msg_text) = last_user_msg {
+                let hook_event = crate::extensions::hooks::events::HookEvent::before_message(msg_text);
                 if let crate::extensions::hooks::events::HookResult::Inject { content } = hook_bus.emit(&hook_event).await {
                     // Prepend injected content to system prompt
                     let base = injected_system.clone().unwrap_or_default();

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -219,6 +219,7 @@ impl StreamMethods {
                                 if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
                                     format!("Tool call blocked by extension: {}", reason)
                                 } else {
+                                let input_for_hook = input.clone();
                                 tokio::select! {
                                     res = tool.execute(input, crate::ToolContext {
                                         channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx.clone()) },
@@ -231,7 +232,7 @@ impl StreamMethods {
                                         };
                                         // ═══ HOOK: after_tool_call (stream single) ═══
                                         let hook_event = crate::extensions::hooks::events::HookEvent::after_tool_call(
-                                            &tool_name, serde_json::json!({}), output.clone(),
+                                            &tool_name, input_for_hook, output.clone(),
                                         );
                                         let _ = hook_bus.emit(&hook_event).await;
                                         output
@@ -308,6 +309,7 @@ impl StreamMethods {
                                     if let crate::extensions::hooks::events::HookResult::Block { reason } = hook_result {
                                         (false, format!("Tool call blocked by extension: {}", reason))
                                     } else {
+                                    let input_for_hook = input.clone();
                                     let (tx_d, mut rx_d) = tokio::sync::mpsc::unbounded_channel::<String>();
                                     let tx_k = tx_stream.clone();
                                     let t_id = tool_id.clone();
@@ -332,7 +334,7 @@ impl StreamMethods {
                                             };
                                             // ═══ HOOK: after_tool_call (stream parallel) ═══
                                             let hook_event = crate::extensions::hooks::events::HookEvent::after_tool_call(
-                                                &tool_name_for_hook, serde_json::json!({}), output.clone(),
+                                                &tool_name_for_hook, input_for_hook, output.clone(),
                                             );
                                             let _ = hook_bus_inner.emit(&hook_event).await;
                                             (false, output)

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -54,7 +54,7 @@ impl StreamMethods {
             tx, cancel, mut steering_rx,
             watcher_exit_path, max_tool_output,
             bash_timeout, bash_max_timeout, subagent_timeout,
-            session_manager, subagent_registry, event_queue,
+            session_manager, subagent_registry, event_queue, hook_bus,
         } = session;
         let mut messages = initial_messages;
 
@@ -104,7 +104,7 @@ impl StreamMethods {
                 .and_then(|m| m["content"].as_str())
             {
                 let hook_event = crate::extensions::hooks::events::HookEvent::before_message(last_user_msg);
-                let _ = session.hook_bus.emit(&hook_event).await;
+                let _ = hook_bus.emit(&hook_event).await;
             }
 
             let response = match ApiMethods::call_api_stream_inner(

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -100,15 +100,21 @@ impl StreamMethods {
 
             // ═══ HOOK: before_message ═══
             // Fire before sending messages to the LLM. Extensions can inject context.
+            let mut injected_system = system_prompt.clone();
             if let Some(last_user_msg) = messages.last()
                 .and_then(|m| m["content"].as_str())
             {
                 let hook_event = crate::extensions::hooks::events::HookEvent::before_message(last_user_msg);
-                let _ = hook_bus.emit(&hook_event).await;
+                if let crate::extensions::hooks::events::HookResult::Inject { content } = hook_bus.emit(&hook_event).await {
+                    // Prepend injected content to system prompt
+                    let base = injected_system.clone().unwrap_or_default();
+                    injected_system = Some(format!("{content}\n\n{base}"));
+                    tracing::debug!(len = content.len(), "Extension context injected into system prompt");
+                }
             }
 
             let response = match ApiMethods::call_api_stream_inner(
-                &auth, &client, &model, &tools_snapshot, &system_prompt, thinking_budget,
+                &auth, &client, &model, &tools_snapshot, &injected_system, thinking_budget,
                 &messages, tx.clone(), &cancel, api_retries, &options,
             ).await {
                 Ok(r) => r,

--- a/tests/extensions_e2e.rs
+++ b/tests/extensions_e2e.rs
@@ -1,0 +1,108 @@
+//! Integration test: spawn the time extension and verify JSON-RPC communication.
+
+#[tokio::test]
+async fn time_extension_injects_timestamp() {
+    use synaps_cli::extensions::hooks::events::{HookEvent, HookKind, HookResult};
+    use synaps_cli::extensions::hooks::HookBus;
+    use synaps_cli::extensions::permissions::{Permission, PermissionSet};
+    use synaps_cli::extensions::runtime::process::ProcessExtension;
+    use synaps_cli::extensions::runtime::ExtensionHandler;
+    use std::sync::Arc;
+
+    // Find the extension script
+    let ext_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples/extensions/time-ext.py");
+    
+    if !ext_path.exists() {
+        eprintln!("Skipping: time-ext.py not found at {:?}", ext_path);
+        return;
+    }
+
+    // Spawn the extension process
+    let handler = ProcessExtension::spawn(
+        "time-ext",
+        "python3",
+        &[ext_path.to_string_lossy().to_string()],
+    )
+    .await
+    .expect("Failed to spawn time extension");
+
+    // Send a before_message event directly
+    let event = HookEvent::before_message("What time is it?");
+    let result = handler.handle(&event).await;
+
+    // Should return Inject with a timestamp
+    match result {
+        HookResult::Inject { content } => {
+            assert!(
+                content.contains("Current date and time"),
+                "Expected timestamp in injected content, got: {}",
+                content
+            );
+            eprintln!("✓ Extension injected: {}", content);
+        }
+        other => panic!("Expected Inject, got {:?}", other),
+    }
+
+    // Test with the HookBus
+    let bus = HookBus::new();
+    let handler: Arc<dyn ExtensionHandler> = Arc::new(
+        ProcessExtension::spawn(
+            "time-ext-2",
+            "python3",
+            &[ext_path.to_string_lossy().to_string()],
+        )
+        .await
+        .expect("Failed to spawn second instance"),
+    );
+
+    let mut perms = PermissionSet::new();
+    perms.grant(Permission::LlmContent); // before_message needs this
+
+    bus.subscribe(HookKind::BeforeMessage, handler.clone(), None, perms)
+        .await
+        .expect("Failed to subscribe");
+
+    let event = HookEvent::before_message("Hello world");
+    let result = bus.emit(&event).await;
+
+    match result {
+        HookResult::Inject { content } => {
+            assert!(content.contains("Current date and time"));
+            eprintln!("✓ HookBus dispatched inject: {}", content);
+        }
+        other => panic!("Expected Inject from bus, got {:?}", other),
+    }
+
+    // Clean shutdown
+    handler.shutdown().await;
+}
+
+#[tokio::test]
+async fn time_extension_continues_for_non_message_hooks() {
+    use synaps_cli::extensions::hooks::events::{HookEvent, HookResult};
+    use synaps_cli::extensions::runtime::process::ProcessExtension;
+    use synaps_cli::extensions::runtime::ExtensionHandler;
+
+    let ext_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("examples/extensions/time-ext.py");
+
+    if !ext_path.exists() {
+        return;
+    }
+
+    let handler = ProcessExtension::spawn(
+        "time-ext",
+        "python3",
+        &[ext_path.to_string_lossy().to_string()],
+    )
+    .await
+    .expect("Failed to spawn");
+
+    // Non-message hooks should get Continue
+    let event = HookEvent::before_tool_call("bash", serde_json::json!({"command": "ls"}));
+    let result = handler.handle(&event).await;
+    assert!(matches!(result, HookResult::Continue), "Expected Continue for tool hook");
+
+    handler.shutdown().await;
+}


### PR DESCRIPTION
## Summary

First-class extension system for SynapsCLI. Extensions are external processes that communicate via JSON-RPC 2.0 over stdio, subscribe to hooks, and can block/modify/inject into the agent loop.

## What's New

### Extension System (~1,500 lines)
- **HookBus** — central dispatcher with tool-specific filtering, timeout protection, permission enforcement
- **5 Hook Events** — `before_tool_call`, `after_tool_call`, `before_message`, `on_session_start`, `on_session_end`
- **6 Permission Flags** — `tools.intercept`, `tools.override`, `privacy.llm_content`, `session.lifecycle`, `tools.register`, `providers.register`
- **JSON-RPC Process Runtime** — Content-Length framed stdio, spawns child processes
- **Extension Manager** — lifecycle management, auto-discovery from `~/.synaps-cli/plugins/`
- **Extension Manifest** — declared in `plugin.json` `extension` field
- **HookResult::Inject** — extensions can inject context into system prompt via `before_message`

### Hook Call Sites (all 4 tool execution paths)
- `runtime/mod.rs` — single + parallel (non-streaming)
- `runtime/stream.rs` — single + parallel (streaming/TUI)
- `chatui/mod.rs` — `on_session_start` + `on_session_end`
- `stream.rs` — `before_message` with context injection

### Synaps Hub (example extension)
- Live web dashboard at `localhost:3456` showing subagent activity
- Tracks agent states: idle, working, multitasking (×N)
- Real-time WebSocket updates
- Auto-starts with synaps, auto-exits when synaps closes
- Drop-in plugin: `~/.synaps-cli/plugins/hub/`

### Time Extension (example)
- Injects current date/time into every LLM call via `before_message` hook
- Integration test proves full JSON-RPC round-trip

## Tests
- 38 unit tests (hooks, events, permissions, manifest, manager)
- 2 integration tests (time extension end-to-end)
- All passing on Avante

## Decisions (from spec)
1. JSON-RPC 2.0 + Content-Length framing
2. Reuse plugins/ directory
3. Prompt-on-first-use trust model
4. OpenAI-compat provider migration first
5. criterion approved for benchmarks
