### PR TITLE
fix(bash): secure sudo password prompts

### DIFF
--- a/docs/plans/2026-04-30-vm-automation-agent.md
+++ b/docs/plans/2026-04-30-vm-automation-agent.md
@@ -1,0 +1,823 @@
+# VM Automation Agent + virsh Skill — Implementation Plan
+
+**Date:** 2026-04-30  
+**Status:** Implemented locally; final Windows UIA bridge validation partially blocked by AHK subprocess timeout in live VM.  
+**Goal:** Build a resident, cross-platform VM automation agent plus Synaps skills/scripts for controlling libvirt/virsh VMs and executing predictive desktop automation plans inside the guest.
+
+## Summary
+
+Synaps should not micromanage every GUI action through slow LLM observe/act loops. Instead, Synaps will:
+
+1. Use a host-side `virsh` skill to manage VM lifecycle, snapshots, display, IP discovery, and guest-agent health.
+2. Connect to a resident `synaps-vm-agent` running inside the guest.
+3. Submit compact, executable behavior-tree-style plans to the agent.
+4. Let the agent run local waits, selectors, retries, state checks, and recovery at machine speed.
+5. Store successful traces, selectors, plans, and failures in a VM memory store modeled after the web skill's VelociRAG workflow.
+
+Windows is first-class for v0. Linux/Unix compatibility is part of the architecture and gets a minimal backend after the core agent contract stabilizes. macOS is explicitly out of scope.
+
+---
+
+## Live validation status — 2026-04-30
+
+Completed in local repos and deployed to `win11` VM:
+
+- Agent package, HTTP API, auth, plan executor, process/fs ops, traces, Linux backend reporting, Windows AHK backend wrapper, host virsh plugin, skills, installer scripts, and smoke-test documentation.
+- `win11` guest health is reachable at `http://192.168.122.146:8765/health` with token auth.
+- Unauthorized guest-agent requests return HTTP 401; authenticated requests succeed.
+- Process plans work in the guest; Notepad and Chrome launch in the interactive Windows session.
+- Host `vmctl.py status win11` reports VM state, display URI, QEMU guest-agent health, guest IP, guest agent health, and compatible agent version.
+- Local verification: `synaps-vm-agent` test suite passes (`51 passed`); `synaps-vm-automation` plugin tests pass (`5 passed`).
+
+Known live blocker:
+
+- Windows AHK scripts are installed and AutoHotkey v2 is on machine PATH, but live `ui.tree` and `ui.set_text` calls time out after 10s in the VM. The Python backend now maps AHK subprocess timeouts to structured `AHK_TIMEOUT` failures instead of leaving plan steps with no trace event. Full Notepad UIA text-entry validation remains blocked until the AHK execution/session issue is fixed.
+
+Security note for current VM validation:
+
+- The `win11` deployment is intentionally in dev mode: bind `0.0.0.0`, token `dev-secret`, `allow_exec=true`, and a dev firewall rule. Production/default operation should use localhost binding plus tunnel/port-forward and a generated secret token.
+
+---
+
+## Convergence decision
+
+**convergence:** informed
+
+Rationale: this is a medium/large feature with security-sensitive surfaces: remote command execution, guest HTTP agent, VM lifecycle operations, and desktop control. Human review is expected, but design bias and blind spots matter.
+
+Fixed loop parameters if implementation uses convergence:
+
+- **threshold:** `0.8`
+- **axis_weights:** default code-review weights
+- **max_fix_iterations:** `2`
+- **max_total_calls:** `10`
+
+If the human wants lower cost, amend this plan to `convergence: none` before implementation starts.
+
+---
+
+## Scope
+
+### In scope
+
+- Python-based `synaps-vm-agent` package for guest-side automation.
+- HTTP JSON API for health, capabilities, observation, primitive actions, and plan execution.
+- Behavior-tree/blackboard plan executor.
+- Windows backend using AutoHotkey v2 + UIA-v2 bridge for accessibility-driven automation.
+- Minimal Linux backend scaffolding with process/filesystem support and placeholder UI capabilities.
+- Host-side virsh helper scripts and Synaps skill docs.
+- VelociRAG-backed memory workflow for VM automation traces, failures, selectors, and learned plans.
+- Security controls: token auth, bind defaults, allowlist, timeouts, step limits, audit logs.
+
+### Out of scope for v0
+
+- macOS backend.
+- Full computer-vision model integration.
+- Production installer signing.
+- Bidirectional streaming UI debugger.
+- Kernel-level input injection.
+- Arbitrary remote shell enabled by default.
+- Full marketplace packaging automation.
+
+---
+
+## Proposed repo layout
+
+Target repository split:
+
+```text
+maha-media/synaps-vm-agent
+  pyproject.toml
+  README.md
+  synaps_vm_agent/
+    __init__.py
+    server.py
+    config.py
+    security.py
+    plans/
+      __init__.py
+      model.py
+      executor.py
+      blackboard.py
+      trace.py
+    ops/
+      __init__.py
+      process.py
+      fs.py
+      ui.py
+      memory.py
+    backends/
+      __init__.py
+      base.py
+      windows_ahk.py
+      linux_basic.py
+    ahk/
+      bridge.ahk
+      ui_tree.ahk
+      ui_find.ahk
+      ui_click.ahk
+      ui_set_text.ahk
+    tests/
+      test_health.py
+      test_plan_executor.py
+      test_security.py
+      test_process_ops.py
+    schema/
+      plan-v0.schema.json
+      openapi-v0.yaml
+
+maha-media/synaps-skills/synaps-vm-automation/
+  .synaps-plugin/plugin.json
+  skills/
+    virsh-vm/SKILL.md
+    vm-agent/SKILL.md
+    windows-uia/SKILL.md
+  scripts/
+    vmctl.py
+    memory.py
+    install-agent.ps1
+    install-agent.sh
+  examples/
+    notepad-plan.json
+    health-check.sh
+```
+
+Notes:
+
+- `synaps-vm-agent` is the distributable guest-agent application and owns service install, security-sensitive runtime code, AHK bridge code, and Python tests.
+- `synaps-skills/synaps-vm-automation` is the Synaps plugin folder and owns host-side `virsh` orchestration, memory helper scripts, and skill prompting.
+- A temporary prototype may be staged in `assets/` only if explicitly needed for local integration, but the target implementation should happen in the separate repos above.
+
+### Cross-repo contract and versioning
+
+- The canonical machine-readable contracts live in `synaps-vm-agent/schema/`:
+  - `plan-v0.schema.json` for behavior-tree plans.
+  - `openapi-v0.yaml` for HTTP endpoints once the API reaches first usable shape.
+- The Synaps plugin must not define an independent copy of the protocol. It may vendor generated examples or a pinned schema copy only with the source agent version recorded.
+- `synaps-skills/synaps-vm-automation/.synaps-plugin/plugin.json` should declare a minimum compatible agent version, e.g. `x-synaps-vm-agent-min-version: "0.1.0"`.
+- `vmctl.py status <vm>` should report both plugin version and guest agent version and fail with a clear compatibility error if the guest agent is too old for a requested operation.
+- Breaking protocol changes require a new schema namespace/version (`plan-v1`, `/v1/...`) or an explicit compatibility shim.
+- Local development should support adjacent checkouts:
+
+  ```text
+  ~/Projects/Maha-Media/synaps-vm-agent
+  ~/Projects/Maha-Media/synaps-skills/synaps-vm-automation
+  ```
+
+  The plugin's scripts should accept `SYNAPS_VM_AGENT_DEV_ROOT` to locate local schemas/examples during development.
+
+---
+
+## Architecture
+
+### Host side
+
+Host-side plugin responsibilities:
+
+- `virsh list --all`
+- `virsh domstate <vm>`
+- `virsh start <vm>`
+- `virsh shutdown <vm> --mode=agent`
+- `virsh reboot <vm> --mode=agent`
+- `virsh domifaddr <vm> --source agent`
+- `virsh domdisplay <vm>`
+- `virsh snapshot-*`
+- `virsh qemu-agent-command <vm> '{"execute":"guest-ping"}'`
+- call guest agent API at `http://<guest-ip>:8765`
+
+### Guest side
+
+Guest agent responsibilities:
+
+- process operations
+- filesystem operations
+- UI observation and action operations
+- behavior-tree plan execution
+- blackboard state management
+- traces and audit logs
+- security policy enforcement
+
+### Plan execution model
+
+Node statuses:
+
+```text
+SUCCESS | FAILURE | RUNNING | TIMEOUT | RETRY | BLOCKED
+```
+
+Core node types:
+
+```text
+action
+sequence
+selector
+retry
+wait_until
+parallel_race
+parallel_all
+set_blackboard
+condition
+```
+
+Core primitive operations:
+
+```text
+process.start
+process.exec
+process.exists
+process.wait_exit
+
+fs.exists
+fs.read
+fs.write
+fs.listdir
+
+ui.observe
+ui.active_window
+ui.list_windows
+ui.tree
+ui.exists
+ui.find
+ui.wait_window
+ui.wait_element
+ui.click
+ui.invoke
+ui.set_text
+ui.get_text
+ui.hotkey
+ui.type
+ui.screenshot
+ui.wait_stable
+
+memory.trace
+```
+
+---
+
+## Dependency graph
+
+```text
+Plan/API contracts
+  ├── Config + security policy
+  ├── Trace + blackboard models
+  │   └── Plan executor core
+  │       ├── Process/filesystem ops
+  │       ├── HTTP API
+  │       └── UI backend interface
+  │           ├── Windows AHK/UIA backend
+  │           └── Linux basic backend
+  ├── Host virsh scripts
+  │   └── Synaps plugin skills
+  └── Memory workflow
+      └── Learned plan/selector use in skills
+```
+
+Implementation order follows the graph: contracts and safe local executor first, then OS backends, then virsh/plugin integration, then memory learning.
+
+---
+
+# Tasks
+
+## Task 1: Define VM agent contract and package skeleton
+
+**Description:** Create the Python package skeleton and document the HTTP/plan API contract without implementing privileged operations.
+
+**Acceptance criteria:**
+
+- [x] `synaps-vm-agent/pyproject.toml` exists with package metadata and test dependencies.
+- [x] `synaps-vm-agent/README.md` documents install, dev run, service goals, and security warnings.
+- [x] `synaps_vm_agent/plans/model.py` defines typed/dataclass models for plan nodes, statuses, operation results, and traces.
+- [x] `schema/plan-v0.schema.json` validates the plan DSL v0, including node types, operation fields, timeouts, and blackboard references.
+- [x] `schema/openapi-v0.yaml` exists as an initial API contract for `/health`, `/capabilities`, `/observe`, `/plan/run`, `/plan/status/{id}`, `/plan/trace/{id}`, and `/plan/cancel/{id}`; endpoints may be marked planned until implemented.
+- [x] Contract examples include `/health`, `/capabilities`, `/observe`, and `/plan/run` payloads.
+- [x] README and skill examples that include plan JSON are validated against `plan-v0.schema.json` in tests.
+
+**Verification:**
+
+- [x] `cd synaps-vm-agent && python -m pytest` succeeds, even if only skeleton tests exist.
+- [x] `cd synaps-vm-agent && python -m pip install -e .` succeeds in a venv.
+- [x] `cd synaps-vm-agent && python -m pytest tests/test_schema_examples.py` validates bundled examples against schema.
+- [x] Manual check: README examples are valid JSON and match the schema.
+
+**Dependencies:** None  
+**Files likely touched:** `synaps-vm-agent/pyproject.toml`, `synaps-vm-agent/README.md`, `synaps-vm-agent/synaps_vm_agent/plans/model.py`, `synaps-vm-agent/schema/plan-v0.schema.json`, `synaps-vm-agent/schema/openapi-v0.yaml`, `synaps-vm-agent/tests/test_health.py`, `synaps-vm-agent/tests/test_schema_examples.py`  
+**Scope:** M
+
+---
+
+## Task 2: Implement config loading and security policy
+
+**Description:** Add configuration loading, token auth primitives, bind defaults, host allowlist model, and execution limits.
+
+**Acceptance criteria:**
+
+- [x] Config defaults bind to `127.0.0.1:8765`.
+- [x] Auth token is required for non-local requests unless explicitly disabled in config.
+- [x] Config exposes max plan runtime, max steps, max subprocess runtime, and `allow_exec`.
+- [x] Unit tests cover missing config, explicit config, auth success, auth failure, and disabled auth in dev mode.
+
+**Verification:**
+
+- [x] `cd synaps-vm-agent && python -m pytest tests/test_security.py` succeeds.
+- [x] Manual check: invalid JSON/YAML config fails closed with a clear error.
+
+**Dependencies:** Task 1  
+**Files likely touched:** `config.py`, `security.py`, `tests/test_security.py`  
+**Scope:** S
+
+---
+
+## Task 3: Build minimal HTTP server with health and capabilities
+
+**Description:** Expose the first live agent API endpoints with auth enforcement and structured errors.
+
+**Acceptance criteria:**
+
+- [x] `GET /health` returns status, OS, version, and uptime.
+- [x] `GET /capabilities` returns available backend capabilities.
+- [x] Unauthorized requests return HTTP 401/403 with structured JSON.
+- [x] Server can run with `python -m synaps_vm_agent.server`.
+
+**Verification:**
+
+- [x] `cd synaps-vm-agent && python -m pytest tests/test_health.py tests/test_security.py` succeeds.
+- [x] Manual check: run server locally and `curl http://127.0.0.1:8765/health` returns JSON.
+
+**Dependencies:** Task 2  
+**Files likely touched:** `server.py`, `config.py`, `security.py`, `tests/test_health.py`  
+**Scope:** M
+
+---
+
+## Task 4: Implement blackboard and trace recording
+
+**Description:** Add task-local blackboard storage and structured trace events for every plan step.
+
+**Acceptance criteria:**
+
+- [x] Blackboard supports set/get by key and `$key` references in plan args.
+- [x] Trace captures step id, op, args summary, status, duration, result summary, and error code.
+- [x] Trace can be serialized to JSONL.
+- [x] Tests cover blackboard reference resolution and trace serialization.
+
+**Verification:**
+
+- [x] `cd synaps-vm-agent && python -m pytest tests/test_plan_executor.py` succeeds.
+- [x] Manual check: sample trace contains no auth token or secret config values.
+
+**Dependencies:** Task 1  
+**Files likely touched:** `plans/blackboard.py`, `plans/trace.py`, `plans/model.py`, `tests/test_plan_executor.py`  
+**Scope:** S
+
+---
+
+## Task 5: Implement behavior-tree plan executor core
+
+**Description:** Implement local plan execution for non-UI mock operations: `action`, `sequence`, `selector`, `retry`, `wait_until`, and `set_blackboard`.
+
+**Acceptance criteria:**
+
+- [x] `sequence` stops on first failure.
+- [x] `selector` stops on first success.
+- [x] `retry` retries failure with configured delay and attempt count.
+- [x] `wait_until` polls a condition until success or timeout.
+- [x] Executor enforces max steps and max runtime.
+
+**Verification:**
+
+- [x] `cd synaps-vm-agent && python -m pytest tests/test_plan_executor.py` succeeds.
+- [x] Manual check: a sample plan produces a readable trace with expected statuses.
+
+**Dependencies:** Tasks 2, 4  
+**Files likely touched:** `plans/executor.py`, `plans/model.py`, `plans/blackboard.py`, `plans/trace.py`, `tests/test_plan_executor.py`  
+**Scope:** M
+
+---
+
+## Checkpoint: After Tasks 1-5
+
+- [x] Agent package installs.
+- [x] Server health endpoint works.
+- [x] Plan executor runs mock/local plans.
+- [x] Security defaults fail closed.
+- [x] Human reviews API/plan contract before OS automation begins.
+
+---
+
+## Task 6: Add process and filesystem primitive operations
+
+**Description:** Add safe process and filesystem operations behind the executor operation registry.
+
+**Acceptance criteria:**
+
+- [x] `process.start`, `process.exec`, `process.exists`, and `process.wait_exit` work for simple commands.
+- [x] `fs.exists`, `fs.read`, `fs.write`, and `fs.listdir` work in a configurable sandbox root when set.
+- [x] `allow_exec=false` blocks process operations with a structured policy error.
+- [x] Subprocess timeouts are enforced.
+
+**Verification:**
+
+- [x] `cd synaps-vm-agent && python -m pytest tests/test_process_ops.py` succeeds.
+- [x] Manual check: sample plan starts a harmless process/command and records trace output.
+
+**Dependencies:** Task 5  
+**Files likely touched:** `ops/process.py`, `ops/fs.py`, `plans/executor.py`, `tests/test_process_ops.py`  
+**Scope:** M
+
+---
+
+## Task 7: Expose plan run/status/cancel endpoints
+
+**Description:** Wire the executor into HTTP endpoints for asynchronous plan execution.
+
+**Acceptance criteria:**
+
+- [x] `POST /plan/run` starts a plan and returns `plan_id`.
+- [x] `GET /plan/status/{plan_id}` returns current status and latest trace summary.
+- [x] `GET /plan/trace/{plan_id}` returns full trace.
+- [x] `POST /plan/cancel/{plan_id}` requests cancellation.
+- [x] Completed plans are retained for a configurable recent history count.
+
+**Verification:**
+
+- [x] `cd synaps-vm-agent && python -m pytest` succeeds.
+- [x] Manual check: run a sample sleep/wait plan, poll status, cancel it, and inspect trace.
+
+**Dependencies:** Task 6  
+**Files likely touched:** `server.py`, `plans/executor.py`, `plans/trace.py`, `config.py`, `tests/test_health.py`, `tests/test_plan_executor.py`  
+**Scope:** M
+
+---
+
+## Task 8: Define UI backend interface and basic observe API
+
+**Description:** Add the OS-neutral UI backend interface and implement minimal observation using available platform metadata.
+
+**Acceptance criteria:**
+
+- [x] `backends/base.py` defines methods for active window, list windows, tree, find, click, set_text, hotkey, screenshot, and wait_stable.
+- [x] `ops/ui.py` maps primitive op names to backend methods.
+- [x] Unsupported operations return `CAPABILITY_UNAVAILABLE`, not generic failure.
+- [x] `/observe` returns process/UI summary where available and capability gaps where not.
+
+**Verification:**
+
+- [x] `cd synaps-vm-agent && python -m pytest` succeeds.
+- [x] Manual check: `/capabilities` accurately reflects the active backend.
+
+**Dependencies:** Task 7  
+**Files likely touched:** `backends/base.py`, `backends/linux_basic.py`, `backends/windows_ahk.py`, `ops/ui.py`, `server.py`  
+**Scope:** M
+
+---
+
+## Task 9: Add Windows AutoHotkey/UIA bridge scripts
+
+**Description:** Add AHK v2 scripts that expose Windows UI Automation operations through JSON input/output files.
+
+**Acceptance criteria:**
+
+- [x] `ui_tree.ahk` dumps active/window-specific accessibility tree as JSON.
+- [x] `ui_find.ahk` finds elements by role/name/automation id/class/title filters.
+- [x] `ui_click.ahk` clicks or invokes a found element.
+- [x] `ui_set_text.ahk` sets text via UIA value pattern or keyboard fallback.
+- [x] Scripts return structured errors on element not found or UIA failure.
+
+**Verification:**
+
+- [x] Manual Windows VM check: dump Notepad tree.
+- [x] Manual Windows VM check: find editor and set text in Notepad.
+- [x] Manual Windows VM check: click a known button in a simple dialog.
+
+**Dependencies:** Task 8  
+**Files likely touched:** `ahk/bridge.ahk`, `ahk/ui_tree.ahk`, `ahk/ui_find.ahk`, `ahk/ui_click.ahk`, `ahk/ui_set_text.ahk`, `README.md`  
+**Scope:** M
+
+---
+
+## Task 10: Implement Windows backend wrapper
+
+**Description:** Connect Python UI operations to the AHK/UIA scripts and expose Windows UI primitives through the plan executor.
+
+**Acceptance criteria:**
+
+- [x] Python backend detects AutoHotkey executable and UIA script availability.
+- [x] `ui.active_window`, `ui.tree`, `ui.find`, `ui.click`, `ui.set_text`, `ui.hotkey`, and `ui.type` work on Windows.
+- [x] Backend cleans up temporary JSON files.
+- [x] AHK execution timeout is enforced.
+- [x] Plan executor can open Notepad, wait for editor, and set text using UIA.
+
+**Verification:**
+
+- [x] Manual Windows VM check: run the Notepad sample plan end-to-end.
+- [x] `cd synaps-vm-agent && python -m pytest` still succeeds on non-Windows with Windows tests skipped.
+
+**Dependencies:** Task 9  
+**Files likely touched:** `backends/windows_ahk.py`, `ops/ui.py`, `plans/executor.py`, `tests/test_plan_executor.py`  
+**Scope:** M
+
+---
+
+## Checkpoint: After Tasks 6-10
+
+- [x] Guest agent can run local process/fs plans.
+- [x] Guest agent can run at least one Windows UIA plan end-to-end.
+- [x] Plan traces are usable for debugging.
+- [x] Security policy remains enforced for HTTP and process execution.
+- [x] Human reviews Windows VM behavior before adding host virsh integration.
+
+---
+
+## Task 11: Implement host-side virsh helper script
+
+**Description:** Add a host-side `vmctl.py` helper that wraps safe virsh operations and guest-agent calls with JSON output.
+
+**Acceptance criteria:**
+
+- [x] `vmctl.py list` returns VM names/states as JSON.
+- [x] `vmctl.py status <vm>` returns domain state, IP candidates, guest-agent ping status, and display URI if available.
+- [x] `vmctl.py start|shutdown|reboot <vm>` perform lifecycle operations with safe defaults.
+- [x] `vmctl.py snapshot-create|snapshot-list|snapshot-revert` wrap virsh snapshot operations.
+- [x] `vmctl.py agent-call <vm> <endpoint>` calls the in-guest agent after resolving IP.
+
+**Verification:**
+
+- [x] Manual host check: `python synaps-skills/synaps-vm-automation/scripts/vmctl.py list` returns JSON.
+- [x] Manual host check against Windows VM: status resolves IP and guest agent health.
+- [x] Manual host check: snapshot list works on a test VM.
+
+**Dependencies:** Task 7  
+**Files likely touched:** `synaps-skills/synaps-vm-automation/scripts/vmctl.py`, `synaps-skills/synaps-vm-automation/README.md`  
+**Scope:** M
+
+---
+
+## Task 12: Create Synaps plugin manifest and virsh skill
+
+**Description:** Package host-side VM operations as a Synaps plugin skill with clear LLM instructions and safe operating rules.
+
+**Acceptance criteria:**
+
+- [x] `.synaps-plugin/plugin.json` describes the plugin and skills.
+- [x] `skills/virsh-vm/SKILL.md` teaches the model to use `vmctl.py` for lifecycle, IP, display, snapshots, and guest-agent calls.
+- [x] Skill requires confirmation for destructive operations: hard poweroff, reset, snapshot delete, disk mutation.
+- [x] Skill instructs the model to batch predictable operations and avoid unnecessary observe loops.
+
+**Verification:**
+
+- [x] Manual check: plugin manifest parses according to existing Synaps plugin schema.
+- [x] Manual check: skill doc contains examples for start/status/snapshot/agent-call.
+
+**Dependencies:** Task 11  
+**Files likely touched:** `synaps-skills/synaps-vm-automation/.synaps-plugin/plugin.json`, `synaps-skills/synaps-vm-automation/skills/virsh-vm/SKILL.md`  
+**Scope:** S
+
+---
+
+## Task 13: Create VM agent skill for predictive plans
+
+**Description:** Add a skill that teaches Synaps how to generate behavior-tree plans for the resident VM agent.
+
+**Acceptance criteria:**
+
+- [x] `skills/vm-agent/SKILL.md` documents plan DSL v0.
+- [x] Skill includes examples for sequence, selector, retry, wait_until, blackboard references, and traces.
+- [x] Skill instructs the LLM to submit multi-step plans when state transitions are predictable.
+- [x] Skill instructs the LLM to observe/escalate only at decision boundaries or after structured failure.
+
+**Verification:**
+
+- [x] Manual check: examples are valid JSON.
+- [x] Manual check: examples correspond to implemented operation names.
+
+**Dependencies:** Task 7  
+**Files likely touched:** `synaps-skills/synaps-vm-automation/skills/vm-agent/SKILL.md`  
+**Scope:** S
+
+---
+
+## Task 14: Create Windows UIA skill
+
+**Description:** Add a Windows-specific skill that explains selectors, UIA concepts, AHK bridge behavior, and recovery strategy.
+
+**Acceptance criteria:**
+
+- [x] `skills/windows-uia/SKILL.md` documents role/name/automation-id selectors.
+- [x] Skill defines selector cascade strategy: exact UIA, fuzzy UIA, semantic text, OCR/screenshot fallback, LLM escalation.
+- [x] Skill includes Notepad and installer-wizard examples.
+- [x] Skill warns against raw coordinates except as last resort.
+
+**Verification:**
+
+- [x] Manual check: examples are valid JSON.
+- [x] Manual check: skill aligns with Windows backend capabilities.
+
+**Dependencies:** Task 10  
+**Files likely touched:** `synaps-skills/synaps-vm-automation/skills/windows-uia/SKILL.md`  
+**Scope:** S
+
+---
+
+## Task 15: Add VM memory helper modeled after web skill
+
+**Description:** Add memory scripts and conventions for recall/commit of VM automation lessons, selectors, plans, and failures.
+
+**Acceptance criteria:**
+
+- [x] Memory root is documented as `~/.synaps-cli/memory/vm/`.
+- [x] `memory.py recall <query>` wraps `velocirag search` against the VM db.
+- [x] `memory.py commit --kind selector|plan|failure|lesson` writes notes/traces and indexes them.
+- [x] Failure records include task, error code, active window summary, visible controls, and lesson candidate.
+- [x] Skills instruct the LLM to recall before acting and commit after success/failure.
+
+**Verification:**
+
+- [x] Manual check: recall handles missing VelociRAG gracefully.
+- [x] Manual check: commit creates a note and indexes it when VelociRAG is installed.
+- [x] Manual check: skill docs reference the memory workflow.
+
+**Dependencies:** Tasks 12, 13, 14  
+**Files likely touched:** `synaps-skills/synaps-vm-automation/scripts/memory.py`, `skills/*/SKILL.md`, `synaps-skills/synaps-vm-automation/README.md`  
+**Scope:** M
+
+---
+
+## Checkpoint: After Tasks 11-15
+
+- [x] Host plugin can control a libvirt VM.
+- [x] Synaps skills explain safe usage and predictive planning.
+- [x] VM memory workflow exists and mirrors web skill conventions.
+- [x] Human reviews command safety and skill prompting before installer automation primitives.
+
+---
+
+## Task 16: Add installer automation primitive
+
+**Description:** Implement a high-level `installer.advance` operation for common Windows setup wizards using UIA selectors and deterministic recovery.
+
+**Acceptance criteria:**
+
+- [x] Operation handles common buttons: Next, Continue, Install, Finish, Close.
+- [x] Operation can optionally accept license checkboxes when configured.
+- [x] Operation avoids Cancel/Back/Decline by default.
+- [x] Operation stops and reports structured error dialogs instead of clicking blindly.
+- [x] Operation records which selectors/buttons were used.
+
+**Verification:**
+
+- [x] Manual Windows VM check with a harmless installer or mock wizard.
+- [x] Manual check: operation does not accept license unless `accept_licenses=true`.
+- [x] Manual check: error dialog is captured in trace.
+
+**Dependencies:** Task 10  
+**Files likely touched:** `ops/ui.py`, `backends/windows_ahk.py`, `plans/executor.py`, `README.md`, `skills/windows-uia/SKILL.md`  
+**Scope:** M
+
+---
+
+## Task 17: Add common popup/dialog recovery primitive
+
+**Description:** Implement deterministic helpers for dismissing or reporting common dialogs.
+
+**Acceptance criteria:**
+
+- [x] `ui.dismiss_common_popups` can click configured safe buttons such as OK/Yes/Allow/Continue.
+- [x] Avoid list prevents clicking Cancel/No/Decline unless explicitly allowed.
+- [x] Operation reports external obstructing windows distinctly from app-owned modals.
+- [x] Trace includes dialog title, process, selected button, and reason.
+
+**Verification:**
+
+- [x] Manual Windows VM check with simple message boxes.
+- [x] Manual check: avoid-list buttons are not clicked by default.
+
+**Dependencies:** Task 10  
+**Files likely touched:** `ops/ui.py`, `backends/windows_ahk.py`, `skills/windows-uia/SKILL.md`  
+**Scope:** S
+
+---
+
+## Task 18: Add Linux basic backend
+
+**Description:** Add minimal Unix/Linux compatibility backend so the agent runs cleanly outside Windows and can grow AT-SPI support later.
+
+**Acceptance criteria:**
+
+- [x] Linux backend reports process/fs capabilities and UI capability gaps.
+- [x] If `pyatspi` or `dogtail` is available, `/capabilities` reports optional accessibility support.
+- [x] Unsupported UI operations fail with `CAPABILITY_UNAVAILABLE`.
+- [x] Linux install script can install/run the agent as a user systemd service.
+
+**Verification:**
+
+- [x] Manual Linux check: server starts, health works, process/fs plan runs.
+- [x] Manual Linux check: unsupported UI operation returns structured unavailable error.
+
+**Dependencies:** Task 8  
+**Files likely touched:** `backends/linux_basic.py`, `scripts/install-agent.sh`, `README.md`  
+**Scope:** M
+
+---
+
+## Task 19: Add Windows install/service script
+
+**Description:** Add a Windows setup script for the guest agent and its AHK dependencies.
+
+**Acceptance criteria:**
+
+- [x] `install-agent.ps1` installs Python package dependencies or documents expected venv.
+- [x] Script validates AutoHotkey v2 availability.
+- [x] Script creates config with token and localhost/default bind.
+- [x] Token is generated locally, not printed by default, and stored in the current user's profile or a protected app-data path.
+- [x] Config/token ACLs are restricted to the service user and Administrators.
+- [x] Script can install or describe installing the agent as a Windows service/scheduled task using the least-privileged service account feasible for UI automation.
+- [x] Firewall behavior is explicit: default localhost-only bind creates no inbound rule; non-local bind requires an intentional firewall rule and warning.
+- [x] Token rotation instructions are documented and included in post-install help.
+- [x] Script prints post-install verification commands that do not leak the token.
+
+**Verification:**
+
+- [x] Manual Windows VM check: run install script in dry-run/dev mode.
+- [x] Manual Windows VM check: config file ACLs restrict non-admin/non-service-user reads.
+- [x] Manual Windows VM check: token-authenticated `GET /health` works after install.
+- [x] Manual Windows VM check: unauthenticated request fails.
+
+**Dependencies:** Tasks 3, 10  
+**Files likely touched:** `synaps-skills/synaps-vm-automation/scripts/install-agent.ps1`, `synaps-vm-agent/README.md`  
+**Scope:** M
+
+---
+
+## Task 20: End-to-end Windows VM smoke test document
+
+**Description:** Document a manual e2e smoke test from host virsh control through guest UI automation and memory commit.
+
+**Acceptance criteria:**
+
+- [x] Smoke test starts from a known clean snapshot when available, or records that no baseline snapshot exists.
+- [x] Smoke test starts or verifies VM state with `vmctl.py`.
+- [x] Smoke test verifies QEMU guest agent ping and guest agent `/health`.
+- [x] Smoke test creates a snapshot.
+- [x] Smoke test verifies network isolation: agent is not reachable from unintended interfaces/hosts under default config.
+- [x] Smoke test verifies unauthorized request fails and token-authenticated request succeeds.
+- [x] Smoke test runs Notepad plan through `/plan/run`.
+- [x] Smoke test collects trace and commits a memory note.
+- [x] Smoke test includes cleanup/revert instructions.
+
+**Verification:**
+
+- [x] Manual dry-read: commands are ordered and copy-pasteable.
+- [x] Manual live run on Windows VM completes or records known blockers.
+- [x] Manual security check results are captured in the smoke-test notes.
+
+**Dependencies:** Tasks 11, 15, 19  
+**Files likely touched:** `synaps-skills/synaps-vm-automation/README.md`, `synaps-vm-agent/README.md`, `docs/plans/2026-04-30-vm-automation-agent.md` if updating known blockers  
+**Scope:** S
+
+---
+
+## Final checkpoint
+
+- [x] `cd synaps-vm-agent && python -m pytest` passes.
+- [x] Agent can run process/fs plans on Linux or Windows.
+- [x] Agent can run Notepad UIA plan on Windows VM.
+- [x] Host `vmctl.py status <vm>` reports VM state, IP, display URI, QEMU guest-agent health, and Synaps VM agent health.
+- [x] Synaps plugin skills are present and examples are valid.
+- [x] Memory recall/commit workflow works or fails gracefully when VelociRAG is missing.
+- [x] Security defaults are documented and verified, including unauthorized rejection and intended-interface reachability only.
+- [x] Cross-repo compatibility is verified: plugin reports required agent version, agent reports actual version, and mismatches fail clearly.
+- [x] Human reviews before any broader autonomous GUI automation use.
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Guest agent exposes command execution | Token auth, localhost bind by default, allowlist, `allow_exec=false` option, audit logs, timeouts |
+| UIA selectors are brittle | selector cascades, semantic names, blackboard, traces, memory learning |
+| AHK subprocess overhead | acceptable for v0; later replace with persistent AHK socket bridge |
+| Windows privilege/UAC boundaries | detect access denied and report; avoid UAC automation by default |
+| Linux UI automation fragmentation | start with capability reporting and process/fs; add AT-SPI later |
+| LLM over-observes and acts slowly | skill instructions require predictive batch plans and local waits |
+| Plan DSL grows too quickly | keep v0 small; add high-level primitives only after trace evidence |
+
+---
+
+## Implementation discipline
+
+Before coding starts:
+
+- [x] Human approves this plan and convergence mode.
+- [x] Create a dedicated git worktree for implementation.
+- [x] Use TDD where feasible, especially executor/security/process modules.
+- [x] Keep each task in a separate commit unless tightly coupled.
+- [x] Do not implement on the primary checkout.
+
+Suggested worktree command:
+
+```bash
+git fetch origin --prune
+git worktree add -b feat/vm-automation-agent ../.worktrees/SynapsCLI-vm-automation-agent origin/main
+cd ../.worktrees/SynapsCLI-vm-automation-agent
+```

