### PR TITLE
Fix notify_inbox hook and improve event streaming handling

### DIFF
--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -249,8 +249,13 @@ pub async fn run(
                     });
 
                     if app.streaming || app.compact_task.is_some() {
-                        // Buffer during streaming — inject after MessageHistory
-                        app.pending_events.push(formatted);
+                        // Steer into active stream if possible, otherwise buffer
+                        let steered = steer_tx.as_ref()
+                            .map(|tx| tx.send(formatted.clone()).is_ok())
+                            .unwrap_or(false);
+                        if !steered {
+                            app.pending_events.push(formatted);
+                        }
                     } else {
                         app.api_messages.push(serde_json::json!({
                             "role": "user",

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -236,7 +236,11 @@ pub async fn run(command: String, args: Vec<String>) {
                     std::process::exit(1);
                 });
                 let code = status.code().unwrap_or(1);
+                let elapsed = agent.last_start.map(|s| s.elapsed().as_secs_f64()).unwrap_or(0.0);
                 log(&format!("[{}] exited with code {}", name, code));
+                if code == 0 && agent.config.hooks.notify_inbox {
+                    supervisor::notify_inbox_completion(name, 1, elapsed, code);
+                }
                 std::process::exit(code);
             }
         }

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -231,14 +231,30 @@ pub async fn run(command: String, args: Vec<String>) {
             }
             // Wait for completion
             if let Some(ref mut child) = agent.child {
-                let status = child.wait().await.unwrap_or_else(|e| {
-                    eprintln!("Error waiting for agent: {}", e);
-                    std::process::exit(1);
-                });
-                let code = status.code().unwrap_or(1);
+                // Wait for agent with a timeout — agent shutdown can hang
+                // if spawned tasks (shell reaper, etc.) don't terminate
+                let wait_result = tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    child.wait()
+                ).await;
+
+                let code = match wait_result {
+                    Ok(Ok(status)) => status.code().unwrap_or(1),
+                    Ok(Err(e)) => {
+                        eprintln!("Error waiting for agent: {}", e);
+                        1
+                    }
+                    Err(_) => {
+                        log(&format!("[{}] agent didn't exit within 30s, killing", name));
+                        let _ = child.kill().await;
+                        0 // Assume clean if it ran the full session
+                    }
+                };
+
                 let elapsed = agent.last_start.map(|s| s.elapsed().as_secs_f64()).unwrap_or(0.0);
                 log(&format!("[{}] exited with code {}", name, code));
                 if code == 0 && agent.config.hooks.notify_inbox {
+                    log(&format!("[{}] notify_inbox hook firing", name));
                     supervisor::notify_inbox_completion(name, 1, elapsed, code);
                 }
                 std::process::exit(code);

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -247,15 +247,23 @@ pub async fn run(command: String, args: Vec<String>) {
                     Err(_) => {
                         log(&format!("[{}] agent didn't exit within 30s, killing", name));
                         let _ = child.kill().await;
-                        0 // Assume clean if it ran the full session
+                        // Reap the killed process to avoid zombie
+                        let reap_status = tokio::time::timeout(
+                            std::time::Duration::from_secs(5),
+                            child.wait()
+                        ).await;
+                        match reap_status {
+                            Ok(Ok(s)) => s.code().unwrap_or(137), // killed
+                            _ => 137 // SIGKILL exit code
+                        }
                     }
                 };
 
                 let elapsed = agent.last_start.map(|s| s.elapsed().as_secs_f64()).unwrap_or(0.0);
                 log(&format!("[{}] exited with code {}", name, code));
-                if code == 0 && agent.config.hooks.notify_inbox {
+                if agent.config.hooks.notify_inbox {
                     log(&format!("[{}] notify_inbox hook firing", name));
-                    supervisor::notify_inbox_completion(name, 1, elapsed, code);
+                    supervisor::notify_inbox_completion(name, agent.session_count, elapsed, code);
                 }
                 std::process::exit(code);
             }

--- a/src/watcher/supervisor.rs
+++ b/src/watcher/supervisor.rs
@@ -2,19 +2,16 @@ use super::*;
 
 /// Drop a completion event into ~/.synaps-cli/inbox/ for the event bus.
 pub(crate) fn notify_inbox_completion(agent_name: &str, session_count: u64, elapsed_secs: f64, exit_code: i32) {
+    use synaps_cli::events::types::Event;
+
+    let event = Event::simple(
+        "watcher",
+        &format!("Agent '{}' completed session #{} ({:.0}s, exit {})", agent_name, session_count, elapsed_secs, exit_code),
+        None,
+    );
+
     let inbox_dir = synaps_cli::config::base_dir().join("inbox");
     let _ = std::fs::create_dir_all(&inbox_dir);
-
-    let event = serde_json::json!({
-        "type": "agent_complete",
-        "agent": agent_name,
-        "session": session_count,
-        "elapsed_secs": elapsed_secs,
-        "exit_code": exit_code,
-        "message": format!("Agent '{}' completed session #{} ({:.0}s)", agent_name, session_count, elapsed_secs),
-        "timestamp": chrono::Utc::now().to_rfc3339(),
-    });
-
     let filename = format!("watcher-{}-{}.json", agent_name, chrono::Utc::now().format("%Y%m%d-%H%M%S"));
     let path = inbox_dir.join(&filename);
     if let Ok(body) = serde_json::to_string_pretty(&event) {

--- a/src/watcher/supervisor.rs
+++ b/src/watcher/supervisor.rs
@@ -2,13 +2,32 @@ use super::*;
 
 /// Drop a completion event into ~/.synaps-cli/inbox/ for the event bus.
 pub(crate) fn notify_inbox_completion(agent_name: &str, session_count: u64, elapsed_secs: f64, exit_code: i32) {
-    use synaps_cli::events::types::Event;
+    use synaps_cli::events::types::{Event, EventSource, EventContent, Severity};
 
-    let event = Event::simple(
-        "watcher",
-        &format!("Agent '{}' completed session #{} ({:.0}s, exit {})", agent_name, session_count, elapsed_secs, exit_code),
-        None,
-    );
+    let event = Event {
+        id: uuid::Uuid::new_v4().to_string(),
+        timestamp: chrono::Utc::now(),
+        source: EventSource {
+            source_type: "watcher".to_string(),
+            name: agent_name.to_string(),
+            callback: None,
+        },
+        channel: None,
+        sender: None,
+        content: EventContent {
+            text: format!("Agent '{}' completed session #{} ({:.0}s, exit {})", agent_name, session_count, elapsed_secs, exit_code),
+            content_type: "agent_complete".to_string(),
+            severity: if exit_code == 0 { Some(Severity::Medium) } else { Some(Severity::High) },
+            data: Some(serde_json::json!({
+                "agent": agent_name,
+                "session": session_count,
+                "elapsed_secs": elapsed_secs,
+                "exit_code": exit_code,
+            })),
+        },
+        expects_response: false,
+        reply_to: None,
+    };
 
     let inbox_dir = synaps_cli::config::base_dir().join("inbox");
     let _ = std::fs::create_dir_all(&inbox_dir);

--- a/src/watcher/supervisor.rs
+++ b/src/watcher/supervisor.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Drop a completion event into ~/.synaps-cli/inbox/ for the event bus.
-fn notify_inbox_completion(agent_name: &str, session_count: u64, elapsed_secs: f64, exit_code: i32) {
+pub(crate) fn notify_inbox_completion(agent_name: &str, session_count: u64, elapsed_secs: f64, exit_code: i32) {
     let inbox_dir = synaps_cli::config::base_dir().join("inbox");
     let _ = std::fs::create_dir_all(&inbox_dir);
 


### PR DESCRIPTION
This pull request introduces improvements to agent process management and event notification in the watcher module, and refines the message handling logic during streaming in the chat UI. The key changes focus on making agent shutdown more robust, improving event notification semantics, and ensuring correct message routing during streaming.

**Watcher process management and notification:**

* Added a timeout when waiting for agent process termination to prevent hangs if spawned tasks do not exit; if the agent does not exit within 30 seconds, it is forcefully killed and a completion event is still logged.
* Enhanced the `notify_inbox_completion` function to use a structured `Event` type for event creation and made it `pub(crate)` for broader internal use. The event message now includes the agent’s exit code and is always written to the inbox directory.

**Chat UI streaming logic:**

* Improved message routing during streaming: messages are now sent to the active stream if possible; if not, they are buffered for later processing, ensuring smoother user experience during concurrent streams.## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests

## Checklist

- [ ] `cargo build` succeeds
- [ ] `cargo test` passes (96 tests)
- [ ] `cargo clippy` — no new warnings
- [ ] Changes are focused (one logical change per PR)
- [ ] New features have tests
- [ ] README/AGENTS.md updated if needed
