### PR TITLE
fix(ui): prevent stale TUI cell artifacts

### DIFF
--- a/src/chatui/app.rs
+++ b/src/chatui/app.rs
@@ -204,6 +204,57 @@ impl App {
             suppress_paste_until: None,
         }
     }
+    /// Build the text shown in the chat transcript for a submitted user message.
+    /// Large pasted payloads are collapsed to a label, while any text typed before
+    /// or after the pasted range remains visible.
+    pub(crate) fn user_display_text_for_submission(&self, input: &str) -> String {
+        if self.pasted_char_count == 0 {
+            return input.to_string();
+        }
+
+        let before_paste = self.input_before_paste.as_deref().unwrap_or("");
+        let before_chars = before_paste.chars().count();
+        let total_chars = input.chars().count();
+        let paste_chars = self.pasted_char_count.min(total_chars.saturating_sub(before_chars));
+        let after_chars = total_chars.saturating_sub(before_chars + paste_chars);
+
+        let paste_byte_start = input
+            .char_indices()
+            .nth(before_chars)
+            .map(|(i, _)| i)
+            .unwrap_or(input.len());
+        let paste_byte_end = input
+            .char_indices()
+            .nth(before_chars + paste_chars)
+            .map(|(i, _)| i)
+            .unwrap_or(input.len());
+
+        let pasted = &input[paste_byte_start..paste_byte_end];
+        let after_paste = if after_chars == 0 {
+            ""
+        } else {
+            &input[paste_byte_end..]
+        };
+
+        let line_count = pasted.lines().count();
+        let paste_label = if line_count > 1 {
+            format!("[Pasted {} lines]", line_count)
+        } else {
+            format!("[Pasted {} chars]", paste_chars)
+        };
+
+        match (before_paste.is_empty(), after_paste.is_empty()) {
+            (true, true) => paste_label,
+            (false, true) => format!("{} {}", before_paste.trim(), paste_label),
+            (true, false) => format!("{} {}", paste_label, after_paste.trim()),
+            (false, false) => format!(
+                "{} {} {}",
+                before_paste.trim(),
+                paste_label,
+                after_paste.trim()
+            ),
+        }
+    }
 
     /// Restore SynapsCLI's TUI after casino (or failed spawn).
     /// Convert char-based cursor_pos to byte offset in self.input.
@@ -696,5 +747,16 @@ mod tests {
         app.tool_start_time = Some(std::time::Instant::now());
 
         assert!(!app.is_active_tool_result(1));
+    }
+
+    #[test]
+    fn pasted_message_display_preserves_text_typed_after_paste() {
+        let mut app = test_app();
+        app.input_before_paste = Some("before".to_string());
+        app.pasted_char_count = "PASTED".chars().count();
+
+        let display = app.user_display_text_for_submission("beforePASTED after");
+
+        assert_eq!(display, "before [Pasted 6 chars] after");
     }
 }

--- a/src/chatui/app.rs
+++ b/src/chatui/app.rs
@@ -342,6 +342,15 @@ impl App {
         self.line_cache = None;
     }
 