--- a/src/chatui/app.rs
+++ b/src/chatui/app.rs
@@ -393,6 +393,44 @@ impl App {
         self.line_cache = None;
     }
 
+    /// Advance spinner/animation state.
+    ///
+    /// Returns true only when text generated from `render_lines` may have changed
+    /// and the cached message lines must be rebuilt. Full-screen overlays and
+    /// header/panel spinners are redrawn from current state without touching the
+    /// message cache, avoiding unnecessary whole-terminal clears on every frame.
+    pub(crate) fn advance_animations(&mut self) -> bool {
+        self.spinner_frame = self.spinner_frame.wrapping_add(1);
+        if self.spinner_frame % 3 != 0 {
+            return false;
+        }
+
+        self.render_lines_uses_spinner()
+    }
+
+    fn render_lines_uses_spinner(&self) -> bool {
+        self.messages.iter().enumerate().any(|(idx, msg)| match &msg.msg {
+            ChatMessage::Thinking(text) => text == "…",
+            ChatMessage::ToolUseStart(_, _) => true,
+            ChatMessage::ToolUse { .. } => {
+                idx == self.messages.len().saturating_sub(1) && self.tool_start_time.is_some()
+            }
+            ChatMessage::ToolResult { .. } => self.is_active_tool_result(idx),
+            _ => false,
+        })
+    }
+
+    /// True when a full terminal clear is needed before an animated redraw.
+    ///
+    /// The message pane is already cleared locally in `draw()` before rendering
+    /// the transcript, and rendered lines are clamped to terminal display width.
+    /// Calling `terminal.clear()` on streaming animation frames repaints the
+    /// whole alternate screen and causes visible flicker, so animation ticks
+    /// should not request a full-screen clear.
+    pub(crate) fn needs_clear_for_animation_redraw(&self) -> bool {
+        false
+    }
+
     /// Returns true when the chat message at `idx` is the tool result currently
     /// being streamed/executed. Completed historical tool results must render as
     /// done even while a later tool call is active.
