### PR TITLE
fix: chat UI rendering and Codex tool loop

### DIFF
--- a/src/chatui/app.rs
+++ b/src/chatui/app.rs
@@ -9,9 +9,26 @@ pub(crate) enum ChatMessage {
     User(String),
     Thinking(String),
     Text(String),
-    ToolUseStart(String, String),  // (tool_name, partial_input)
-    ToolUse { tool_name: String, input: String },
-    ToolResult { content: String, elapsed_ms: Option<u64> },
+    /// Streaming tool-use placeholder. `tool_id` lets the chat UI route
+    /// subsequent input deltas and the final finalize event to *this*
+    /// block when multiple tools run in parallel — without it, the
+    /// "always update last message" hack misroutes deltas/results to
+    /// whichever tool block happens to be most recent.
+    ToolUseStart {
+        tool_id: String,
+        tool_name: String,
+        partial_input: String,
+    },
+    ToolUse {
+        tool_id: String,
+        tool_name: String,
+        input: String,
+    },
+    ToolResult {
+        tool_id: String,
+        content: String,
+        elapsed_ms: Option<u64>,
+    },
     Error(String),
     System(String),
     Event { source: String, severity: String, text: String },
@@ -77,6 +94,10 @@ pub(crate) struct App {
     /// Counter for unique subagent IDs within a session
     /// Tracks when the current tool started executing (for elapsed time display)
     pub(crate) tool_start_time: Option<std::time::Instant>,
+    /// Per-tool start times keyed by `tool_id`. Lets parallel tool calls
+    /// each show their own elapsed-time on the result block, instead of
+    /// sharing a single timer that the last-started tool clobbers.
+    pub(crate) tool_start_times: std::collections::HashMap<String, std::time::Instant>,
     /// Saved context from an aborted response — injected into the next user message
     pub(crate) abort_context: Option<String>,
     /// Message queued while streaming — auto-sent when current response finishes
@@ -180,6 +201,7 @@ impl App {
             last_line_count: 0,
             subagents: Vec::new(),
             tool_start_time: None,
+            tool_start_times: std::collections::HashMap::new(),
             abort_context: None,
             queued_message: None,
             input_before_paste: None,
@@ -414,7 +436,7 @@ impl App {
     fn render_lines_uses_spinner(&self) -> bool {
         self.messages.iter().enumerate().any(|(idx, msg)| match &msg.msg {
             ChatMessage::Thinking(text) => text == "…",
-            ChatMessage::ToolUseStart(_, _) => true,
+            ChatMessage::ToolUseStart { .. } => true,
             ChatMessage::ToolUse { .. } => {
                 idx == self.messages.len().saturating_sub(1) && self.tool_start_time.is_some()
             }
@@ -445,10 +467,33 @@ impl App {
 
     /// Find the file extension from the ToolUse message preceding a ToolResult at index `idx`.
     pub(crate) fn find_preceding_read_extension(&self, idx: usize) -> String {
-        // Walk backwards from idx to find the preceding ToolUse
+        // Prefer matching by tool_id when the result carries one — under
+        // parallel tool calls a `ToolResult` may not be positionally
+        // adjacent to its matching `ToolUse`.
+        let target_id: Option<String> = match self.messages.get(idx).map(|m| &m.msg) {
+            Some(ChatMessage::ToolResult { tool_id, .. }) if !tool_id.is_empty() => Some(tool_id.clone()),
+            _ => None,
+        };
+        if let Some(id) = target_id {
+            for m in self.messages.iter() {
+                if let ChatMessage::ToolUse { tool_id, tool_name, input } = &m.msg {
+                    if tool_id == &id && tool_name == "read" {
+                        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(input) {
+                            if let Some(path) = parsed["path"].as_str() {
+                                if let Some(ext) = std::path::Path::new(path).extension() {
+                                    return ext.to_string_lossy().to_string();
+                                }
+                            }
+                        }
+                        return String::new();
+                    }
+                }
+            }
+        }
+        // Fallback: walk backwards from idx to find the preceding ToolUse
         if idx == 0 { return String::new(); }
         for i in (0..idx).rev() {
-            if let ChatMessage::ToolUse { ref tool_name, ref input } = self.messages[i].msg {
+            if let ChatMessage::ToolUse { ref tool_name, ref input, .. } = self.messages[i].msg {
                 if tool_name == "read" {
                     // Extract path from the JSON input
                     if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(input) {
@@ -468,13 +513,162 @@ impl App {
 
     /// Find the tool name from the ToolUse message preceding a ToolResult at index `idx`.
     pub(crate) fn find_preceding_tool_name(&self, idx: usize) -> Option<String> {
+        // Prefer matching by tool_id when the result carries one — this
+        // is the only way to render parallel-tool outputs correctly,
+        // since results may not be positionally adjacent to their
+        // matching tool_use.
+        if let Some(ChatMessage::ToolResult { tool_id, .. }) = self.messages.get(idx).map(|m| &m.msg) {
+            if !tool_id.is_empty() {
+                for m in self.messages.iter() {
+                    match &m.msg {
+                        ChatMessage::ToolUse { tool_id: tid, tool_name, .. }
+                        | ChatMessage::ToolUseStart { tool_id: tid, tool_name, .. }
+                            if tid == tool_id =>
+                        {
+                            return Some(tool_name.clone());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
         if idx == 0 { return None; }
         for i in (0..idx).rev() {
             if let ChatMessage::ToolUse { ref tool_name, .. } = self.messages[i].msg {
                 return Some(tool_name.clone());
             }
+            if let ChatMessage::ToolUseStart { ref tool_name, .. } = self.messages[i].msg {
+                return Some(tool_name.clone());
+            }
         }
         None
+    }
+
+    // ── Tool-event routing ──────────────────────────────────────────────
+    //
+    // Stream events arrive interleaved when the model fans out parallel
+    // tool calls. The chat UI keeps a flat `Vec<ChatMessage>`, so to keep
+    // each on-screen tool block correct we must route every delta /
+    // finalize / result event back to the block whose `tool_id` matches.
+    //
+    // The earlier "always update last message" approach worked for
+    // sequential tool calls but corrupts state under parallelism — input
+    // deltas from tool A would land on tool B's `ToolUseStart`, and the
+    // first arriving result would be silently overwritten by the second.
+
+    /// Locate the index of a `ToolUseStart` block with this `tool_id`.
+    pub(crate) fn find_tool_use_start_idx(&self, tool_id: &str) -> Option<usize> {
+        self.messages.iter().rposition(|m| matches!(
+            &m.msg,
+            ChatMessage::ToolUseStart { tool_id: tid, .. } if tid == tool_id
+        ))
+    }
+
+    /// Locate the latest `ToolResult` block for this `tool_id`.
+    pub(crate) fn find_tool_result_idx(&self, tool_id: &str) -> Option<usize> {
+        self.messages.iter().rposition(|m| matches!(
+            &m.msg,
+            ChatMessage::ToolResult { tool_id: tid, .. } if tid == tool_id
+        ))
+    }
+
+    /// Begin streaming a new tool call. Records start time per-tool so
+    /// elapsed-ms is correct under parallel execution.
+    pub(crate) fn on_tool_use_start(&mut self, tool_id: String, tool_name: String) {
+        let now = std::time::Instant::now();
+        self.tool_start_time = Some(now);
+        if !tool_id.is_empty() {
+            self.tool_start_times.insert(tool_id.clone(), now);
+        }
+        self.push_msg(ChatMessage::ToolUseStart {
+            tool_id,
+            tool_name,
+            partial_input: String::new(),
+        });
+    }
+
+    /// Append a chunk of the tool's input JSON to the matching
+    /// `ToolUseStart` block. Falls back to "last ToolUseStart" only when
+    /// the event lacks a tool_id (legacy paths).
+    pub(crate) fn on_tool_use_delta(&mut self, tool_id: &str, delta: &str) {
+        let target_idx = if !tool_id.is_empty() {
+            self.find_tool_use_start_idx(tool_id)
+        } else {
+            self.messages.iter().rposition(|m| matches!(&m.msg, ChatMessage::ToolUseStart { .. }))
+        };
+        if let Some(idx) = target_idx {
+            if let ChatMessage::ToolUseStart { ref mut partial_input, .. } = self.messages[idx].msg {
+                partial_input.push_str(delta);
+                self.invalidate();
+            }
+        }
+    }
+
+    /// Finalize a streaming tool call. Replaces the matching
+    /// `ToolUseStart` in place — keeping its position so on-screen order
+    /// matches the order the model emitted the calls.
+    pub(crate) fn on_tool_use_finalized(&mut self, tool_id: String, tool_name: String, input_str: String) {
+        // Track start time even if we never saw a ToolUseStart (some
+        // providers go straight to a finalized tool_use).
+        if !tool_id.is_empty() {
+            self.tool_start_times.entry(tool_id.clone()).or_insert_with(std::time::Instant::now);
+        }
+        self.tool_start_time = Some(std::time::Instant::now());
+
+        if let Some(idx) = self.find_tool_use_start_idx(&tool_id) {
+            self.messages[idx].msg = ChatMessage::ToolUse { tool_id, tool_name, input: input_str };
+            self.invalidate();
+            return;
+        }
+        // No matching start (e.g. provider only emits finalized blocks) —
+        // append a new finalized block at the end.
+        self.push_msg(ChatMessage::ToolUse { tool_id, tool_name, input: input_str });
+    }
+
+    /// Stream a chunk of tool output. Appends to the matching
+    /// `ToolResult` if one exists, otherwise creates a new placeholder.
+    pub(crate) fn on_tool_result_delta(&mut self, tool_id: String, delta: String) {
+        if let Some(idx) = self.find_tool_result_idx(&tool_id) {
+            if let ChatMessage::ToolResult { ref mut content, elapsed_ms, .. } = self.messages[idx].msg {
+                if elapsed_ms.is_none() {
+                    content.push_str(&delta);
+                    self.invalidate();
+                    return;
+                }
+            }
+        }
+        self.push_msg(ChatMessage::ToolResult { tool_id, content: delta, elapsed_ms: None });
+    }
+
+    /// Finalize a tool result. Replaces any in-flight `ToolResult` for
+    /// this `tool_id` (including a delta-buffered one) and stamps the
+    /// elapsed time using the per-tool start time.
+    pub(crate) fn on_tool_result(&mut self, tool_id: String, result: String) {
+        let elapsed = self
+            .tool_start_times
+            .remove(&tool_id)
+            .map(|t| t.elapsed().as_millis() as u64);
+        // Clear the shared "active tool" timer once the *latest* tool
+        // finishes — otherwise the bash trace animation lingers.
+        if self.tool_start_times.is_empty() {
+            self.tool_start_time = None;
+        }
+
+        if let Some(idx) = self.find_tool_result_idx(&tool_id) {
+            if let ChatMessage::ToolResult { ref mut content, elapsed_ms, .. } = self.messages[idx].msg {
+                if elapsed_ms.is_none() {
+                    *content = result;
+                    self.messages[idx].msg = ChatMessage::ToolResult {
+                        tool_id,
+                        content: std::mem::take(content),
+                        elapsed_ms: elapsed,
+                    };
+                    self.invalidate();
+                    return;
+                }
+            }
+        }
+        self.push_msg(ChatMessage::ToolResult { tool_id, content: result, elapsed_ms: elapsed });
     }
 
     /// Capture all assistant output since the last user message as abort context.
@@ -499,7 +693,7 @@ impl App {
                         parts.push(format!("[response]: {}", t));
                     }
                 }
-                ChatMessage::ToolUse { tool_name, input } => {
+                ChatMessage::ToolUse { tool_name, input, .. } => {
                     // Truncate input to keep context lean
                     let input_preview: String = input.chars().take(200).collect();
                     parts.push(format!("[tool_use]: {} — {}", tool_name, input_preview));
@@ -754,18 +948,22 @@ mod tests {
     fn active_tool_result_is_only_latest_incomplete_result() {
         let mut app = test_app();
         app.push_msg(ChatMessage::ToolUse {
+            tool_id: "call_1".to_string(),
             tool_name: "bash".to_string(),
             input: "{}".to_string(),
         });
         app.push_msg(ChatMessage::ToolResult {
+            tool_id: "call_1".to_string(),
             content: "first output".to_string(),
             elapsed_ms: None,
         });
         app.push_msg(ChatMessage::ToolUse {
+            tool_id: "call_2".to_string(),
             tool_name: "bash".to_string(),
             input: "{}".to_string(),
         });
         app.push_msg(ChatMessage::ToolResult {
+            tool_id: "call_2".to_string(),
             content: "second output".to_string(),
             elapsed_ms: None,
         });
@@ -779,10 +977,12 @@ mod tests {
     fn completed_latest_tool_result_is_not_active() {
         let mut app = test_app();
         app.push_msg(ChatMessage::ToolUse {
+            tool_id: "call_1".to_string(),
             tool_name: "bash".to_string(),
             input: "{}".to_string(),
         });
         app.push_msg(ChatMessage::ToolResult {
+            tool_id: "call_1".to_string(),
             content: "done".to_string(),
             elapsed_ms: Some(25),
         });
@@ -817,10 +1017,12 @@ mod tests {
     fn animation_tick_for_active_bash_result_invalidates_message_cache() {
         let mut app = test_app();
         app.push_msg(ChatMessage::ToolUse {
+            tool_id: "call_1".to_string(),
             tool_name: "bash".to_string(),
             input: "{}".to_string(),
         });
         app.push_msg(ChatMessage::ToolResult {
+            tool_id: "call_1".to_string(),
             content: String::new(),
             elapsed_ms: None,
         });
@@ -905,5 +1107,207 @@ mod tests {
         let display = app.user_display_text_for_submission("beforePASTED after");
 
         assert_eq!(display, "before [Pasted 6 chars] after");
+    }
+
+    // ── Parallel tool-event routing (Bug 2 regression coverage) ─────────
+
+    fn last_tool_use(app: &App, tool_id: &str) -> Option<(String, String)> {
+        app.messages.iter().find_map(|m| match &m.msg {
+            ChatMessage::ToolUse { tool_id: tid, tool_name, input } if tid == tool_id => {
+                Some((tool_name.clone(), input.clone()))
+            }
+            _ => None,
+        })
+    }
+
+    fn tool_use_start_partial(app: &App, tool_id: &str) -> Option<String> {
+        app.messages.iter().find_map(|m| match &m.msg {
+            ChatMessage::ToolUseStart { tool_id: tid, partial_input, .. } if tid == tool_id => {
+                Some(partial_input.clone())
+            }
+            _ => None,
+        })
+    }
+
+    fn tool_result_content(app: &App, tool_id: &str) -> Option<String> {
+        app.messages.iter().find_map(|m| match &m.msg {
+            ChatMessage::ToolResult { tool_id: tid, content, .. } if tid == tool_id => {
+                Some(content.clone())
+            }
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn parallel_tool_use_deltas_are_routed_by_tool_id() {
+        // Regression: deltas from two interleaved parallel tool calls
+        // must each land on their own ToolUseStart block. The pre-fix
+        // behavior always appended to the most recent ToolUseStart,
+        // corrupting the second tool's input with the first's deltas.
+        let mut app = test_app();
+        app.on_tool_use_start("call_a".to_string(), "bash".to_string());
+        app.on_tool_use_start("call_b".to_string(), "read".to_string());
+
+        // Codex sends deltas in interleaved order — exercise that.
+        app.on_tool_use_delta("call_b", "{\"path\":");
+        app.on_tool_use_delta("call_a", "{\"command\":");
+        app.on_tool_use_delta("call_a", "\"ls\"}");
+        app.on_tool_use_delta("call_b", "\"a\"}");
+
+        assert_eq!(
+            tool_use_start_partial(&app, "call_a").as_deref(),
+            Some(r#"{"command":"ls"}"#),
+            "call_a partial input must accumulate only call_a's deltas"
+        );
+        assert_eq!(
+            tool_use_start_partial(&app, "call_b").as_deref(),
+            Some(r#"{"path":"a"}"#),
+            "call_b partial input must accumulate only call_b's deltas"
+        );
+    }
+
+    #[test]
+    fn parallel_tool_use_finalize_collapses_matching_start() {
+        // Regression: finalize event must replace the matching
+        // ToolUseStart in place, not push a new ToolUse at the end —
+        // so on-screen order matches the order tools were called.
+        let mut app = test_app();
+        app.on_tool_use_start("call_a".to_string(), "bash".to_string());
+        app.on_tool_use_start("call_b".to_string(), "read".to_string());
+
+        app.on_tool_use_finalized(
+            "call_a".to_string(),
+            "bash".to_string(),
+            r#"{"command":"ls"}"#.to_string(),
+        );
+        app.on_tool_use_finalized(
+            "call_b".to_string(),
+            "read".to_string(),
+            r#"{"path":"a"}"#.to_string(),
+        );
+
+        // Both are now ToolUse, no lingering ToolUseStart.
+        let lingering_starts = app
+            .messages
+            .iter()
+            .filter(|m| matches!(&m.msg, ChatMessage::ToolUseStart { .. }))
+            .count();
+        assert_eq!(
+            lingering_starts, 0,
+            "every ToolUseStart must collapse on finalize — leftover starts cause perpetual bash-trace animations"
+        );
+        assert_eq!(
+            last_tool_use(&app, "call_a"),
+            Some(("bash".to_string(), r#"{"command":"ls"}"#.to_string()))
+        );
+        assert_eq!(
+            last_tool_use(&app, "call_b"),
+            Some(("read".to_string(), r#"{"path":"a"}"#.to_string()))
+        );
+
+        // On-screen order matches call order (call_a appears before call_b).
+        let positions: Vec<&str> = app
+            .messages
+            .iter()
+            .filter_map(|m| match &m.msg {
+                ChatMessage::ToolUse { tool_id, .. } => Some(tool_id.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(positions, vec!["call_a", "call_b"]);
+    }
+
+    #[test]
+    fn parallel_tool_results_do_not_overwrite_each_other() {
+        // Regression: two ToolResult events arriving back-to-back must
+        // each land on their own block by tool_id. The pre-fix path
+        // pushed the first as a new message and then *overwrote* it
+        // with the second — losing the first tool's output entirely.
+        let mut app = test_app();
+        app.on_tool_use_start("call_a".to_string(), "bash".to_string());
+        app.on_tool_use_start("call_b".to_string(), "bash".to_string());
+        app.on_tool_use_finalized(
+            "call_a".to_string(),
+            "bash".to_string(),
+            "{}".to_string(),
+        );
+        app.on_tool_use_finalized(
+            "call_b".to_string(),
+            "bash".to_string(),
+            "{}".to_string(),
+        );
+
+        app.on_tool_result("call_a".to_string(), "first output".to_string());
+        app.on_tool_result("call_b".to_string(), "second output".to_string());
+
+        assert_eq!(
+            tool_result_content(&app, "call_a").as_deref(),
+            Some("first output"),
+            "call_a's result must survive — was overwritten by call_b in the buggy implementation"
+        );
+        assert_eq!(
+            tool_result_content(&app, "call_b").as_deref(),
+            Some("second output")
+        );
+    }
+
+    #[test]
+    fn tool_result_delta_streams_into_matching_block() {
+        let mut app = test_app();
+        app.on_tool_use_start("call_a".to_string(), "bash".to_string());
+        app.on_tool_use_start("call_b".to_string(), "bash".to_string());
+        app.on_tool_use_finalized(
+            "call_a".to_string(),
+            "bash".to_string(),
+            "{}".to_string(),
+        );
+        app.on_tool_use_finalized(
+            "call_b".to_string(),
+            "bash".to_string(),
+            "{}".to_string(),
+        );
+
+        // Interleaved deltas — must accumulate into the right block.
+        app.on_tool_result_delta("call_a".to_string(), "alpha-".to_string());
+        app.on_tool_result_delta("call_b".to_string(), "beta-".to_string());
+        app.on_tool_result_delta("call_a".to_string(), "one".to_string());
+        app.on_tool_result_delta("call_b".to_string(), "two".to_string());
+
+        // Then finalize results.
+        app.on_tool_result("call_a".to_string(), "alpha-one".to_string());
+        app.on_tool_result("call_b".to_string(), "beta-two".to_string());
+
+        assert_eq!(
+            tool_result_content(&app, "call_a").as_deref(),
+            Some("alpha-one")
+        );
+        assert_eq!(
+            tool_result_content(&app, "call_b").as_deref(),
+            Some("beta-two")
+        );
+    }
+
+    #[test]
+    fn parallel_tool_results_record_per_tool_elapsed_time() {
+        let mut app = test_app();
+        app.on_tool_use_start("call_a".to_string(), "bash".to_string());
+        app.on_tool_use_start("call_b".to_string(), "bash".to_string());
+
+        // Sleep deliberately tiny so Instant::elapsed > 0 is guaranteed.
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        app.on_tool_result("call_a".to_string(), "a".to_string());
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        app.on_tool_result("call_b".to_string(), "b".to_string());
+
+        let a_elapsed = app.messages.iter().find_map(|m| match &m.msg {
+            ChatMessage::ToolResult { tool_id, elapsed_ms, .. } if tool_id == "call_a" => *elapsed_ms,
+            _ => None,
+        });
+        let b_elapsed = app.messages.iter().find_map(|m| match &m.msg {
+            ChatMessage::ToolResult { tool_id, elapsed_ms, .. } if tool_id == "call_b" => *elapsed_ms,
+            _ => None,
+        });
+        assert!(a_elapsed.is_some(), "call_a must record elapsed_ms from its own start_time");
+        assert!(b_elapsed.is_some(), "call_b must record elapsed_ms from its own start_time");
     }
 }

--- a/src/chatui/draw.rs
+++ b/src/chatui/draw.rs
@@ -91,6 +91,7 @@ pub(crate) fn draw(
     registry: &std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
     secret_prompts: &synaps_cli::tools::SecretPromptQueue,
 ) -> io::Result<()> {
+    super::viewport::scrub_crossterm_terminal_edges(terminal, Style::default().bg(THEME.load().bg))?;
     let model = runtime.model();
     let thinking = runtime.thinking_level();
     // Don't draw while casino owns the terminal

--- a/src/chatui/helpers.rs
+++ b/src/chatui/helpers.rs
@@ -134,7 +134,8 @@ pub(super) fn rebuild_display_messages(api_messages: &[Value], app: &mut App) {
                             Some("tool_use") => {
                                 let name = block["name"].as_str().unwrap_or("").to_string();
                                 let input = serde_json::to_string(&block["input"]).unwrap_or_default();
-                                app.push_msg(ChatMessage::ToolUse { tool_name: name, input });
+                                let tool_id = block["id"].as_str().unwrap_or("").to_string();
+                                app.push_msg(ChatMessage::ToolUse { tool_id, tool_name: name, input });
                             }
                             _ => {}
                         }

--- a/src/chatui/mod.rs
+++ b/src/chatui/mod.rs
@@ -16,6 +16,7 @@ mod models;
 mod help_find;
 mod helpers;
 mod lifecycle;
+mod viewport;
 
 use app::{App, ChatMessage};
 use draw::{draw, boot_effect, quit_effect};

--- a/src/chatui/render.rs
+++ b/src/chatui/render.rs
@@ -188,7 +188,7 @@ impl App {
                     }
                 }
 
-                ChatMessage::ToolUseStart(tool_name, partial_input) => {
+                ChatMessage::ToolUseStart { tool_name, partial_input, .. } => {
                     // Breathing room before tool block
                     lines.push(Line::from(""));
                     let (icon, display_name, server_tag) = format_tool_name(tool_name);
@@ -260,7 +260,7 @@ impl App {
                     }
                 }
 
-                ChatMessage::ToolUse { tool_name, input } => {
+                ChatMessage::ToolUse { tool_name, input, .. } => {
                     // Breathing room before tool block
                     lines.push(Line::from(""));
                     // Compact tool header
@@ -374,7 +374,7 @@ impl App {
                     }
                 }
 
-                ChatMessage::ToolResult { ref content, elapsed_ms } => {
+                ChatMessage::ToolResult { ref content, elapsed_ms, .. } => {
                     let result = content;
                     let is_error = result.starts_with("Tool execution failed")
                         || result.starts_with("Unknown tool");

--- a/src/chatui/stream_handler.rs
+++ b/src/chatui/stream_handler.rs
@@ -42,54 +42,24 @@ pub(super) async fn handle_stream_event(
         StreamEvent::Llm(LlmEvent::Text(text)) => {
             app.append_or_update_text(&text);
         }
-        StreamEvent::Llm(LlmEvent::ToolUseStart(name)) => {
-            app.tool_start_time = Some(std::time::Instant::now());
-            app.push_msg(ChatMessage::ToolUseStart(name, String::new()));
+        StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name, tool_id }) => {
+            app.on_tool_use_start(tool_id, tool_name);
         }
-        StreamEvent::Llm(LlmEvent::ToolUseDelta(delta)) => {
-            if let Some(last) = app.messages.last_mut() {
-                if let ChatMessage::ToolUseStart(_, ref mut partial) = last.msg {
-                    partial.push_str(&delta);
-                    app.invalidate();
-                }
-            }
+        StreamEvent::Llm(LlmEvent::ToolUseDelta { tool_id, delta }) => {
+            app.on_tool_use_delta(&tool_id, &delta);
         }
-        StreamEvent::Llm(LlmEvent::ToolUse { tool_name, input, .. }) => {
-            app.tool_start_time = Some(std::time::Instant::now());
+        StreamEvent::Llm(LlmEvent::ToolUse { tool_name, tool_id, input }) => {
             let input_str = serde_json::to_string(&input).unwrap_or_default();
-            if let Some(last) = app.messages.last_mut() {
-                if let ChatMessage::ToolUseStart(name, _) = &last.msg {
-                    if name == &tool_name {
-                        last.msg = ChatMessage::ToolUse { tool_name, input: input_str };
-                        app.invalidate();
-                        return StreamAction::Continue;
-                    }
-                }
-            }
-            app.push_msg(ChatMessage::ToolUse { tool_name, input: input_str });
+            app.on_tool_use_finalized(tool_id, tool_name, input_str);
+            return StreamAction::Continue;
         }
-        StreamEvent::Llm(LlmEvent::ToolResultDelta { delta, .. }) => {
-            if let Some(last) = app.messages.last_mut() {
-                if let ChatMessage::ToolResult { ref mut content, .. } = last.msg {
-                    content.push_str(&delta);
-                    app.invalidate();
-                    return StreamAction::Continue;
-                }
-            }
-            app.push_msg(ChatMessage::ToolResult { content: delta, elapsed_ms: None });
+        StreamEvent::Llm(LlmEvent::ToolResultDelta { delta, tool_id }) => {
+            app.on_tool_result_delta(tool_id, delta);
+            return StreamAction::Continue;
         }
-        StreamEvent::Llm(LlmEvent::ToolResult { result, .. }) => {
-            let elapsed = app.tool_start_time.take()
-                .map(|t| t.elapsed().as_millis() as u64);
-            if let Some(last) = app.messages.last_mut() {
-                if let ChatMessage::ToolResult { ref mut content, elapsed_ms: ref mut el, .. } = last.msg {
-                    *content = result;
-                    *el = elapsed;
-                    app.invalidate();
-                    return StreamAction::Continue;
-                }
-            }
-            app.push_msg(ChatMessage::ToolResult { content: result, elapsed_ms: elapsed });
+        StreamEvent::Llm(LlmEvent::ToolResult { result, tool_id }) => {
+            app.on_tool_result(tool_id, result);
+            return StreamAction::Continue;
         }
         StreamEvent::Session(SessionEvent::MessageHistory(history)) => {
             app.api_messages = history;

--- a/src/chatui/viewport.rs
+++ b/src/chatui/viewport.rs
@@ -1,0 +1,110 @@
+use std::io::{self, Write};
+
+use crossterm::{cursor::MoveTo, style::Print, QueueableCommand};
+#[cfg(test)]
+use ratatui::backend::Backend;
+use ratatui::{
+    backend::CrosstermBackend,
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+    text::Line,
+    widgets::{Paragraph, Widget},
+    Terminal,
+};
+
+/// Terminal cells that should be physically blanked before each diff draw.
+///
+/// Some terminals/tmux combinations can leave stale glyphs in the first or last
+/// column when the pane scrolls by one row outside ratatui's buffered model. The
+/// diff renderer may believe those edge cells are already blank and skip writing
+/// them, so we proactively scrub the physical edge columns.
+pub(crate) fn edge_scrub_positions(area: Rect) -> Vec<(u16, u16)> {
+    if area.width == 0 || area.height == 0 {
+        return Vec::new();
+    }
+
+    let mut positions = Vec::with_capacity(area.height as usize * if area.width > 1 { 2 } else { 1 });
+    for y in area.y..area.y.saturating_add(area.height) {
+        positions.push((area.x, y));
+        if area.width > 1 {
+            positions.push((area.x + area.width - 1, y));
+        }
+    }
+    positions
+}
+
+/// Clear edge columns in ratatui's inactive back buffer before rendering.
+///
+/// This makes the next diff pass emit blanks for edge cells even when ratatui's
+/// previous-frame model already thinks those cells are blank. That is the stale
+/// state seen after external terminal/pane scrolling: the physical terminal has
+/// residue, but the diff buffer does not.
+pub(crate) fn scrub_edge_columns_in_buffer(buf: &mut Buffer, area: Rect, style: Style) {
+    for (x, y) in edge_scrub_positions(area) {
+        if let Some(cell) = buf.cell_mut((x, y)) {
+            cell.reset();
+            cell.set_style(style);
+        }
+    }
+}
+
+/// Physically blank the terminal edge columns and reset ratatui's back buffer so
+/// the following draw does not optimize those blanks away.
+#[cfg(test)]
+pub(crate) fn scrub_terminal_edges<B>(terminal: &mut Terminal<B>, style: Style) -> io::Result<()>
+where
+    B: Backend,
+{
+    let size = terminal.size()?;
+    let area = Rect::new(0, 0, size.width, size.height);
+    scrub_edge_columns_in_buffer(terminal.current_buffer_mut(), area, style);
+    terminal.backend_mut().flush()
+}
+
+/// Crossterm-specific physical edge scrub used by the real chat UI terminal.
+///
+/// Test backends cannot accept crossterm commands, so this is split from the
+/// buffer reset above. The public chat path calls this version; tests exercise
+/// the generic buffer behavior separately.
+#[cfg_attr(test, allow(dead_code))]
+pub(crate) fn scrub_crossterm_terminal_edges<W>(
+    terminal: &mut Terminal<CrosstermBackend<W>>,
+    style: Style,
+) -> io::Result<()>
+where
+    W: Write,
+{
+    let size = terminal.size()?;
+    let area = Rect::new(0, 0, size.width, size.height);
+    let backend = terminal.backend_mut();
+    for (x, y) in edge_scrub_positions(area) {
+        backend.queue(MoveTo(x, y))?;
+        backend.queue(Print(" "))?;
+    }
+    scrub_edge_columns_in_buffer(terminal.current_buffer_mut(), area, style);
+    std::io::Write::flush(terminal.backend_mut())
+}
+
+/// Render a scrolled transcript viewport without relying on terminal scroll-region
+/// optimizations. Clearing the viewport cells before drawing prevents edge-column
+/// residue when content moves upward by one row and a previously occupied first or
+/// last cell is blank in the new frame.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn render_scrolled_lines(
+    buf: &mut Buffer,
+    area: Rect,
+    lines: &[Line<'static>],
+    style: Style,
+) {
+    for y in area.y..area.y.saturating_add(area.height) {
+        for x in area.x..area.x.saturating_add(area.width) {
+            if let Some(cell) = buf.cell_mut((x, y)) {
+                cell.reset();
+                cell.set_style(style);
+            }
+        }
+    }
+
+    Paragraph::new(lines.to_vec()).style(style).render(area, buf);
+}

--- a/src/cmd/agent.rs
+++ b/src/cmd/agent.rs
@@ -342,7 +342,7 @@ pub async fn run(config_path: String, trigger_context: String) {
                         }));
                     }
                 }
-                StreamEvent::Llm(LlmEvent::ToolUseStart(name)) => {
+                StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name: name, .. }) => {
                     total_tool_calls += 1;
                     tool_call_num += 1;
                     log(agent_name, &format!("tool: {}", name));
@@ -453,7 +453,7 @@ pub async fn run(config_path: String, trigger_context: String) {
             tokio::select! {
                 event = stream.next() => {
                     match event {
-                        Some(StreamEvent::Llm(LlmEvent::ToolUseStart(name))) if name == "watcher_exit" => {
+                        Some(StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name: name, .. })) if name == "watcher_exit" => {
                             watcher_exit_called = true;
                         }
                         Some(StreamEvent::Session(SessionEvent::Done)) | None => break,

--- a/src/cmd/chat.rs
+++ b/src/cmd/chat.rs
@@ -58,12 +58,12 @@ pub async fn run() -> Result<()> {
                     print!("{}", text);
                     flush_stdout();
                 }
-                StreamEvent::Llm(LlmEvent::ToolUseStart(tool_name)) => {
+                StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name, .. }) => {
                     if in_thinking { println!(); in_thinking = false; }
                     print!("⚙️  Using tool: {} (args: ", tool_name);
                     flush_stdout();
                 }
-                StreamEvent::Llm(LlmEvent::ToolUseDelta(delta)) => {
+                StreamEvent::Llm(LlmEvent::ToolUseDelta { delta, .. }) => {
                     print!("{}", delta);
                     flush_stdout();
                 }

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -236,7 +236,7 @@ pub async fn run(
                                 eprint!("{}", text);
                             }
                         }
-                        StreamEvent::Llm(LlmEvent::ToolUseStart(name)) => {
+                        StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name: name, .. }) => {
                             log(&format!("  tool: {}", name));
                         }
                         StreamEvent::Llm(LlmEvent::ToolResult { result, .. }) => {

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -326,10 +326,10 @@ async fn handle_user_message(content: String, state: &Arc<ServerState>) {
                     history.push(HistoryEntry::Text { content: text, time: ts });
                 }
             }
-            StreamEvent::Llm(LlmEvent::ToolUseStart(tool_name)) => {
+            StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name, .. }) => {
                 let _ = broadcast.send(ServerMessage::ToolUseStart { tool_name });
             }
-            StreamEvent::Llm(LlmEvent::ToolUseDelta(delta)) => {
+            StreamEvent::Llm(LlmEvent::ToolUseDelta { delta, .. }) => {
                 let _ = broadcast.send(ServerMessage::ToolUseDelta(delta));
             }
             StreamEvent::Llm(LlmEvent::ToolUse { tool_name, tool_id, input }) => {

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -275,7 +275,10 @@ impl ApiMethods {
                                     current_tool_id = content_block["id"].as_str().unwrap_or("").to_string();
                                     current_tool_input_json.clear();
                                     in_tool_use = true;
-                                    let _ = tx.send(StreamEvent::Llm(LlmEvent::ToolUseStart(current_tool_name.clone())));
+                                    let _ = tx.send(StreamEvent::Llm(LlmEvent::ToolUseStart {
+                                        tool_name: current_tool_name.clone(),
+                                        tool_id: current_tool_id.clone(),
+                                    }));
                                 }
                                 Some("text") => {
                                     if !current_text.is_empty() {
@@ -314,7 +317,10 @@ impl ApiMethods {
                                 Some("input_json_delta") => {
                                     if let Some(json_chunk) = delta["partial_json"].as_str() {
                                         current_tool_input_json.push_str(json_chunk);
-                                        let _ = tx.send(StreamEvent::Llm(LlmEvent::ToolUseDelta(json_chunk.to_string())));
+                                        let _ = tx.send(StreamEvent::Llm(LlmEvent::ToolUseDelta {
+                                            tool_id: current_tool_id.clone(),
+                                            delta: json_chunk.to_string(),
+                                        }));
                                     }
                                 }
                                 _ => {}

--- a/src/runtime/openai/stream.rs
+++ b/src/runtime/openai/stream.rs
@@ -412,8 +412,12 @@ impl CodexSseDecoder {
                 if !delta.is_empty() {
                     let tool = self.ensure_tool(idx);
                     tool.arguments.push_str(delta);
+                    let tool_id = tool.id.clone();
                     let _ = tx.send(StreamEvent::Llm(
-                        crate::runtime::types::LlmEvent::ToolUseDelta(delta.to_string()),
+                        crate::runtime::types::LlmEvent::ToolUseDelta {
+                            tool_id,
+                            delta: delta.to_string(),
+                        },
                     ));
                 }
             }
@@ -461,7 +465,10 @@ impl CodexSseDecoder {
         if !tool.started && !tool.name.is_empty() {
             tool.started = true;
             let _ = tx.send(StreamEvent::Llm(
-                crate::runtime::types::LlmEvent::ToolUseStart(tool.name.clone()),
+                crate::runtime::types::LlmEvent::ToolUseStart {
+                    tool_name: tool.name.clone(),
+                    tool_id: tool.id.clone(),
+                },
             ));
         }
     }
@@ -492,7 +499,10 @@ impl CodexSseDecoder {
         if !tool.started && !tool.name.is_empty() {
             tool.started = true;
             let _ = tx.send(StreamEvent::Llm(
-                crate::runtime::types::LlmEvent::ToolUseStart(tool.name.clone()),
+                crate::runtime::types::LlmEvent::ToolUseStart {
+                    tool_name: tool.name.clone(),
+                    tool_id: tool.id.clone(),
+                },
             ));
         }
         let completed = if !tool.id.is_empty() && !tool.name.is_empty() {
@@ -765,21 +775,33 @@ mod codex_decoder_tests {
         let starts: Vec<_> = events
             .iter()
             .filter_map(|e| match e {
-                StreamEvent::Llm(LlmEvent::ToolUseStart(name)) => Some(name.as_str()),
+                StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name, tool_id }) => {
+                    Some((tool_name.as_str(), tool_id.as_str()))
+                }
                 _ => None,
             })
             .collect();
-        assert_eq!(starts, vec!["bash"], "exactly one ToolUseStart");
+        assert_eq!(
+            starts,
+            vec![("bash", "call_abc")],
+            "exactly one ToolUseStart with correct tool_id"
+        );
 
-        // Two argument deltas streamed.
+        // Two argument deltas streamed (each carrying the tool_id so
+        // parallel calls can be routed correctly by the chat UI).
         let deltas: Vec<_> = events
             .iter()
             .filter_map(|e| match e {
-                StreamEvent::Llm(LlmEvent::ToolUseDelta(d)) => Some(d.as_str()),
+                StreamEvent::Llm(LlmEvent::ToolUseDelta { tool_id, delta }) => {
+                    Some((tool_id.as_str(), delta.as_str()))
+                }
                 _ => None,
             })
             .collect();
-        assert_eq!(deltas, vec![r#"{"cmd""#, r#":"ls"}"#]);
+        assert_eq!(
+            deltas,
+            vec![("call_abc", r#"{"cmd""#), ("call_abc", r#":"ls"}"#)]
+        );
     }
 
     #[test]

--- a/src/runtime/openai/stream.rs
+++ b/src/runtime/openai/stream.rs
@@ -339,6 +339,23 @@ struct CodexToolAccumulator {
     started: bool,
 }
 
+/// Parse a function-call arguments string into a JSON `Value`, mirroring
+/// `runtime::api::parse_tool_input` so the chat UI's `LlmEvent::ToolUse`
+/// handling sees the same shape regardless of provider.
+///
+/// Empty / whitespace input becomes `{}`. Invalid JSON becomes
+/// `{"__parse_error": "..."}` — the agent loop already understands that
+/// shape and converts it into an `is_error: true` tool_result.
+fn parse_tool_arguments(raw: &str) -> Value {
+    if raw.trim().is_empty() {
+        return json!({});
+    }
+    match serde_json::from_str(raw) {
+        Ok(v) => v,
+        Err(e) => json!({ "__parse_error": format!("invalid tool input JSON: {}", e) }),
+    }
+}
+
 impl CodexSseDecoder {
     fn push_line(
         &mut self,
@@ -494,6 +511,21 @@ impl CodexSseDecoder {
             if self.completed_tools.iter().any(|done| done.id == call.id) {
                 return;
             }
+            // Emit the finalized `ToolUse` event so the chat UI can collapse
+            // the streaming `ToolUseStart` (animated) into a stable
+            // `ToolUse` block. Without this the bash-trace animation
+            // persists forever and parallel tool blocks render as "still
+            // running" even after they've completed. Mirrors the
+            // Anthropic path in `runtime/api.rs` which emits the same
+            // event on tool-use content_block_stop.
+            let input = parse_tool_arguments(&call.function.arguments);
+            let _ = tx.send(StreamEvent::Llm(
+                crate::runtime::types::LlmEvent::ToolUse {
+                    tool_name: call.function.name.clone(),
+                    tool_id: call.id.clone(),
+                    input,
+                },
+            ));
             self.completed_tools.push(ToolCall {
                 id: call.id,
                 kind: call.kind,
@@ -777,6 +809,104 @@ mod codex_decoder_tests {
         assert_eq!(by_id["call_1"].function.arguments, r#"{"cmd":"ls"}"#);
         assert_eq!(by_id["call_2"].function.name, "read");
         assert_eq!(by_id["call_2"].function.arguments, r#"{"path":"a"}"#);
+    }
+
+    #[test]
+    fn output_item_done_emits_tool_use_event() {
+        // Regression: the codex decoder must emit `LlmEvent::ToolUse` once a
+        // function_call's `output_item.done` arrives so the chat UI can
+        // collapse `ChatMessage::ToolUseStart` (animated) into the finalized
+        // `ChatMessage::ToolUse`. Without this the bash-trace animation
+        // persists forever and parallel tool blocks render as "still
+        // running" even after they've completed.
+        let lines = [
+            r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","call_id":"call_abc","name":"bash"}}"#,
+            "",
+            r#"data: {"type":"response.function_call_arguments.delta","output_index":0,"delta":"{\"command\":\"ls\"}"}"#,
+            "",
+            r#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","call_id":"call_abc","name":"bash","arguments":"{\"command\":\"ls\"}"}}"#,
+            "",
+        ];
+        let (_decoder, _text, events) = drive(&lines);
+
+        let tool_uses: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::Llm(LlmEvent::ToolUse { tool_name, tool_id, input }) => {
+                    Some((tool_name.as_str(), tool_id.as_str(), input.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(tool_uses.len(), 1, "expected exactly one ToolUse finalize event");
+        assert_eq!(tool_uses[0].0, "bash");
+        assert_eq!(tool_uses[0].1, "call_abc");
+        assert_eq!(
+            tool_uses[0].2,
+            serde_json::json!({"command": "ls"}),
+            "input must be parsed as a JSON Value, not a string"
+        );
+    }
+
+    #[test]
+    fn parallel_tool_calls_emit_tool_use_per_index() {
+        // Regression: parallel tool calls must each get their own ToolUse
+        // finalize event with the correct tool_id, so the chat UI can route
+        // their results back to the right block by id.
+        let lines = [
+            r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","call_id":"call_1","name":"bash"}}"#,
+            "",
+            r#"data: {"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","call_id":"call_2","name":"read"}}"#,
+            "",
+            r#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","call_id":"call_1","name":"bash","arguments":"{\"command\":\"ls\"}"}}"#,
+            "",
+            r#"data: {"type":"response.output_item.done","output_index":1,"item":{"type":"function_call","call_id":"call_2","name":"read","arguments":"{\"path\":\"a\"}"}}"#,
+            "",
+        ];
+        let (_decoder, _text, events) = drive(&lines);
+
+        let tool_uses: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::Llm(LlmEvent::ToolUse { tool_name, tool_id, input }) => {
+                    Some((tool_name.clone(), tool_id.clone(), input.clone()))
+                }
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(tool_uses.len(), 2, "one ToolUse finalize per parallel call");
+        let by_id: std::collections::BTreeMap<&str, &(String, String, serde_json::Value)> =
+            tool_uses.iter().map(|t| (t.1.as_str(), t)).collect();
+        assert_eq!(by_id["call_1"].0, "bash");
+        assert_eq!(by_id["call_1"].2, serde_json::json!({"command": "ls"}));
+        assert_eq!(by_id["call_2"].0, "read");
+        assert_eq!(by_id["call_2"].2, serde_json::json!({"path": "a"}));
+    }
+
+    #[test]
+    fn malformed_arguments_emit_tool_use_with_parse_error() {
+        // If the model produces invalid JSON arguments, surface a structured
+        // parse error in the `input` (matching how the Anthropic path
+        // handles it via parse_tool_input) so the agent loop can return an
+        // error tool_result instead of silently dropping the tool.
+        let lines = [
+            r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","call_id":"call_bad","name":"bash"}}"#,
+            "",
+            r#"data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","call_id":"call_bad","name":"bash","arguments":"{not json"}}"#,
+            "",
+        ];
+        let (_decoder, _text, events) = drive(&lines);
+
+        let tool_use = events.iter().find_map(|e| match e {
+            StreamEvent::Llm(LlmEvent::ToolUse { input, .. }) => Some(input.clone()),
+            _ => None,
+        });
+        let input = tool_use.expect("ToolUse event missing");
+        assert!(
+            input.get("__parse_error").and_then(Value::as_str).is_some(),
+            "malformed arguments must surface __parse_error, got {input}"
+        );
     }
 
     #[test]

--- a/src/runtime/openai/translate.rs
+++ b/src/runtime/openai/translate.rs
@@ -279,11 +279,17 @@ pub fn messages_to_oai(
 pub fn oai_event_to_llm(event: &OaiEvent) -> Option<StreamEvent> {
     match event {
         OaiEvent::TextDelta(t) => Some(StreamEvent::Llm(LlmEvent::Text(t.clone()))),
-        OaiEvent::ToolCallStart { name, .. } => {
-            Some(StreamEvent::Llm(LlmEvent::ToolUseStart(name.clone())))
+        OaiEvent::ToolCallStart { name, id, .. } => {
+            Some(StreamEvent::Llm(LlmEvent::ToolUseStart {
+                tool_name: name.clone(),
+                tool_id: id.clone(),
+            }))
         }
-        OaiEvent::ToolCallArgumentsDelta { delta, .. } => {
-            Some(StreamEvent::Llm(LlmEvent::ToolUseDelta(delta.clone())))
+        OaiEvent::ToolCallArgumentsDelta { delta, id, .. } => {
+            Some(StreamEvent::Llm(LlmEvent::ToolUseDelta {
+                tool_id: id.clone(),
+                delta: delta.clone(),
+            }))
         }
         OaiEvent::Usage { prompt_tokens, completion_tokens } => {
             Some(StreamEvent::Session(SessionEvent::Usage {

--- a/src/runtime/openai/types.rs
+++ b/src/runtime/openai/types.rs
@@ -220,6 +220,7 @@ pub enum OaiEvent {
     },
     ToolCallArgumentsDelta {
         index: u32,
+        id: String,
         delta: String,
     },
     ToolCallsComplete {

--- a/src/runtime/openai/wire.rs
+++ b/src/runtime/openai/wire.rs
@@ -226,6 +226,7 @@ impl StreamDecoder {
                     acc.arguments.push_str(&args);
                     sink.extend(Some(OaiEvent::ToolCallArgumentsDelta {
                         index: idx,
+                        id: acc.id.clone(),
                         delta: args,
                     }));
                 }

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -13,8 +13,22 @@ pub enum StreamEvent {
 pub enum LlmEvent {
     Thinking(String),
     Text(String),
-    ToolUseStart(String),
-    ToolUseDelta(String),
+    /// A tool-use block has begun streaming. `tool_id` is the call id the
+    /// model will reference in its eventual `tool_use` content block —
+    /// chat UIs use it to route subsequent `ToolUseDelta` chunks and the
+    /// final `ToolUse` finalize event to the correct on-screen block when
+    /// multiple tools run in parallel.
+    ToolUseStart {
+        tool_name: String,
+        tool_id: String,
+    },
+    /// Streaming chunk of a tool's input JSON. `tool_id` matches the
+    /// `ToolUseStart` it belongs to; with parallel tool calls the model
+    /// may interleave deltas from different tools.
+    ToolUseDelta {
+        tool_id: String,
+        delta: String,
+    },
     ToolUse {
         tool_name: String,
         tool_id: String,

--- a/src/tools/subagent/oneshot.rs
+++ b/src/tools/subagent/oneshot.rs
@@ -166,7 +166,7 @@ impl Tool for SubagentTool {
                                 crate::StreamEvent::Llm(LlmEvent::Text(text)) => {
                                     final_text.push_str(&text);
                                 }
-                                crate::StreamEvent::Llm(LlmEvent::ToolUseStart(name)) => {
+                                crate::StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name: name, .. }) => {
                                     tool_count += 1;
                                     if let Some(ref tx) = tx_events_inner {
                                         let _ = tx.send(crate::StreamEvent::Agent(AgentEvent::SubagentUpdate {

--- a/src/tools/subagent/resume.rs
+++ b/src/tools/subagent/resume.rs
@@ -206,7 +206,7 @@ impl Tool for SubagentResumeTool {
                                     crate::StreamEvent::Llm(LlmEvent::Text(text)) => {
                                         state_a.write().unwrap().partial_text.push_str(&text);
                                     }
-                                    crate::StreamEvent::Llm(LlmEvent::ToolUseStart(name)) => {
+                                    crate::StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name: name, .. }) => {
                                         tool_count += 1;
                                         if let Some(ref tx) = tx_events_a {
                                             let _ = tx.send(crate::StreamEvent::Agent(AgentEvent::SubagentUpdate {

--- a/src/tools/subagent/start.rs
+++ b/src/tools/subagent/start.rs
@@ -208,7 +208,7 @@ impl Tool for SubagentStartTool {
                                     crate::StreamEvent::Llm(LlmEvent::Text(text)) => {
                                         state_a.write().unwrap().partial_text.push_str(&text);
                                     }
-                                    crate::StreamEvent::Llm(LlmEvent::ToolUseStart(name)) => {
+                                    crate::StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name: name, .. }) => {
                                         tool_count += 1;
                                         if let Some(ref tx) = tx_events_a {
                                             let _ = tx.send(crate::StreamEvent::Agent(AgentEvent::SubagentUpdate {

--- a/tests/chatui_viewport.rs
+++ b/tests/chatui_viewport.rs
@@ -1,0 +1,106 @@
+use ratatui::{
+    backend::TestBackend,
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Style},
+    text::{Line, Span},
+    Terminal,
+};
+
+#[cfg(test)]
+mod crossterm {
+    pub mod cursor {
+        #[allow(dead_code)]
+        pub struct MoveTo(pub u16, pub u16);
+    }
+    pub mod style {
+        #[allow(dead_code)]
+        pub struct Print<T>(pub T);
+    }
+    #[allow(dead_code)]
+    pub trait QueueableCommand: std::io::Write + Sized {
+        fn queue(&mut self, _command: impl Sized) -> std::io::Result<&mut Self> {
+            Ok(self)
+        }
+    }
+    impl<T: std::io::Write> QueueableCommand for T {}
+}
+
+#[path = "../src/chatui/viewport.rs"]
+mod viewport;
+
+fn ch(buf: &Buffer, x: u16, y: u16) -> &str {
+    buf.cell((x, y)).unwrap().symbol()
+}
+
+#[test]
+fn edge_scrub_positions_include_both_terminal_edge_columns() {
+    let positions = viewport::edge_scrub_positions(Rect::new(0, 0, 4, 3));
+    assert_eq!(positions, vec![(0, 0), (3, 0), (0, 1), (3, 1), (0, 2), (3, 2)]);
+}
+
+#[test]
+fn edge_scrub_positions_do_not_duplicate_single_column_terminal() {
+    let positions = viewport::edge_scrub_positions(Rect::new(5, 7, 1, 2));
+    assert_eq!(positions, vec![(5, 7), (5, 8)]);
+}
+
+#[test]
+fn scrub_edge_columns_resets_previous_frame_model_so_blank_edges_are_redrawn() {
+    let backend = TestBackend::new(4, 2);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    terminal
+        .draw(|frame| {
+            let buf = frame.buffer_mut();
+            buf.cell_mut((0, 0)).unwrap().set_symbol("L");
+            buf.cell_mut((3, 0)).unwrap().set_symbol("R");
+            buf.cell_mut((0, 1)).unwrap().set_symbol("l");
+            buf.cell_mut((3, 1)).unwrap().set_symbol("r");
+        })
+        .unwrap();
+
+    // Simulate ratatui's back buffer believing the next edge state is blank,
+    // which would normally make the diff skip writing physical blanks.
+    viewport::scrub_terminal_edges(&mut terminal, Style::default()).unwrap();
+
+    let completed = terminal
+        .draw(|frame| {
+            frame.buffer_mut().reset();
+            frame.buffer_mut().cell_mut((1, 0)).unwrap().set_symbol("x");
+        })
+        .unwrap();
+
+    assert_eq!(ch(completed.buffer, 0, 0), " ");
+    assert_eq!(ch(completed.buffer, 3, 0), " ");
+    assert_eq!(ch(completed.buffer, 0, 1), " ");
+    assert_eq!(ch(completed.buffer, 3, 1), " ");
+}
+
+#[test]
+fn render_scrolled_lines_clears_left_and_right_edges_from_previous_frame() {
+    let area = Rect::new(0, 0, 10, 3);
+    let style = Style::default().bg(Color::Black);
+    let mut buf = Buffer::filled(area, ratatui::buffer::Cell::new(" "));
+
+    let previous = vec![
+        Line::from(Span::raw("R")),
+        Line::from(Span::raw("middle")),
+        Line::from(Span::raw("last-edgeX")),
+    ];
+    viewport::render_scrolled_lines(&mut buf, area, &previous, style);
+    assert_eq!(ch(&buf, 0, 0), "R");
+    assert_eq!(ch(&buf, 9, 2), "X");
+
+    let next = vec![
+        Line::from(Span::raw("middle")),
+        Line::from(Span::raw("last-edgeX")),
+        Line::from(Span::raw("done")),
+    ];
+    viewport::render_scrolled_lines(&mut buf, area, &next, style);
+
+    assert_eq!(ch(&buf, 0, 0), "m");
+    assert_eq!(ch(&buf, 0, 1), "l");
+    assert_eq!(ch(&buf, 0, 2), "d");
+    assert_eq!(ch(&buf, 9, 2), " ", "right-edge glyphs from the previous frame must be cleared");
+}


### PR DESCRIPTION
## Summary
- scrub terminal edge artifacts in chat UI rendering
- emit Codex tool-use events when output items complete
- route parallel tool events by tool_id

## Verification
- cargo test --no-run