+    /// Returns true when the chat message at `idx` is the tool result currently
+    /// being streamed/executed. Completed historical tool results must render as
+    /// done even while a later tool call is active.
+    pub(crate) fn is_active_tool_result(&self, idx: usize) -> bool {
+        self.tool_start_time.is_some()
+            && idx == self.messages.len().saturating_sub(1)
+            && matches!(self.messages.get(idx).map(|m| &m.msg), Some(ChatMessage::ToolResult { elapsed_ms: None, .. }))
+    }
+
     /// Find the file extension from the ToolUse message preceding a ToolResult at index `idx`.
     pub(crate) fn find_preceding_read_extension(&self, idx: usize) -> String {
         // Walk backwards from idx to find the preceding ToolUse
@@ -638,4 +647,54 @@ impl App {
         }
     }
 
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_app() -> App {
+        App::new(Session::new("test-model", "low", None))
+    }
+
+    #[test]
+    fn active_tool_result_is_only_latest_incomplete_result() {
+        let mut app = test_app();
+        app.push_msg(ChatMessage::ToolUse {
+            tool_name: "bash".to_string(),
+            input: "{}".to_string(),
+        });
+        app.push_msg(ChatMessage::ToolResult {
+            content: "first output".to_string(),
+            elapsed_ms: None,
+        });
+        app.push_msg(ChatMessage::ToolUse {
+            tool_name: "bash".to_string(),
+            input: "{}".to_string(),
+        });
+        app.push_msg(ChatMessage::ToolResult {
+            content: "second output".to_string(),
+            elapsed_ms: None,
+        });
+        app.tool_start_time = Some(std::time::Instant::now());
+
+        assert!(!app.is_active_tool_result(1), "completed historical result must render done while later tool runs");
+        assert!(app.is_active_tool_result(3), "latest incomplete result is the actively running tool result");
+    }
+
+    #[test]
+    fn completed_latest_tool_result_is_not_active() {
+        let mut app = test_app();
+        app.push_msg(ChatMessage::ToolUse {
+            tool_name: "bash".to_string(),
+            input: "{}".to_string(),
+        });
+        app.push_msg(ChatMessage::ToolResult {
+            content: "done".to_string(),
+            elapsed_ms: Some(25),
+        });
+        app.tool_start_time = Some(std::time::Instant::now());
+
+        assert!(!app.is_active_tool_result(1));
+    }
 }

--- a/src/chatui/highlight.rs
+++ b/src/chatui/highlight.rs
@@ -9,6 +9,7 @@ use syntect::util::LinesWithEndings;
 use std::sync::LazyLock;
 
 use super::theme::THEME;
+use unicode_width::UnicodeWidthStr;
 
 /// Clamp a `Line` to fit within `width` terminal columns.
 /// Walks spans left-to-right, truncating/dropping once the budget is exceeded.