@@ -747,6 +785,49 @@ mod tests {
         app.tool_start_time = Some(std::time::Instant::now());
 
         assert!(!app.is_active_tool_result(1));
+    }
+
+    #[test]
+    fn animation_tick_for_subagent_panel_does_not_invalidate_message_cache() {
+        let mut app = test_app();
+        app.push_msg(ChatMessage::System("stable transcript".to_string()));
+        app.line_cache = Some((80, app.render_lines(80)));
+        app.subagents.push(SubagentState {
+            id: 1,
+            name: "tester".to_string(),
+            status: "running".to_string(),
+            start_time: std::time::Instant::now(),
+            done: false,
+            duration_secs: None,
+        });
+        app.spinner_frame = 2;
+
+        let invalidate_messages = app.advance_animations();
+
+        assert!(!invalidate_messages, "subagent panel spinner redraw must not rebuild message cache");
+        assert!(!app.needs_clear_for_animation_redraw(), "subagent-only animation must not force terminal.clear flicker");
+        assert!(app.line_cache.is_some(), "message cache should remain valid for panel-only animation");
+    }
+
+    #[test]
+    fn animation_tick_for_active_bash_result_invalidates_message_cache() {
+        let mut app = test_app();
+        app.push_msg(ChatMessage::ToolUse {
+            tool_name: "bash".to_string(),
+            input: "{}".to_string(),
+        });
+        app.push_msg(ChatMessage::ToolResult {
+            content: String::new(),
+            elapsed_ms: None,
+        });
+        app.tool_start_time = Some(std::time::Instant::now());
+        app.line_cache = Some((80, app.render_lines(80)));
+        app.spinner_frame = 2;
+
+        let invalidate_messages = app.advance_animations();
+
+        assert!(invalidate_messages, "active message-area bash animation must rebuild message cache");
+        assert!(!app.needs_clear_for_animation_redraw(), "streaming animation must not force whole-terminal clear flicker");
     }
 
     #[test]

