### PR TITLE
fix(bash): honor requested timeouts

### DIFF
--- a/src/chatui/settings/defs.rs
+++ b/src/chatui/settings/defs.rs
@@ -114,7 +114,7 @@ define_settings! {
         };
 
     bash_max_timeout, "Bash max timeout", ToolLimits, EditorKind::Text { numeric: true },
-        "Upper bound on requested bash timeouts.",
+        "Legacy setting retained for config compatibility; requested bash timeouts are no longer clamped.",
         |runtime, _app, value| {
             if let Ok(n) = value.parse::<u64>() { runtime.set_bash_max_timeout(n); }
         };

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -9,7 +9,7 @@ impl Tool for BashTool {
     fn name(&self) -> &str { "bash" }
 
     fn description(&self) -> &str {
-        "Execute a bash command and return its output. Use for running programs, installing packages, git operations, and any shell commands. Commands time out after 30 seconds."
+        "Execute a bash command and return its output. Use for running programs, installing packages, git operations, and any shell commands. Commands time out after 30 seconds by default; pass a larger timeout when needed."
     }
 
     fn parameters(&self) -> Value {
@@ -22,7 +22,7 @@ impl Tool for BashTool {
                 },
                 "timeout": {
                     "type": "integer",
-                    "description": "Timeout in seconds (default: 30, max: 300)"
+                    "description": "Timeout in seconds (default: 30). Use a larger value for long-running commands."
                 }
             },
             "required": ["command"]
@@ -33,7 +33,7 @@ impl Tool for BashTool {
         let command = params["command"].as_str()
             .ok_or_else(|| RuntimeError::Tool("Missing command parameter".to_string()))?;
 
-        let timeout_secs = params["timeout"].as_u64().unwrap_or(ctx.limits.bash_timeout).min(ctx.limits.bash_max_timeout);
+        let timeout_secs = params["timeout"].as_u64().unwrap_or(ctx.limits.bash_timeout);
         let max_output = ctx.limits.max_tool_output;
 
         let mut child = tokio::process::Command::new("bash")

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -372,6 +372,22 @@ async fn test_bash_tool_execution() {
     assert!(result.unwrap_err().to_string().contains("timed out"));
 }
 
+#[tokio::test]
+async fn test_bash_tool_requested_timeout_is_not_clamped_by_max_timeout() {
+    let tool = BashTool;
+    let mut ctx = create_tool_context();
+    ctx.limits.bash_max_timeout = 1;
+
+    let params = json!({
+        "command": "sleep 2; echo done",
+        "timeout": 3
+    });
+
+    let result = tool.execute(params, ctx).await;
+    assert!(result.is_ok(), "requested timeout should not be clamped by bash_max_timeout: {result:?}");
+    assert!(result.unwrap().contains("done"));
+}
+
 // ── New Tests ────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- stop clamping explicit bash tool timeout requests by bash_max_timeout
- update tool/settings descriptions to reflect timeout behavior
- add regression coverage that a requested timeout larger than bash_max_timeout is honored

## Verification
- cargo test test_bash_tool_requested_timeout_is_not_clamped_by_max_timeout --lib
- cargo check --bin synaps