@@ -20,16 +21,27 @@ pub(crate) fn clamp_line(line: Line<'static>, width: usize) -> Line<'static> {
     let mut remaining = width;
     let mut clamped: Vec<Span<'static>> = Vec::new();
     for span in line.spans {
-        let span_len = span.content.chars().count();
+        let span_width = UnicodeWidthStr::width(span.content.as_ref());
         if remaining == 0 {
             break;
         }
-        if span_len <= remaining {
-            remaining -= span_len;
+        if span_width <= remaining {
+            remaining -= span_width;
             clamped.push(span);
         } else {
-            // Truncate this span to fit
-            let truncated: String = span.content.chars().take(remaining).collect();
+            // Truncate this span by display width. Multi-column chars must be
+            // counted by terminal cells, not scalar values, or a supposedly
+            // clamped line can still overrun the viewport and leave artifacts.
+            let mut used = 0;
+            let mut truncated = String::new();
+            for ch in span.content.chars() {
+                let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+                if used + ch_width > remaining {
+                    break;
+                }
+                used += ch_width;
+                truncated.push(ch);
+            }
             clamped.push(Span::styled(truncated, span.style));
             remaining = 0;
         }

--- a/src/chatui/highlight.rs
+++ b/src/chatui/highlight.rs
@@ -344,3 +344,44 @@ pub(crate) fn highlight_read_output(lines: &[&str], ext: &str, margin: &str) -> 
     Some(result)
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{style::Style, text::{Line, Span}};
+    use unicode_width::UnicodeWidthStr;
+
+    #[test]
+    fn clamp_line_truncates_by_display_width_not_char_count() {
+        let line = Line::from(vec![Span::styled("ab漢字c", Style::default())]);
+
+        let clamped = clamp_line(line, 5);
+        let rendered: String = clamped
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+
+        assert_eq!(rendered, "ab漢");
+        assert_eq!(UnicodeWidthStr::width(rendered.as_str()), 4);
+    }
+
+    #[test]
+    fn clamp_line_preserves_spans_within_display_width_budget() {
+        let line = Line::from(vec![
+            Span::styled("ab", Style::default()),
+            Span::styled("漢", Style::default()),
+            Span::styled("cd", Style::default()),
+        ]);
+
+        let clamped = clamp_line(line, 4);
+        let rendered: String = clamped
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+
+        assert_eq!(rendered, "ab漢");
+        assert_eq!(UnicodeWidthStr::width(rendered.as_str()), 4);
+    }
+}

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -800,26 +800,7 @@ pub async fn run(
                                     app.queued_message = Some(input);
                                     continue;
                                 }
-                                // Build display text with paste info
-                                let display_text = if app.pasted_char_count > 0 {
-                                    let typed = app.input_before_paste.as_deref().unwrap_or("");
-                                    let typed_char_count = typed.chars().count();
-                                    let paste_byte_start = input.char_indices()
-                                        .nth(typed_char_count)
-                                        .map(|(i, _)| i)
-                                        .unwrap_or(input.len());
-                                    let paste_content = &input[paste_byte_start..];
-                                    let line_count = paste_content.lines().count();
-                                    let pasted_char_count = input.chars().count().saturating_sub(typed_char_count);
-                                    let paste_label = if line_count > 1 {
-                                        format!("[Pasted {} lines]", line_count)
-                                    } else {
-                                        format!("[Pasted {} chars]", pasted_char_count)
-                                    };
-                                    if typed.is_empty() { paste_label } else { format!("{} {}", typed.trim(), paste_label) }
-                                } else {
-                                    input.clone()
-                                };
+                                let display_text = app.user_display_text_for_submission(&input);
                                 app.push_msg(ChatMessage::User(display_text));
                                 app.input_before_paste = None;
                                 app.pasted_char_count = 0;

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -401,6 +401,11 @@ pub async fn run(
 
             // ── Tick: animations + spinner (~60fps) ──
             _ = tokio::time::sleep(std::time::Duration::from_millis(16)), if boot_fx.is_some() || exit_fx.is_some() || app.streaming || app.compact_task.is_some() || app.messages.is_empty() || app.logo_dismiss_t.is_some() || app.logo_build_t.is_some() || app.gamba_child.is_some() => {
+                if let Ok(size) = terminal.size() {
+                    if size.width > 0 && size.height > 0 {
+                        terminal.clear().ok();
+                    }
+                }
                 if let Some(ref mut t) = app.logo_build_t {
                     *t += 0.025;
                     if *t >= 1.0 { app.logo_build_t = None; }

--- a/src/chatui/render.rs
+++ b/src/chatui/render.rs
@@ -413,8 +413,8 @@ impl App {
                                     Style::default().fg(THEME.load().subagent_time),
                                 ),
                             ]));
-                        } else if elapsed_ms.is_none() && self.tool_start_time.is_some() {
-                            // Tool still executing — show animation
+                        } else if self.is_active_tool_result(i) {
+                            // Tool still executing — show animation only for the active result.
                             let preceding_tool_name = self.find_preceding_tool_name(i);
                             let elapsed_str = if let Some(start) = self.tool_start_time {
                                 let secs = start.elapsed().as_secs_f64();

--- a/src/chatui/settings/defs.rs
+++ b/src/chatui/settings/defs.rs
@@ -114,7 +114,7 @@ define_settings! {
         };
 
     bash_max_timeout, "Bash max timeout", ToolLimits, EditorKind::Text { numeric: true },
-        "Upper bound on requested bash timeouts.",
+        "Legacy setting retained for config compatibility; requested bash timeouts are no longer clamped.",
         |runtime, _app, value| {
             if let Ok(n) = value.parse::<u64>() { runtime.set_bash_max_timeout(n); }
         };

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -19,6 +19,17 @@ fn is_valid_name(s: &str) -> bool {
 
 /// Resolve an agent name to a system prompt.
 pub fn resolve_agent_prompt(name: &str) -> std::result::Result<String, String> {
+    // Defense-in-depth: callers should already filter blank names to None, but if
+    // one slips through we must not search `~/.synaps-cli/agents/.md` — that path
+    // looks valid on disk and produces a confusing error that models retry forever.
+    // Reject names that are empty or entirely whitespace/control chars (incl. NUL).
+    if name.chars().all(|c| c.is_whitespace() || c.is_control()) {
+        return Err(
+            "Empty 'agent' parameter. Pass a non-empty agent name, omit the field entirely, \
+             or provide 'system_prompt' inline instead.".to_string()
+        );
+    }
+
     // 1. File path — name contains '/'
     if name.contains('/') {
         let path = expand_path(name);
@@ -236,5 +247,27 @@ mod tests {
         assert!(is_valid_name("sage"));
         assert!(is_valid_name("my_agent_123"));
         assert!(is_valid_name("BBE"));
+    }
+
+    #[test]
+    fn resolve_agent_prompt_rejects_blank_name() {
+        // Empty string, whitespace, and NUL must all error early — never search disk.
+        for name in ["", " ", "  \t  ", "\n", "\u{0}"] {
+            let err = resolve_agent_prompt(name).unwrap_err();
+            assert!(
+                err.contains("Empty 'agent' parameter"),
+                "blank name {:?} should produce the empty-agent error, got: {}",
+                name,
+                err,
+            );
+            // Critical: the error must NOT mention `agents/.md` — that's the bug
+            // signature that caused models to loop with sentinel agent values.
+            assert!(
+                !err.contains("agents/.md"),
+                "blank name {:?} leaked path-search error: {}",
+                name,
+                err,
+            );
+        }
     }
 }

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -9,7 +9,7 @@ impl Tool for BashTool {
     fn name(&self) -> &str { "bash" }
 
     fn description(&self) -> &str {
-        "Execute a bash command and return its output. Use for running programs, installing packages, git operations, and any shell commands. Commands time out after 30 seconds."
+        "Execute a bash command and return its output. Use for running programs, installing packages, git operations, and any shell commands. Commands time out after 30 seconds by default; pass a larger timeout when needed."
     }
 
     fn parameters(&self) -> Value {
@@ -22,7 +22,7 @@ impl Tool for BashTool {
                 },
                 "timeout": {
                     "type": "integer",
-                    "description": "Timeout in seconds (default: 30, max: 300)"
+                    "description": "Timeout in seconds (default: 30). Use a larger value for long-running commands."
                 }
             },
             "required": ["command"]
@@ -33,7 +33,7 @@ impl Tool for BashTool {
         let command = params["command"].as_str()
             .ok_or_else(|| RuntimeError::Tool("Missing command parameter".to_string()))?;
 
-        let timeout_secs = params["timeout"].as_u64().unwrap_or(ctx.limits.bash_timeout).min(ctx.limits.bash_max_timeout);
+        let timeout_secs = params["timeout"].as_u64().unwrap_or(ctx.limits.bash_timeout);
         let max_output = ctx.limits.max_tool_output;
 
         let mut child = tokio::process::Command::new("bash")

--- a/src/tools/subagent.rs
+++ b/src/tools/subagent.rs
@@ -49,8 +49,20 @@ impl Tool for SubagentTool {
             .ok_or_else(|| RuntimeError::Tool("Missing 'task' parameter".to_string()))?
             .to_string();
 
-        let agent_name = params["agent"].as_str().map(|s| s.to_string());
-        let inline_prompt = params["system_prompt"].as_str().map(|s| s.to_string());
+        // Treat blank / whitespace / control-char strings as absent — see
+        // subagent_start.rs for full rationale. Models occasionally pass `agent: ""`
+        // (or "\u{0}", or " ") alongside a real `system_prompt`; without this filter
+        // we'd try to resolve an empty agent name and fail, instead of falling
+        // through to the inline prompt.
+        let is_blank = |s: &String| s.chars().all(|c| c.is_whitespace() || c.is_control());
+        let agent_name = params["agent"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
+        let inline_prompt = params["system_prompt"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
         let model_override = params["model"].as_str().map(|s| s.to_string());
         let timeout_secs = params["timeout"].as_u64().unwrap_or(ctx.limits.subagent_timeout);
 

--- a/src/tools/subagent_start.rs
+++ b/src/tools/subagent_start.rs
@@ -65,8 +65,20 @@ impl Tool for SubagentStartTool {
             .ok_or_else(|| RuntimeError::Tool("Missing 'task' parameter".to_string()))?
             .to_string();
 
-        let agent_name    = params["agent"].as_str().map(|s| s.to_string());
-        let inline_prompt = params["system_prompt"].as_str().map(|s| s.to_string());
+        // Treat blank / whitespace / control-char strings as absent.
+        // Some model providers serialize "unset" as "" rather than omitting the field,
+        // and we must not try to resolve "" (or " ", or "\u{0}") as an agent name —
+        // doing so produces a hard "Agent '' not found" error that the model then
+        // retries forever with sentinel values instead of falling back to system_prompt.
+        let is_blank = |s: &String| s.chars().all(|c| c.is_whitespace() || c.is_control());
+        let agent_name = params["agent"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
+        let inline_prompt = params["system_prompt"]
+            .as_str()
+            .map(|s| s.to_string())
+            .filter(|s| !is_blank(s));
         let model_override = params["model"].as_str().map(|s| s.to_string());
         let timeout_secs   = params["timeout"].as_u64().unwrap_or(ctx.limits.subagent_timeout);
 

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -372,6 +372,22 @@ async fn test_bash_tool_execution() {
     assert!(result.unwrap_err().to_string().contains("timed out"));
 }
 
+#[tokio::test]
+async fn test_bash_tool_requested_timeout_is_not_clamped_by_max_timeout() {
+    let tool = BashTool;
+    let mut ctx = create_tool_context();
+    ctx.limits.bash_max_timeout = 1;
+
+    let params = json!({
+        "command": "sleep 2; echo done",
+        "timeout": 3
+    });
+
+    let result = tool.execute(params, ctx).await;
+    assert!(result.is_ok(), "requested timeout should not be clamped by bash_max_timeout: {result:?}");
+    assert!(result.unwrap().contains("done"));
+}
+
 // ── New Tests ────────────────────────────────────────────────────────────
 
 #[test]

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -463,6 +463,54 @@ fn test_resolve_agent_prompt_path_not_found() {
     assert!(error.contains("Failed to read agent file"));
 }
 
+#[test]
+fn test_resolve_agent_prompt_blank_rejected_without_agent_lookup() {
+    let result = resolve_agent_prompt("");
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert!(error.contains("Empty 'agent' parameter"));
+    assert!(!error.contains("agents/.md"));
+}
+
+#[tokio::test]
+async fn test_subagent_start_blank_agent_uses_system_prompt() {
+    use std::sync::{Arc, Mutex};
+
+    let tool = SubagentStartTool;
+    let mut ctx = create_tool_context();
+    ctx.capabilities.subagent_registry = Some(Arc::new(Mutex::new(SubagentRegistry::new())));
+
+    let params = json!({
+        "agent": "",
+        "system_prompt": "You are a concise test subagent. Reply with only: ok",
+        "task": "Say ok",
+        "model": "claude-sonnet-4-6",
+        "timeout": 1
+    });
+
+    let result = tool.execute(params, ctx).await;
+    assert!(result.is_ok(), "blank agent should not be resolved as ~/.synaps-cli/agents/.md: {result:?}");
+    let body: serde_json::Value = serde_json::from_str(&result.unwrap()).unwrap();
+    assert_eq!(body["agent_name"], "inline");
+    assert!(body["handle_id"].as_str().unwrap_or_default().starts_with("sa_"));
+}
+
+#[tokio::test]
+async fn test_subagent_blank_agent_uses_system_prompt() {
+    let tool = SubagentTool;
+    let ctx = create_tool_context();
+    let params = json!({
+        "agent": "",
+        "system_prompt": "You are a concise test subagent. Reply with only: ok",
+        "task": "Say ok",
+        "model": "claude-sonnet-4-6",
+        "timeout": 1
+    });
+
+    let result = tool.execute(params, ctx).await;
+    assert!(result.is_ok(), "blank agent should not be resolved as ~/.synaps-cli/agents/.md: {result:?}");
+}
+
 #[tokio::test]
 async fn test_grep_tool_execution() {
     let temp_dir = std::env::temp_dir();


### PR DESCRIPTION
## Summary
- clear the terminal during animated redraw ticks to remove stale cells from prior frames
- clamp highlighted/rendered tool output by Unicode display width instead of scalar char count
- add regression coverage for multi-column character clamping

## Flicker note
This branch is the original stale-cell artifact fix. The later streaming flicker mitigation lives on `fix/secure-sudo-bash-prompt` and avoids whole-screen clears during normal streaming; this PR intentionally only covers the stale-width/artifact branch.

## Verification
- `cargo test clamp_line --bin synaps -- --nocapture`
  - 2 passed; 0 failed
- `cargo test --bin synaps -- --nocapture`
  - 80 passed; 0 failed
- `cargo build`
  - finished successfully