--- a/src/chatui/app.rs
+++ b/src/chatui/app.rs
@@ -204,6 +204,57 @@ impl App {
             suppress_paste_until: None,
         }
     }
+    /// Build the text shown in the chat transcript for a submitted user message.
+    /// Large pasted payloads are collapsed to a label, while any text typed before
+    /// or after the pasted range remains visible.
+    pub(crate) fn user_display_text_for_submission(&self, input: &str) -> String {
+        if self.pasted_char_count == 0 {
+            return input.to_string();
+        }
+
+        let before_paste = self.input_before_paste.as_deref().unwrap_or("");
+        let before_chars = before_paste.chars().count();
+        let total_chars = input.chars().count();
+        let paste_chars = self.pasted_char_count.min(total_chars.saturating_sub(before_chars));
+        let after_chars = total_chars.saturating_sub(before_chars + paste_chars);
+
+        let paste_byte_start = input
+            .char_indices()
+            .nth(before_chars)
+            .map(|(i, _)| i)
+            .unwrap_or(input.len());
+        let paste_byte_end = input
+            .char_indices()
+            .nth(before_chars + paste_chars)
+            .map(|(i, _)| i)
+            .unwrap_or(input.len());
+
+        let pasted = &input[paste_byte_start..paste_byte_end];
+        let after_paste = if after_chars == 0 {
+            ""
+        } else {
+            &input[paste_byte_end..]
+        };
+
+        let line_count = pasted.lines().count();
+        let paste_label = if line_count > 1 {
+            format!("[Pasted {} lines]", line_count)
+        } else {
+            format!("[Pasted {} chars]", paste_chars)
+        };
+
+        match (before_paste.is_empty(), after_paste.is_empty()) {
+            (true, true) => paste_label,
+            (false, true) => format!("{} {}", before_paste.trim(), paste_label),
+            (true, false) => format!("{} {}", paste_label, after_paste.trim()),
+            (false, false) => format!(
+                "{} {} {}",
+                before_paste.trim(),
+                paste_label,
+                after_paste.trim()
+            ),
+        }
+    }
 
     /// Restore SynapsCLI's TUI after casino (or failed spawn).
     /// Convert char-based cursor_pos to byte offset in self.input.
@@ -696,5 +747,16 @@ mod tests {
         app.tool_start_time = Some(std::time::Instant::now());
 
         assert!(!app.is_active_tool_result(1));
+    }
+
+    #[test]
+    fn pasted_message_display_preserves_text_typed_after_paste() {
+        let mut app = test_app();
+        app.input_before_paste = Some("before".to_string());
+        app.pasted_char_count = "PASTED".chars().count();
+
+        let display = app.user_display_text_for_submission("beforePASTED after");
+
+        assert_eq!(display, "before [Pasted 6 chars] after");
     }
 }

--- a/src/chatui/app.rs
+++ b/src/chatui/app.rs
@@ -342,6 +342,15 @@ impl App {
         self.line_cache = None;
     }
 
+    /// Returns true when the chat message at `idx` is the tool result currently
+    /// being streamed/executed. Completed historical tool results must render as
+    /// done even while a later tool call is active.
+    pub(crate) fn is_active_tool_result(&self, idx: usize) -> bool {
+        self.tool_start_time.is_some()
+            && idx == self.messages.len().saturating_sub(1)
+            && matches!(self.messages.get(idx).map(|m| &m.msg), Some(ChatMessage::ToolResult { elapsed_ms: None, .. }))
+    }
+
     /// Find the file extension from the ToolUse message preceding a ToolResult at index `idx`.
     pub(crate) fn find_preceding_read_extension(&self, idx: usize) -> String {
         // Walk backwards from idx to find the preceding ToolUse
@@ -638,4 +647,54 @@ impl App {
         }
     }
 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_app() -> App {
+        App::new(Session::new("test-model", "low", None))
+    }
+
+    #[test]
+    fn active_tool_result_is_only_latest_incomplete_result() {
+        let mut app = test_app();
+        app.push_msg(ChatMessage::ToolUse {
+            tool_name: "bash".to_string(),
+            input: "{}".to_string(),
+        });
+        app.push_msg(ChatMessage::ToolResult {
+            content: "first output".to_string(),
+            elapsed_ms: None,
+        });
+        app.push_msg(ChatMessage::ToolUse {
+            tool_name: "bash".to_string(),
+            input: "{}".to_string(),
+        });
+        app.push_msg(ChatMessage::ToolResult {
+            content: "second output".to_string(),
+            elapsed_ms: None,
+        });
+        app.tool_start_time = Some(std::time::Instant::now());
+
+        assert!(!app.is_active_tool_result(1), "completed historical result must render done while later tool runs");
+        assert!(app.is_active_tool_result(3), "latest incomplete result is the actively running tool result");
+    }
+
+    #[test]
+    fn completed_latest_tool_result_is_not_active() {
+        let mut app = test_app();
+        app.push_msg(ChatMessage::ToolUse {
+            tool_name: "bash".to_string(),
+            input: "{}".to_string(),
+        });
+        app.push_msg(ChatMessage::ToolResult {
+            content: "done".to_string(),
+            elapsed_ms: Some(25),
+        });
+        app.tool_start_time = Some(std::time::Instant::now());
+
+        assert!(!app.is_active_tool_result(1));
+    }
 }

