### PR TITLE
feat: add local voice dictation provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +242,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,7 +369,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -354,6 +413,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -406,6 +476,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +495,16 @@ name = "colorsys"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54261aba646433cb567ec89844be4c4825ca92a4f8afba52fc4dd88436e31bbd"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -456,6 +545,49 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -565,6 +697,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
@@ -796,6 +934,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,6 +1091,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -1165,7 +1315,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1388,6 +1538,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1640,16 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libredox"
@@ -1492,6 +1706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,6 +1740,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1580,6 +1809,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,6 +1847,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1626,12 +1894,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1705,6 +2006,29 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1910,6 +2234,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -2133,6 +2466,12 @@ dependencies = [
  "web-sys",
  "winreg 0.50.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -2512,6 +2851,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "cpal",
  "crossterm",
  "dirs",
  "fs4",
@@ -2546,6 +2886,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "whisper-rs",
 ]
 
 [[package]]
@@ -2833,8 +3174,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2847,6 +3188,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,9 +3205,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3312,6 +3683,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "whisper-rs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
+dependencies = [
+ "libc",
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
+dependencies = [
+ "bindgen",
+ "cfg-if",
+ "cmake",
+ "fs_extra",
+ "semver",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3343,6 +3737,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3351,7 +3765,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
 ]
 
@@ -3385,6 +3799,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
@@ -3399,6 +3822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -3439,6 +3871,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
@@ -3470,6 +3917,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -3482,6 +3935,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -3491,6 +3950,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3512,6 +3977,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -3521,6 +3992,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3536,6 +4013,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -3545,6 +4028,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3563,6 +4052,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ tower-http = { version = "0.5", features = ["cors"] }
 tokio-tungstenite = "0.21"
 unicode-width = "0.2.0"
 arboard = "3"
+whisper-rs = { version = "0.16.0", optional = true }
+cpal = { version = "0.15", optional = true }
 
 # Shell / PTY deps
 portable-pty = "0.9"
@@ -65,6 +67,18 @@ libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+default = []
+voice = []
+voice-stt-whisper = ["voice", "dep:whisper-rs"]
+voice-mic = ["voice", "dep:cpal"]
+voice-tts-kokoros = ["voice"]
+voice-metal = ["voice-stt-whisper", "whisper-rs/metal"]
+voice-cuda = ["voice-stt-whisper", "whisper-rs/cuda"]
+voice-vulkan = ["voice-stt-whisper", "whisper-rs/vulkan"]
+voice-openblas = ["voice-stt-whisper", "whisper-rs/openblas"]
+voice-tts = ["voice-tts-kokoros"]
 
 [[bin]]
 name = "synaps"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ libc = "0.2"
 tempfile = "3"
 
 [features]
-default = []
+default = ["voice-stt-whisper", "voice-mic"]
 voice = []
 voice-stt-whisper = ["voice", "dep:whisper-rs"]
 voice-mic = ["voice", "dep:cpal"]

--- a/docs/code-review/2026-04-30-local-voice-provider-plan-review.md
+++ b/docs/code-review/2026-04-30-local-voice-provider-plan-review.md
@@ -1,0 +1,246 @@
+# Code Review: Local Voice Provider Implementation Plan
+
+Reviewed plan: `docs/plans/2026-04-30-local-voice-provider.md`  
+Date: 2026-04-30
+
+## Verdict: REQUEST CHANGES
+
+## Overview
+
+The plan is well-structured, incremental, and correctly identifies major risk areas: native dependencies, TUI event-loop impact, MSRV/Kokoros compatibility, privacy, and accessibility. However, several architectural and safety requirements are either underspecified or deferred too late, which could lead to a difficult implementation or privacy/security regressions.
+
+## Issues
+
+### 🟡 Important — Provider contracts do not define event delivery or threading model
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:96-129`
+
+Task 2 defines `VoiceEvent`, `SpeechToTextProvider`, and `TextToSpeechProvider`, but the proposed traits only expose `start`, `stop`, and `speak`. There is no contract for how events are emitted back to the TUI loop.
+
+This matters because later tasks depend on partial transcripts, final transcripts, errors, TTS state, and responsive cancellation. Without defining whether providers use channels, callbacks, async streams, or a shared event bus, implementation may drift into ad hoc patterns.
+
+Suggested fix: add acceptance criteria and proposed shape for event emission, for example:
+
+```rust
+pub trait SpeechToTextProvider {
+    fn start(&mut self, events: VoiceEventSender) -> Result<()>;
+    fn stop(&mut self) -> Result<()>;
+    fn is_running(&self) -> bool;
+}
+```
+
+Or define a `VoiceRuntime` that owns providers and sends `VoiceEvent`s into the app-level event channel.
+
+---
+
+### 🟡 Important — App input abstraction lacks source/backpressure design
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:146-163`
+
+Task 3 introduces:
+
+```rust
+enum AppInputEvent {
+    Terminal(crossterm::event::Event),
+    Voice(VoiceEvent),
+}
+```
+
+That is a good direction, but the plan does not describe how terminal events and voice events are multiplexed without blocking the TUI. This is important because mic/STT/TTS workers will be cross-thread producers, and terminal polling often has its own blocking behavior.
+
+Suggested fix: include requirements for:
+
+- bounded event channels;
+- non-blocking TUI event loop;
+- prioritization/fairness between terminal and voice events;
+- graceful shutdown of worker threads;
+- no unbounded queue growth from partial transcripts.
+
+---
+
+### 🟡 Important — `voice` feature may pull in mic dependencies too early
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:181-197`
+
+Task 4 is a Whisper STT spike that “does not yet use the mic,” but the proposed Cargo feature is:
+
+```toml
+voice = ["dep:cpal", "dep:whisper-rs"]
+```
+
+This pulls in `cpal` even for a model/fixture-only transcription spike. That weakens the earlier goal that heavy native dependencies are carefully gated.
+
+Suggested fix: split features more granularly:
+
+```toml
+voice = []
+voice-stt-whisper = ["voice", "dep:whisper-rs"]
+voice-mic = ["voice", "dep:cpal"]
+voice-tts-kokoros = ["voice", ...]
+```
+
+Then have later convenience features compose them if needed.
+
+---
+
+### 🟡 Important — VAD plan underspecifies testing and tuning
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:245-265`
+
+The simple RMS VAD is reasonable for a first implementation, but the plan does not specify configurable thresholds, minimum speech duration, pre-roll buffering, or sample-rate assumptions. Without those, the system may clip the beginning of utterances or emit finals for noise.
+
+Suggested fix: add acceptance criteria for:
+
+- configurable RMS threshold;
+- minimum speech duration before accepting an utterance;
+- pre-roll buffer so initial phonemes are not dropped;
+- max utterance duration;
+- tests for silence, short noise burst, continuous speech, and speech followed by silence.
+
+---
+
+### 🟡 Important — Sanitization policy needs to be defined earlier and more concretely
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:275-285`
+
+Task 7 correctly says transcript length should be capped and control characters sanitized. However, the exact policy is not defined, and this behavior is important enough to specify before wiring transcripts into input contexts.
+
+Suggested fix: define a reusable helper such as:
+
+```rust
+sanitize_voice_transcript(input: &str, max_chars: usize) -> String
+```
+
+Acceptance criteria should include:
+
+- strips or replaces control characters except allowed `\n` when appropriate;
+- normalizes CRLF;
+- enforces char boundary-safe truncation;
+- rejects or escapes terminal control sequences;
+- unit tests for Unicode, ANSI escape sequences, very long input, and multiline text.
+
+---
+
+### 🔴 Critical — Voice commands can trigger destructive/contextual actions without an explicit safety model
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:338-365`
+
+Task 9 maps phrases like “submit”, “escape”, “go up”, and “go down” into app actions. This can be risky: accidental speech, background audio, or transcription errors could submit prompts, close modals, or perform unintended actions.
+
+The plan says mapping is “conservative and configurable,” but this needs stronger acceptance criteria.
+
+Suggested fix: require:
+
+- voice commands off by default or gated behind explicit config;
+- destructive actions require explicit enablement;
+- “submit” only works when `voice.stt_auto_submit` or `voice.commands.submit_enabled` is enabled;
+- commands are only recognized in command mode or with a wake phrase/prefix, e.g. “Synaps submit”;
+- unit tests for ambiguous phrases and near matches.
+
+---
+
+### 🟡 Important — Kokoros binary fallback needs command-execution safety requirements
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:416-420`
+
+The fallback path shells out to a local `koko` binary. That is a reasonable fallback, but the plan does not specify how the process is invoked safely.
+
+Suggested fix: add acceptance criteria:
+
+- use `std::process::Command` with args, never shell string concatenation;
+- configurable binary path must be validated or clearly trusted as user-controlled local config;
+- text input passed through stdin or argument-safe mechanism;
+- bounded input size;
+- timeout/kill behavior on hung subprocess;
+- stderr surfaced as setup/runtime error without leaking sensitive text unless debug-enabled.
+
+---
+
+### 🔴 Critical — Privacy safeguards are deferred too late
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:470-479`
+
+Task 13 says no raw audio or transcripts should be logged. This should not wait until the end. Audio and transcript handling begins in Tasks 4–7, and TTS text handling begins around Tasks 11–12.
+
+Suggested fix: move privacy/logging requirements into earlier tasks:
+
+- Task 4: do not log audio buffers or full transcripts by default.
+- Task 5: do not log raw mic data/device-sensitive details beyond necessary diagnostics.
+- Task 7: do not log inserted transcripts unless explicit debug setting is enabled.
+- Task 11/12: do not log TTS text by default.
+
+Task 13 can remain as final audit/polish, but the invariant should exist from first implementation.
+
+---
+
+### 🟡 Important — Model setup docs should include integrity and licensing
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:497-514`
+
+The docs task covers model downloads and platform dependencies, but does not mention checksums, trusted sources, model licenses, or expected disk sizes. Since this feature depends on local model files, setup instructions should help users avoid corrupted or untrusted downloads.
+
+Suggested fix: add docs acceptance criteria for:
+
+- official/trusted download URLs;
+- checksum or hash verification where available;
+- license notes for Whisper/Kokoro/Kokoros artifacts;
+- expected model sizes;
+- where models are stored;
+- no automatic download unless explicitly approved by user.
+
+---
+
+### 🟡 Important — Config schema should specify path expansion and validation behavior
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:50-90`
+
+The config examples use `~/.synaps-cli/...`, but the plan does not specify whether `~` expansion is supported, whether relative paths are allowed, or when paths are validated.
+
+Suggested fix: add acceptance criteria:
+
+- `~` expansion behavior is defined and tested;
+- missing model paths produce actionable errors only when feature/use path is active;
+- voice-disabled config should not fail because model paths are missing;
+- invalid backend names produce clear config errors;
+- defaults do not require model files.
+
+---
+
+### 🟢 Suggestion — Kokoros compatibility spike could happen earlier
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:375-395`
+
+The Kokoros compatibility spike is placed after STT UX tasks. That is acceptable if TTS is lower priority, but the MSRV risk is known upfront and may affect feature structure, docs, CI, and dependency policy.
+
+Suggestion: run Task 10 earlier in parallel with Tasks 1–3, or immediately after Task 1, so the project knows whether TTS will be direct crate, process-based, or deferred before designing provider traits too narrowly.
+
+---
+
+### 🟢 Suggestion — Checkpoints should include CI/build matrix expectations
+
+**Location:** `docs/plans/2026-04-30-local-voice-provider.md:525-567`
+
+The checkpoint structure is good, but it would be stronger if each checkpoint explicitly listed expected build combinations.
+
+Suggestion: add build matrix checks such as:
+
+```text
+cargo build
+cargo test
+cargo build --no-default-features
+cargo build --features voice-stt-whisper
+cargo build --features voice-mic
+cargo build --features voice-tts-kokoros
+```
+
+As applicable.
+
+## Positives
+
+- The plan is incremental and reviewable, with sensible task sizing.
+- Voice is explicitly off by default.
+- Native dependencies are intended to be feature-gated.
+- The plan correctly identifies Kokoros/Rust 2024/MSRV as a compatibility risk.
+- It separates STT, mic capture, VAD, dictation, commands, TTS, accessibility, and docs into manageable tasks.
+- It includes manual verification for TUI responsiveness and user-visible behavior.
+- It recognizes privacy concerns around raw audio and transcripts, though those safeguards should be moved earlier.

--- a/docs/plans/2026-04-30-local-voice-provider.md
+++ b/docs/plans/2026-04-30-local-voice-provider.md
@@ -1,0 +1,649 @@
+# Local Voice Provider Plan: whisper-rs + Kokoros
+
+Date: 2026-04-30
+
+## Summary
+
+Set up a local voice provider stack for SynapsCLI:
+
+- **STT:** `whisper-rs` over `whisper.cpp`
+- **TTS:** Kokoro Rust / Kokoros from <https://github.com/lucasjinreal/Kokoros>
+- **TUI integration:** provider sits at the base `chatui` event loop and emits app-level voice events.
+
+Important compatibility note: Kokoros was reportedly updated recently for current Rust. Proceed with a direct Kokoros compatibility spike first; if direct embedding is still blocked, report the exact blocker before falling back to a local `koko` provider process.
+
+---
+
+## Convergence mode
+
+Approved: `convergence: holdout`
+
+Reason: this touches the base TUI loop, audio capture, native dependencies, accessibility behavior, and local model management. Holdout mode provides strict role isolation for higher confidence.
+
+Fixed params:
+
+- `threshold`: `0.8`
+- `axis_weights`: default code-review weights
+- `max_fix_iterations`: `2`
+- `max_total_calls`: `10`
+
+---
+
+## User-approved decisions
+
+1. Convergence mode: `holdout`.
+2. Kokoros/MSRV: proceed assuming direct Kokoros embedding should work with current Rust/Kokoros updates; verify in the compatibility spike before choosing fallback.
+3. First voice UX: push-to-talk first, with toggle optional through settings/fallback.
+
+---
+
+## Dependency graph
+
+```text
+Config + feature flags
+  ├── Voice event types / provider traits
+  │   ├── STT provider: cpal + whisper-rs
+  │   ├── TTS provider: Kokoros adapter
+  │   └── TUI event-loop integration
+  │       ├── voice dictation into active input context
+  │       ├── voice command mapping
+  │       └── accessibility/status UI
+  └── Tests + docs + setup guidance
+```
+
+---
+
+## Task 1: Voice feature flags and config schema
+
+**Description:** Add optional voice configuration without changing runtime behavior yet.
+
+**Acceptance criteria:**
+- [ ] Voice is off by default.
+- [ ] Config supports STT/TTS provider settings.
+- [ ] Config defines path expansion/validation semantics: `~` expansion is supported when paths are used; missing model paths are actionable errors only when the relevant voice provider is active; defaults do not require model files.
+- [ ] Invalid backend/mode names produce clear warnings or errors without silently activating unknown providers.
+- [ ] Heavy native dependencies are gated behind feature flags.
+- [ ] Existing builds without voice remain unaffected.
+
+**Likely config keys:**
+
+```text
+voice.enabled = false
+voice.mode = push_to_talk
+voice.stt_backend = whisper-rs
+voice.stt_model_path = ~/.synaps-cli/models/whisper/ggml-base.en.bin
+voice.stt_language = en
+voice.stt_show_partials = true
+voice.stt_auto_submit = false
+voice.stt_silence_submit_ms = 1000
+voice.stt_vad_rms_threshold = 0.01
+voice.stt_min_speech_ms = 250
+voice.stt_preroll_ms = 300
+voice.stt_max_utterance_ms = 30000
+voice.max_transcript_chars = 16000
+
+voice.tts_enabled = false
+voice.tts_backend = kokoros
+voice.tts_model_path = ~/.synaps-cli/models/kokoro/kokoro-v1.0.onnx
+voice.tts_voices_path = ~/.synaps-cli/models/kokoro/voices-v1.0.bin
+voice.tts_voice = af_sky
+voice.tts_auto_speak = false
+```
+
+**Verification:**
+- [ ] `cargo test`
+- [ ] `cargo build`
+- [ ] Manual: config parser accepts voice keys and preserves unknown keys.
+
+**Dependencies:** None  
+**Files likely touched:**
+- `Cargo.toml`
+- `src/core/config.rs`
+- possibly `src/chatui/settings/defs.rs`
+- possibly `src/chatui/settings/schema.rs`
+
+**Scope:** S
+
+---
+
+## Task 2: Define voice provider contracts and events
+
+**Description:** Add internal voice abstractions independent of Whisper/Kokoros implementation.
+
+**Acceptance criteria:**
+- [ ] `VoiceEvent` supports start, stop, partial transcript, final transcript, TTS state, and error.
+- [ ] A `VoiceEventSender` / channel contract is defined for provider-to-runtime event delivery.
+- [ ] `VoiceRuntime` or equivalent owner coordinates providers, worker lifecycle, cancellation, and event forwarding.
+- [ ] `SpeechToTextProvider` trait is defined and emits events through the approved channel contract.
+- [ ] `TextToSpeechProvider` trait is defined and emits events through the approved channel contract.
+- [ ] Provider work is explicitly off the TUI thread, with graceful shutdown semantics.
+- [ ] No TUI behavior changes yet.
+
+**Proposed shape:**
+
+```rust
+pub enum VoiceEvent {
+    ListeningStarted,
+    ListeningStopped,
+    PartialTranscript(String),
+    FinalTranscript(String),
+    Error(String),
+    TtsStarted,
+    TtsStopped,
+}
+
+pub type VoiceEventSender = tokio::sync::mpsc::Sender<VoiceEvent>;
+
+pub trait SpeechToTextProvider {
+    fn start(&mut self, events: VoiceEventSender) -> Result<()>;
+    fn stop(&mut self) -> Result<()>;
+    fn is_running(&self) -> bool;
+}
+
+pub trait TextToSpeechProvider {
+    fn speak(&mut self, text: &str, events: VoiceEventSender) -> Result<()>;
+    fn stop(&mut self) -> Result<()>;
+}
+```
+
+Design notes:
+- Use bounded channels for provider events.
+- Prefer `try_send` or backpressure-aware sends for high-frequency partials.
+- Providers must never mutate TUI state directly.
+
+**Verification:**
+- [ ] `cargo test`
+- [ ] `cargo build`
+- [ ] Unit tests for event/state types where useful.
+
+**Dependencies:** Task 1  
+**Files likely touched:**
+- `src/voice/mod.rs`
+- `src/voice/types.rs`
+- `src/lib.rs`
+
+**Scope:** S
+
+---
+
+## Task 3: Add app-level input event abstraction
+
+**Description:** Decouple the TUI loop from raw `crossterm::Event` enough for voice events to enter through the same base loop.
+
+**Acceptance criteria:**
+- [ ] Existing keyboard, mouse, paste behavior is unchanged.
+- [ ] TUI loop can accept both terminal events and voice events.
+- [ ] Terminal and voice sources are multiplexed through non-blocking `tokio::select!` branches or equivalent.
+- [ ] Voice event channel is bounded; high-frequency partial transcript events cannot grow memory without bound.
+- [ ] Terminal input remains responsive during voice event bursts.
+- [ ] Voice worker shutdown is triggered when the TUI exits.
+- [ ] Voice events currently no-op or show status only.
+
+**Proposed shape:**
+
+```rust
+enum AppInputEvent {
+    Terminal(crossterm::event::Event),
+    Voice(VoiceEvent),
+}
+```
+
+**Verification:**
+- [ ] `cargo test`
+- [ ] `cargo build`
+- [ ] Manual: type in TUI, paste, slash commands, settings modal, models modal still work.
+
+**Dependencies:** Task 2  
+**Files likely touched:**
+- `src/chatui/mod.rs`
+- `src/chatui/input.rs`
+- maybe `src/chatui/app.rs`
+
+**Scope:** M
+
+---
+
+## Task 4: Whisper STT provider spike
+
+**Description:** Build a minimal feature-gated `whisper-rs` provider that can load a model and transcribe a supplied PCM buffer or WAV fixture. This does not yet use the mic.
+
+**Acceptance criteria:**
+- [ ] Feature-gated dependency on `whisper-rs`.
+- [ ] Provider loads configured model path.
+- [ ] Provider transcribes a short known audio file or test fixture when present.
+- [ ] Missing model path produces clear error, not panic.
+- [ ] Model paths are validated only when the Whisper provider is constructed/used, not when voice is disabled.
+- [ ] Raw audio buffers and full transcripts are not logged by default.
+
+**Cargo feature candidates:**
+
+```toml
+voice = []
+voice-stt-whisper = ["voice", "dep:whisper-rs"]
+voice-mic = ["voice", "dep:cpal"]
+voice-tts-kokoros = ["voice", ...]
+voice-metal = ["voice-stt-whisper", "whisper-rs/metal"]
+voice-cuda = ["voice-stt-whisper", "whisper-rs/cuda"]
+voice-vulkan = ["voice-stt-whisper", "whisper-rs/vulkan"]
+voice-openblas = ["voice-stt-whisper", "whisper-rs/openblas"]
+```
+
+**Verification:**
+- [ ] `cargo build`
+- [ ] `cargo build --features voice`
+- [ ] Optional/manual: run fixture transcription with local model.
+
+**Dependencies:** Task 2  
+**Files likely touched:**
+- `Cargo.toml`
+- `src/voice/stt_whisper.rs`
+- `src/voice/mod.rs`
+
+**Scope:** M
+
+---
+
+## Task 5: Microphone capture provider with `cpal`
+
+**Description:** Add local microphone capture and feed 16kHz mono PCM into the STT worker.
+
+**Acceptance criteria:**
+- [ ] Mic capture starts/stops on command.
+- [ ] Audio capture runs off the TUI thread.
+- [ ] Audio stream uses bounded channels/ring buffer.
+- [ ] Mic permission/device errors are surfaced as `VoiceEvent::Error`.
+- [ ] Raw mic data is never logged; device diagnostics avoid unnecessary sensitive details.
+
+**Design notes:**
+- Use `cpal` for cross-platform capture.
+- Convert input to mono float PCM.
+- Resample to 16kHz if needed. A resampler crate may be needed; otherwise begin with a simple first-pass conversion.
+- Do not log raw audio.
+
+**Verification:**
+- [ ] `cargo build --features voice`
+- [ ] Manual: start/stop mic without freezing TUI.
+- [ ] Manual: unplug/no mic error is visible and recoverable.
+
+**Dependencies:** Task 4  
+**Files likely touched:**
+- `Cargo.toml`
+- `src/voice/audio.rs`
+- `src/voice/stt_whisper.rs`
+
+**Scope:** M
+
+---
+
+## Task 6: VAD / utterance segmentation
+
+**Description:** Avoid transcribing silence and decide when a final transcript is ready.
+
+**Acceptance criteria:**
+- [ ] Silence does not continuously trigger expensive Whisper calls.
+- [ ] User speech results in a final transcript after configured silence.
+- [ ] `voice.stt_silence_submit_ms` is respected.
+- [ ] RMS threshold is configurable and has a documented default.
+- [ ] Minimum speech duration filters short noise bursts.
+- [ ] Pre-roll buffering avoids clipping initial phonemes.
+- [ ] Maximum utterance duration prevents unbounded recording/transcription work.
+- [ ] Auto-submit remains disabled by default.
+
+**Implementation options:**
+1. Start with simple RMS energy threshold + silence timer.
+2. Upgrade to Whisper VAD or Silero later.
+
+Recommended first implementation: simple VAD, because it is easier to validate and avoids more native complexity initially.
+
+**Verification:**
+- [ ] `cargo build --features voice`
+- [ ] Unit tests for segmentation state machine: silence, short noise burst, continuous speech, speech followed by silence, pre-roll preservation, and max-duration cutoff.
+- [ ] Manual: speak -> final transcript appears; silence alone does not.
+
+**Dependencies:** Task 5  
+**Files likely touched:**
+- `src/voice/vad.rs`
+- `src/voice/stt_whisper.rs`
+
+**Scope:** M
+
+---
+
+## Task 7: Voice dictation into TUI input contexts
+
+**Description:** Final STT transcripts insert into the active TUI input context.
+
+**Acceptance criteria:**
+- [ ] In normal chat input, final transcript inserts at cursor.
+- [ ] In settings text editors, final transcript inserts into editor buffer.
+- [ ] In plugin marketplace URL editor, final transcript inserts into editor buffer.
+- [ ] Transcript length is capped and control chars are sanitized.
+- [ ] A reusable `sanitize_voice_transcript(input: &str, max_chars: usize)` helper exists before UI insertion.
+- [ ] Sanitizer normalizes CRLF, strips or replaces disallowed control characters, removes ANSI/terminal escape sequences, and truncates at valid UTF-8 boundaries.
+- [ ] Inserted transcripts are not logged unless an explicit debug setting enables transcript logging.
+
+**Important:** Apply the same or stricter limit policy as paste. Current main paste limit is 100k chars; voice should probably be smaller, e.g. 8k or 16k chars per utterance.
+
+**Verification:**
+- [ ] `cargo test`
+- [ ] Unit tests for sanitizer: Unicode, ANSI escape sequences, very long input, CRLF normalization, control chars, and multiline policy.
+- [ ] `cargo build --features voice`
+- [ ] Manual: dictate into chat input.
+- [ ] Manual: dictate into settings editor.
+
+**Dependencies:** Task 6  
+**Files likely touched:**
+- `src/chatui/input.rs`
+- `src/chatui/settings/input.rs`
+- `src/chatui/plugins/input.rs`
+- `src/voice/types.rs`
+
+**Scope:** M
+
+---
+
+## Task 8: Push-to-talk and voice control keybinds
+
+**Description:** Add keybindings to start/stop/toggle voice capture.
+
+**Acceptance criteria:**
+- [ ] Default keybind starts/stops listening.
+- [ ] Push-to-talk mode supported if terminal key release events are available/reliable.
+- [ ] Toggle mode supported as fallback.
+- [ ] Voice state visible in TUI.
+
+**Likely approach:**
+- First implement push-to-talk.
+- Keep toggle mode as a settings/fallback option if terminal key-release behavior is unreliable.
+
+Possible defaults:
+- `Ctrl+Alt+V`: toggle dictation
+- `/voice on`, `/voice off`, `/voice status`
+
+**Verification:**
+- [ ] `cargo build --features voice`
+- [ ] Manual: toggle listening.
+- [ ] Manual: status indicator changes.
+
+**Dependencies:** Task 7  
+**Files likely touched:**
+- `src/chatui/input.rs`
+- `src/chatui/commands.rs`
+- `src/chatui/draw.rs`
+- `src/chatui/app.rs`
+
+**Scope:** M
+
+---
+
+## Task 9: Voice command mapping
+
+**Description:** Translate spoken phrases into app actions.
+
+**Acceptance criteria:**
+- [ ] “submit” can submit current input only when explicitly enabled by `voice.stt_auto_submit` or `voice.commands.submit_enabled`.
+- [ ] Destructive/contextual actions such as submit, escape/cancel, and modal-closing commands are off by default or require explicit command mode/wake prefix.
+- [ ] “cancel” / “escape” maps to abort/close only in safe, explicitly enabled contexts.
+- [ ] “slash settings” becomes `/settings`.
+- [ ] “slash model” / “slash models” opens model flow.
+- [ ] Command mapping is conservative and configurable.
+- [ ] Ambiguous phrases and near matches are treated as dictation, not commands.
+
+**Examples:**
+
+```text
+"slash settings" -> "/settings"
+"slash compact" -> "/compact"
+"submit" -> Enter action
+"new line" -> "\n"
+"escape" -> Esc action
+"go up" -> Up key equivalent
+"go down" -> Down key equivalent
+```
+
+**Verification:**
+- [ ] Unit tests for phrase mapping, ambiguous phrases, near matches, disabled command mode, wake prefix/command mode, and submit gating.
+- [ ] Manual: voice opens settings.
+- [ ] Manual: voice submits only when explicitly commanded or auto-submit enabled.
+
+**Dependencies:** Task 8  
+**Files likely touched:**
+- `src/voice/commands.rs`
+- `src/chatui/input.rs`
+
+**Scope:** M
+
+---
+
+## Task 10: Kokoros compatibility spike
+
+**Description:** Determine whether Kokoros can be embedded directly as a crate under SynapsCLI’s current Rust/MSRV constraints. Run this spike as early as practical after Task 1 or alongside Tasks 2–3 so provider contracts are not designed around the wrong TTS shape.
+
+**Known issue / current assumption:**
+- SynapsCLI currently declares `rust-version = "1.80"`.
+- Kokoros was reportedly updated recently for current Rust.
+- Direct embedding is preferred if it builds cleanly with the accepted toolchain/MSRV policy.
+
+**Acceptance criteria:**
+- [ ] Confirm whether direct dependency builds in this repo.
+- [ ] Identify exact minimum Rust version required.
+- [ ] Decide one of:
+  - direct crate integration
+  - git subdependency with MSRV bump
+  - local binary/provider-process integration
+  - defer TTS embedding
+
+**Verification:**
+- [ ] `cargo build --features voice-tts`
+- [ ] Document result in implementation notes.
+
+**Dependencies:** Task 1  
+**Files likely touched:**
+- `Cargo.toml`
+- temporary spike only, unless accepted
+
+**Scope:** S
+
+---
+
+## Task 11: Kokoros TTS adapter
+
+**Description:** Implement Kokoros as a feature-gated TTS provider.
+
+**Preferred path if direct crate works:**
+- Call Kokoros APIs directly.
+- Load model and voices from config paths.
+- Generate audio to memory or temp file.
+- Play through local audio output.
+
+**Fallback path if direct crate is blocked:**
+- Shell out to local `koko` binary.
+- Use `koko stream` or `koko text`.
+- Treat this as provider-process mode.
+- Keep it optional and local-only.
+
+**Acceptance criteria:**
+- [ ] `voice.tts_enabled = true` can speak a test string.
+- [ ] TTS does not block the TUI loop.
+- [ ] TTS can be interrupted/stopped.
+- [ ] Missing Kokoros model/voices produces clear setup message.
+- [ ] No remote API is used.
+- [ ] If falling back to local `koko` process mode, invoke it with `std::process::Command` args only; never shell-concatenate text or paths.
+- [ ] TTS text is bounded and passed via stdin or another argument-safe mechanism.
+- [ ] Hung subprocesses have timeout/kill behavior.
+- [ ] stderr/setup errors are surfaced without logging sensitive TTS text unless debug-enabled.
+- [ ] TTS text is not logged by default.
+
+**Verification:**
+- [ ] `cargo build --features voice-tts`
+- [ ] Manual: synthesize “hello from Synaps”.
+- [ ] Manual: interrupt speech.
+
+**Dependencies:** Task 10  
+**Files likely touched:**
+- `Cargo.toml`
+- `src/voice/tts_kokoros.rs`
+- `src/voice/audio_out.rs`
+- `src/voice/mod.rs`
+
+**Scope:** M
+
+---
+
+## Task 12: Auto-speak assistant responses
+
+**Description:** Optional TTS playback for assistant messages, similar to VS Code’s auto-synthesize behavior.
+
+**Acceptance criteria:**
+- [ ] Off by default.
+- [ ] If the user used voice input and `voice.tts_auto_speak = true`, assistant text is spoken.
+- [ ] Streaming responses are chunked sensibly, ideally sentence-by-sentence.
+- [ ] Markdown/code/tool output is not read verbatim unless configured.
+- [ ] TTS text/chunks are not logged by default.
+
+**Verification:**
+- [ ] Manual: dictate a prompt, hear response.
+- [ ] Manual: disable auto-speak and confirm silence.
+- [ ] Manual: code blocks are skipped or summarized according to default policy.
+
+**Dependencies:** Task 11  
+**Files likely touched:**
+- `src/chatui/stream_handler.rs`
+- `src/chatui/mod.rs`
+- `src/voice/tts_kokoros.rs`
+
+**Scope:** M
+
+---
+
+## Task 13: Accessibility indicators and safety polish
+
+**Description:** Make voice state accessible, clear, and safe.
+
+**Acceptance criteria:**
+- [ ] TUI shows listening/processing/error status.
+- [ ] Optional terminal bell or accessibility signal on start/stop.
+- [ ] No raw audio is logged; this is audited from Tasks 4–5 onward, not introduced at the end.
+- [ ] Transcripts are not logged unless explicit debug config is enabled; this is audited from Task 7 onward.
+- [ ] Mic is never opened unless voice is enabled or user triggers it.
+
+**Verification:**
+- [ ] Manual: listening status is obvious.
+- [ ] Manual: errors are visible.
+- [ ] Review logs for no transcript/audio leakage.
+
+**Dependencies:** Tasks 8, 11  
+**Files likely touched:**
+- `src/chatui/draw.rs`
+- `src/chatui/app.rs`
+- `src/core/logging.rs`
+- `src/voice/mod.rs`
+
+**Scope:** S
+
+---
+
+## Task 14: Documentation and setup scripts
+
+**Description:** Document local model setup for Whisper and Kokoros.
+
+**Acceptance criteria:**
+- [ ] README/docs explain how to enable voice feature.
+- [ ] Docs explain model downloads and paths.
+- [ ] Docs list trusted/official download URLs where available, checksum/hash verification where available, model licenses, expected disk sizes, and storage locations.
+- [ ] Docs state that SynapsCLI will not automatically download voice models unless the user explicitly approves.
+- [ ] Docs list platform dependencies:
+  - microphone permissions
+  - Linux ALSA/Pulse/PipeWire notes
+  - Kokoros `pkg-config` + `libopus-dev`
+  - GPU acceleration feature flags
+- [ ] Troubleshooting section included.
+
+**Verification:**
+- [ ] Docs reviewed.
+- [ ] Fresh setup path is executable by a user.
+
+**Dependencies:** Tasks 4, 10, 11  
+**Files likely touched:**
+- `README.md`
+- `docs/voice.md`
+- maybe setup scripts
+
+**Scope:** S
+
+---
+
+# Checkpoints
+
+## Checkpoint A: After Tasks 1–3
+
+Goal: architectural foundation.
+
+- [ ] Existing app builds and behaves unchanged.
+- [ ] Voice event path exists but no native audio dependencies required.
+- [ ] Build matrix passes for the current scope: `cargo build`, targeted tests, `cargo build --features voice`, and any granular feature builds introduced by Tasks 2–3.
+
+## Checkpoint B: After Tasks 4–6
+
+Goal: local STT works outside full UX.
+
+- [ ] `whisper-rs` model loads.
+- [ ] Mic capture works.
+- [ ] Speech produces final transcript events.
+- [ ] TUI remains responsive.
+- [ ] Privacy invariant holds: no raw audio buffers or full transcripts in normal logs.
+- [ ] Build matrix passes for introduced native features, e.g. `voice-stt-whisper`, `voice-mic`, and selected acceleration flags where available.
+
+## Checkpoint C: After Tasks 7–9
+
+Goal: voice can operate the app.
+
+- [ ] Dictation into chat works.
+- [ ] Voice commands work for basic app actions.
+- [ ] Submit behavior is safe and configurable.
+- [ ] Transcript sanitizer tests pass and command mapping tests cover disabled/ambiguous cases.
+
+## Checkpoint D: After Tasks 10–12
+
+Goal: TTS works.
+
+- [ ] Kokoros path chosen: direct crate or local binary provider.
+- [ ] App can speak text locally.
+- [ ] Optional assistant response TTS works.
+- [ ] If process fallback is used, subprocess invocation is argument-safe, bounded, interruptible, and timeout-protected.
+- [ ] TTS text is not logged by default.
+
+## Checkpoint E: After Tasks 13–14
+
+Goal: accessibility and release polish.
+
+- [ ] Clear status indicators.
+- [ ] No privacy leaks in logs.
+- [ ] Setup docs are complete.
+
+---
+
+# Recommended implementation order
+
+1. Task 1 — config/features
+2. Task 2 — provider contracts
+3. Task 3 — app input abstraction
+4. Task 4 — Whisper provider spike
+5. Task 5 — mic capture
+6. Task 6 — VAD/finalization
+7. Task 7 — dictation insertion
+8. Task 8 — keybinds/PTT first, toggle fallback
+9. Task 9 — voice commands
+10. Task 10 — Kokoros spike (may run earlier after Task 1 / alongside Tasks 2–3)
+11. Task 11 — Kokoros adapter
+12. Task 12 — auto-speak responses
+13. Task 13 — accessibility/safety
+14. Task 14 — docs
+
+---
+
+# Decisions approved before implementation
+
+1. Convergence mode: `holdout`.
+2. Kokoros/MSRV: proceed assuming direct Kokoros embedding should work with current Rust/Kokoros updates; verify in the compatibility spike before choosing fallback.
+3. First voice UX: push-to-talk first, with toggle optional through settings/fallback.

--- a/src/bin/voice_mic_demo.rs
+++ b/src/bin/voice_mic_demo.rs
@@ -1,0 +1,25 @@
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+fn main() -> synaps_cli::Result<()> {
+    let mut args = std::env::args_os();
+    let program = args.next().unwrap_or_else(|| "voice-mic-demo".into());
+    let Some(model_path) = args.next() else {
+        eprintln!("usage: {} <whisper-model-path> [seconds] [language|auto]", std::path::Path::new(&program).display());
+        std::process::exit(2);
+    };
+    let seconds = args
+        .next()
+        .and_then(|value| value.to_string_lossy().parse::<u64>().ok())
+        .unwrap_or(8);
+    let language = args
+        .next()
+        .map(|value| value.to_string_lossy().to_string())
+        .filter(|value| !value.trim().is_empty() && !value.eq_ignore_ascii_case("auto"));
+
+    synaps_cli::run_whisper_mic_demo(std::path::PathBuf::from(model_path), language, seconds)
+}
+
+#[cfg(not(all(feature = "voice-stt-whisper", feature = "voice-mic")))]
+fn main() {
+    eprintln!("voice-mic-demo requires --features voice-stt-whisper,voice-mic");
+    std::process::exit(2);
+}

--- a/src/chatui/app.rs
+++ b/src/chatui/app.rs
@@ -127,6 +127,44 @@ pub(crate) struct App {
     /// immediately after MouseDown(Right). We suppress only within a short TTL
     /// window (~150ms) to avoid eating legitimate Ctrl+V pastes.
     pub(crate) suppress_paste_until: Option<std::time::Instant>,
+    /// User-facing local voice capture state for header/status rendering.
+    pub(crate) voice: VoiceUiState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VoiceUiMode {
+    PushToTalk,
+    Toggle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VoiceUiState {
+    pub(crate) enabled: bool,
+    pub(crate) listening: bool,
+    pub(crate) mode: VoiceUiMode,
+    pub(crate) last_error: Option<String>,
+}
+
+impl Default for VoiceUiState {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            listening: false,
+            mode: VoiceUiMode::PushToTalk,
+            last_error: None,
+        }
+    }
+}
+
+impl VoiceUiState {
+    pub(crate) fn from_config(config: &synaps_cli::VoiceConfig) -> Self {
+        Self {
+            enabled: config.enabled,
+            listening: false,
+            mode: if config.mode == "toggle" { VoiceUiMode::Toggle } else { VoiceUiMode::PushToTalk },
+            last_error: None,
+        }
+    }
 }
 
 pub(crate) const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -202,6 +240,7 @@ impl App {
             msg_area_rect: None,
             visible_line_range: None,
             suppress_paste_until: None,
+            voice: VoiceUiState::default(),
         }
     }
 

--- a/src/chatui/commands.rs
+++ b/src/chatui/commands.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use synaps_cli::{Runtime, Session, list_sessions, resolve_session};
+use synaps_cli::{Runtime, Session, list_sessions, resolve_session, VoiceCommandAction, VoiceCommandConfig};
 
 use super::app::{App, ChatMessage};
 
@@ -67,6 +67,8 @@ pub(super) enum CommandAction {
     /// Assign (or clear, if empty) a name to the current session. Persists via save.
     /// Show account usage and reset times.
     Status,
+    /// Control local voice capture: /voice on|off|status.
+    Voice { subcommand: String },
 }
 
 /// Levenshtein edit distance between two strings.
@@ -324,6 +326,7 @@ pub(super) async fn handle_command(
                 "/settings — open the settings menu",
                 "/plugins — manage marketplaces and installed plugins",
                 "/status — show account usage and reset times",
+                "/voice on|off|status — control local voice dictation",
                 "/ping — health-check configured providers (set keys in /settings)",
                 "/gamba — open the casino 🎰",
             ];
@@ -396,6 +399,28 @@ pub(super) async fn handle_command(
         }
         "status" => {
             return CommandAction::Status;
+        }
+        "voice" => {
+            let subcommand = match arg.trim() {
+                "" | "status" => "status",
+                "on" | "start" => "on",
+                "off" | "stop" => "off",
+                other => {
+                    app.push_msg(ChatMessage::System(format!("usage: /voice on|off|status (unknown: {})", other)));
+                    return CommandAction::None;
+                }
+            };
+            return CommandAction::Voice { subcommand: subcommand.to_string() };
+        }
+        "voice-map-test" if cfg!(test) => {
+            let config = VoiceCommandConfig { commands_enabled: true, submit_enabled: false, escape_enabled: false };
+            match synaps_cli::map_spoken_phrase(arg, config) {
+                VoiceCommandAction::SlashCommand { command, arg } => return CommandAction::Voice { subcommand: format!("mapped /{} {}", command, arg).trim().to_string() },
+                VoiceCommandAction::Submit => return CommandAction::Voice { subcommand: "mapped submit".to_string() },
+                VoiceCommandAction::Escape => return CommandAction::Voice { subcommand: "mapped escape".to_string() },
+                VoiceCommandAction::NewLine => return CommandAction::Voice { subcommand: "mapped newline".to_string() },
+                VoiceCommandAction::Dictation(text) => return CommandAction::Voice { subcommand: format!("dictation {}", text) },
+            }
         }
         "ping" => {
             return CommandAction::Ping;

--- a/src/chatui/draw.rs
+++ b/src/chatui/draw.rs
@@ -139,6 +139,10 @@ pub(crate) fn draw(
                 format!(" {} {} agent{} ({} done) ", spinner, active, if active != 1 { "s" } else { "" }, done),
                 Style::default().fg(THEME.load().subagent_name),
             )
+        } else if app.voice.enabled && app.voice.listening {
+            Span::styled(" 🎙 voice ", Style::default().fg(THEME.load().status_streaming))
+        } else if app.voice.enabled {
+            Span::styled(" ◌ voice ready ", Style::default().fg(THEME.load().status_ready))
         } else if app.streaming {
             let pulse = ((app.spinner_frame as f64 / 20.0).sin() * 0.3 + 0.7).max(0.4);
             let (sr, sg, sb) = match THEME.load().status_streaming { Color::Rgb(r, g, b) => (r, g, b), _ => (128, 128, 128) };

--- a/src/chatui/input.rs
+++ b/src/chatui/input.rs
@@ -371,7 +371,10 @@ fn handle_key(
     }
     match (code, modifiers) {
         (KeyCode::F(8), _) => {
-            return InputAction::VoiceControlPressed;
+            return match kind {
+                crossterm::event::KeyEventKind::Release => InputAction::VoiceControlReleased,
+                _ => InputAction::VoiceControlPressed,
+            };
         }
         (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
             return InputAction::Quit;
@@ -631,6 +634,30 @@ mod voice_keybind_tests {
             .unwrap();
         runtime.set_model("test-model".to_string());
         runtime
+    }
+
+    #[test]
+    fn f8_press_and_release_support_toggle_without_double_toggling() {
+        let mut app = App::new(synaps_cli::Session::new("test-model", "low", None));
+        let runtime = test_runtime();
+        let (registry, keybinds) = registries();
+        let press = Event::Key(KeyEvent::new_with_kind(
+            KeyCode::F(8),
+            KeyModifiers::NONE,
+            KeyEventKind::Press,
+        ));
+        let release = Event::Key(KeyEvent::new_with_kind(
+            KeyCode::F(8),
+            KeyModifiers::NONE,
+            KeyEventKind::Release,
+        ));
+
+        let press_action = handle_event(press, &mut app, &runtime, false, &registry, &keybinds);
+        let release_action = handle_event(release, &mut app, &runtime, false, &registry, &keybinds);
+
+        assert!(matches!(press_action, InputAction::VoiceControlPressed));
+        assert!(matches!(release_action, InputAction::VoiceControlReleased));
+        assert!(app.input.is_empty());
     }
 
     #[test]

--- a/src/chatui/input.rs
+++ b/src/chatui/input.rs
@@ -32,6 +32,10 @@ pub(super) enum InputAction {
     /// Settings modal asked to open the plugins marketplace as a nested overlay.
     OpenPluginsMarketplace,
     PingModels,
+    /// Voice control key pressed (Ctrl+Alt+V). Main loop maps to PTT or toggle mode.
+    VoiceControlPressed,
+    /// Voice control key released (Ctrl+Alt+V). Main loop maps to PTT stop when enabled.
+    VoiceControlReleased,
 }
 
 /// Process a crossterm Event and return what the main loop should do.
@@ -150,7 +154,7 @@ pub(super) fn handle_event(
         return InputAction::None;
     }
     match event {
-        Event::Key(key) => handle_key(key.code, key.modifiers, app, streaming, registry, keybinds),
+        Event::Key(key) => handle_key(key.code, key.modifiers, key.kind, app, streaming, registry, keybinds),
         Event::Mouse(mouse) => {
             handle_mouse(mouse, app)
         }
@@ -318,6 +322,7 @@ fn paste_from_clipboard() -> Option<String> {
 fn handle_key(
     code: KeyCode,
     modifiers: KeyModifiers,
+    kind: crossterm::event::KeyEventKind,
     app: &mut App,
     streaming: bool,
     registry: &Arc<CommandRegistry>,
@@ -329,6 +334,15 @@ fn handle_key(
     // below returns early after setting its own cycle state.)
     if !matches!(code, KeyCode::Tab) {
         app.tab_cycle = None;
+    }
+
+    // Voice control is reserved before plugin/user keybinds so voice can always be
+    // stopped even if custom keybinds are misconfigured.
+    if code == KeyCode::Char('v') && modifiers.contains(KeyModifiers::CONTROL) && modifiers.contains(KeyModifiers::ALT) {
+        return match kind {
+            crossterm::event::KeyEventKind::Release => InputAction::VoiceControlReleased,
+            _ => InputAction::VoiceControlPressed,
+        };
     }
 
     // Plugin/user keybinds — check before core binds, but only when not streaming
@@ -356,6 +370,9 @@ fn handle_key(
         }
     }
     match (code, modifiers) {
+        (KeyCode::F(8), _) => {
+            return InputAction::VoiceControlPressed;
+        }
         (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
             return InputAction::Quit;
         }
@@ -408,6 +425,12 @@ fn handle_key(
             app.show_full_output = !app.show_full_output;
             app.invalidate();
         }
+        (KeyCode::Char('v'), KeyModifiers::ALT) => {
+            return InputAction::VoiceControlPressed;
+        }
+        (KeyCode::Char('v'), modifiers) if modifiers.contains(KeyModifiers::ALT) => {
+            return InputAction::VoiceControlPressed;
+        }
         (KeyCode::Char(c), _) => {
             let byte_pos = app.cursor_byte_pos();
             app.input.insert(byte_pos, c);
@@ -443,6 +466,17 @@ fn handle_key(
         _ => {}
     }
     InputAction::None
+}
+
+pub(super) fn submit_current_input(app: &mut App, registry: &Arc<CommandRegistry>, streaming: bool) -> InputAction {
+    if app.input.is_empty() {
+        return InputAction::None;
+    }
+    if streaming {
+        process_streaming_submit(app)
+    } else {
+        process_submit(app, registry)
+    }
 }
 
 /// User pressed Enter with non-empty input while not streaming.
@@ -575,4 +609,68 @@ fn jump_word_right(app: &mut App) {
     while pos < len && chars[pos] != ' ' { pos += 1; }
     while pos < len && chars[pos] == ' ' { pos += 1; }
     app.cursor_pos = pos;
+}
+
+#[cfg(test)]
+mod voice_keybind_tests {
+    use super::*;
+    use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+    use std::sync::Arc;
+
+    fn registries() -> (Arc<CommandRegistry>, synaps_cli::skills::keybinds::KeybindRegistry) {
+        (
+            Arc::new(CommandRegistry::new(synaps_cli::skills::BUILTIN_COMMANDS, vec![])),
+            synaps_cli::skills::keybinds::KeybindRegistry::new(),
+        )
+    }
+
+    fn test_runtime() -> synaps_cli::Runtime {
+        let mut runtime = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(synaps_cli::Runtime::new())
+            .unwrap();
+        runtime.set_model("test-model".to_string());
+        runtime
+    }
+
+    #[test]
+    fn ctrl_alt_v_requests_voice_toggle_without_inserting_text() {
+        let mut app = App::new(synaps_cli::Session::new("test-model", "low", None));
+        let runtime = test_runtime();
+        let (registry, keybinds) = registries();
+        let event = Event::Key(KeyEvent::new(
+            KeyCode::Char('v'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        ));
+
+        let action = handle_event(event, &mut app, &runtime, false, &registry, &keybinds);
+
+        assert!(matches!(action, InputAction::VoiceControlPressed));
+        assert!(app.input.is_empty());
+    }
+
+    #[test]
+    fn ctrl_alt_v_press_and_release_support_push_to_talk() {
+        let mut app = App::new(synaps_cli::Session::new("test-model", "low", None));
+        let runtime = test_runtime();
+        let (registry, keybinds) = registries();
+        let press = Event::Key(KeyEvent {
+            code: KeyCode::Char('v'),
+            modifiers: KeyModifiers::CONTROL | KeyModifiers::ALT,
+            kind: KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::NONE,
+        });
+        let release = Event::Key(KeyEvent {
+            code: KeyCode::Char('v'),
+            modifiers: KeyModifiers::CONTROL | KeyModifiers::ALT,
+            kind: KeyEventKind::Release,
+            state: crossterm::event::KeyEventState::NONE,
+        });
+
+        let press_action = handle_event(press, &mut app, &runtime, false, &registry, &keybinds);
+        let release_action = handle_event(release, &mut app, &runtime, false, &registry, &keybinds);
+
+        assert!(matches!(press_action, InputAction::VoiceControlPressed));
+        assert!(matches!(release_action, InputAction::VoiceControlReleased));
+    }
 }

--- a/src/chatui/input_event.rs
+++ b/src/chatui/input_event.rs
@@ -1,0 +1,84 @@
+use crossterm::event::Event;
+use synaps_cli::{VoiceEvent, VoiceEventReceiver};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum AppInputEvent {
+    Terminal(Event),
+    Voice(VoiceEvent),
+}
+
+pub(super) async fn next_app_input_event(
+    event_reader: &mut crossterm::event::EventStream,
+    mut voice_events: Option<&mut VoiceEventReceiver>,
+) -> Option<AppInputEvent> {
+    let mut voice_open = voice_events
+        .as_ref()
+        .is_some_and(|receiver| !receiver.is_closed());
+
+    loop {
+        if voice_open {
+            let receiver = voice_events.as_mut().expect("voice_open requires receiver");
+            tokio::select! {
+                maybe_terminal = futures::StreamExt::next(event_reader) => {
+                    return match maybe_terminal {
+                        Some(Ok(event)) => Some(AppInputEvent::Terminal(event)),
+                        Some(Err(_)) | None => None,
+                    };
+                }
+                maybe_voice = receiver.recv() => {
+                    match maybe_voice {
+                        Some(event) => return Some(AppInputEvent::Voice(event)),
+                        None => voice_open = false,
+                    }
+                }
+            }
+        } else {
+            return match futures::StreamExt::next(event_reader).await {
+                Some(Ok(event)) => Some(AppInputEvent::Terminal(event)),
+                Some(Err(_)) | None => None,
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    #[test]
+    fn wraps_terminal_events_without_changing_them() {
+        let terminal_event = Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL));
+        let app_event = AppInputEvent::Terminal(terminal_event.clone());
+
+        assert_eq!(app_event, AppInputEvent::Terminal(terminal_event));
+    }
+
+    #[test]
+    fn wraps_voice_events_as_app_input() {
+        let voice_event = VoiceEvent::ListeningStarted;
+        let app_event = AppInputEvent::Voice(voice_event.clone());
+
+        assert_eq!(app_event, AppInputEvent::Voice(voice_event));
+    }
+
+    #[tokio::test]
+    async fn voice_events_do_not_wait_for_terminal_input() {
+        let (_tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(async move {
+            let event = rx.recv().await.map(AppInputEvent::Voice);
+            let _ = result_tx.send(event);
+        });
+
+        _tx.try_send(VoiceEvent::ListeningStarted).unwrap();
+
+        let app_event = tokio::time::timeout(std::time::Duration::from_millis(50), result_rx)
+            .await
+            .expect("voice receive should not block on terminal")
+            .expect("task should send result");
+
+        assert_eq!(app_event, Some(AppInputEvent::Voice(VoiceEvent::ListeningStarted)));
+    }
+}

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -315,7 +315,7 @@ fn handle_voice_event_for_input(
 ) -> InputAction {
     match event {
         synaps_cli::VoiceEvent::FinalTranscript(transcript) => {
-            if !app.voice.listening {
+            if !app.voice.enabled {
                 return InputAction::None;
             }
             match voice_input::handle_voice_transcript(app, &transcript, max_transcript_chars, command_config) {

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -10,6 +10,8 @@ mod draw;
 mod commands;
 mod input;
 mod stream_handler;
+mod input_event;
+mod voice_input;
 mod settings;
 mod plugins;
 mod models;
@@ -18,6 +20,7 @@ use app::{App, ChatMessage};
 use draw::{draw, boot_effect, quit_effect};
 use commands::CommandAction;
 use input::InputAction;
+use input_event::AppInputEvent;
 use stream_handler::StreamAction;
 
 use synaps_cli::{Runtime, StreamEvent, Result, CancellationToken, Session, latest_session, resolve_session};
@@ -27,7 +30,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use futures::StreamExt;
+use futures::StreamExt as _;
 use ratatui::{
     backend::CrosstermBackend,
     Terminal,
@@ -74,6 +77,40 @@ fn apply_setting(
                 st.row_error = Some((key.to_string(), e.to_string()));
             }
         }
+    }
+}
+
+fn build_voice_runtime(_config: &synaps_cli::VoiceConfig) -> Result<synaps_cli::VoiceRuntime> {
+    let voice_runtime = synaps_cli::VoiceRuntime::new();
+    #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+    let mut voice_runtime = voice_runtime;
+    #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+    if _config.stt_backend == "whisper-rs" {
+        let provider = synaps_cli::WhisperSttProvider::from_config(_config)?;
+        voice_runtime.set_stt_provider(Box::new(provider));
+    }
+    Ok(voice_runtime)
+}
+
+fn command_action_name(action: &CommandAction) -> &'static str {
+    match action {
+        CommandAction::None => "none",
+        CommandAction::StartStream => "start-stream",
+        CommandAction::Quit => "quit",
+        CommandAction::LaunchGamba => "gamba",
+        CommandAction::OpenModels => "models",
+        CommandAction::OpenSettings => "settings",
+        CommandAction::OpenPlugins => "plugins",
+        CommandAction::ReloadPlugins => "plugins-reload",
+        CommandAction::LoadSkill { .. } => "load-skill",
+        CommandAction::Compact { .. } => "compact",
+        CommandAction::Ping => "ping",
+        CommandAction::Chain => "chain",
+        CommandAction::ChainList => "chain-list",
+        CommandAction::ChainName { .. } => "chain-name",
+        CommandAction::ChainUnname { .. } => "chain-unname",
+        CommandAction::Status => "status",
+        CommandAction::Voice { .. } => "voice",
     }
 }
 
@@ -124,6 +161,197 @@ async fn fetch_usage() -> std::result::Result<Vec<String>, String> {
     if let Some(rows) = format_block("Sonnet (7-day)", &data["seven_day_sonnet"]) { lines.extend(rows); }
 
     Ok(lines)
+}
+
+async fn start_user_stream(
+    input: String,
+    app: &mut App,
+    runtime: &Runtime,
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    boot_fx: &mut Option<Effect>,
+    exit_fx: &mut Option<Effect>,
+    registry: &std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
+    last_frame: &mut Instant,
+) -> (
+    std::pin::Pin<Box<dyn futures::Stream<Item = StreamEvent> + Send>>,
+    CancellationToken,
+    tokio::sync::mpsc::UnboundedSender<String>,
+) {
+    let display_text = if app.pasted_char_count > 0 {
+        let typed = app.input_before_paste.as_deref().unwrap_or("");
+        let typed_char_count = typed.chars().count();
+        let paste_byte_start = input.char_indices()
+            .nth(typed_char_count)
+            .map(|(i, _)| i)
+            .unwrap_or(input.len());
+        let paste_content = &input[paste_byte_start..];
+        let line_count = paste_content.lines().count();
+        let pasted_char_count = input.chars().count().saturating_sub(typed_char_count);
+        let paste_label = if line_count > 1 {
+            format!("[Pasted {} lines]", line_count)
+        } else {
+            format!("[Pasted {} chars]", pasted_char_count)
+        };
+        if typed.is_empty() { paste_label } else { format!("{} {}", typed.trim(), paste_label) }
+    } else {
+        input.clone()
+    };
+    app.push_msg(ChatMessage::User(display_text));
+    app.input_before_paste = None;
+    app.pasted_char_count = 0;
+    let api_content = if let Some(ref ctx) = app.abort_context {
+        let combined = format!("{}\n\n{}", ctx, input);
+        app.abort_context = None;
+        combined
+    } else {
+        input
+    };
+    app.api_messages.push(json!({"role": "user", "content": api_content}));
+    let ct = CancellationToken::new();
+    let (s_tx, s_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    app.status_text = Some("connecting…".to_string());
+    app.streaming = true;
+    app.spinner_frame = 0;
+    let elapsed = last_frame.elapsed();
+    *last_frame = Instant::now();
+    let _ = draw(terminal, app, runtime, boot_fx, exit_fx, elapsed, registry);
+    let stream = runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx)).await;
+    app.status_text = None;
+    app.push_msg(ChatMessage::Thinking("…".to_string()));
+    (stream, ct, s_tx)
+}
+
+fn voice_event_status(event: &synaps_cli::VoiceEvent) -> (&'static str, tracing::Level) {
+    match event {
+        synaps_cli::VoiceEvent::ListeningStarted => ("voice listening started", tracing::Level::DEBUG),
+        synaps_cli::VoiceEvent::ListeningStopped => ("voice listening stopped", tracing::Level::DEBUG),
+        synaps_cli::VoiceEvent::PartialTranscript(_) => ("voice partial transcript received", tracing::Level::DEBUG),
+        synaps_cli::VoiceEvent::FinalTranscript(_) => ("voice final transcript received", tracing::Level::DEBUG),
+        synaps_cli::VoiceEvent::Error(_) => ("voice provider error", tracing::Level::WARN),
+        synaps_cli::VoiceEvent::TtsStarted => ("voice tts started", tracing::Level::DEBUG),
+        synaps_cli::VoiceEvent::TtsStopped => ("voice tts stopped", tracing::Level::DEBUG),
+    }
+}
+
+fn handle_voice_event(event: synaps_cli::VoiceEvent) {
+    let (message, level) = voice_event_status(&event);
+    match event {
+        synaps_cli::VoiceEvent::Error(err) => tracing::warn!("{}: {}", message, err),
+        _ if level == tracing::Level::WARN => tracing::warn!("{}", message),
+        _ => tracing::debug!("{}", message),
+    }
+}
+
+fn handle_voice_control_pressed(
+    app: &mut App,
+    voice_runtime: &mut Option<synaps_cli::VoiceRuntime>,
+    _config: &synaps_cli::VoiceConfig,
+) {
+    if voice_runtime.is_none() {
+        app.voice.enabled = false;
+        app.voice.listening = false;
+        app.status_text = Some("voice unavailable".to_string());
+        app.invalidate();
+        return;
+    }
+
+    app.voice.enabled = true;
+    app.status_text = None;
+    let runtime = voice_runtime.as_mut().expect("voice_runtime checked above");
+
+    if app.voice.listening || runtime.state() == synaps_cli::VoiceProviderState::Running {
+        match runtime.stop_listening() {
+            Ok(()) => {
+                app.voice.listening = false;
+                app.status_text = Some("voice off".to_string());
+            }
+            Err(err) => {
+                app.voice.last_error = Some(err.to_string());
+                app.status_text = Some("voice stop failed".to_string());
+            }
+        }
+    } else {
+        match runtime.start_listening() {
+            Ok(()) => {
+                app.voice.listening = true;
+                app.voice.last_error = None;
+                app.status_text = Some("voice listening".to_string());
+            }
+            Err(err) => {
+                app.voice.listening = false;
+                app.voice.last_error = Some(err.to_string());
+                app.status_text = Some("voice start failed".to_string());
+            }
+        }
+    }
+    app.invalidate();
+}
+
+fn handle_voice_control_released(
+    app: &mut App,
+    voice_runtime: &mut Option<synaps_cli::VoiceRuntime>,
+    _config: &synaps_cli::VoiceConfig,
+) {
+    if app.voice.mode != app::VoiceUiMode::PushToTalk {
+        return;
+    }
+    if let Some(runtime) = voice_runtime.as_mut() {
+        if let Err(err) = runtime.stop_listening() {
+            app.voice.last_error = Some(err.to_string());
+        }
+    }
+    app.voice.listening = false;
+    app.status_text = None;
+    app.invalidate();
+}
+
+fn handle_voice_event_for_input(
+    event: synaps_cli::VoiceEvent,
+    app: &mut App,
+    max_transcript_chars: usize,
+    command_config: synaps_cli::VoiceCommandConfig,
+    registry: &std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
+    streaming: bool,
+) -> InputAction {
+    match event {
+        synaps_cli::VoiceEvent::FinalTranscript(transcript) => {
+            if !app.voice.listening {
+                return InputAction::None;
+            }
+            match voice_input::handle_voice_transcript(app, &transcript, max_transcript_chars, command_config) {
+                voice_input::VoiceTranscriptOutcome::Ignored => {}
+                voice_input::VoiceTranscriptOutcome::Inserted => app.invalidate(),
+                voice_input::VoiceTranscriptOutcome::SlashCommand { command, arg } => {
+                    return InputAction::SlashCommand(command, arg);
+                }
+                voice_input::VoiceTranscriptOutcome::Submit => {
+                    return input::submit_current_input(app, registry, streaming);
+                }
+                voice_input::VoiceTranscriptOutcome::Escape => {
+                    return InputAction::Abort;
+                }
+            }
+        }
+        synaps_cli::VoiceEvent::ListeningStarted => {
+            app.voice.listening = true;
+            app.voice.last_error = None;
+            handle_voice_event(synaps_cli::VoiceEvent::ListeningStarted);
+            app.invalidate();
+        }
+        synaps_cli::VoiceEvent::ListeningStopped => {
+            app.voice.listening = false;
+            handle_voice_event(synaps_cli::VoiceEvent::ListeningStopped);
+            app.invalidate();
+        }
+        synaps_cli::VoiceEvent::Error(err) => {
+            app.voice.listening = false;
+            app.voice.last_error = Some(err.clone());
+            handle_voice_event(synaps_cli::VoiceEvent::Error(err));
+            app.invalidate();
+        }
+        other => handle_voice_event(other),
+    }
+    InputAction::None
 }
 
 fn rebuild_display_messages(api_messages: &[Value], app: &mut App) {
@@ -254,6 +482,7 @@ pub async fn run(
     // Sync the context bar denominator with the runtime's effective window
     // (respects config override like `context_window = 200k`).
     app.last_turn_context_window = runtime.context_window();
+    app.voice = app::VoiceUiState::from_config(&config.voice);
     // MCP server count logged but not shown — the banner hides the ASCII art.
     if mcp_server_count > 0 {
         tracing::info!("{} MCP servers available (use connect_mcp_server to activate)", mcp_server_count);
@@ -268,6 +497,36 @@ pub async fn run(
     let mut terminal = Terminal::new(backend)
         .map_err(|e| synaps_cli::error::RuntimeError::Tool(format!("terminal setup failed: {}", e)))?;
     let mut event_reader = EventStream::new();
+    let max_voice_transcript_chars = config.voice.max_transcript_chars;
+    let voice_command_config = synaps_cli::VoiceCommandConfig {
+        commands_enabled: config.voice.commands_enabled,
+        submit_enabled: config.voice.stt_auto_submit || config.voice.commands_submit_enabled,
+        escape_enabled: false,
+    };
+    let mut voice_runtime: Option<synaps_cli::VoiceRuntime> = if config.voice.enabled {
+        match build_voice_runtime(&config.voice) {
+            Ok(mut voice_runtime) => {
+                if app.voice.mode == app::VoiceUiMode::Toggle {
+                    if let Err(err) = voice_runtime.start_listening() {
+                        tracing::warn!("voice startup failed: {}", err);
+                        app.voice.last_error = Some(err.to_string());
+                    } else {
+                        app.voice.listening = true;
+                    }
+                }
+                Some(voice_runtime)
+            }
+            Err(err) => {
+                tracing::warn!("voice setup failed: {}", err);
+                app.voice.last_error = Some(err.to_string());
+                app.voice.enabled = false;
+                app.push_msg(ChatMessage::Error(format!("voice setup failed: {}", err)));
+                None
+            }
+        }
+    } else {
+        None
+    };
     let mut stream: Option<std::pin::Pin<Box<dyn futures::Stream<Item = StreamEvent> + Send>>> = None;
     let mut cancel_token: Option<CancellationToken> = None;
     let mut steer_tx: Option<tokio::sync::mpsc::UnboundedSender<String>> = None;
@@ -505,14 +764,23 @@ pub async fn run(
                 continue;
             }
 
-            // ── Input: keyboard, mouse, paste ──
-            maybe_event = event_reader.next(), if app.gamba_child.is_none() => {
+            // ── Input: keyboard, mouse, paste, voice ──
+            maybe_event = input_event::next_app_input_event(
+                &mut event_reader,
+                voice_runtime.as_mut().map(|voice| voice.event_receiver_mut()),
+            ), if app.gamba_child.is_none() => {
                 match maybe_event {
-                    Some(Ok(event)) => {
+                    Some(AppInputEvent::Terminal(event)) => {
                         let is_streaming = app.streaming;
                         let action = input::handle_event(event, &mut app, &runtime, is_streaming, &registry, &keybind_registry);
                         match action {
                             InputAction::None => {}
+                            InputAction::VoiceControlPressed => {
+                                handle_voice_control_pressed(&mut app, &mut voice_runtime, &config.voice);
+                            }
+                            InputAction::VoiceControlReleased => {
+                                handle_voice_control_released(&mut app, &mut voice_runtime, &config.voice);
+                            }
                             InputAction::Quit => {
                                 exit_fx = Some(quit_effect());
                             }
@@ -773,6 +1041,44 @@ pub async fn run(
                                             }
                                         }
                                     }
+                                    CommandAction::Voice { subcommand } => {
+                                        match subcommand.as_str() {
+                                            "on" => {
+                                                if voice_runtime.is_none() {
+                                                    match build_voice_runtime(&config.voice) {
+                                                        Ok(runtime) => voice_runtime = Some(runtime),
+                                                        Err(err) => {
+                                                            app.voice.last_error = Some(err.to_string());
+                                                            app.push_msg(ChatMessage::Error(format!("voice setup failed: {}", err)));
+                                                        }
+                                                    }
+                                                }
+                                                app.voice.enabled = voice_runtime.is_some();
+                                                app.voice.listening = voice_runtime
+                                                    .as_ref()
+                                                    .is_some_and(|runtime| runtime.state() == synaps_cli::VoiceProviderState::Running);
+                                                app.voice.mode = app::VoiceUiMode::Toggle;
+                                                app.status_text = None;
+                                                app.push_msg(ChatMessage::System("voice controls enabled — press F8 to toggle dictation".to_string()));
+                                            }
+                                            "off" => {
+                                                if let Some(runtime) = voice_runtime.as_mut() {
+                                                    if let Err(err) = runtime.stop_listening() {
+                                                        app.voice.last_error = Some(err.to_string());
+                                                    }
+                                                }
+                                                app.voice.enabled = false;
+                                                app.voice.listening = false;
+                                                app.status_text = Some("voice off".to_string());
+                                                app.push_msg(ChatMessage::System("voice disabled".to_string()));
+                                            }
+                                            _ => {
+                                                let mode = match app.voice.mode { app::VoiceUiMode::PushToTalk => "push-to-talk", app::VoiceUiMode::Toggle => "toggle" };
+                                                let state = if app.voice.listening { "listening" } else if app.voice.enabled { "enabled" } else { "disabled" };
+                                                app.push_msg(ChatMessage::System(format!("voice: {} ({})", state, mode)));
+                                            }
+                                        }
+                                    }
                                     CommandAction::Ping => {
                                         app.push_msg(ChatMessage::System("📡 Pinging models...".to_string()));
                                         app.ping_print = true;
@@ -800,49 +1106,17 @@ pub async fn run(
                                     app.queued_message = Some(input);
                                     continue;
                                 }
-                                // Build display text with paste info
-                                let display_text = if app.pasted_char_count > 0 {
-                                    let typed = app.input_before_paste.as_deref().unwrap_or("");
-                                    let typed_char_count = typed.chars().count();
-                                    let paste_byte_start = input.char_indices()
-                                        .nth(typed_char_count)
-                                        .map(|(i, _)| i)
-                                        .unwrap_or(input.len());
-                                    let paste_content = &input[paste_byte_start..];
-                                    let line_count = paste_content.lines().count();
-                                    let pasted_char_count = input.chars().count().saturating_sub(typed_char_count);
-                                    let paste_label = if line_count > 1 {
-                                        format!("[Pasted {} lines]", line_count)
-                                    } else {
-                                        format!("[Pasted {} chars]", pasted_char_count)
-                                    };
-                                    if typed.is_empty() { paste_label } else { format!("{} {}", typed.trim(), paste_label) }
-                                } else {
-                                    input.clone()
-                                };
-                                app.push_msg(ChatMessage::User(display_text));
-                                app.input_before_paste = None;
-                                app.pasted_char_count = 0;
-                                // Inject abort context if previous response was interrupted
-                                let api_content = if let Some(ref ctx) = app.abort_context {
-                                    let combined = format!("{}\n\n{}", ctx, input);
-                                    app.abort_context = None;
-                                    combined
-                                } else {
-                                    input
-                                };
-                                app.api_messages.push(json!({"role": "user", "content": api_content}));
-                                let ct = CancellationToken::new();
-                                let (s_tx, s_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-                                app.status_text = Some("connecting…".to_string());
-                                app.streaming = true;
-                                app.spinner_frame = 0;
-                                let elapsed = last_frame.elapsed();
-                                last_frame = Instant::now();
-                                let _ = draw(&mut terminal, &mut app, &runtime, &mut boot_fx, &mut exit_fx, elapsed, &registry);
-                                stream = Some(runtime.run_stream_with_messages(app.api_messages.clone(), ct.clone(), Some(s_rx)).await);
-                                app.status_text = None;
-                                app.push_msg(ChatMessage::Thinking("…".to_string()));
+                                let (new_stream, ct, s_tx) = start_user_stream(
+                                    input,
+                                    &mut app,
+                                    &runtime,
+                                    &mut terminal,
+                                    &mut boot_fx,
+                                    &mut exit_fx,
+                                    &registry,
+                                    &mut last_frame,
+                                ).await;
+                                stream = Some(new_stream);
                                 cancel_token = Some(ct);
                                 steer_tx = Some(s_tx);
                             }
@@ -904,6 +1178,7 @@ pub async fn run(
                                         CommandAction::ChainName { .. } => {}
                                         CommandAction::ChainUnname { .. } => {}
                                         CommandAction::Status => {}
+                                        CommandAction::Voice { .. } => {}
                                         CommandAction::Ping => {}
                                     }
                                 } else {
@@ -1038,7 +1313,53 @@ pub async fn run(
                             }
                         }
                     }
-                    Some(Err(_)) | None => break,
+                    Some(AppInputEvent::Voice(voice_event)) => {
+                        let is_streaming = app.streaming;
+                        let action = handle_voice_event_for_input(
+                            voice_event,
+                            &mut app,
+                            max_voice_transcript_chars,
+                            voice_command_config,
+                            &registry,
+                            is_streaming,
+                        );
+                        match action {
+                            InputAction::None => {}
+                            InputAction::SlashCommand(cmd, arg) => {
+                                match commands::handle_command(&cmd, &arg, &mut app, &mut runtime, &system_prompt_path, &registry, &keybind_registry).await {
+                                    CommandAction::OpenSettings => app.settings = Some(settings::SettingsState::new()),
+                                    CommandAction::OpenModels => app.models = Some(models::ModelsModalState::new()),
+                                    CommandAction::None => {}
+                                    other => app.push_msg(ChatMessage::System(format!("voice command not available here: {}", command_action_name(&other)))),
+                                }
+                            }
+                            InputAction::Submit(input) => {
+                                if app.compact_task.is_some() {
+                                    app.push_msg(ChatMessage::System(format!("queued: {}", input)));
+                                    app.queued_message = Some(input);
+                                    continue;
+                                }
+                                let (new_stream, ct, s_tx) = start_user_stream(
+                                    input,
+                                    &mut app,
+                                    &runtime,
+                                    &mut terminal,
+                                    &mut boot_fx,
+                                    &mut exit_fx,
+                                    &registry,
+                                    &mut last_frame,
+                                ).await;
+                                stream = Some(new_stream);
+                                cancel_token = Some(ct);
+                                steer_tx = Some(s_tx);
+                            }
+                            InputAction::Abort => {
+                                if let Some(ref ct) = cancel_token { ct.cancel(); }
+                            }
+                            _ => {}
+                        }
+                    }
+                    None => break,
                 }
             }
 
@@ -1138,6 +1459,14 @@ pub async fn run(
     }
 
     // Save session on exit
+    if let Some(mut voice_runtime) = voice_runtime.take() {
+        if let Err(err) = voice_runtime.shutdown() {
+            tracing::warn!("voice shutdown failed: {}", err);
+        }
+        if let Err(err) = voice_runtime.join_workers().await {
+            tracing::warn!("voice worker join failed: {}", err);
+        }
+    }
     app.save_session().await;
 
     // Signal the inbox watcher's blocking thread to exit, then abort the async task.

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -505,17 +505,7 @@ pub async fn run(
     };
     let mut voice_runtime: Option<synaps_cli::VoiceRuntime> = if config.voice.enabled {
         match build_voice_runtime(&config.voice) {
-            Ok(mut voice_runtime) => {
-                if app.voice.mode == app::VoiceUiMode::Toggle {
-                    if let Err(err) = voice_runtime.start_listening() {
-                        tracing::warn!("voice startup failed: {}", err);
-                        app.voice.last_error = Some(err.to_string());
-                    } else {
-                        app.voice.listening = true;
-                    }
-                }
-                Some(voice_runtime)
-            }
+            Ok(voice_runtime) => Some(voice_runtime),
             Err(err) => {
                 tracing::warn!("voice setup failed: {}", err);
                 app.voice.last_error = Some(err.to_string());

--- a/src/chatui/plugins/input.rs
+++ b/src/chatui/plugins/input.rs
@@ -78,6 +78,17 @@ fn list_enter(state: &mut PluginsModalState) -> InputOutcome {
     }
 }
 
+pub(crate) fn insert_voice_text(state: &mut PluginsModalState, text: &str) -> bool {
+    match &mut state.mode {
+        RightMode::AddMarketplaceEditor { buffer, error } => {
+            buffer.push_str(text);
+            *error = None;
+            true
+        }
+        _ => false,
+    }
+}
+
 fn editor_key(state: &mut PluginsModalState, key: KeyEvent) -> InputOutcome {
     let RightMode::AddMarketplaceEditor { buffer, error } = &mut state.mode else { return InputOutcome::None };
     match key.code {
@@ -335,6 +346,24 @@ mod tests {
                 if plugin_name == "p" && host == "github.com" && source == "https://github.com/u/r"
         ));
         assert!(matches!(s.mode, RightMode::List));
+    }
+
+    #[test]
+    fn voice_text_inserts_into_add_marketplace_editor() {
+        let mut s = crate::chatui::plugins::PluginsModalState::new(PluginsState::default());
+        s.mode = crate::chatui::plugins::state::RightMode::AddMarketplaceEditor {
+            buffer: "https://".into(), error: Some("bad".into()),
+        };
+
+        assert!(insert_voice_text(&mut s, "github.com/m/repo"));
+
+        match s.mode {
+            crate::chatui::plugins::state::RightMode::AddMarketplaceEditor { buffer, error } => {
+                assert_eq!(buffer, "https://github.com/m/repo");
+                assert!(error.is_none());
+            }
+            _ => panic!("expected marketplace editor"),
+        }
     }
 
     #[test]

--- a/src/chatui/plugins/mod.rs
+++ b/src/chatui/plugins/mod.rs
@@ -8,3 +8,4 @@ pub(crate) mod actions;
 pub(crate) use state::PluginsModalState;
 pub(crate) use draw::render;
 pub(crate) use input::{handle_event, InputOutcome};
+pub(crate) use input::insert_voice_text;

--- a/src/chatui/settings/input.rs
+++ b/src/chatui/settings/input.rs
@@ -261,6 +261,18 @@ pub(crate) fn handle_event(
     }
 }
 
+pub(crate) fn insert_voice_text(state: &mut SettingsState, text: &str) -> bool {
+    match state.edit_mode.as_mut() {
+        Some(ActiveEditor::Text { buffer, .. })
+        | Some(ActiveEditor::CustomModel { buffer, .. })
+        | Some(ActiveEditor::ApiKey { buffer, .. }) => {
+            buffer.push_str(text);
+            true
+        }
+        _ => false,
+    }
+}
+
 fn handle_editor_key(state: &mut SettingsState, key: KeyEvent) -> InputOutcome {
     let editor = state.edit_mode.as_mut().expect("caller checks");
     match editor {
@@ -491,6 +503,43 @@ mod tests {
                 assert!(enabled);
             }
             _ => panic!("expected TogglePlugin"),
+        }
+    }
+
+    #[test]
+    fn voice_text_inserts_into_text_editor_buffer() {
+        let mut state = SettingsState::new();
+        state.edit_mode = Some(ActiveEditor::Text {
+            buffer: "abc".into(),
+            setting_key: "model",
+            numeric: false,
+            error: Some("bad".into()),
+        });
+
+        assert!(insert_voice_text(&mut state, " def"));
+
+        match state.edit_mode {
+            Some(ActiveEditor::Text { buffer, error, .. }) => {
+                assert_eq!(buffer, "abc def");
+                assert!(error.is_some());
+            }
+            _ => panic!("expected text editor"),
+        }
+    }
+
+    #[test]
+    fn voice_text_inserts_into_api_key_editor_buffer() {
+        let mut state = SettingsState::new();
+        state.edit_mode = Some(ActiveEditor::ApiKey {
+            provider_id: "local.url".into(),
+            buffer: "http://".into(),
+        });
+
+        assert!(insert_voice_text(&mut state, "localhost"));
+
+        match state.edit_mode {
+            Some(ActiveEditor::ApiKey { buffer, .. }) => assert_eq!(buffer, "http://localhost"),
+            _ => panic!("expected api key editor"),
         }
     }
 }

--- a/src/chatui/settings/mod.rs
+++ b/src/chatui/settings/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod input;
 
 pub(crate) use draw::render;
 pub(crate) use input::{handle_event, InputOutcome};
+pub(crate) use input::insert_voice_text;
 
 const BUILTIN_THEMES: &[&str] = &[
     "default", "neon-rain", "amber", "phosphor", "solarized-dark", "blood",

--- a/src/chatui/voice_input.rs
+++ b/src/chatui/voice_input.rs
@@ -1,0 +1,107 @@
+use super::app::App;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum VoiceTranscriptOutcome {
+    Ignored,
+    Inserted,
+    SlashCommand { command: String, arg: String },
+    Submit,
+    Escape,
+}
+
+#[cfg(test)]
+pub(crate) fn insert_voice_transcript(app: &mut App, transcript: &str, max_chars: usize) -> bool {
+    matches!(
+        handle_voice_transcript(
+            app,
+            transcript,
+            max_chars,
+            synaps_cli::VoiceCommandConfig::dictation_only(),
+        ),
+        VoiceTranscriptOutcome::Inserted
+    )
+}
+
+pub(crate) fn handle_voice_transcript(
+    app: &mut App,
+    transcript: &str,
+    max_chars: usize,
+    command_config: synaps_cli::VoiceCommandConfig,
+) -> VoiceTranscriptOutcome {
+    let sanitized = synaps_cli::sanitize_voice_transcript(transcript, max_chars);
+    if sanitized.is_empty() {
+        return VoiceTranscriptOutcome::Ignored;
+    }
+
+    if app.settings.is_none() && app.plugins.is_none() {
+        match synaps_cli::map_spoken_phrase(&sanitized, command_config) {
+            synaps_cli::VoiceCommandAction::SlashCommand { command, arg } => {
+                return VoiceTranscriptOutcome::SlashCommand { command, arg };
+            }
+            synaps_cli::VoiceCommandAction::Submit => return VoiceTranscriptOutcome::Submit,
+            synaps_cli::VoiceCommandAction::Escape => return VoiceTranscriptOutcome::Escape,
+            synaps_cli::VoiceCommandAction::NewLine => {
+                let byte_pos = app.cursor_byte_pos();
+                app.input.insert(byte_pos, '\n');
+                app.cursor_pos += 1;
+                return VoiceTranscriptOutcome::Inserted;
+            }
+            synaps_cli::VoiceCommandAction::Dictation(_) => {}
+        }
+    }
+
+    if let Some(settings) = app.settings.as_mut() {
+        return if super::settings::insert_voice_text(settings, &sanitized) {
+            VoiceTranscriptOutcome::Inserted
+        } else {
+            VoiceTranscriptOutcome::Ignored
+        };
+    }
+
+    if let Some(plugins) = app.plugins.as_mut() {
+        return if super::plugins::insert_voice_text(plugins, &sanitized) {
+            VoiceTranscriptOutcome::Inserted
+        } else {
+            VoiceTranscriptOutcome::Ignored
+        };
+    }
+
+    let byte_pos = app.cursor_byte_pos();
+    app.input.insert_str(byte_pos, &sanitized);
+    app.cursor_pos += sanitized.chars().count();
+    VoiceTranscriptOutcome::Inserted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synaps_cli::Session;
+
+    fn app() -> App {
+        App::new(Session::new("test-model", "medium", None))
+    }
+
+    #[test]
+    fn inserts_sanitized_transcript_at_chat_cursor() {
+        let mut app = app();
+        app.input = "hello world".to_string();
+        app.cursor_pos = 5;
+
+        assert!(insert_voice_transcript(&mut app, "\u{1b}[31m voice", 100));
+
+        assert_eq!(app.input, "hello voice world");
+        assert_eq!(app.cursor_pos, 11);
+    }
+
+    #[test]
+    fn ignores_empty_sanitized_transcript() {
+        let mut app = app();
+        app.input = "hello".to_string();
+        app.cursor_pos = 5;
+
+        assert!(!insert_voice_transcript(&mut app, "\u{0000}", 100));
+
+        assert_eq!(app.input, "hello");
+        assert_eq!(app.cursor_pos, 5);
+    }
+}

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -3,6 +3,59 @@ use std::path::PathBuf;
 use std::sync::OnceLock;
 use crate::tools::shell::config::ShellConfig;
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct VoiceConfig {
+    pub enabled: bool,
+    pub mode: String,
+    pub stt_backend: String,
+    pub stt_model_path: PathBuf,
+    pub stt_language: String,
+    pub stt_show_partials: bool,
+    pub stt_auto_submit: bool,
+    pub stt_silence_submit_ms: u64,
+    pub stt_vad_rms_threshold: f32,
+    pub stt_min_speech_ms: u64,
+    pub stt_preroll_ms: u64,
+    pub stt_max_utterance_ms: u64,
+    pub max_transcript_chars: usize,
+    pub tts_enabled: bool,
+    pub tts_backend: String,
+    pub tts_model_path: PathBuf,
+    pub tts_voices_path: PathBuf,
+    pub tts_voice: String,
+    pub tts_auto_speak: bool,
+    pub commands_enabled: bool,
+    pub commands_submit_enabled: bool,
+}
+
+impl Default for VoiceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            mode: "toggle".to_string(),
+            stt_backend: "whisper-rs".to_string(),
+            stt_model_path: PathBuf::from("~/.synaps-cli/models/whisper/ggml-base.en.bin"),
+            stt_language: "en".to_string(),
+            stt_show_partials: true,
+            stt_auto_submit: false,
+            stt_silence_submit_ms: 1000,
+            stt_vad_rms_threshold: 0.01,
+            stt_min_speech_ms: 250,
+            stt_preroll_ms: 300,
+            stt_max_utterance_ms: 30_000,
+            max_transcript_chars: 16_000,
+            tts_enabled: false,
+            tts_backend: "kokoros".to_string(),
+            tts_model_path: PathBuf::from("~/.synaps-cli/models/kokoro/kokoro-v1.0.onnx"),
+            tts_voices_path: PathBuf::from("~/.synaps-cli/models/kokoro/voices-v1.0.bin"),
+            tts_voice: "af_sky".to_string(),
+            tts_auto_speak: false,
+            commands_enabled: true,
+            commands_submit_enabled: false,
+        }
+    }
+}
+
 static PROFILE_NAME: OnceLock<Option<String>> = OnceLock::new();
 static PROVIDER_KEYS: OnceLock<BTreeMap<String, String>> = OnceLock::new();
 
@@ -99,6 +152,7 @@ pub struct SynapsConfig {
     pub favorite_models: Vec<String>,
     pub disabled_skills: Vec<String>,
     pub shell: ShellConfig,
+    pub voice: VoiceConfig,
     pub provider_keys: BTreeMap<String, String>,
     pub keybinds: std::collections::HashMap<String, String>,
 }
@@ -120,6 +174,7 @@ impl Default for SynapsConfig {
             favorite_models: Vec::new(),
             disabled_skills: Vec::new(),
             shell: ShellConfig::default(),
+            voice: VoiceConfig::default(),
             provider_keys: BTreeMap::new(),
             keybinds: std::collections::HashMap::new(),
         }
@@ -147,6 +202,139 @@ fn parse_comma_list(val: &str) -> Vec<String> {
 
 fn write_comma_list(key: &str, values: &[String]) -> std::io::Result<()> {
     write_config_value(key, &values.join(", "))
+}
+
+fn parse_bool(val: &str) -> Option<bool> {
+    match val.trim().to_ascii_lowercase().as_str() {
+        "true" | "yes" | "on" | "1" => Some(true),
+        "false" | "no" | "off" | "0" => Some(false),
+        _ => None,
+    }
+}
+
+fn parse_voice_config_key(voice_config: &mut VoiceConfig, key: &str, val: &str) {
+    match key {
+        "voice.enabled" => {
+            if let Some(enabled) = parse_bool(val) {
+                voice_config.enabled = enabled;
+            } else {
+                eprintln!("Warning: invalid value for voice.enabled: '{}', using default", val);
+            }
+        }
+        "voice.mode" => {
+            if matches!(val, "push_to_talk" | "toggle") {
+                voice_config.mode = val.to_string();
+            } else {
+                eprintln!("Warning: invalid value for voice.mode: '{}', using default", val);
+            }
+        }
+        "voice.stt_backend" => {
+            if val == "whisper-rs" {
+                voice_config.stt_backend = val.to_string();
+            } else {
+                eprintln!("Warning: invalid value for voice.stt_backend: '{}', using default", val);
+            }
+        }
+        "voice.stt_model_path" => voice_config.stt_model_path = PathBuf::from(val),
+        "voice.stt_language" => voice_config.stt_language = val.to_string(),
+        "voice.stt_show_partials" => {
+            if let Some(show_partials) = parse_bool(val) {
+                voice_config.stt_show_partials = show_partials;
+            } else {
+                eprintln!("Warning: invalid value for voice.stt_show_partials: '{}', using default", val);
+            }
+        }
+        "voice.stt_auto_submit" => {
+            if let Some(auto_submit) = parse_bool(val) {
+                voice_config.stt_auto_submit = auto_submit;
+            } else {
+                eprintln!("Warning: invalid value for voice.stt_auto_submit: '{}', using default", val);
+            }
+        }
+        "voice.stt_silence_submit_ms" => {
+            if let Ok(silence_ms) = val.parse::<u64>() {
+                voice_config.stt_silence_submit_ms = silence_ms;
+            } else {
+                eprintln!("Warning: invalid value for voice.stt_silence_submit_ms: '{}', using default", val);
+            }
+        }
+        "voice.stt_vad_rms_threshold" => {
+            if let Ok(threshold) = val.parse::<f32>() {
+                voice_config.stt_vad_rms_threshold = threshold;
+            } else {
+                eprintln!("Warning: invalid value for voice.stt_vad_rms_threshold: '{}', using default", val);
+            }
+        }
+        "voice.stt_min_speech_ms" => {
+            if let Ok(min_speech_ms) = val.parse::<u64>() {
+                voice_config.stt_min_speech_ms = min_speech_ms;
+            } else {
+                eprintln!("Warning: invalid value for voice.stt_min_speech_ms: '{}', using default", val);
+            }
+        }
+        "voice.stt_preroll_ms" => {
+            if let Ok(preroll_ms) = val.parse::<u64>() {
+                voice_config.stt_preroll_ms = preroll_ms;
+            } else {
+                eprintln!("Warning: invalid value for voice.stt_preroll_ms: '{}', using default", val);
+            }
+        }
+        "voice.stt_max_utterance_ms" => {
+            if let Ok(max_utterance_ms) = val.parse::<u64>() {
+                voice_config.stt_max_utterance_ms = max_utterance_ms;
+            } else {
+                eprintln!("Warning: invalid value for voice.stt_max_utterance_ms: '{}', using default", val);
+            }
+        }
+        "voice.max_transcript_chars" => {
+            if let Ok(max_chars) = val.parse::<usize>() {
+                voice_config.max_transcript_chars = max_chars;
+            } else {
+                eprintln!("Warning: invalid value for voice.max_transcript_chars: '{}', using default", val);
+            }
+        }
+        "voice.tts_enabled" => {
+            if let Some(enabled) = parse_bool(val) {
+                voice_config.tts_enabled = enabled;
+            } else {
+                eprintln!("Warning: invalid value for voice.tts_enabled: '{}', using default", val);
+            }
+        }
+        "voice.tts_backend" => {
+            if val == "kokoros" {
+                voice_config.tts_backend = val.to_string();
+            } else {
+                eprintln!("Warning: invalid value for voice.tts_backend: '{}', using default", val);
+            }
+        }
+        "voice.tts_model_path" => voice_config.tts_model_path = PathBuf::from(val),
+        "voice.tts_voices_path" => voice_config.tts_voices_path = PathBuf::from(val),
+        "voice.tts_voice" => voice_config.tts_voice = val.to_string(),
+        "voice.tts_auto_speak" => {
+            if let Some(auto_speak) = parse_bool(val) {
+                voice_config.tts_auto_speak = auto_speak;
+            } else {
+                eprintln!("Warning: invalid value for voice.tts_auto_speak: '{}', using default", val);
+            }
+        }
+        "voice.commands_enabled" => {
+            if let Some(enabled) = parse_bool(val) {
+                voice_config.commands_enabled = enabled;
+            } else {
+                eprintln!("Warning: invalid value for voice.commands_enabled: '{}', using default", val);
+            }
+        }
+        "voice.commands.submit_enabled" => {
+            if let Some(enabled) = parse_bool(val) {
+                voice_config.commands_submit_enabled = enabled;
+            } else {
+                eprintln!("Warning: invalid value for voice.commands.submit_enabled: '{}', using default", val);
+            }
+        }
+        _ => {
+            // Unknown voice.* keys are preserved (not rejected)
+        }
+    }
 }
 
 /// Parse shell.* configuration keys and update the ShellConfig.
@@ -218,16 +406,9 @@ fn parse_shell_config_key(shell_config: &mut ShellConfig, key: &str, val: &str) 
     }
 }
 
-/// Parse the config file at ~/.synaps-cli/config (or profile variant).
-/// Returns default config if file doesn't exist or can't be read.
-pub fn load_config() -> SynapsConfig {
-    let path = resolve_read_path("config");
+fn parse_config_content(content: &str) -> SynapsConfig {
     let mut config = SynapsConfig::default();
-    
-    let Ok(content) = std::fs::read_to_string(&path) else {
-        return config;
-    };
-    
+
     for line in content.lines() {
         let line = line.trim();
         if line.is_empty() || line.starts_with('#') { continue; }
@@ -285,6 +466,8 @@ pub fn load_config() -> SynapsConfig {
                 // Handle shell.* keys
                 if key.starts_with("shell.") {
                     parse_shell_config_key(&mut config.shell, key, val);
+                } else if key.starts_with("voice.") {
+                    parse_voice_config_key(&mut config.voice, key, val);
                 } else if let Some(provider_key) = key.strip_prefix("provider.") {
                     config.provider_keys.insert(provider_key.to_string(), val.to_string());
                 } else if let Some(keybind_key) = key.strip_prefix("keybind.") {
@@ -294,6 +477,19 @@ pub fn load_config() -> SynapsConfig {
             }
         }
     }
+
+    config
+}
+
+/// Parse the config file at ~/.synaps-cli/config (or profile variant).
+/// Returns default config if file doesn't exist or can't be read.
+pub fn load_config() -> SynapsConfig {
+    let path = resolve_read_path("config");
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return SynapsConfig::default();
+    };
+
+    let config = parse_config_content(&content);
 
     // Publish provider keys to the process-wide cache for the API router.
     // First writer wins (OnceLock) — subsequent load_config calls are no-ops.
@@ -446,6 +642,27 @@ mod tests {
         assert!(config.disabled_skills.is_empty());
         assert_eq!(config.shell.max_sessions, 5);
         assert_eq!(config.shell.idle_timeout.as_secs(), 600);
+        assert!(!config.voice.enabled);
+        assert_eq!(config.voice.mode, "toggle");
+        assert_eq!(config.voice.stt_backend, "whisper-rs");
+        assert_eq!(config.voice.stt_model_path, PathBuf::from("~/.synaps-cli/models/whisper/ggml-base.en.bin"));
+        assert_eq!(config.voice.stt_language, "en");
+        assert!(config.voice.stt_show_partials);
+        assert!(!config.voice.stt_auto_submit);
+        assert_eq!(config.voice.stt_silence_submit_ms, 1000);
+        assert_eq!(config.voice.stt_vad_rms_threshold, 0.01);
+        assert_eq!(config.voice.stt_min_speech_ms, 250);
+        assert_eq!(config.voice.stt_preroll_ms, 300);
+        assert_eq!(config.voice.stt_max_utterance_ms, 30_000);
+        assert_eq!(config.voice.max_transcript_chars, 16_000);
+        assert!(!config.voice.tts_enabled);
+        assert_eq!(config.voice.tts_backend, "kokoros");
+        assert_eq!(config.voice.tts_model_path, PathBuf::from("~/.synaps-cli/models/kokoro/kokoro-v1.0.onnx"));
+        assert_eq!(config.voice.tts_voices_path, PathBuf::from("~/.synaps-cli/models/kokoro/voices-v1.0.bin"));
+        assert_eq!(config.voice.tts_voice, "af_sky");
+        assert!(!config.voice.tts_auto_speak);
+        assert!(config.voice.commands_enabled);
+        assert!(!config.voice.commands_submit_enabled);
     }
 
     fn make_test_home(subdir: &str) -> std::path::PathBuf {
@@ -543,6 +760,95 @@ mod tests {
         let contents = std::fs::read_to_string(&cfg).unwrap();
         assert!(contents.contains("model = claude-sonnet-4-6"));
         let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn load_config_parses_voice_keys() {
+        let config = parse_config_content(r#"
+voice.enabled = true
+voice.mode = toggle
+voice.stt_backend = whisper-rs
+voice.stt_model_path = /models/whisper.bin
+voice.stt_language = es
+voice.stt_show_partials = false
+voice.stt_auto_submit = true
+voice.stt_silence_submit_ms = 1500
+voice.stt_vad_rms_threshold = 0.02
+voice.stt_min_speech_ms = 300
+voice.stt_preroll_ms = 400
+voice.stt_max_utterance_ms = 45000
+voice.max_transcript_chars = 8000
+voice.tts_enabled = true
+voice.tts_backend = kokoros
+voice.tts_model_path = /models/kokoro.onnx
+voice.tts_voices_path = /models/voices.bin
+voice.tts_voice = af_heart
+voice.tts_auto_speak = true
+voice.commands_enabled = false
+voice.commands.submit_enabled = true
+voice.future_unknown = preserved-by-ignored-parser
+"#);
+        assert!(config.voice.enabled);
+        assert_eq!(config.voice.mode, "toggle");
+        assert_eq!(config.voice.stt_backend, "whisper-rs");
+        assert_eq!(config.voice.stt_model_path, PathBuf::from("/models/whisper.bin"));
+        assert_eq!(config.voice.stt_language, "es");
+        assert!(!config.voice.stt_show_partials);
+        assert!(config.voice.stt_auto_submit);
+        assert_eq!(config.voice.stt_silence_submit_ms, 1500);
+        assert_eq!(config.voice.stt_vad_rms_threshold, 0.02);
+        assert_eq!(config.voice.stt_min_speech_ms, 300);
+        assert_eq!(config.voice.stt_preroll_ms, 400);
+        assert_eq!(config.voice.stt_max_utterance_ms, 45_000);
+        assert_eq!(config.voice.max_transcript_chars, 8_000);
+        assert!(config.voice.tts_enabled);
+        assert_eq!(config.voice.tts_backend, "kokoros");
+        assert_eq!(config.voice.tts_model_path, PathBuf::from("/models/kokoro.onnx"));
+        assert_eq!(config.voice.tts_voices_path, PathBuf::from("/models/voices.bin"));
+        assert_eq!(config.voice.tts_voice, "af_heart");
+        assert!(config.voice.tts_auto_speak);
+        assert!(!config.voice.commands_enabled);
+        assert!(config.voice.commands_submit_enabled);
+    }
+
+    #[test]
+    fn invalid_voice_values_keep_defaults() {
+        let config = parse_config_content(r#"
+voice.enabled = maybe
+voice.stt_show_partials = maybe
+voice.stt_auto_submit = maybe
+voice.stt_silence_submit_ms = nope
+voice.stt_vad_rms_threshold = nope
+voice.stt_min_speech_ms = nope
+voice.stt_preroll_ms = nope
+voice.stt_max_utterance_ms = nope
+voice.max_transcript_chars = nope
+voice.tts_enabled = maybe
+voice.tts_auto_speak = maybe
+"#);
+        assert!(!config.voice.enabled);
+        assert!(config.voice.stt_show_partials);
+        assert!(!config.voice.stt_auto_submit);
+        assert_eq!(config.voice.stt_silence_submit_ms, 1000);
+        assert_eq!(config.voice.stt_vad_rms_threshold, 0.01);
+        assert_eq!(config.voice.stt_min_speech_ms, 250);
+        assert_eq!(config.voice.stt_preroll_ms, 300);
+        assert_eq!(config.voice.stt_max_utterance_ms, 30_000);
+        assert_eq!(config.voice.max_transcript_chars, 16_000);
+        assert!(!config.voice.tts_enabled);
+        assert!(!config.voice.tts_auto_speak);
+    }
+
+    #[test]
+    fn invalid_voice_enum_values_keep_defaults() {
+        let config = parse_config_content(r#"
+voice.mode = continuous
+voice.stt_backend = deepgram
+voice.tts_backend = elevenlabs
+"#);
+        assert_eq!(config.voice.mode, "toggle");
+        assert_eq!(config.voice.stt_backend, "whisper-rs");
+        assert_eq!(config.voice.tts_backend, "kokoros");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod tools;
 pub mod mcp;
 pub mod skills;
 pub mod events;
+pub mod voice;
 
 // Re-export core modules at crate root for backward compatibility
 pub use core::config;
@@ -15,12 +16,22 @@ pub use core::error;
 pub use core::watcher_types;
 pub use core::models;
 pub use core::chain;
+pub use voice::{
+    SpeechToTextProvider, TextToSpeechProvider, VoiceEvent, VoiceEventReceiver, VoiceEventSender,
+    VoiceProviderState, VoiceRuntime, VoiceRuntimeHandle,
+    sanitize_voice_transcript, DEFAULT_MAX_VOICE_TRANSCRIPT_CHARS,
+    map_spoken_phrase, VoiceCommandAction, VoiceCommandConfig,
+};
+#[cfg(feature = "voice-stt-whisper")]
+pub use voice::WhisperSttProvider;
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+pub use voice::run_whisper_mic_demo;
 
 pub use runtime::{Runtime, StreamEvent, LlmEvent, SessionEvent, AgentEvent};
 pub use tools::{Tool, ToolContext, ToolRegistry};
 pub use session::{Session, SessionInfo, find_session, latest_session, list_sessions, resolve_session, find_session_by_name, validate_name};
 pub use error::{RuntimeError, Result};
-pub use config::{SynapsConfig, load_config, resolve_system_prompt};
+pub use config::{SynapsConfig, VoiceConfig, load_config, resolve_system_prompt};
 pub use watcher_types::{
     AgentConfig, SessionLimits, HandoffState, ExitReason, SessionStats,
     WatcherCommand, WatcherResponse, AgentStatusInfo

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -51,7 +51,7 @@ pub struct LoadedSkill {
 pub const BUILTIN_COMMANDS: &[&str] = &[
     "clear", "compact", "chain", "model", "models", "system", "thinking", "sessions",
     "resume", "saveas", "theme", "gamba", "help", "quit", "exit",
-    "settings", "plugins", "status", "ping", "keybinds",
+    "settings", "plugins", "status", "voice", "ping", "keybinds",
 ];
 
 /// Load all skills, apply disable filters, build the command registry,

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -1,0 +1,99 @@
+use crate::{Result, RuntimeError};
+
+pub const WHISPER_SAMPLE_RATE_HZ: u32 = 16_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AudioFormat {
+    pub sample_rate_hz: u32,
+    pub channels: u16,
+}
+
+impl AudioFormat {
+    pub fn new(sample_rate_hz: u32, channels: u16) -> Self {
+        Self {
+            sample_rate_hz,
+            channels: channels.max(1),
+        }
+    }
+}
+
+pub fn interleaved_to_mono_f32(input: &[f32], channels: u16) -> Vec<f32> {
+    let channel_count = usize::from(channels.max(1));
+    if channel_count == 1 {
+        return input.to_vec();
+    }
+
+    input
+        .chunks(channel_count)
+        .map(|frame| frame.iter().copied().sum::<f32>() / frame.len() as f32)
+        .collect()
+}
+
+pub fn resample_linear_mono(input: &[f32], from_rate_hz: u32, to_rate_hz: u32) -> Result<Vec<f32>> {
+    if from_rate_hz == 0 || to_rate_hz == 0 {
+        return Err(RuntimeError::Tool(
+            "audio sample rate must be greater than zero".to_string(),
+        ));
+    }
+    if input.is_empty() || from_rate_hz == to_rate_hz {
+        return Ok(input.to_vec());
+    }
+
+    let output_len = ((input.len() as u64 * to_rate_hz as u64) / from_rate_hz as u64).max(1) as usize;
+    let ratio = from_rate_hz as f64 / to_rate_hz as f64;
+    let mut output = Vec::with_capacity(output_len);
+
+    for out_index in 0..output_len {
+        let src_pos = out_index as f64 * ratio;
+        let left = src_pos.floor() as usize;
+        let right = (left + 1).min(input.len() - 1);
+        let frac = (src_pos - left as f64) as f32;
+        let sample = input[left] * (1.0 - frac) + input[right] * frac;
+        output.push(sample);
+    }
+
+    Ok(output)
+}
+
+pub fn convert_interleaved_to_whisper_pcm(input: &[f32], format: AudioFormat) -> Result<Vec<f32>> {
+    let mono = interleaved_to_mono_f32(input, format.channels);
+    resample_linear_mono(&mono, format.sample_rate_hz, WHISPER_SAMPLE_RATE_HZ)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stereo_interleaved_audio_is_averaged_to_mono() {
+        let mono = interleaved_to_mono_f32(&[1.0, 0.0, 0.25, 0.75], 2);
+
+        assert_eq!(mono, vec![0.5, 0.5]);
+    }
+
+    #[test]
+    fn mono_audio_is_left_unchanged() {
+        let mono = interleaved_to_mono_f32(&[0.1, -0.2, 0.3], 1);
+
+        assert_eq!(mono, vec![0.1, -0.2, 0.3]);
+    }
+
+    #[test]
+    fn resampling_from_48khz_to_16khz_keeps_expected_length() {
+        let input = vec![0.5; 48_000];
+
+        let output = resample_linear_mono(&input, 48_000, 16_000).unwrap();
+
+        assert_eq!(output.len(), 16_000);
+        assert!(output.iter().all(|sample| (*sample - 0.5).abs() < f32::EPSILON));
+    }
+
+    #[test]
+    fn invalid_sample_rate_returns_error_without_panicking() {
+        let err = resample_linear_mono(&[0.0], 0, 16_000)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("sample rate"));
+    }
+}

--- a/src/voice/commands.rs
+++ b/src/voice/commands.rs
@@ -1,0 +1,138 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VoiceCommandAction {
+    Dictation(String),
+    SlashCommand { command: String, arg: String },
+    Submit,
+    Escape,
+    NewLine,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct VoiceCommandConfig {
+    pub commands_enabled: bool,
+    pub submit_enabled: bool,
+    pub escape_enabled: bool,
+}
+
+impl VoiceCommandConfig {
+    pub fn dictation_only() -> Self {
+        Self { commands_enabled: false, submit_enabled: false, escape_enabled: false }
+    }
+}
+
+pub fn map_spoken_phrase(phrase: &str, config: VoiceCommandConfig) -> VoiceCommandAction {
+    let trimmed = phrase.trim();
+    if trimmed.is_empty() || !config.commands_enabled {
+        return VoiceCommandAction::Dictation(trimmed.to_string());
+    }
+
+    let normalized = normalize_phrase(trimmed);
+    if normalized == "new line" || normalized == "newline" {
+        return VoiceCommandAction::NewLine;
+    }
+    if normalized == "submit" || normalized == "send" || normalized == "send it" {
+        return if config.submit_enabled || normalized == "send" || normalized == "send it" {
+            VoiceCommandAction::Submit
+        } else {
+            VoiceCommandAction::Dictation(trimmed.to_string())
+        };
+    }
+    if normalized == "escape" || normalized == "cancel" {
+        return if config.escape_enabled {
+            VoiceCommandAction::Escape
+        } else {
+            VoiceCommandAction::Dictation(trimmed.to_string())
+        };
+    }
+
+    if let Some(rest) = normalized.strip_prefix("slash ") {
+        return match rest {
+            "settings" => VoiceCommandAction::SlashCommand { command: "settings".into(), arg: String::new() },
+            "model" | "models" => VoiceCommandAction::SlashCommand { command: "models".into(), arg: String::new() },
+            "compact" => VoiceCommandAction::SlashCommand { command: "compact".into(), arg: String::new() },
+            "status" => VoiceCommandAction::SlashCommand { command: "status".into(), arg: String::new() },
+            "plugins" => VoiceCommandAction::SlashCommand { command: "plugins".into(), arg: String::new() },
+            _ => VoiceCommandAction::Dictation(trimmed.to_string()),
+        };
+    }
+
+    VoiceCommandAction::Dictation(trimmed.to_string())
+}
+
+fn normalize_phrase(input: &str) -> String {
+    input
+        .trim()
+        .trim_matches(|c: char| matches!(c, '.' | ',' | '!' | '?' | ':' | ';'))
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(submit_enabled: bool) -> VoiceCommandConfig {
+        VoiceCommandConfig { commands_enabled: true, submit_enabled, escape_enabled: false }
+    }
+
+    #[test]
+    fn slash_settings_maps_to_exact_slash_command() {
+        assert_eq!(
+            map_spoken_phrase("slash settings", cfg(false)),
+            VoiceCommandAction::SlashCommand { command: "settings".into(), arg: String::new() }
+        );
+    }
+
+    #[test]
+    fn slash_model_and_models_open_model_flow() {
+        assert_eq!(
+            map_spoken_phrase("Slash model.", cfg(false)),
+            VoiceCommandAction::SlashCommand { command: "models".into(), arg: String::new() }
+        );
+        assert_eq!(
+            map_spoken_phrase("slash models", cfg(false)),
+            VoiceCommandAction::SlashCommand { command: "models".into(), arg: String::new() }
+        );
+    }
+
+    #[test]
+    fn submit_is_dictation_unless_submit_is_enabled() {
+        assert_eq!(map_spoken_phrase("submit", cfg(false)), VoiceCommandAction::Dictation("submit".into()));
+        assert_eq!(map_spoken_phrase("submit", cfg(true)), VoiceCommandAction::Submit);
+    }
+
+    #[test]
+    fn send_and_send_it_submit_without_extra_config() {
+        assert_eq!(map_spoken_phrase("send", cfg(false)), VoiceCommandAction::Submit);
+        assert_eq!(map_spoken_phrase("send it", cfg(false)), VoiceCommandAction::Submit);
+        assert_eq!(map_spoken_phrase("Send it.", cfg(false)), VoiceCommandAction::Submit);
+    }
+
+    #[test]
+    fn near_matches_and_ambiguous_phrases_remain_dictation() {
+        assert_eq!(map_spoken_phrase("slash setting", cfg(false)), VoiceCommandAction::Dictation("slash setting".into()));
+        assert_eq!(map_spoken_phrase("open settings", cfg(false)), VoiceCommandAction::Dictation("open settings".into()));
+    }
+
+    #[test]
+    fn commands_disabled_treats_everything_as_dictation() {
+        assert_eq!(
+            map_spoken_phrase("slash settings", VoiceCommandConfig::dictation_only()),
+            VoiceCommandAction::Dictation("slash settings".into())
+        );
+    }
+
+    #[test]
+    fn new_line_maps_to_text_insertion_not_submit() {
+        assert_eq!(map_spoken_phrase("new line", cfg(false)), VoiceCommandAction::NewLine);
+    }
+
+    #[test]
+    fn escape_is_dictation_unless_escape_is_explicitly_enabled() {
+        assert_eq!(map_spoken_phrase("escape", cfg(false)), VoiceCommandAction::Dictation("escape".into()));
+        let config = VoiceCommandConfig { commands_enabled: true, submit_enabled: false, escape_enabled: true };
+        assert_eq!(map_spoken_phrase("cancel", config), VoiceCommandAction::Escape);
+    }
+}

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -1,0 +1,22 @@
+pub mod types;
+pub mod audio;
+pub mod vad;
+pub mod transcript;
+pub mod commands;
+
+#[cfg(feature = "voice-stt-whisper")]
+pub mod stt_whisper;
+
+#[cfg(feature = "voice-stt-whisper")]
+pub use stt_whisper::WhisperSttProvider;
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+pub use stt_whisper::run_whisper_mic_demo;
+
+pub use audio::{convert_interleaved_to_whisper_pcm, interleaved_to_mono_f32, resample_linear_mono, AudioFormat};
+pub use transcript::{sanitize_voice_transcript, DEFAULT_MAX_VOICE_TRANSCRIPT_CHARS};
+pub use commands::{map_spoken_phrase, VoiceCommandAction, VoiceCommandConfig};
+pub use vad::{VadConfig, VoiceActivityDetector};
+pub use types::{
+    SpeechToTextProvider, TextToSpeechProvider, VoiceEvent, VoiceEventReceiver,
+    VoiceEventSender, VoiceProviderState, VoiceRuntime, VoiceRuntimeHandle,
+};

--- a/src/voice/stt_whisper.rs
+++ b/src/voice/stt_whisper.rs
@@ -1,0 +1,652 @@
+use std::path::{Path, PathBuf};
+#[cfg(feature = "voice-stt-whisper")]
+use std::sync::OnceLock;
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+use std::thread::{self, JoinHandle};
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+use std::time::Duration;
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+use cpal::Sample;
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+use crate::{Result, RuntimeError, SpeechToTextProvider, VoiceEventSender};
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+use crate::voice::audio::{convert_interleaved_to_whisper_pcm, AudioFormat, WHISPER_SAMPLE_RATE_HZ};
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+use crate::voice::vad::{VadConfig, VoiceActivityDetector};
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+use crate::VoiceEvent;
+
+#[cfg(feature = "voice-stt-whisper")]
+static WHISPER_LOG_HOOKS: OnceLock<()> = OnceLock::new();
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+const MIC_AUDIO_BUFFER_CAPACITY: usize = 32;
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+const MIC_WORKER_POLL_MS: u64 = 20;
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+const DEFAULT_DEMO_EVENT_BUFFER: usize = 16;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WhisperSttConfig {
+    pub model_path: PathBuf,
+    pub language: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranscriptionOptions {
+    pub language: Option<String>,
+    pub translate: bool,
+}
+
+#[derive(Debug)]
+pub struct WhisperSttProvider {
+    config: WhisperSttConfig,
+    running: bool,
+    #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+    vad_config: Option<VadConfig>,
+    #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+    stop_signal: Option<Arc<AtomicBool>>,
+    #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+    worker: Option<JoinHandle<()>>,
+}
+
+impl WhisperSttProvider {
+    pub fn new(model_path: impl AsRef<Path>, language: Option<String>) -> Result<Self> {
+        let model_path = model_path.as_ref().to_path_buf();
+        validate_model_path(&model_path)?;
+        Ok(Self {
+            config: WhisperSttConfig { model_path, language },
+            running: false,
+            #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+            vad_config: None,
+            #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+            stop_signal: None,
+            #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+            worker: None,
+        })
+    }
+
+    pub fn from_config(config: &crate::VoiceConfig) -> Result<Self> {
+        let model_path = expand_whisper_model_path(&config.stt_model_path);
+        Self::from_config_fields(model_path, language_option(&config.stt_language), config)
+    }
+
+    #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+    fn from_config_fields(
+        model_path: PathBuf,
+        language: Option<String>,
+        config: &crate::VoiceConfig,
+    ) -> Result<Self> {
+        let mut provider = Self::new(model_path, language)?;
+        provider.vad_config = Some(VadConfig {
+            sample_rate_hz: WHISPER_SAMPLE_RATE_HZ,
+            rms_threshold: config.stt_vad_rms_threshold,
+            silence_submit_ms: config.stt_silence_submit_ms,
+            min_speech_ms: config.stt_min_speech_ms,
+            preroll_ms: config.stt_preroll_ms,
+            max_utterance_ms: config.stt_max_utterance_ms,
+        });
+        if let Some(vad_config) = provider.vad_config {
+            VoiceActivityDetector::new(vad_config)?;
+        }
+        Ok(provider)
+    }
+
+    #[cfg(not(all(feature = "voice-stt-whisper", feature = "voice-mic")))]
+    fn from_config_fields(
+        model_path: PathBuf,
+        language: Option<String>,
+        _config: &crate::VoiceConfig,
+    ) -> Result<Self> {
+        Self::new(model_path, language)
+    }
+
+    pub fn model_path(&self) -> &Path {
+        &self.config.model_path
+    }
+
+    pub fn language(&self) -> Option<&str> {
+        self.config.language.as_deref()
+    }
+
+    pub fn transcription_options(&self) -> TranscriptionOptions {
+        TranscriptionOptions {
+            language: self.config.language.clone(),
+            translate: false,
+        }
+    }
+
+    #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+    fn transcribe_captured_pcm(&self, pcm: &[f32]) -> Result<String> {
+        transcribe_pcm_16khz(&self.config.model_path, pcm, self.config.language.as_deref())
+    }
+}
+
+impl SpeechToTextProvider for WhisperSttProvider {
+    #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+    fn start(&mut self, events: VoiceEventSender) -> Result<()> {
+        if self.running {
+            return Ok(());
+        }
+
+        let stop_signal = Arc::new(AtomicBool::new(false));
+        let worker_stop_signal = stop_signal.clone();
+        let model_path = self.config.model_path.clone();
+        let language = self.config.language.clone();
+        let vad_config = self.vad_config.unwrap_or_default();
+
+        let worker = thread::Builder::new()
+            .name("synaps-voice-mic".to_string())
+            .spawn(move || {
+                run_mic_worker(model_path, language, vad_config, events, worker_stop_signal);
+            })
+            .map_err(|err| RuntimeError::Tool(format!("failed to start voice microphone worker: {err}")))?;
+
+        self.stop_signal = Some(stop_signal);
+        self.worker = Some(worker);
+        self.running = true;
+        Ok(())
+    }
+
+    #[cfg(not(all(feature = "voice-stt-whisper", feature = "voice-mic")))]
+    fn start(&mut self, _events: VoiceEventSender) -> Result<()> {
+        self.running = true;
+        Ok(())
+    }
+
+    fn stop(&mut self) -> Result<()> {
+        #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+        {
+            if let Some(stop_signal) = &self.stop_signal {
+                stop_signal.store(true, Ordering::SeqCst);
+            }
+            if let Some(worker) = self.worker.take() {
+                worker
+                    .join()
+                    .map_err(|_| RuntimeError::Tool("voice microphone worker panicked".to_string()))?;
+            }
+            self.stop_signal = None;
+        }
+        self.running = false;
+        Ok(())
+    }
+
+    fn is_running(&self) -> bool {
+        self.running
+    }
+}
+
+impl Drop for WhisperSttProvider {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}
+
+pub fn validate_model_path(path: &Path) -> Result<()> {
+    if path.to_string_lossy().contains('\0') {
+        return Err(RuntimeError::Tool(
+            "whisper model path contains an invalid null byte".to_string(),
+        ));
+    }
+    if !path.exists() {
+        return Err(RuntimeError::Tool(format!(
+            "whisper model path does not exist: {}",
+            path.display()
+        )));
+    }
+    if !path.is_file() {
+        return Err(RuntimeError::Tool(format!(
+            "whisper model path is not a file: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+pub fn expand_whisper_model_path(path: &Path) -> PathBuf {
+    let path_string = path.to_string_lossy();
+    let expanded = if path_string == "~" {
+        if let Ok(home) = std::env::var("HOME") {
+            PathBuf::from(home)
+        } else {
+            path.to_path_buf()
+        }
+    } else if let Some(rest) = path_string.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            PathBuf::from(home).join(rest)
+        } else {
+            path.to_path_buf()
+        }
+    } else {
+        path.to_path_buf()
+    };
+
+    if expanded.exists() {
+        return expanded;
+    }
+
+    // The historical default points at ggml-base.en.bin, but local installs may
+    // only have another Whisper ggml model downloaded (e.g. tiny for demos).
+    // If the user did not explicitly choose a different filename, discover an
+    // available local model in the same directory instead of failing on the
+    // absent default path.
+    if expanded.file_name().and_then(|name| name.to_str()) == Some("ggml-base.en.bin") {
+        if let Some(parent) = expanded.parent() {
+            if let Ok(entries) = std::fs::read_dir(parent) {
+                let mut candidates = entries
+                    .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                    .filter(|path| path.is_file())
+                    .filter(|path| {
+                        path.file_name()
+                            .and_then(|name| name.to_str())
+                            .is_some_and(|name| name.starts_with("ggml-") && name.ends_with(".bin"))
+                    })
+                    .collect::<Vec<_>>();
+                candidates.sort();
+                if let Some(candidate) = candidates.into_iter().next() {
+                    return candidate;
+                }
+            }
+        }
+    }
+
+    expanded
+}
+
+fn language_option(language: &str) -> Option<String> {
+    let trimmed = language.trim();
+    if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("auto") {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+fn run_mic_worker(
+    model_path: PathBuf,
+    language: Option<String>,
+    vad_config: VadConfig,
+    events: VoiceEventSender,
+    stop_signal: Arc<AtomicBool>,
+) {
+    if let Err(err) = capture_and_transcribe_mic(model_path, language, vad_config, events.clone(), stop_signal) {
+        emit_voice_event(&events, VoiceEvent::Error(err.to_string()));
+    }
+    emit_voice_event(&events, VoiceEvent::ListeningStopped);
+}
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+fn capture_and_transcribe_mic(
+    model_path: PathBuf,
+    language: Option<String>,
+    vad_config: VadConfig,
+    events: VoiceEventSender,
+    stop_signal: Arc<AtomicBool>,
+) -> Result<()> {
+    let (audio_tx, audio_rx) = std::sync::mpsc::sync_channel::<Vec<f32>>(MIC_AUDIO_BUFFER_CAPACITY);
+
+    let stream = MicInputStream::open(events.clone(), audio_tx)?;
+    let mut vad = VoiceActivityDetector::new(vad_config)?;
+
+    stream.play()?;
+    emit_voice_event(&events, VoiceEvent::ListeningStarted);
+
+    while !stop_signal.load(Ordering::SeqCst) {
+        match audio_rx.recv_timeout(Duration::from_millis(MIC_WORKER_POLL_MS)) {
+            Ok(chunk) => {
+                let converted = stream.convert_chunk(&chunk)?;
+                for utterance in vad.process_chunk(&converted) {
+                    transcribe_and_emit(&model_path, &language, &utterance, &events)?;
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+
+    if let Some(utterance) = vad.finish() {
+        transcribe_and_emit(&model_path, &language, &utterance, &events)?;
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+fn transcribe_and_emit(
+    model_path: &Path,
+    language: &Option<String>,
+    pcm: &[f32],
+    events: &VoiceEventSender,
+) -> Result<()> {
+    let transcript = transcribe_pcm_16khz(model_path, pcm, language.as_deref())?;
+    if !transcript.is_empty() {
+        emit_voice_event(events, VoiceEvent::FinalTranscript(transcript));
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+struct MicInputStream {
+    stream: cpal::Stream,
+    format: AudioFormat,
+}
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+impl MicInputStream {
+    fn open(events: VoiceEventSender, audio_tx: std::sync::mpsc::SyncSender<Vec<f32>>) -> Result<Self> {
+        let host = cpal::default_host();
+        let device = host
+            .default_input_device()
+            .ok_or_else(|| RuntimeError::Tool("no default microphone input device is available".to_string()))?;
+        let config = device
+            .default_input_config()
+            .map_err(|err| RuntimeError::Tool(format!("failed to read default microphone input config: {err}")))?;
+        let sample_rate_hz = config.sample_rate().0;
+        let channels = config.channels();
+        let stream_config: cpal::StreamConfig = config.clone().into();
+        let stream = match config.sample_format() {
+            cpal::SampleFormat::F32 => build_input_stream::<f32>(&device, &stream_config, audio_tx.clone(), events),
+            cpal::SampleFormat::I16 => build_input_stream::<i16>(&device, &stream_config, audio_tx.clone(), events),
+            cpal::SampleFormat::U16 => build_input_stream::<u16>(&device, &stream_config, audio_tx.clone(), events),
+            sample_format => Err(RuntimeError::Tool(format!(
+                "unsupported microphone sample format: {sample_format:?}"
+            ))),
+        }?;
+        Ok(Self {
+            stream,
+            format: AudioFormat::new(sample_rate_hz, channels),
+        })
+    }
+
+    fn play(&self) -> Result<()> {
+        self.stream
+            .play()
+            .map_err(|err| RuntimeError::Tool(format!("failed to start microphone input stream: {err}")))
+    }
+
+    fn convert_chunk(&self, chunk: &[f32]) -> Result<Vec<f32>> {
+        convert_interleaved_to_whisper_pcm(chunk, self.format)
+    }
+}
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+fn input_samples_to_f32<T>(data: &[T]) -> Vec<f32>
+where
+    T: cpal::Sample + cpal::SizedSample,
+    f32: cpal::FromSample<T>,
+{
+    data.iter().copied().map(f32::from_sample).collect()
+}
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+fn build_input_stream<T>(
+    device: &cpal::Device,
+    config: &cpal::StreamConfig,
+    audio_tx: std::sync::mpsc::SyncSender<Vec<f32>>,
+    events: VoiceEventSender,
+) -> Result<cpal::Stream>
+where
+    T: cpal::Sample + cpal::SizedSample,
+    f32: cpal::FromSample<T>,
+{
+    device
+        .build_input_stream(
+            config,
+            move |data: &[T], _| {
+                let chunk = input_samples_to_f32(data);
+                let _ = audio_tx.try_send(chunk);
+            },
+            move |err| {
+                emit_voice_event(&events, VoiceEvent::Error(format!("microphone input stream error: {err}")));
+            },
+            None,
+        )
+        .map_err(|err| RuntimeError::Tool(format!("failed to build microphone input stream: {err}")))
+}
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+fn emit_voice_event(events: &VoiceEventSender, event: VoiceEvent) {
+    let _ = events.try_send(event);
+}
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+pub fn run_whisper_mic_demo(model_path: PathBuf, language: Option<String>, seconds: u64) -> Result<()> {
+    let print_transcript = demo_print_transcript_enabled(std::env::var("SYNAPS_VOICE_DEMO_PRINT_TRANSCRIPT").ok().as_deref());
+    let provider = WhisperSttProvider::new(&model_path, language)?;
+    let (audio_tx, audio_rx) = std::sync::mpsc::sync_channel::<Vec<f32>>(MIC_AUDIO_BUFFER_CAPACITY);
+    let (events, mut rx) = tokio::sync::mpsc::channel(DEFAULT_DEMO_EVENT_BUFFER);
+    let stop_signal = Arc::new(AtomicBool::new(false));
+    let worker_stop_signal = stop_signal.clone();
+    let event_worker = thread::Builder::new()
+        .name("synaps-voice-demo-events".to_string())
+        .spawn(move || {
+            while let Some(event) = rx.blocking_recv() {
+                match event {
+                    VoiceEvent::ListeningStarted => eprintln!("[voice] listening started"),
+                    VoiceEvent::ListeningStopped => eprintln!("[voice] listening stopped"),
+                    VoiceEvent::PartialTranscript(_) => eprintln!("[voice] partial transcript received"),
+                    VoiceEvent::FinalTranscript(_) => eprintln!("[voice] final transcript received"),
+                    VoiceEvent::Error(err) => eprintln!("[voice] error: {err}"),
+                    VoiceEvent::TtsStarted => eprintln!("[voice] tts started"),
+                    VoiceEvent::TtsStopped => eprintln!("[voice] tts stopped"),
+                }
+            }
+        })
+        .map_err(|err| RuntimeError::Tool(format!("failed to start voice demo event worker: {err}")))?;
+
+    let stream = MicInputStream::open(events.clone(), audio_tx)?;
+    stream.play()?;
+    emit_voice_event(&events, VoiceEvent::ListeningStarted);
+    eprintln!("[voice] recording for {seconds}s; speak now, then wait for transcription...");
+    let capture_until = std::time::Instant::now() + Duration::from_secs(seconds);
+    let target_samples = WHISPER_SAMPLE_RATE_HZ as usize * seconds.max(1) as usize;
+    let mut pcm = Vec::with_capacity(target_samples);
+    while std::time::Instant::now() < capture_until && !worker_stop_signal.load(Ordering::SeqCst) {
+        match audio_rx.recv_timeout(Duration::from_millis(MIC_WORKER_POLL_MS)) {
+            Ok(chunk) => pcm.extend(stream.convert_chunk(&chunk)?),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    stop_signal.store(true, Ordering::SeqCst);
+    drop(stream);
+    emit_voice_event(&events, VoiceEvent::ListeningStopped);
+    if pcm.is_empty() {
+        return Err(RuntimeError::Tool("microphone produced no audio samples".to_string()));
+    }
+    eprintln!("[voice] captured audio; transcribing...");
+    let transcript = provider.transcribe_captured_pcm(&pcm)?;
+    if transcript.is_empty() {
+        eprintln!("[voice] final transcript was empty");
+    } else if print_transcript {
+        eprintln!("[voice] final transcript: {transcript}");
+    } else {
+        eprintln!("[voice] final transcript received (not printed for privacy; set SYNAPS_VOICE_DEMO_PRINT_TRANSCRIPT=1 for this demo only)");
+    }
+    drop(events);
+    event_worker
+        .join()
+        .map_err(|_| RuntimeError::Tool("voice demo event worker panicked".to_string()))?;
+    Ok(())
+}
+
+#[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+fn demo_print_transcript_enabled(value: Option<&str>) -> bool {
+    matches!(
+        value.map(str::trim),
+        Some("1") | Some("true") | Some("TRUE") | Some("yes") | Some("YES") | Some("on") | Some("ON")
+    )
+}
+
+#[cfg(feature = "voice-stt-whisper")]
+pub fn transcribe_pcm_16khz(model_path: &Path, pcm: &[f32], language: Option<&str>) -> Result<String> {
+    if pcm.is_empty() {
+        return Err(RuntimeError::Tool(
+            "whisper transcription requires non-empty 16kHz mono PCM".to_string(),
+        ));
+    }
+    validate_model_path(model_path)?;
+
+    WHISPER_LOG_HOOKS.get_or_init(|| {
+        whisper_rs::install_logging_hooks();
+    });
+    let context = whisper_rs::WhisperContext::new_with_params(
+        model_path,
+        whisper_rs::WhisperContextParameters::default(),
+    )
+    .map_err(|err| RuntimeError::Tool(format!("failed to load whisper model: {err}")))?;
+    let mut state = context
+        .create_state()
+        .map_err(|err| RuntimeError::Tool(format!("failed to create whisper state: {err}")))?;
+    let mut params = whisper_rs::FullParams::new(whisper_rs::SamplingStrategy::Greedy { best_of: 1 });
+    params.set_print_progress(false);
+    params.set_print_realtime(false);
+    params.set_print_timestamps(false);
+    params.set_print_special(false);
+    params.set_no_timestamps(true);
+    params.set_language(language);
+
+    state
+        .full(params, pcm)
+        .map_err(|err| RuntimeError::Tool(format!("whisper transcription failed: {err}")))?;
+
+    let mut transcript = String::new();
+    for segment in state.as_iter() {
+        let text = segment
+            .to_str()
+            .map_err(|err| RuntimeError::Tool(format!("failed to read whisper transcript segment: {err}")))?;
+        transcript.push_str(text);
+    }
+    Ok(transcript.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_model_path_returns_actionable_error() {
+        let path = PathBuf::from("/tmp/synaps-cli-missing-whisper-model.bin");
+
+        let err = WhisperSttProvider::new(&path, Some("en".to_string()))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("whisper model path does not exist"));
+        assert!(err.contains(path.to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn directory_model_path_returns_actionable_error() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let err = WhisperSttProvider::new(dir.path(), None)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("whisper model path is not a file"));
+    }
+
+    #[test]
+    fn null_byte_model_path_returns_actionable_error() {
+        let path = PathBuf::from("/tmp/synaps\0whisper.bin");
+
+        let err = validate_model_path(&path).unwrap_err().to_string();
+
+        assert!(err.contains("invalid null byte"));
+    }
+
+    #[test]
+    fn provider_construction_accepts_existing_model_file_path() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+
+        let provider = WhisperSttProvider::new(file.path(), Some("en".to_string())).unwrap();
+
+        assert_eq!(provider.model_path(), file.path());
+        assert_eq!(provider.language(), Some("en"));
+    }
+
+    #[test]
+    fn provider_start_stop_tracks_running_state_without_opening_microphone() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let mut provider = WhisperSttProvider::new(file.path(), None).unwrap();
+        let (events, _rx) = tokio::sync::mpsc::channel(1);
+
+        assert!(!provider.is_running());
+        provider.start(events).unwrap();
+        assert!(provider.is_running());
+        provider.stop().unwrap();
+        assert!(!provider.is_running());
+    }
+
+    #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+    #[test]
+    fn input_samples_are_converted_to_f32_without_opening_microphone() {
+        assert_eq!(input_samples_to_f32(&[0.0_f32, -0.5, 0.5]), vec![0.0, -0.5, 0.5]);
+
+        let i16_audio = input_samples_to_f32(&[0_i16, i16::MAX]);
+        assert_eq!(i16_audio[0], 0.0);
+        assert!((i16_audio[1] - 1.0).abs() < 0.0001);
+
+        let u16_audio = input_samples_to_f32(&[0_u16, u16::MAX]);
+        assert!((u16_audio[0] + 1.0).abs() < 0.0001);
+        assert!((u16_audio[1] - 1.0).abs() < 0.0001);
+    }
+
+    #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+    #[test]
+    fn mic_event_sender_drops_when_channel_is_full_without_blocking() {
+        let (events, _rx) = tokio::sync::mpsc::channel(1);
+
+        emit_voice_event(&events, VoiceEvent::ListeningStarted);
+        emit_voice_event(&events, VoiceEvent::ListeningStopped);
+    }
+
+    #[cfg(all(feature = "voice-stt-whisper", feature = "voice-mic"))]
+    #[test]
+    fn demo_prints_transcript_only_when_explicitly_enabled() {
+        assert!(!demo_print_transcript_enabled(None));
+        assert!(!demo_print_transcript_enabled(Some("")));
+        assert!(!demo_print_transcript_enabled(Some("false")));
+        assert!(demo_print_transcript_enabled(Some("1")));
+        assert!(demo_print_transcript_enabled(Some("true")));
+        assert!(demo_print_transcript_enabled(Some("yes")));
+    }
+
+    #[test]
+    fn model_path_expands_home_prefix_without_validating_until_provider_construction() {
+        let home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", home.path());
+
+        let expanded = expand_whisper_model_path(Path::new("~/models/whisper.bin"));
+
+        assert_eq!(expanded, home.path().join("models/whisper.bin"));
+    }
+
+    #[test]
+    fn auto_language_maps_to_none_for_whisper_auto_detection() {
+        assert_eq!(language_option("auto"), None);
+        assert_eq!(language_option(""), None);
+        assert_eq!(language_option(" en "), Some("en".to_string()));
+    }
+
+    #[cfg(feature = "voice-stt-whisper")]
+    #[test]
+    fn empty_pcm_returns_clear_error_before_loading_model() {
+        let path = PathBuf::from("/tmp/synaps-cli-missing-whisper-model.bin");
+
+        let err = transcribe_pcm_16khz(&path, &[], Some("en"))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("non-empty 16kHz mono PCM"));
+    }
+}

--- a/src/voice/transcript.rs
+++ b/src/voice/transcript.rs
@@ -1,0 +1,66 @@
+pub const DEFAULT_MAX_VOICE_TRANSCRIPT_CHARS: usize = 16_000;
+
+pub fn sanitize_voice_transcript(input: &str, max_chars: usize) -> String {
+    let normalized = input.replace("\r\n", "\n").replace('\r', "\n");
+    let without_ansi = strip_ansi_escape_sequences(&normalized);
+    let mut output = String::new();
+    for ch in without_ansi.chars() {
+        if output.chars().count() >= max_chars {
+            break;
+        }
+        match ch {
+            '\n' | '\t' => output.push(ch),
+            c if c.is_control() => {}
+            c => output.push(c),
+        }
+    }
+    output
+}
+
+fn strip_ansi_escape_sequences(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && matches!(chars.peek(), Some('[')) {
+            chars.next();
+            for next in chars.by_ref() {
+                if ('@'..='~').contains(&next) {
+                    break;
+                }
+            }
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_crlf_and_stray_cr() {
+        assert_eq!(sanitize_voice_transcript("a\r\nb\rc", 100), "a\nb\nc");
+    }
+
+    #[test]
+    fn strips_ansi_escape_sequences() {
+        assert_eq!(sanitize_voice_transcript("hello \u{1b}[31mred\u{1b}[0m", 100), "hello red");
+    }
+
+    #[test]
+    fn strips_disallowed_control_characters_but_keeps_tab_and_newline() {
+        assert_eq!(sanitize_voice_transcript("a\u{0000}b\t c\n", 100), "ab\t c\n");
+    }
+
+    #[test]
+    fn truncates_by_chars_without_splitting_unicode() {
+        assert_eq!(sanitize_voice_transcript("🙂🙂🙂abc", 4), "🙂🙂🙂a");
+    }
+
+    #[test]
+    fn zero_max_chars_returns_empty_string() {
+        assert_eq!(sanitize_voice_transcript("hello", 0), "");
+    }
+}

--- a/src/voice/types.rs
+++ b/src/voice/types.rs
@@ -1,0 +1,362 @@
+use crate::{Result, RuntimeError};
+
+pub type VoiceEventSender = tokio::sync::mpsc::Sender<VoiceEvent>;
+pub type VoiceEventReceiver = tokio::sync::mpsc::Receiver<VoiceEvent>;
+
+pub const DEFAULT_VOICE_EVENT_BUFFER: usize = 128;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VoiceEvent {
+    ListeningStarted,
+    ListeningStopped,
+    PartialTranscript(String),
+    FinalTranscript(String),
+    Error(String),
+    TtsStarted,
+    TtsStopped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VoiceProviderState {
+    Stopped,
+    Running,
+    Stopping,
+}
+
+pub trait SpeechToTextProvider: Send {
+    fn start(&mut self, events: VoiceEventSender) -> Result<()>;
+    fn stop(&mut self) -> Result<()>;
+    fn is_running(&self) -> bool;
+}
+
+pub trait TextToSpeechProvider: Send {
+    fn speak(&mut self, text: &str, events: VoiceEventSender) -> Result<()>;
+    fn stop(&mut self) -> Result<()>;
+    fn is_running(&self) -> bool;
+}
+
+#[derive(Debug)]
+pub struct VoiceRuntimeHandle {
+    events: VoiceEventSender,
+}
+
+impl VoiceRuntimeHandle {
+    pub fn events(&self) -> VoiceEventSender {
+        self.events.clone()
+    }
+
+    pub fn try_emit(&self, event: VoiceEvent) -> Result<()> {
+        self.events
+            .try_send(event)
+            .map_err(|err| RuntimeError::Tool(format!("voice event channel unavailable: {err}")))
+    }
+}
+
+pub struct VoiceRuntime {
+    events_tx: VoiceEventSender,
+    events_rx: VoiceEventReceiver,
+    stt: Option<Box<dyn SpeechToTextProvider>>,
+    tts: Option<Box<dyn TextToSpeechProvider>>,
+    state: VoiceProviderState,
+    worker_handles: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl VoiceRuntime {
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_VOICE_EVENT_BUFFER)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        let (events_tx, events_rx) = tokio::sync::mpsc::channel(capacity.max(1));
+        Self {
+            events_tx,
+            events_rx,
+            stt: None,
+            tts: None,
+            state: VoiceProviderState::Stopped,
+            worker_handles: Vec::new(),
+        }
+    }
+
+    pub fn with_providers(
+        stt: Option<Box<dyn SpeechToTextProvider>>,
+        tts: Option<Box<dyn TextToSpeechProvider>>,
+    ) -> Self {
+        let mut runtime = Self::new();
+        runtime.stt = stt;
+        runtime.tts = tts;
+        runtime
+    }
+
+    pub fn handle(&self) -> VoiceRuntimeHandle {
+        VoiceRuntimeHandle {
+            events: self.events_tx.clone(),
+        }
+    }
+
+    pub fn event_sender(&self) -> VoiceEventSender {
+        self.events_tx.clone()
+    }
+
+    pub fn try_emit(&self, event: VoiceEvent) -> Result<()> {
+        self.events_tx
+            .try_send(event)
+            .map_err(|err| RuntimeError::Tool(format!("voice event channel unavailable: {err}")))
+    }
+
+    pub async fn join_worker(&self, handle: tokio::task::JoinHandle<()>) -> Result<()> {
+        handle
+            .await
+            .map_err(|err| RuntimeError::Tool(format!("voice worker join failed: {err}")))
+    }
+
+    pub fn track_worker(&mut self, handle: tokio::task::JoinHandle<()>) {
+        self.worker_handles.push(handle);
+    }
+
+    pub async fn join_workers(&mut self) -> Result<()> {
+        while let Some(handle) = self.worker_handles.pop() {
+            handle
+                .await
+                .map_err(|err| RuntimeError::Tool(format!("voice worker join failed: {err}")))?;
+        }
+        Ok(())
+    }
+
+    pub async fn recv(&mut self) -> Option<VoiceEvent> {
+        self.events_rx.recv().await
+    }
+
+    pub fn try_recv(&mut self) -> Option<VoiceEvent> {
+        self.events_rx.try_recv().ok()
+    }
+
+    pub fn event_receiver_mut(&mut self) -> &mut VoiceEventReceiver {
+        &mut self.events_rx
+    }
+
+    pub fn close_events(&mut self) {
+        self.events_rx.close();
+    }
+
+    pub fn state(&self) -> VoiceProviderState {
+        self.state
+    }
+
+    pub fn set_stt_provider(&mut self, provider: Box<dyn SpeechToTextProvider>) {
+        self.stt = Some(provider);
+    }
+
+    pub fn set_tts_provider(&mut self, provider: Box<dyn TextToSpeechProvider>) {
+        self.tts = Some(provider);
+    }
+
+    pub fn start_listening(&mut self) -> Result<()> {
+        if let Some(stt) = self.stt.as_mut() {
+            stt.start(self.events_tx.clone())?;
+            self.state = VoiceProviderState::Running;
+        }
+        Ok(())
+    }
+
+    pub fn stop_listening(&mut self) -> Result<()> {
+        if let Some(stt) = self.stt.as_mut() {
+            self.state = VoiceProviderState::Stopping;
+            stt.stop()?;
+        }
+        self.state = VoiceProviderState::Stopped;
+        Ok(())
+    }
+
+    pub fn speak(&mut self, text: &str) -> Result<()> {
+        if let Some(tts) = self.tts.as_mut() {
+            tts.speak(text, self.events_tx.clone())?;
+        }
+        Ok(())
+    }
+
+    pub fn stop_tts(&mut self) -> Result<()> {
+        if let Some(tts) = self.tts.as_mut() {
+            tts.stop()?;
+        }
+        Ok(())
+    }
+
+    pub fn shutdown(&mut self) -> Result<()> {
+        self.close_events();
+        self.stop_listening()?;
+        self.stop_tts()?;
+        Ok(())
+    }
+}
+
+impl Default for VoiceRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for VoiceRuntime {
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct StubStt {
+        starts: usize,
+        stops: usize,
+        running: bool,
+        events: Arc<Mutex<Vec<VoiceEvent>>>,
+    }
+
+    impl SpeechToTextProvider for StubStt {
+        fn start(&mut self, events: VoiceEventSender) -> Result<()> {
+            self.starts += 1;
+            self.running = true;
+            let event = VoiceEvent::ListeningStarted;
+            self.events.lock().unwrap().push(event.clone());
+            events
+                .try_send(event)
+                .map_err(|err| RuntimeError::Tool(format!("voice event channel unavailable: {err}")))?;
+            Ok(())
+        }
+
+        fn stop(&mut self) -> Result<()> {
+            self.stops += 1;
+            self.running = false;
+            Ok(())
+        }
+
+        fn is_running(&self) -> bool {
+            self.running
+        }
+    }
+
+    #[derive(Default)]
+    struct StubTts {
+        speaks: Vec<String>,
+        stops: usize,
+    }
+
+    impl TextToSpeechProvider for StubTts {
+        fn speak(&mut self, text: &str, events: VoiceEventSender) -> Result<()> {
+            self.speaks.push(text.to_string());
+            events
+                .try_send(VoiceEvent::TtsStarted)
+                .map_err(|err| RuntimeError::Tool(format!("voice event channel unavailable: {err}")))?;
+            events
+                .try_send(VoiceEvent::TtsStopped)
+                .map_err(|err| RuntimeError::Tool(format!("voice event channel unavailable: {err}")))?;
+            Ok(())
+        }
+
+        fn stop(&mut self) -> Result<()> {
+            self.stops += 1;
+            Ok(())
+        }
+
+        fn is_running(&self) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn voice_event_covers_stt_tts_and_errors() {
+        assert_eq!(VoiceEvent::ListeningStarted, VoiceEvent::ListeningStarted);
+        assert_eq!(VoiceEvent::ListeningStopped, VoiceEvent::ListeningStopped);
+        assert_eq!(VoiceEvent::PartialTranscript("hel".into()), VoiceEvent::PartialTranscript("hel".into()));
+        assert_eq!(VoiceEvent::FinalTranscript("hello".into()), VoiceEvent::FinalTranscript("hello".into()));
+        assert_eq!(VoiceEvent::Error("mic unavailable".into()), VoiceEvent::Error("mic unavailable".into()));
+        assert_eq!(VoiceEvent::TtsStarted, VoiceEvent::TtsStarted);
+        assert_eq!(VoiceEvent::TtsStopped, VoiceEvent::TtsStopped);
+    }
+
+    #[tokio::test]
+    async fn runtime_forwards_stt_events_through_bounded_channel() {
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let stt = StubStt {
+            events: observed.clone(),
+            ..StubStt::default()
+        };
+        let mut runtime = VoiceRuntime::with_capacity(1);
+        runtime.set_stt_provider(Box::new(stt));
+
+        runtime.start_listening().unwrap();
+
+        assert_eq!(runtime.state(), VoiceProviderState::Running);
+        assert_eq!(runtime.recv().await, Some(VoiceEvent::ListeningStarted));
+        assert_eq!(observed.lock().unwrap().as_slice(), &[VoiceEvent::ListeningStarted]);
+    }
+
+    #[tokio::test]
+    async fn runtime_forwards_tts_events_through_channel() {
+        let mut runtime = VoiceRuntime::with_capacity(4);
+        runtime.set_tts_provider(Box::new(StubTts::default()));
+
+        runtime.speak("hello from Synaps").unwrap();
+
+        assert_eq!(runtime.recv().await, Some(VoiceEvent::TtsStarted));
+        assert_eq!(runtime.recv().await, Some(VoiceEvent::TtsStopped));
+    }
+
+    #[test]
+    fn runtime_channel_is_bounded_and_backpressure_aware() {
+        let runtime = VoiceRuntime::with_capacity(1);
+        runtime.try_emit(VoiceEvent::PartialTranscript("one".into())).unwrap();
+
+        let result = runtime.try_emit(VoiceEvent::PartialTranscript("two".into()));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn shutdown_stops_without_tui_side_effects() {
+        let mut runtime = VoiceRuntime::with_capacity(1);
+        runtime.set_stt_provider(Box::new(StubStt::default()));
+        runtime.set_tts_provider(Box::new(StubTts::default()));
+        runtime.start_listening().unwrap();
+
+        runtime.shutdown().unwrap();
+
+        assert_eq!(runtime.state(), VoiceProviderState::Stopped);
+    }
+
+    #[tokio::test]
+    async fn closing_events_unblocks_receiver_and_worker_can_be_joined() {
+        let mut runtime = VoiceRuntime::with_capacity(1);
+        runtime.close_events();
+
+        let worker = tokio::spawn(async {});
+
+        assert_eq!(runtime.recv().await, None);
+        runtime.join_worker(worker).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn tracked_workers_are_joined_during_graceful_shutdown() {
+        let mut runtime = VoiceRuntime::with_capacity(1);
+        runtime.track_worker(tokio::spawn(async {}));
+        runtime.track_worker(tokio::spawn(async {}));
+
+        runtime.join_workers().await.unwrap();
+        runtime.join_workers().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn worker_panics_surface_as_join_errors() {
+        let mut runtime = VoiceRuntime::with_capacity(1);
+        runtime.track_worker(tokio::spawn(async {
+            panic!("voice worker panic for test");
+        }));
+
+        let err = runtime.join_workers().await.unwrap_err().to_string();
+
+        assert!(err.contains("voice worker join failed"));
+    }
+}

--- a/src/voice/vad.rs
+++ b/src/voice/vad.rs
@@ -1,0 +1,246 @@
+use std::collections::VecDeque;
+
+use crate::{Result, RuntimeError};
+
+use super::audio::WHISPER_SAMPLE_RATE_HZ;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VadConfig {
+    pub sample_rate_hz: u32,
+    pub rms_threshold: f32,
+    pub silence_submit_ms: u64,
+    pub min_speech_ms: u64,
+    pub preroll_ms: u64,
+    pub max_utterance_ms: u64,
+}
+
+impl Default for VadConfig {
+    fn default() -> Self {
+        Self {
+            sample_rate_hz: WHISPER_SAMPLE_RATE_HZ,
+            rms_threshold: 0.01,
+            silence_submit_ms: 1_000,
+            min_speech_ms: 250,
+            preroll_ms: 300,
+            max_utterance_ms: 30_000,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct VoiceActivityDetector {
+    config: VadConfig,
+    preroll: VecDeque<f32>,
+    utterance: Vec<f32>,
+    speaking: bool,
+    speech_samples: usize,
+    trailing_silence_samples: usize,
+}
+
+impl VoiceActivityDetector {
+    pub fn new(config: VadConfig) -> Result<Self> {
+        validate_vad_config(config)?;
+        Ok(Self {
+            config,
+            preroll: VecDeque::with_capacity(samples_for_ms(config.sample_rate_hz, config.preroll_ms)),
+            utterance: Vec::new(),
+            speaking: false,
+            speech_samples: 0,
+            trailing_silence_samples: 0,
+        })
+    }
+
+    pub fn process_chunk(&mut self, chunk: &[f32]) -> Vec<Vec<f32>> {
+        let mut utterances = Vec::new();
+        if chunk.is_empty() {
+            return utterances;
+        }
+
+        let is_speech = rms(chunk) >= self.config.rms_threshold;
+        if is_speech {
+            if !self.speaking {
+                self.start_utterance_with_preroll();
+            }
+            self.utterance.extend_from_slice(chunk);
+            self.speech_samples = self.speech_samples.saturating_add(chunk.len());
+            self.trailing_silence_samples = 0;
+        } else if self.speaking {
+            self.utterance.extend_from_slice(chunk);
+            self.trailing_silence_samples = self.trailing_silence_samples.saturating_add(chunk.len());
+        } else {
+            self.push_preroll(chunk);
+        }
+
+        let max_samples = samples_for_ms(self.config.sample_rate_hz, self.config.max_utterance_ms);
+        if self.speaking && self.utterance.len() >= max_samples {
+            if let Some(utterance) = self.take_valid_utterance() {
+                utterances.push(utterance);
+            }
+        } else {
+            let silence_samples = samples_for_ms(self.config.sample_rate_hz, self.config.silence_submit_ms);
+            if self.speaking && self.trailing_silence_samples >= silence_samples {
+                if let Some(utterance) = self.take_valid_utterance() {
+                    utterances.push(utterance);
+                }
+            }
+        }
+
+        utterances
+    }
+
+    pub fn finish(&mut self) -> Option<Vec<f32>> {
+        if self.speaking {
+            self.take_valid_utterance()
+        } else {
+            None
+        }
+    }
+
+    fn start_utterance_with_preroll(&mut self) {
+        self.speaking = true;
+        self.utterance.extend(self.preroll.drain(..));
+    }
+
+    fn push_preroll(&mut self, chunk: &[f32]) {
+        let max_preroll_samples = samples_for_ms(self.config.sample_rate_hz, self.config.preroll_ms);
+        for sample in chunk {
+            self.preroll.push_back(*sample);
+            while self.preroll.len() > max_preroll_samples {
+                self.preroll.pop_front();
+            }
+        }
+    }
+
+    fn take_valid_utterance(&mut self) -> Option<Vec<f32>> {
+        let min_samples = samples_for_ms(self.config.sample_rate_hz, self.config.min_speech_ms);
+        let max_samples = samples_for_ms(self.config.sample_rate_hz, self.config.max_utterance_ms);
+        let speech_samples = self.speech_samples;
+        let mut utterance = std::mem::take(&mut self.utterance);
+        self.speaking = false;
+        self.speech_samples = 0;
+        self.trailing_silence_samples = 0;
+        self.preroll.clear();
+
+        if utterance.len() > max_samples {
+            utterance.truncate(max_samples);
+        }
+
+        if speech_samples >= min_samples {
+            Some(utterance)
+        } else {
+            None
+        }
+    }
+}
+
+fn validate_vad_config(config: VadConfig) -> Result<()> {
+    if config.sample_rate_hz == 0 {
+        return Err(RuntimeError::Tool("VAD sample rate must be greater than zero".to_string()));
+    }
+    if !config.rms_threshold.is_finite() || config.rms_threshold < 0.0 {
+        return Err(RuntimeError::Tool("VAD RMS threshold must be a finite non-negative value".to_string()));
+    }
+    if config.max_utterance_ms == 0 {
+        return Err(RuntimeError::Tool("VAD max utterance duration must be greater than zero".to_string()));
+    }
+    Ok(())
+}
+
+fn samples_for_ms(sample_rate_hz: u32, ms: u64) -> usize {
+    ((sample_rate_hz as u64).saturating_mul(ms) / 1_000) as usize
+}
+
+fn rms(chunk: &[f32]) -> f32 {
+    if chunk.is_empty() {
+        return 0.0;
+    }
+    let mean_square = chunk.iter().map(|sample| sample * sample).sum::<f32>() / chunk.len() as f32;
+    mean_square.sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> VadConfig {
+        VadConfig {
+            sample_rate_hz: 1_000,
+            rms_threshold: 0.1,
+            silence_submit_ms: 100,
+            min_speech_ms: 50,
+            preroll_ms: 20,
+            max_utterance_ms: 500,
+        }
+    }
+
+    #[test]
+    fn silence_does_not_emit_utterances() {
+        let mut vad = VoiceActivityDetector::new(test_config()).unwrap();
+
+        for _ in 0..20 {
+            assert!(vad.process_chunk(&vec![0.0; 10]).is_empty());
+        }
+        assert!(vad.finish().is_none());
+    }
+
+    #[test]
+    fn speech_followed_by_configured_silence_emits_final_utterance() {
+        let mut vad = VoiceActivityDetector::new(test_config()).unwrap();
+
+        assert!(vad.process_chunk(&vec![0.2; 60]).is_empty());
+        assert!(vad.process_chunk(&vec![0.0; 90]).is_empty());
+        let utterances = vad.process_chunk(&vec![0.0; 10]);
+
+        assert_eq!(utterances.len(), 1);
+        assert!(utterances[0].len() >= 60);
+    }
+
+    #[test]
+    fn short_noise_burst_below_min_speech_is_discarded() {
+        let mut vad = VoiceActivityDetector::new(test_config()).unwrap();
+
+        assert!(vad.process_chunk(&vec![0.2; 30]).is_empty());
+        assert!(vad.process_chunk(&vec![0.0; 100]).is_empty());
+        assert!(vad.finish().is_none());
+    }
+
+    #[test]
+    fn preroll_is_preserved_when_speech_starts() {
+        let mut vad = VoiceActivityDetector::new(test_config()).unwrap();
+
+        assert!(vad.process_chunk(&vec![0.01; 20]).is_empty());
+        assert!(vad.process_chunk(&vec![0.2; 60]).is_empty());
+        let utterance = vad.process_chunk(&vec![0.0; 100]).remove(0);
+
+        assert!(utterance.starts_with(&vec![0.01; 20]));
+    }
+
+    #[test]
+    fn max_utterance_duration_forces_emit_without_waiting_for_silence() {
+        let mut vad = VoiceActivityDetector::new(test_config()).unwrap();
+
+        let utterances = vad.process_chunk(&vec![0.2; 500]);
+
+        assert_eq!(utterances.len(), 1);
+        assert_eq!(utterances[0].len(), 500);
+    }
+
+    #[test]
+    fn oversized_input_chunk_is_capped_at_max_utterance_duration() {
+        let mut vad = VoiceActivityDetector::new(test_config()).unwrap();
+
+        let utterances = vad.process_chunk(&vec![0.2; 800]);
+
+        assert_eq!(utterances.len(), 1);
+        assert_eq!(utterances[0].len(), 500);
+    }
+
+    #[test]
+    fn invalid_config_returns_error_without_panicking() {
+        let err = VoiceActivityDetector::new(VadConfig { sample_rate_hz: 0, ..test_config() })
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("sample rate"));
+    }
+}


### PR DESCRIPTION
## Summary
- add local voice config, feature flags, provider runtime contracts, and bounded voice events
- add Whisper/cpal microphone dictation with VAD utterance segmentation
- insert sanitized final transcripts into chat/settings/plugins input contexts
- add /voice on|off|status, F8 voice toggle, and conservative spoken commands including send/send it
- include voice mic demo binary and local model path fallback discovery

## Verification
- cargo check --bin synaps
- cargo check --features voice-stt-whisper,voice-mic --bin synaps
- cargo test voice --lib
- cargo test voice_input --bin synaps
- cargo test voice_keybind_tests --bin synaps