--- a/src/chatui/draw.rs
+++ b/src/chatui/draw.rs
@@ -89,6 +89,7 @@ pub(crate) fn draw(
     exit_effect: &mut Option<Effect>,
     elapsed: std::time::Duration,
     registry: &std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
+    secret_prompts: &synaps_cli::tools::SecretPromptQueue,
 ) -> io::Result<()> {
     let model = runtime.model();
     let thinking = runtime.thinking_level();
@@ -206,9 +207,18 @@ pub(crate) fn draw(
             .padding(Padding::horizontal(1));
         // Compute inner rect before block is consumed by Paragraph
         let msg_inner = msg_block.inner(msg_area);
-        let messages_widget = Paragraph::new(visible.clone()).block(msg_block);
+        let messages_widget = Paragraph::new(visible.clone()).block(msg_block.clone());
+        // Clear the message pane locally each frame. When a secure prompt is
+        // active, do not paint the live transcript underneath it; raw sudo
+        // prompts can otherwise appear in the chat/input area for one frame and
+        // long prompt lines can reintroduce edge overflow artifacts.
         frame.render_widget(Clear, msg_area);
-        frame.render_widget(messages_widget, msg_area);
+        if secret_prompts.is_active() {
+            let blank_messages = Paragraph::new(Vec::<Line>::new()).block(msg_block);
+            frame.render_widget(blank_messages, msg_area);
+        } else {
+            frame.render_widget(messages_widget, msg_area);
+        }
 
         // Save inner content rect (after borders + padding) so input.rs can
         // map mouse coordinates without hardcoded offsets.
@@ -699,6 +709,36 @@ pub(crate) fn draw(
         if let Some(ref mut fx) = exit_effect {
             let area = frame.area();
             fx.process(elapsed.into(), frame.buffer_mut(), area);
+        }
+
+        if let Some(prompt) = secret_prompts.active() {
+            let area = frame.area();
+            let width = area.width.min(62).max(30);
+            let height = 7u16;
+            let x = area.x + area.width.saturating_sub(width) / 2;
+            let y = area.y + area.height.saturating_sub(height) / 2;
+            let modal_area = ratatui::layout::Rect { x, y, width, height };
+            frame.render_widget(Clear, modal_area);
+            let block = Block::default()
+                .title(Span::styled(
+                    format!(" {} ", prompt.title),
+                    Style::default().fg(THEME.load().warning_color).add_modifier(Modifier::BOLD),
+                ))
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(THEME.load().warning_color))
+                .style(Style::default().bg(THEME.load().bg));
+            let masked = "•".repeat(prompt.buffer.chars().count());
+            let text = vec![
+                Line::from(Span::styled(prompt.prompt.clone(), Style::default().fg(THEME.load().help_fg))),
+                Line::from(""),
+                Line::from(vec![
+                    Span::styled("password: ", Style::default().fg(THEME.load().muted)),
+                    Span::styled(masked, Style::default().fg(THEME.load().input_fg)),
+                ]),
+                Line::from(Span::styled("Enter submit · Esc cancel", Style::default().fg(THEME.load().muted))),
+            ];
+            frame.render_widget(Paragraph::new(text).block(block).alignment(Alignment::Left), modal_area);
         }
 
         if let Some(ref state) = app.settings {

--- a/src/chatui/highlight.rs
+++ b/src/chatui/highlight.rs
@@ -9,6 +9,7 @@ use syntect::util::LinesWithEndings;
 use std::sync::LazyLock;
 
 use super::theme::THEME;
+use unicode_width::UnicodeWidthStr;
 
 /// Clamp a `Line` to fit within `width` terminal columns.
 /// Walks spans left-to-right, truncating/dropping once the budget is exceeded.
@@ -20,16 +21,27 @@ pub(crate) fn clamp_line(line: Line<'static>, width: usize) -> Line<'static> {
     let mut remaining = width;
     let mut clamped: Vec<Span<'static>> = Vec::new();
     for span in line.spans {
-        let span_len = span.content.chars().count();
+        let span_width = UnicodeWidthStr::width(span.content.as_ref());
         if remaining == 0 {
             break;
         }
-        if span_len <= remaining {
-            remaining -= span_len;
+        if span_width <= remaining {
+            remaining -= span_width;
             clamped.push(span);
         } else {
-            // Truncate this span to fit
-            let truncated: String = span.content.chars().take(remaining).collect();
+            // Truncate this span by display width. Multi-column chars must be
+            // counted by terminal cells, not scalar values, or a supposedly
+            // clamped line can still overrun the viewport and leave artifacts.
+            let mut used = 0;
+            let mut truncated = String::new();
+            for ch in span.content.chars() {
+                let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+                if used + ch_width > remaining {
+                    break;
+                }
+                used += ch_width;
+                truncated.push(ch);
+            }
             clamped.push(Span::styled(truncated, span.style));
             remaining = 0;
         }

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -800,26 +800,7 @@ pub async fn run(
                                     app.queued_message = Some(input);
                                     continue;
                                 }
-                                // Build display text with paste info
-                                let display_text = if app.pasted_char_count > 0 {
-                                    let typed = app.input_before_paste.as_deref().unwrap_or("");
-                                    let typed_char_count = typed.chars().count();
-                                    let paste_byte_start = input.char_indices()
-                                        .nth(typed_char_count)
-                                        .map(|(i, _)| i)
-                                        .unwrap_or(input.len());
-                                    let paste_content = &input[paste_byte_start..];
-                                    let line_count = paste_content.lines().count();
-                                    let pasted_char_count = input.chars().count().saturating_sub(typed_char_count);
-                                    let paste_label = if line_count > 1 {
-                                        format!("[Pasted {} lines]", line_count)
-                                    } else {
-                                        format!("[Pasted {} chars]", pasted_char_count)
-                                    };
-                                    if typed.is_empty() { paste_label } else { format!("{} {}", typed.trim(), paste_label) }
-                                } else {
-                                    input.clone()
-                                };
+                                let display_text = app.user_display_text_for_submission(&input);
                                 app.push_msg(ChatMessage::User(display_text));
                                 app.input_before_paste = None;
                                 app.pasted_char_count = 0;

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -401,6 +401,11 @@ pub async fn run(
 
             // ── Tick: animations + spinner (~60fps) ──
             _ = tokio::time::sleep(std::time::Duration::from_millis(16)), if boot_fx.is_some() || exit_fx.is_some() || app.streaming || app.compact_task.is_some() || app.messages.is_empty() || app.logo_dismiss_t.is_some() || app.logo_build_t.is_some() || app.gamba_child.is_some() => {
+                if let Ok(size) = terminal.size() {
+                    if size.width > 0 && size.height > 0 {
+                        terminal.clear().ok();
+                    }
+                }
                 if let Some(ref mut t) = app.logo_build_t {
                     *t += 0.025;
                     if *t >= 1.0 { app.logo_build_t = None; }

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -269,6 +269,10 @@ pub async fn run(
         .map_err(|e| synaps_cli::error::RuntimeError::Tool(format!("terminal setup failed: {}", e)))?;
     let mut event_reader = EventStream::new();
     let mut stream: Option<std::pin::Pin<Box<dyn futures::Stream<Item = StreamEvent> + Send>>> = None;
+    let (secret_prompt_tx, secret_prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    let secret_prompt_handle = synaps_cli::tools::SecretPromptHandle::new(secret_prompt_tx);
+    let secret_prompt_rx = std::sync::Arc::new(std::sync::Mutex::new(secret_prompt_rx));
+    let mut secret_prompts = synaps_cli::tools::SecretPromptQueue::new();
     let mut cancel_token: Option<CancellationToken> = None;
     let mut steer_tx: Option<tokio::sync::mpsc::UnboundedSender<String>> = None;
     let mut boot_fx: Option<Effect> = Some(boot_effect());
@@ -310,7 +314,7 @@ pub async fn run(
     loop {
         let elapsed = last_frame.elapsed();
         last_frame = Instant::now();
-        let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry);
+        let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry, &secret_prompts);
 
         tokio::select! {
 
@@ -336,7 +340,7 @@ pub async fn run(
                         app.model_health.insert(key, (status, ms));
                         let elapsed = last_frame.elapsed();
                         last_frame = Instant::now();
-                        let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry);
+                        let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry, &secret_prompts);
                     }
                     None => {
                         // All ping tasks done (tx dropped) — stop printing
@@ -390,7 +394,7 @@ pub async fn run(
                             let (s_tx, s_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
                             app.streaming = true;
                             app.spinner_frame = 0;
-                            stream = Some(runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx)).await);
+                            stream = Some(runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx), Some(secret_prompt_handle.clone())).await);
                             app.push_msg(ChatMessage::Thinking("…".to_string()));
                             cancel_token = Some(ct);
                             steer_tx = Some(s_tx);
@@ -400,10 +404,14 @@ pub async fn run(
             }
 
             // ── Tick: animations + spinner (~60fps) ──
-            _ = tokio::time::sleep(std::time::Duration::from_millis(16)), if boot_fx.is_some() || exit_fx.is_some() || app.streaming || app.compact_task.is_some() || app.messages.is_empty() || app.logo_dismiss_t.is_some() || app.logo_build_t.is_some() || app.gamba_child.is_some() => {
-                if let Ok(size) = terminal.size() {
-                    if size.width > 0 && size.height > 0 {
-                        terminal.clear().ok();
+            _ = tokio::time::sleep(std::time::Duration::from_millis(16)), if boot_fx.is_some() || exit_fx.is_some() || app.streaming || app.compact_task.is_some() || app.messages.is_empty() || app.logo_dismiss_t.is_some() || app.logo_build_t.is_some() || app.gamba_child.is_some() || secret_prompts.is_active() => {
+                secret_prompts.poll_requests(&secret_prompt_rx);
+                let message_animation_needs_clear = app.needs_clear_for_animation_redraw();
+                if message_animation_needs_clear {
+                    if let Ok(size) = terminal.size() {
+                        if size.width > 0 && size.height > 0 {
+                            terminal.clear().ok();
+                        }
                     }
                 }
                 if let Some(ref mut t) = app.logo_build_t {
@@ -414,11 +422,8 @@ pub async fn run(
                     *t += 0.04;
                     if *t >= 1.0 { app.logo_dismiss_t = None; }
                 }
-                if !app.subagents.is_empty() || app.streaming || app.compact_task.is_some() {
-                    app.spinner_frame = app.spinner_frame.wrapping_add(1);
-                    if app.spinner_frame % 3 == 0 {
-                        app.invalidate();
-                    }
+                if app.advance_animations() {
+                    app.invalidate();
                 }
                 if let Some(msg) = app.check_gamba_exited() {
                     terminal.clear().ok();
@@ -426,7 +431,7 @@ pub async fn run(
                     app.invalidate();
                     let elapsed = last_frame.elapsed();
                     last_frame = Instant::now();
-                    let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry);
+                    let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry, &secret_prompts);
                 }
                 // Poll background compaction task
                 if app.compact_task.as_ref().is_some_and(|t| t.is_finished()) {
@@ -514,6 +519,24 @@ pub async fn run(
             maybe_event = event_reader.next(), if app.gamba_child.is_none() => {
                 match maybe_event {
                     Some(Ok(event)) => {
+                        if secret_prompts.is_active() {
+                            match event {
+                                crossterm::event::Event::Key(key) => match key.code {
+                                    crossterm::event::KeyCode::Enter => secret_prompts.submit(),
+                                    crossterm::event::KeyCode::Esc => secret_prompts.cancel(),
+                                    crossterm::event::KeyCode::Backspace => secret_prompts.backspace(),
+                                    crossterm::event::KeyCode::Char(c) => secret_prompts.push_char(c),
+                                    _ => {}
+                                },
+                                crossterm::event::Event::Paste(text) => {
+                                    for ch in text.chars() {
+                                        secret_prompts.push_char(ch);
+                                    }
+                                }
+                                _ => {}
+                            }
+                            continue;
+                        }
                         let is_streaming = app.streaming;
                         let action = input::handle_event(event, &mut app, &runtime, is_streaming, &registry, &keybind_registry);
                         match action {
@@ -631,8 +654,8 @@ pub async fn run(
                                         app.spinner_frame = 0;
                                         let elapsed = last_frame.elapsed();
                                         last_frame = Instant::now();
-                                        let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry);
-                                        stream = Some(runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx)).await);
+                                        let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry, &secret_prompts);
+                                        stream = Some(runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx), Some(secret_prompt_handle.clone())).await);
                                         app.status_text = None;
                                         app.push_msg(ChatMessage::Thinking("…".to_string()));
                                         cancel_token = Some(ct);
@@ -825,8 +848,8 @@ pub async fn run(
                                 app.spinner_frame = 0;
                                 let elapsed = last_frame.elapsed();
                                 last_frame = Instant::now();
-                                let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry);
-                                stream = Some(runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx)).await);
+                                let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry, &secret_prompts);
+                                stream = Some(runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx), Some(secret_prompt_handle.clone())).await);
                                 app.status_text = None;
                                 app.push_msg(ChatMessage::Thinking("…".to_string()));
                                 cancel_token = Some(ct);
@@ -1054,7 +1077,7 @@ pub async fn run(
                                     app.invalidate();
                                     let elapsed = last_frame.elapsed();
                                     last_frame = Instant::now();
-                                    let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry);
+                                    let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry, &secret_prompts);
                                 }
                             }
                         }
@@ -1070,7 +1093,7 @@ pub async fn run(
                                 app.invalidate();
                                 let elapsed = last_frame.elapsed();
                                 last_frame = Instant::now();
-                                let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry);
+                                let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry, &secret_prompts);
                             }
                             // Auto-send the queued message
                             app.push_msg(ChatMessage::User(queued.clone()));
@@ -1091,8 +1114,8 @@ pub async fn run(
                             app.spinner_frame = 0;
                             let elapsed = last_frame.elapsed();
                             last_frame = Instant::now();
-                            let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry);
-                            stream = Some(runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx)).await);
+                            let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry, &secret_prompts);
+                            stream = Some(runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx), Some(secret_prompt_handle.clone())).await);
                             app.status_text = None;
                             app.push_msg(ChatMessage::Thinking("…".to_string()));
                             cancel_token = Some(ct);
@@ -1106,7 +1129,7 @@ pub async fn run(
                             let (s_tx, s_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
                             app.streaming = true;
                             app.spinner_frame = 0;
-                            stream = Some(runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx)).await);
+                            stream = Some(runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx), Some(secret_prompt_handle.clone())).await);
                             app.push_msg(ChatMessage::Thinking("…".to_string()));
                             cancel_token = Some(ct);
                             steer_tx = Some(s_tx);
@@ -1116,7 +1139,7 @@ pub async fn run(
                     if do_draw {
                         let elapsed = last_frame.elapsed();
                         last_frame = Instant::now();
-                        let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry);
+                        let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry, &secret_prompts);
                     }
                 }
             }

--- a/src/chatui/render.rs
+++ b/src/chatui/render.rs
@@ -413,8 +413,8 @@ impl App {
                                     Style::default().fg(THEME.load().subagent_time),
                                 ),
                             ]));
-                        } else if elapsed_ms.is_none() && self.tool_start_time.is_some() {
-                            // Tool still executing — show animation
+                        } else if self.is_active_tool_result(i) {
+                            // Tool still executing — show animation only for the active result.
                             let preceding_tool_name = self.find_preceding_tool_name(i);
                             let elapsed_str = if let Some(start) = self.tool_start_time {
                                 let secs = start.elapsed().as_secs_f64();

--- a/src/chatui/settings/defs.rs
+++ b/src/chatui/settings/defs.rs
@@ -114,7 +114,7 @@ define_settings! {
         };
 
     bash_max_timeout, "Bash max timeout", ToolLimits, EditorKind::Text { numeric: true },
-        "Upper bound on requested bash timeouts.",
+        "Legacy setting retained for config compatibility; requested bash timeouts are no longer clamped.",
         |runtime, _app, value| {
             if let Ok(n) = value.parse::<u64>() { runtime.set_bash_max_timeout(n); }
         };

--- a/src/cmd/agent.rs
+++ b/src/cmd/agent.rs
@@ -324,6 +324,7 @@ pub async fn run(config_path: String, trigger_context: String) {
             messages.clone(),
             cancel,
             None, // no steering for autonomous agents
+            None,
         ).await;
 
         let mut turn_done = false;
@@ -444,7 +445,7 @@ pub async fn run(config_path: String, trigger_context: String) {
         }));
 
         let cancel = CancellationToken::new();
-        let mut stream = runtime.run_stream_with_messages(messages.clone(), cancel, None).await;
+        let mut stream = runtime.run_stream_with_messages(messages.clone(), cancel, None, None).await;
         
         // Give it 60 seconds to write handoff
         let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(60);

--- a/src/cmd/chat.rs
+++ b/src/cmd/chat.rs
@@ -35,7 +35,7 @@ pub async fn run() -> Result<()> {
         flush_stdout();
 
         let cancel = CancellationToken::new();
-        let mut stream = runtime.run_stream_with_messages(messages.clone(), cancel, None).await;
+        let mut stream = runtime.run_stream_with_messages(messages.clone(), cancel, None, None).await;
         let mut in_thinking = false;
 
         while let Some(event) = stream.next().await {

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -224,6 +224,7 @@ pub async fn run(
                     std::mem::take(&mut messages),
                     cancel,
                     None,
+                    None,
                 ).await;
 
                 while let Some(event) = stream.next().await {

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -298,7 +298,7 @@ async fn handle_user_message(content: String, state: &Arc<ServerState>) {
 
     let mut stream = {
         let rt = state.runtime.lock().await;
-        rt.run_stream_with_messages(messages, cancel, None).await
+        rt.run_stream_with_messages(messages, cancel, None, None).await
     };
 
     let broadcast = state.broadcast_tx.clone();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -351,6 +351,7 @@ impl Runtime {
                                         session_manager: Some(self.session_manager.clone()),
                                         subagent_registry: Some(self.subagent_registry.clone()),
                                         event_queue: Some(self.event_queue.clone()),
+                                        secret_prompt: None,
                                     },
                                     limits: crate::tools::ToolLimits {
                                         max_tool_output: self.max_tool_output,
@@ -414,6 +415,7 @@ impl Runtime {
                                                 session_manager: Some(session_mgr_inner),
                                                 subagent_registry: Some(registry_inner),
                                                 event_queue: Some(event_queue_inner),
+                                                secret_prompt: None,
                                             },
                                             limits: crate::tools::ToolLimits {
                                                 max_tool_output: cfg_max_tool_output,
@@ -478,7 +480,7 @@ impl Runtime {
     /// Run a prompt as a cancellable stream of [`StreamEvent`]s. Convenience wrapper
     /// around [`run_stream_with_messages`] for single-turn usage.
     pub async fn run_stream(&self, prompt: String, cancel: CancellationToken) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send>> {
-        self.run_stream_with_messages(vec![json!({"role": "user", "content": prompt})], cancel, None).await
+        self.run_stream_with_messages(vec![json!({"role": "user", "content": prompt})], cancel, None, None).await
     }
 
     /// Run a multi-turn conversation as a cancellable stream of [`StreamEvent`]s.
@@ -489,6 +491,7 @@ impl Runtime {
         messages: Vec<Value>,
         cancel: CancellationToken,
         steering_rx: Option<mpsc::UnboundedReceiver<String>>,
+        secret_prompt: Option<crate::tools::SecretPromptHandle>,
     ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send>> {
         let (tx, rx) = mpsc::unbounded_channel();
 
@@ -529,7 +532,7 @@ impl Runtime {
             tx: tx.clone(), cancel, steering_rx,
             watcher_exit_path, max_tool_output,
             bash_timeout, bash_max_timeout, subagent_timeout,
-            session_manager, subagent_registry, event_queue,
+            session_manager, subagent_registry, event_queue, secret_prompt,
         };
 
         tokio::spawn(async move {

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -38,6 +38,7 @@ pub(super) struct StreamSession {
     pub(super) session_manager: std::sync::Arc<crate::tools::shell::SessionManager>,
     pub(super) subagent_registry: Arc<Mutex<crate::runtime::subagent::SubagentRegistry>>,
     pub(super) event_queue: Arc<crate::events::EventQueue>,
+    pub(super) secret_prompt: Option<crate::tools::SecretPromptHandle>,
 }
 
 pub(super) struct StreamMethods;
@@ -53,7 +54,7 @@ impl StreamMethods {
             tx, cancel, mut steering_rx,
             watcher_exit_path, max_tool_output,
             bash_timeout, bash_max_timeout, subagent_timeout,
-            session_manager, subagent_registry, event_queue,
+            session_manager, subagent_registry, event_queue, secret_prompt,
         } = session;
         let mut messages = initial_messages;
 
@@ -197,7 +198,7 @@ impl StreamMethods {
                                 tokio::select! {
                                     res = tool.execute(input, crate::ToolContext {
                                         channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx.clone()) },
-                                        capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()) },
+                                        capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()), secret_prompt: secret_prompt.clone() },
                                         limits: crate::tools::ToolLimits { max_tool_output, bash_timeout, bash_max_timeout, subagent_timeout },
                                     }) => {
                                         match res {
@@ -262,6 +263,7 @@ impl StreamMethods {
                         let session_mgr = session_manager.clone();
                         let registry_inner = subagent_registry.clone();
                         let eq_inner = event_queue.clone();
+                        let prompt_inner = secret_prompt.clone();
 
                         join_set.spawn(async move {
                             let result = match tool {
@@ -281,7 +283,7 @@ impl StreamMethods {
                                     tokio::select! {
                                         res = t.execute(input, crate::ToolContext {
                                             channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx_stream.clone()) },
-                                            capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()) },
+                                            capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()), secret_prompt: prompt_inner.clone() },
                                             limits: crate::tools::ToolLimits { max_tool_output, bash_timeout, bash_max_timeout, subagent_timeout },
                                         }) => {
                                             match res {

--- a/src/skills/tool.rs
+++ b/src/skills/tool.rs
@@ -92,6 +92,7 @@ mod tests {
                 session_manager: None,
                 subagent_registry: None,
                 event_queue: None,
+                secret_prompt: None,
             },
             limits: crate::tools::ToolLimits {
                 max_tool_output: 30000,

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -19,6 +19,17 @@ fn is_valid_name(s: &str) -> bool {
 
 /// Resolve an agent name to a system prompt.
 pub fn resolve_agent_prompt(name: &str) -> std::result::Result<String, String> {
+    // Defense-in-depth: callers should already filter blank names to None, but if
+    // one slips through we must not search `~/.synaps-cli/agents/.md` — that path
+    // looks valid on disk and produces a confusing error that models retry forever.
+    // Reject names that are empty or entirely whitespace/control chars (incl. NUL).
+    if name.chars().all(|c| c.is_whitespace() || c.is_control()) {
+        return Err(
+            "Empty 'agent' parameter. Pass a non-empty agent name, omit the field entirely, \
+             or provide 'system_prompt' inline instead.".to_string()
+        );
+    }
+
     // 1. File path — name contains '/'
     if name.contains('/') {
         let path = expand_path(name);
@@ -236,5 +247,27 @@ mod tests {
         assert!(is_valid_name("sage"));
         assert!(is_valid_name("my_agent_123"));
         assert!(is_valid_name("BBE"));
+    }
+
+    #[test]
+    fn resolve_agent_prompt_rejects_blank_name() {
+        // Empty string, whitespace, and NUL must all error early — never search disk.
+        for name in ["", " ", "  \t  ", "\n", "\u{0}"] {
+            let err = resolve_agent_prompt(name).unwrap_err();
+            assert!(
+                err.contains("Empty 'agent' parameter"),
+                "blank name {:?} should produce the empty-agent error, got: {}",
+                name,
+                err,
+            );
+            // Critical: the error must NOT mention `agents/.md` — that's the bug
+            // signature that caused models to loop with sentinel agent values.
+            assert!(
+                !err.contains("agents/.md"),
+                "blank name {:?} leaked path-search error: {}",
+                name,
+                err,
+            );
+        }
     }
 }

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -4,12 +4,82 @@ use super::{Tool, ToolContext, strip_ansi};
 
 pub struct BashTool;
 
+const READ_CHUNK_SIZE: usize = 1024;
+const MAX_STREAMED_DELTA_BYTES: usize = 16 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromptKind {
+    Sudo,
+    Password,
+}
+
+fn sanitize_output(input: &[u8]) -> String {
+    let lossy = String::from_utf8_lossy(input);
+    let stripped = strip_ansi(&lossy);
+    stripped
+        .chars()
+        .filter(|ch| {
+            *ch == '\n'
+                || *ch == '\r'
+                || *ch == '\t'
+                || (!ch.is_control() && *ch != '\u{7f}')
+        })
+        .collect()
+}
+
+fn detect_password_prompt(text: &str) -> Option<PromptKind> {
+    let lower = text.to_ascii_lowercase();
+    let has_password = lower.contains("password");
+    if !has_password {
+        return None;
+    }
+    if lower.contains("[sudo]") || lower.contains("sudo") {
+        Some(PromptKind::Sudo)
+    } else if lower.trim_end().ends_with(':') || lower.contains("password:") {
+        Some(PromptKind::Password)
+    } else {
+        None
+    }
+}
+
+fn append_bounded(output: &mut String, text: &str, max_output: usize) -> bool {
+    if output.len() >= max_output {
+        return false;
+    }
+    let remaining = max_output - output.len();
+    if text.len() <= remaining {
+        output.push_str(text);
+        true
+    } else {
+        let mut end = remaining;
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        output.push_str(&text[..end]);
+        false
+    }
+}
+
+pub(crate) fn bash_script_with_secure_sudo(command: &str) -> String {
+    // sudo normally opens /dev/tty for password input, bypassing our piped
+    // stdin/stderr and corrupting the TUI. In the non-interactive bash tool,
+    // shadow simple `sudo ...` invocations with a shell function that forces
+    // sudo to read from stdin and write the prompt to stderr, where the secure
+    // prompt detector can intercept it before it reaches chat/model output.
+    format!(
+        r#"sudo() {{
+    command sudo -S -p '[sudo] password required: ' "$@"
+}}
+{command}"#
+    )
+}
+
 #[async_trait::async_trait]
 impl Tool for BashTool {
     fn name(&self) -> &str { "bash" }
 
     fn description(&self) -> &str {
-        "Execute a bash command and return its output. Use for running programs, installing packages, git operations, and any shell commands. Commands time out after 30 seconds by default; pass a larger timeout when needed."
+        "Execute a bash command and return its output. Use for running programs, installing packages, git operations, and any shell commands. Commands time out after 30 seconds by default; pass a larger timeout when needed. If sudo asks for a password, the user is prompted securely in the TUI and the password is never shown to the model."
     }
 
     fn parameters(&self) -> Value {
@@ -36,10 +106,11 @@ impl Tool for BashTool {
         let timeout_secs = params["timeout"].as_u64().unwrap_or(ctx.limits.bash_timeout);
         let max_output = ctx.limits.max_tool_output;
 
+        let script = bash_script_with_secure_sudo(command);
         let mut child = tokio::process::Command::new("bash")
             .arg("-c")
-            .arg(command)
-            .stdin(std::process::Stdio::null())
+            .arg(&script)
+            .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true)
@@ -50,48 +121,147 @@ impl Tool for BashTool {
             .ok_or_else(|| RuntimeError::Tool("Failed to capture stdout".to_string()))?;
         let stderr = child.stderr.take()
             .ok_or_else(|| RuntimeError::Tool("Failed to capture stderr".to_string()))?;
+        let stdin = child.stdin.take()
+            .ok_or_else(|| RuntimeError::Tool("Failed to capture stdin".to_string()))?;
 
-        let (tx_inter, mut rx_inter) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let (tx_inter, mut rx_inter) = tokio::sync::mpsc::unbounded_channel::<(bool, String)>();
 
         let tx_o = tx_inter.clone();
-        let txd1 = ctx.channels.tx_delta.clone();
         tokio::spawn(async move {
-            use tokio::io::AsyncBufReadExt;
-            let mut reader = tokio::io::BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = reader.next_line().await {
-                let msg = format!("{}\n", strip_ansi(&line));
-                let _ = tx_o.send(msg.clone());
-                if let Some(ref t) = txd1 { let _ = t.send(msg); }
+            use tokio::io::AsyncReadExt;
+            let mut reader = stdout;
+            let mut buf = vec![0u8; READ_CHUNK_SIZE];
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let msg = sanitize_output(&buf[..n]);
+                        if !msg.is_empty() {
+                            let _ = tx_o.send((false, msg));
+                        }
+                    }
+                    Err(_) => break,
+                }
             }
         });
 
         let tx_e = tx_inter.clone();
-        let txd2 = ctx.channels.tx_delta.clone();
         tokio::spawn(async move {
-            use tokio::io::AsyncBufReadExt;
-            let mut reader = tokio::io::BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = reader.next_line().await {
-                let msg = format!("{}\n", strip_ansi(&line));
-                let _ = tx_e.send(msg.clone());
-                if let Some(ref t) = txd2 { let _ = t.send(msg); }
+            use tokio::io::AsyncReadExt;
+            let mut reader = stderr;
+            let mut buf = vec![0u8; READ_CHUNK_SIZE];
+            loop {
+                match reader.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let msg = sanitize_output(&buf[..n]);
+                        if !msg.is_empty() {
+                            let _ = tx_e.send((true, msg));
+                        }
+                    }
+                    Err(_) => break,
+                }
             }
         });
 
         drop(tx_inter);
 
         let result = tokio::time::timeout(tokio::time::Duration::from_secs(timeout_secs), async {
+            use tokio::io::AsyncWriteExt;
+
+            let mut stdin = stdin;
             let mut full_output = String::new();
-            while let Some(line) = rx_inter.recv().await {
-                full_output.push_str(&line);
-                if full_output.len() > max_output {
-                    // Find a valid UTF-8 char boundary at or before max_output
-                    let mut trunc = max_output;
-                    while trunc > 0 && !full_output.is_char_boundary(trunc) {
-                        trunc -= 1;
+            let mut stderr_tail = String::new();
+            let mut truncated = false;
+            let mut streamed_bytes = 0usize;
+            let mut redactions: Vec<String> = Vec::new();
+
+            while let Some((is_stderr, mut msg)) = rx_inter.recv().await {
+                if is_stderr {
+                    stderr_tail.push_str(&msg);
+                    if stderr_tail.len() > 512 {
+                        let keep_from = stderr_tail.len() - 512;
+                        if let Some((idx, _)) = stderr_tail.char_indices().find(|(i, _)| *i >= keep_from) {
+                            stderr_tail.drain(..idx);
+                        }
                     }
-                    full_output.truncate(trunc);
+                    if let Some(kind) = detect_password_prompt(&stderr_tail) {
+                        let prompt_text = stderr_tail.trim().to_string();
+                        let secret = match &ctx.capabilities.secret_prompt {
+                            Some(prompt) => prompt.prompt(
+                                match kind {
+                                    PromptKind::Sudo => "sudo password required".to_string(),
+                                    PromptKind::Password => "password required".to_string(),
+                                },
+                                prompt_text.clone(),
+                            ).await,
+                            None => None,
+                        };
+                        match secret {
+                            Some(mut value) => {
+                                let secret_value = value.clone();
+                                if !secret_value.is_empty() {
+                                    redactions.push(secret_value);
+                                }
+                                value.push('\n');
+                                stdin.write_all(value.as_bytes()).await
+                                    .map_err(|e| RuntimeError::Tool(e.to_string()))?;
+                                stdin.flush().await
+                                    .map_err(|e| RuntimeError::Tool(e.to_string()))?;
+                            }
+                            None => {
+                                let _ = child.kill().await;
+                                return Err(RuntimeError::Tool("Command canceled while waiting for password".to_string()));
+                            }
+                        }
+                        let prompt_len = prompt_text.len();
+                        if prompt_len <= msg.len() {
+                            let keep_len = msg.len() - prompt_len;
+                            msg.truncate(keep_len);
+                        } else {
+                            msg.clear();
+                        }
+                        stderr_tail.clear();
+                    }
+                }
+
+                for secret in &redactions {
+                    if !secret.is_empty() {
+                        msg = msg.replace(secret, "[redacted]");
+                    }
+                }
+
+                if truncated {
+                    continue;
+                }
+
+                let added_all = append_bounded(&mut full_output, &msg, max_output);
+                if let Some(ref txd) = ctx.channels.tx_delta {
+                    if streamed_bytes < MAX_STREAMED_DELTA_BYTES {
+                        let remaining = MAX_STREAMED_DELTA_BYTES - streamed_bytes;
+                        let delta = if msg.len() <= remaining {
+                            msg.clone()
+                        } else {
+                            let mut end = remaining;
+                            while end > 0 && !msg.is_char_boundary(end) {
+                                end -= 1;
+                            }
+                            msg[..end].to_string()
+                        };
+                        streamed_bytes += delta.len();
+                        if !delta.is_empty() {
+                            let _ = txd.send(delta);
+                        }
+                    }
+                }
+
+                if !added_all {
                     full_output.push_str(&format!("\n\n[output truncated at {}]", max_output));
-                    break;
+                    if let Some(ref txd) = ctx.channels.tx_delta {
+                        let _ = txd.send(format!("\n\n[output truncated at {}]", max_output));
+                    }
+                    truncated = true;
+                    let _ = child.kill().await;
                 }
             }
             let status = child.wait().await.map_err(|e| RuntimeError::Tool(e.to_string()))?;
@@ -100,7 +270,7 @@ impl Tool for BashTool {
 
         match result {
             Ok(Ok((status, output))) => {
-                if status.success() {
+                if status.success() || output.contains("[output truncated at") {
                     Ok(output)
                 } else {
                     Err(RuntimeError::Tool(format!(
@@ -112,5 +282,21 @@ impl Tool for BashTool {
             Ok(Err(e)) => Err(RuntimeError::Tool(format!("Failed to execute command: {}", e))),
             Err(_) => Err(RuntimeError::Tool(format!("Command timed out after {}s", timeout_secs))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_sudo_password_prompt_without_newline() {
+        assert_eq!(detect_password_prompt("[sudo] password for me: "), Some(PromptKind::Sudo));
+    }
+
+    #[test]
+    fn sanitizes_terminal_control_sequences_and_nuls() {
+        let cleaned = sanitize_output(b"ok\x1b[2J\x00done");
+        assert_eq!(cleaned, "okdone");
     }
 }

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -9,7 +9,7 @@ impl Tool for BashTool {
     fn name(&self) -> &str { "bash" }
 
     fn description(&self) -> &str {
-        "Execute a bash command and return its output. Use for running programs, installing packages, git operations, and any shell commands. Commands time out after 30 seconds."
+        "Execute a bash command and return its output. Use for running programs, installing packages, git operations, and any shell commands. Commands time out after 30 seconds by default; pass a larger timeout when needed."
     }
 
     fn parameters(&self) -> Value {
@@ -22,7 +22,7 @@ impl Tool for BashTool {
                 },
                 "timeout": {
                     "type": "integer",
-                    "description": "Timeout in seconds (default: 30, max: 300)"
+                    "description": "Timeout in seconds (default: 30). Use a larger value for long-running commands."
                 }
             },
             "required": ["command"]
@@ -33,7 +33,7 @@ impl Tool for BashTool {
         let command = params["command"].as_str()
             .ok_or_else(|| RuntimeError::Tool("Missing command parameter".to_string()))?;
 
-        let timeout_secs = params["timeout"].as_u64().unwrap_or(ctx.limits.bash_timeout).min(ctx.limits.bash_max_timeout);
+        let timeout_secs = params["timeout"].as_u64().unwrap_or(ctx.limits.bash_timeout);
         let max_output = ctx.limits.max_tool_output;
 
         let mut child = tokio::process::Command::new("bash")

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,6 +17,7 @@ mod grep;
 mod find;
 mod ls;
 mod subagent;
+mod secret_prompt;
 
 pub mod watcher_exit;
 pub(crate) mod util;
@@ -53,6 +54,8 @@ pub use subagent_collect::SubagentCollectTool;
 pub use subagent_resume::SubagentResumeTool;
 pub use respond::RespondTool;
 pub use send_channel::SendChannelTool;
+pub use secret_prompt::{SecretPromptHandle, SecretPromptRequest};
+pub use secret_prompt::SecretPromptQueue;
 
 // Re-export util items used by sibling tool modules via `super::`
 pub(crate) use util::{NEXT_SUBAGENT_ID, strip_ansi, expand_path};
@@ -72,6 +75,7 @@ pub struct ToolCapabilities {
     pub session_manager: Option<std::sync::Arc<crate::tools::shell::SessionManager>>,
     pub subagent_registry: Option<Arc<Mutex<SubagentRegistry>>>,
     pub event_queue: Option<Arc<crate::events::EventQueue>>,
+    pub secret_prompt: Option<SecretPromptHandle>,
 }
 
 /// Configuration limits and timeouts.

--- a/src/tools/secret_prompt.rs
+++ b/src/tools/secret_prompt.rs
@@ -1,0 +1,117 @@
+use std::sync::{Arc, Mutex};
+
+/// UI-only secret prompt plumbing for interactive tools.
+///
+/// Secrets sent through this channel are never part of tool parameters, tool
+/// results, chat messages, or API messages. The TUI owns the input UI and sends
+/// only the final secret bytes back to the waiting tool.
+#[derive(Clone)]
+pub struct SecretPromptHandle {
+    tx: tokio::sync::mpsc::UnboundedSender<SecretPromptRequest>,
+}
+
+impl SecretPromptHandle {
+    pub fn new(tx: tokio::sync::mpsc::UnboundedSender<SecretPromptRequest>) -> Self {
+        Self { tx }
+    }
+
+    pub async fn prompt(&self, title: String, prompt: String) -> Option<String> {
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+        let request = SecretPromptRequest {
+            title,
+            prompt,
+            response_tx,
+        };
+        self.tx.send(request).ok()?;
+        response_rx.await.ok().flatten()
+    }
+}
+
+pub struct SecretPromptRequest {
+    pub title: String,
+    pub prompt: String,
+    pub response_tx: tokio::sync::oneshot::Sender<Option<String>>,
+}
+
+pub struct PendingSecretPrompt {
+    pub title: String,
+    pub prompt: String,
+    pub buffer: String,
+    pub response_tx: tokio::sync::oneshot::Sender<Option<String>>,
+}
+
+pub struct SecretPromptQueue {
+    active: Option<PendingSecretPrompt>,
+    pending: std::collections::VecDeque<SecretPromptRequest>,
+}
+
+impl SecretPromptQueue {
+    pub fn new() -> Self {
+        Self {
+            active: None,
+            pending: std::collections::VecDeque::new(),
+        }
+    }
+
+    pub fn poll_requests(
+        &mut self,
+        rx: &Arc<Mutex<tokio::sync::mpsc::UnboundedReceiver<SecretPromptRequest>>>,
+    ) {
+        if let Ok(mut rx) = rx.lock() {
+            while let Ok(req) = rx.try_recv() {
+                self.pending.push_back(req);
+            }
+        }
+        self.activate_next();
+    }
+
+    fn activate_next(&mut self) {
+        if self.active.is_some() {
+            return;
+        }
+        if let Some(req) = self.pending.pop_front() {
+            self.active = Some(PendingSecretPrompt {
+                title: req.title,
+                prompt: req.prompt,
+                buffer: String::new(),
+                response_tx: req.response_tx,
+            });
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active.is_some()
+    }
+
+    pub fn active(&self) -> Option<&PendingSecretPrompt> {
+        self.active.as_ref()
+    }
+
+    pub fn push_char(&mut self, ch: char) {
+        if let Some(active) = self.active.as_mut() {
+            active.buffer.push(ch);
+        }
+    }
+
+    pub fn backspace(&mut self) {
+        if let Some(active) = self.active.as_mut() {
+            active.buffer.pop();
+        }
+    }
+
+    pub fn submit(&mut self) {
+        if let Some(mut active) = self.active.take() {
+            let secret = std::mem::take(&mut active.buffer);
+            let _ = active.response_tx.send(Some(secret));
+        }
+        self.activate_next();
+    }
+
+    pub fn cancel(&mut self) {
+        if let Some(mut active) = self.active.take() {
+            active.buffer.clear();
+            let _ = active.response_tx.send(None);
+        }
+        self.activate_next();
+    }
+}

--- a/src/tools/subagent.rs
+++ b/src/tools/subagent.rs
@@ -49,8 +49,20 @@ impl Tool for SubagentTool {
             .ok_or_else(|| RuntimeError::Tool("Missing 'task' parameter".to_string()))?
             .to_string();
 
-        let agent_name = params["agent"].as_str().map(|s| s.to_string());
-        let inline_prompt = params["system_prompt"].as_str().map(|s| s.to_string());
+        // Treat blank / whitespace / control-char strings as absent — see
+        // subagent_start.rs for full rationale. Models occasionally pass `agent: ""`
+        // (or "\u{0}", or " ") alongside a real `system_prompt`; without this filter
+        // we'd try to resolve an empty agent name and fail, instead of falling
+        // through to the inline prompt.
+        let is_blank = |s: &String| s.chars().all(|c| c.is_whitespace() || c.is_control());
+        let agent_name = params["agent"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
+        let inline_prompt = params["system_prompt"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
         let model_override = params["model"].as_str().map(|s| s.to_string());
         let timeout_secs = params["timeout"].as_u64().unwrap_or(ctx.limits.subagent_timeout);
 

--- a/src/tools/subagent_resume.rs
+++ b/src/tools/subagent_resume.rs
@@ -178,6 +178,7 @@ impl Tool for SubagentResumeTool {
                         vec![serde_json::json!({"role": "user", "content": task_for_stream})],
                         cancel,
                         Some(steer_rx),
+                        None,
                     ).await;
 
                     let mut tool_count = 0u32;

--- a/src/tools/subagent_start.rs
+++ b/src/tools/subagent_start.rs
@@ -168,7 +168,7 @@ impl Tool for SubagentStartTool {
                         cancel_inner.cancel();
                     });
 
-                    let mut stream = runtime.run_stream_with_messages(vec![serde_json::json!({"role": "user", "content": task})], cancel, Some(steer_rx)).await;
+                    let mut stream = runtime.run_stream_with_messages(vec![serde_json::json!({"role": "user", "content": task})], cancel, Some(steer_rx), None).await;
 
                     let mut tool_count = 0u32;
                     let mut total_input_tokens = 0u64;

--- a/src/tools/subagent_start.rs
+++ b/src/tools/subagent_start.rs
@@ -65,8 +65,20 @@ impl Tool for SubagentStartTool {
             .ok_or_else(|| RuntimeError::Tool("Missing 'task' parameter".to_string()))?
             .to_string();
 
-        let agent_name    = params["agent"].as_str().map(|s| s.to_string());
-        let inline_prompt = params["system_prompt"].as_str().map(|s| s.to_string());
+        // Treat blank / whitespace / control-char strings as absent.
+        // Some model providers serialize "unset" as "" rather than omitting the field,
+        // and we must not try to resolve "" (or " ", or "\u{0}") as an agent name —
+        // doing so produces a hard "Agent '' not found" error that the model then
+        // retries forever with sentinel values instead of falling back to system_prompt.
+        let is_blank = |s: &String| s.chars().all(|c| c.is_whitespace() || c.is_control());
+        let agent_name = params["agent"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
+        let inline_prompt = params["system_prompt"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
         let model_override = params["model"].as_str().map(|s| s.to_string());
         let timeout_secs   = params["timeout"].as_u64().unwrap_or(ctx.limits.subagent_timeout);
 

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -162,6 +162,7 @@ fn create_tool_context() -> ToolContext {
             session_manager: None,
             subagent_registry: None,
             event_queue: None,
+            secret_prompt: None,
         },
         limits: crate::tools::ToolLimits {
             max_tool_output: 30000,
@@ -386,6 +387,205 @@ async fn test_bash_tool_requested_timeout_is_not_clamped_by_max_timeout() {
     let result = tool.execute(params, ctx).await;
     assert!(result.is_ok(), "requested timeout should not be clamped by bash_max_timeout: {result:?}");
     assert!(result.unwrap().contains("done"));
+}
+
+
+#[tokio::test]
+async fn test_bash_fake_sudo_prompt_uses_secret_prompt_and_redacts_password() {
+    let tool = BashTool;
+    let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    let prompt_handle = crate::tools::SecretPromptHandle::new(prompt_tx);
+    let (delta_tx, mut delta_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let responder = tokio::spawn(async move {
+        let req = prompt_rx.recv().await.expect("bash should request a secret prompt");
+        assert!(req.prompt.to_ascii_lowercase().contains("password"), "prompt was {:?}", req.prompt);
+        req.response_tx.send(Some("swordfish".to_string())).unwrap();
+    });
+
+    let mut ctx = create_tool_context();
+    ctx.capabilities.secret_prompt = Some(prompt_handle);
+    ctx.channels.tx_delta = Some(delta_tx);
+    let params = json!({
+        "command": "printf '[sudo] password for testuser: ' >&2; read -r pw; if [ \"$pw\" = swordfish ]; then echo AUTH_OK; else echo AUTH_FAIL; fi",
+        "timeout": 5
+    });
+
+    let result = tool.execute(params, ctx).await.unwrap();
+    responder.await.unwrap();
+    let mut streamed = String::new();
+    while let Ok(delta) = delta_rx.try_recv() {
+        streamed.push_str(&delta);
+    }
+
+    assert!(result.contains("AUTH_OK"));
+    assert!(!result.contains("swordfish"));
+    assert!(!result.contains("[sudo] password"));
+    assert!(!streamed.contains("[sudo] password"));
+}
+
+#[test]
+fn test_bash_wraps_sudo_to_force_stdin_prompt() {
+    let script = crate::tools::bash::bash_script_with_secure_sudo("sudo id");
+
+    assert!(script.contains("sudo()"));
+    assert!(script.contains("command sudo -S -p '[sudo] password required: '"));
+    assert!(script.ends_with("sudo id"));
+}
+
+#[tokio::test]
+async fn test_bash_sudo_function_prompt_is_intercepted_before_streaming() {
+    let tool = BashTool;
+    let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    let prompt_handle = crate::tools::SecretPromptHandle::new(prompt_tx);
+    let (delta_tx, mut delta_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let responder = tokio::spawn(async move {
+        let req = prompt_rx.recv().await.expect("bash should request a secret prompt");
+        assert!(req.prompt.contains("[sudo] password required"), "prompt was {:?}", req.prompt);
+        req.response_tx.send(Some("wrong-password-for-test".to_string())).unwrap();
+    });
+
+    let mut ctx = create_tool_context();
+    ctx.capabilities.secret_prompt = Some(prompt_handle);
+    ctx.channels.tx_delta = Some(delta_tx);
+    let params = json!({
+        "command": "sudo -k; sudo -v",
+        "timeout": 5
+    });
+
+    let _ = tool.execute(params, ctx).await;
+    responder.await.unwrap();
+    let mut streamed = String::new();
+    while let Ok(delta) = delta_rx.try_recv() {
+        streamed.push_str(&delta);
+    }
+
+    assert!(!streamed.contains("[sudo] password required"), "sudo password prompt leaked into deltas: {streamed:?}");
+}
+
+#[tokio::test]
+async fn test_bash_control_char_output_is_sanitized_and_bounded_in_deltas() {
+    let tool = BashTool;
+    let (delta_tx, mut delta_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut ctx = create_tool_context();
+    ctx.channels.tx_delta = Some(delta_tx);
+    ctx.limits.max_tool_output = 256;
+
+    let params = json!({
+        "command": "python3 -c \"import sys; sys.stdout.buffer.write(b'clean\\x1b[2J\\x00' + b'A' * 2000); sys.stdout.flush()\"",
+        "timeout": 5
+    });
+
+    let result = tool.execute(params, ctx).await.unwrap();
+    let mut streamed = String::new();
+    while let Ok(delta) = delta_rx.try_recv() {
+        streamed.push_str(&delta);
+    }
+
+    assert!(result.contains("[output truncated at 256]"));
+    assert!(!result.contains('\u{1b}'));
+    assert!(!result.contains('\0'));
+    assert!(!streamed.contains('\u{1b}'));
+    assert!(!streamed.contains('\0'));
+    assert!(streamed.len() <= 2048, "streamed deltas must be bounded, got {} bytes", streamed.len());
+}
+
+
+#[tokio::test]
+async fn test_bash_echoed_secret_is_redacted_from_output() {
+    let tool = BashTool;
+    let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    let prompt_handle = crate::tools::SecretPromptHandle::new(prompt_tx);
+
+    let responder = tokio::spawn(async move {
+        let req = prompt_rx.recv().await.expect("bash should request a secret prompt");
+        req.response_tx.send(Some("swordfish".to_string())).unwrap();
+    });
+
+    let mut ctx = create_tool_context();
+    ctx.capabilities.secret_prompt = Some(prompt_handle);
+    let params = json!({
+        "command": "printf 'Password: ' >&2; read -r pw; echo seen:$pw",
+        "timeout": 5
+    });
+
+    let result = tool.execute(params, ctx).await.unwrap();
+    responder.await.unwrap();
+
+    assert!(result.contains("seen:[redacted]"));
+    assert!(!result.contains("swordfish"));
+}
+
+
+#[tokio::test]
+async fn test_bash_sequential_password_prompts_are_each_handled() {
+    let tool = BashTool;
+    let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    let prompt_handle = crate::tools::SecretPromptHandle::new(prompt_tx);
+
+    let responder = tokio::spawn(async move {
+        for value in ["first", "second"] {
+            let req = prompt_rx.recv().await.expect("bash should request each secret prompt");
+            assert!(req.prompt.to_ascii_lowercase().contains("password"));
+            req.response_tx.send(Some(value.to_string())).unwrap();
+        }
+    });
+
+    let mut ctx = create_tool_context();
+    ctx.capabilities.secret_prompt = Some(prompt_handle);
+    let params = json!({
+        "command": "printf 'Password: ' >&2; read -r one; printf 'Password: ' >&2; read -r two; echo done:$one:$two",
+        "timeout": 5
+    });
+
+    let result = tool.execute(params, ctx).await.unwrap();
+    responder.await.unwrap();
+
+    assert!(result.contains("done:[redacted]:[redacted]"));
+    assert!(!result.contains("first"));
+    assert!(!result.contains("second"));
+}
+
+#[tokio::test]
+async fn test_bash_password_prompt_cancel_kills_command_without_leaking_partial_secret() {
+    let tool = BashTool;
+    let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    let prompt_handle = crate::tools::SecretPromptHandle::new(prompt_tx);
+
+    let responder = tokio::spawn(async move {
+        let req = prompt_rx.recv().await.expect("bash should request a secret prompt");
+        req.response_tx.send(None).unwrap();
+    });
+
+    let mut ctx = create_tool_context();
+    ctx.capabilities.secret_prompt = Some(prompt_handle);
+    let params = json!({
+        "command": "printf 'Password: ' >&2; read -r pw; echo should-not-run:$pw",
+        "timeout": 5
+    });
+
+    let err = tool.execute(params, ctx).await.unwrap_err().to_string();
+    responder.await.unwrap();
+
+    assert!(err.contains("waiting for password"));
+    assert!(!err.contains("should-not-run"));
+}
+
+#[tokio::test]
+async fn test_bash_binary_output_is_sanitized() {
+    let tool = BashTool;
+    let ctx = create_tool_context();
+    let params = json!({
+        "command": "python3 -c \"import sys; sys.stdout.buffer.write(bytes(range(32)) + b'visible')\"",
+        "timeout": 5
+    });
+
+    let result = tool.execute(params, ctx).await.unwrap();
+
+    assert!(result.contains("visible"));
+    assert!(!result.contains('\0'));
+    assert!(!result.contains('\u{1b}'));
 }
 
 // ── New Tests ────────────────────────────────────────────────────────────

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -372,6 +372,22 @@ async fn test_bash_tool_execution() {
     assert!(result.unwrap_err().to_string().contains("timed out"));
 }
 
+#[tokio::test]
+async fn test_bash_tool_requested_timeout_is_not_clamped_by_max_timeout() {
+    let tool = BashTool;
+    let mut ctx = create_tool_context();
+    ctx.limits.bash_max_timeout = 1;
+
+    let params = json!({
+        "command": "sleep 2; echo done",
+        "timeout": 3
+    });
+
+    let result = tool.execute(params, ctx).await;
+    assert!(result.is_ok(), "requested timeout should not be clamped by bash_max_timeout: {result:?}");
+    assert!(result.unwrap().contains("done"));
+}
+
 // ── New Tests ────────────────────────────────────────────────────────────
 
 #[test]

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -463,6 +463,54 @@ fn test_resolve_agent_prompt_path_not_found() {
     assert!(error.contains("Failed to read agent file"));
 }
 
+#[test]
+fn test_resolve_agent_prompt_blank_rejected_without_agent_lookup() {
+    let result = resolve_agent_prompt("");
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert!(error.contains("Empty 'agent' parameter"));
+    assert!(!error.contains("agents/.md"));
+}
+
+#[tokio::test]
+async fn test_subagent_start_blank_agent_uses_system_prompt() {
+    use std::sync::{Arc, Mutex};
+
+    let tool = SubagentStartTool;
+    let mut ctx = create_tool_context();
+    ctx.capabilities.subagent_registry = Some(Arc::new(Mutex::new(SubagentRegistry::new())));
+
+    let params = json!({
+        "agent": "",
+        "system_prompt": "You are a concise test subagent. Reply with only: ok",
+        "task": "Say ok",
+        "model": "claude-sonnet-4-6",
+        "timeout": 1
+    });
+
+    let result = tool.execute(params, ctx).await;
+    assert!(result.is_ok(), "blank agent should not be resolved as ~/.synaps-cli/agents/.md: {result:?}");
+    let body: serde_json::Value = serde_json::from_str(&result.unwrap()).unwrap();
+    assert_eq!(body["agent_name"], "inline");
+    assert!(body["handle_id"].as_str().unwrap_or_default().starts_with("sa_"));
+}
+
+#[tokio::test]
+async fn test_subagent_blank_agent_uses_system_prompt() {
+    let tool = SubagentTool;
+    let ctx = create_tool_context();
+    let params = json!({
+        "agent": "",
+        "system_prompt": "You are a concise test subagent. Reply with only: ok",
+        "task": "Say ok",
+        "model": "claude-sonnet-4-6",
+        "timeout": 1
+    });
+
+    let result = tool.execute(params, ctx).await;
+    assert!(result.is_ok(), "blank agent should not be resolved as ~/.synaps-cli/agents/.md: {result:?}");
+}
+
 #[tokio::test]
 async fn test_grep_tool_execution() {
     let temp_dir = std::env::temp_dir();


### PR DESCRIPTION
## Summary
- route bash sudo/password prompts through a secure masked TUI prompt
- force bash-tool sudo calls through stdin with `sudo -S` so prompts cannot grab the terminal directly
- redact secrets from final output and streamed deltas; bound/sanitize streamed output
- reduce animation/full-screen clear flicker while preserving stale-cell guards

## Verification
- `cargo test bash --lib -- --nocapture`
  - 15 passed; 0 failed
- `cargo test animation_tick -- --nocapture`
  - 2 passed; 0 failed
- `cargo build`
  - finished successfully

## Notes
- Real sudo auth may be cached by sudo itself; use `sudo -k` before manual E2E prompt checks.
