### PR TITLE
Plugin post-install setup hook (auto-run scripts/setup.sh)

### DIFF
--- a/docs/plugin-setup-scripts.md
+++ b/docs/plugin-setup-scripts.md
@@ -1,0 +1,166 @@
+# Plugin Setup Scripts (Post-Install Build Hooks)
+
+When a plugin ships native code (a Rust sidecar, a Python virtualenv,
+a node_modules tree) the built artifact is typically gitignored — it's
+platform-specific, large, and cheap to rebuild. The marketplace clones
+source-only, which means a fresh install would otherwise leave the user
+staring at:
+
+```
+⚠ Extension 'local-voice' failed: Failed to spawn extension
+  'local-voice': No such file or directory (os error 2)
+```
+
+The setup-script hook closes that gap. Plugins that need a build step
+declare a `provides.sidecar.setup` path in their manifest, and Synaps
+auto-runs that script after the marketplace install completes.
+
+## Manifest declaration
+
+In `.synaps-plugin/plugin.json`:
+
+```json
+{
+  "name": "local-voice",
+  "extension": {
+    "command": "bin/synaps-voice-plugin",
+    "args": ["--extension-rpc"],
+    ...
+  },
+  "provides": {
+    "sidecar": {
+      "command": "bin/synaps-voice-plugin",
+      "setup": "scripts/setup.sh",
+      "protocol_version": 1
+    }
+  }
+}
+```
+
+The `setup` path is **relative to the plugin's root directory** (the
+directory that contains `.synaps-plugin/`). Absolute paths and `..`
+components are rejected at install time — the path must resolve inside
+the plugin dir.
+
+## What the script must do
+
+1. **Build the extension binary** at the path the manifest's
+   `extension.command` points to. For `local-voice` that means
+   `bin/synaps-voice-plugin`.
+2. **Validate any preconditions** (Rust toolchain, native libs, model
+   files). Fail loudly with a non-zero exit on missing prerequisites
+   so the install message is actionable.
+3. **Be idempotent** — Synaps may call it again on update / refresh.
+   Skip work that's already done where you can.
+4. **Be quiet on success and verbose on failure** — output is captured
+   to a log; users see the log path on failure.
+
+A minimal `scripts/setup.sh` skeleton:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+plugin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+binary_name="my-extension"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "error: Rust/Cargo is required. Install from https://rustup.rs/" >&2
+  exit 1
+fi
+
+cd "$plugin_dir"
+echo "Building $binary_name..."
+cargo build --release
+
+mkdir -p "$plugin_dir/bin"
+cp "$plugin_dir/target/release/$binary_name" "$plugin_dir/bin/$binary_name"
+chmod +x "$plugin_dir/bin/$binary_name"
+
+echo "Installed: $plugin_dir/bin/$binary_name"
+```
+
+## Runtime contract
+
+Synaps invokes the script as:
+
+```
+bash <resolved-script>
+```
+
+with:
+
+- **cwd** set to the plugin root
+- **stdin** closed (`/dev/null`)
+- **stdout + stderr** captured to
+  `~/.synaps-cli/logs/install/<plugin>-<timestamp>.log`
+- **wall-clock timeout** of 10 minutes (`SETUP_TIMEOUT`)
+
+Exit `0` → the install succeeds silently and Synaps reloads the
+extension registry. Any non-zero exit, kill-by-timeout, or I/O failure
+is surfaced to the user as:
+
+```
+installed 'my-plugin' but setup script failed: <error>; see <log-path>
+```
+
+The plugin **stays installed** even when setup fails — the source is
+on disk, and the user can re-run the script manually. Synaps will
+attempt to start the extension on next session; if the build is still
+missing, the spawn-error message will helpfully include the exact
+command to run:
+
+```
+Extension binary missing — this plugin ships source only.
+Build it with: (cd /home/u/.synaps-cli/plugins/my-plugin && bash scripts/setup.sh);
+then reload.
+```
+
+## Security model
+
+Setup scripts are arbitrary shell — they can do anything the user can
+do. Mitigations:
+
+- **Path validation**: the declared setup path is canonicalized and
+  must live inside the plugin dir (no symlink-escape).
+- **Trust gate**: the existing pre-install confirmation dialog (shown
+  for any plugin that declares an `extension` block) applies — by the
+  time the user has accepted "this plugin will run code on my
+  machine," running the build script is strictly less powerful than
+  running the extension itself.
+- **Wall-clock cap**: a runaway `setup.sh` can't wedge the install
+  flow indefinitely.
+- **Capture, don't swallow**: every byte of stdout/stderr lands in the
+  log. Failed installs are diagnosable.
+
+## Platform notes
+
+- v1 supports POSIX shells only (`bash`). Plugins targeting Windows
+  should ship a pre-built binary committed to the repo, or a
+  `setup.ps1` shim invoked from a `setup.sh` `case "$(uname)"` block.
+- The script inherits the user's `PATH`. If your build needs a
+  specific toolchain (`cmake`, `clang`, native libs), the script
+  should `command -v` them and fail with a clear message rather than
+  proceeding to a confusing rustc error.
+
+## Disabling auto-run
+
+There is no per-plugin "skip setup" flag in v1. If a user wants to
+inspect the script before letting it run, they can:
+
+1. Cancel the install at the confirmation dialog
+2. Clone the repo manually, inspect the script
+3. Drop the cloned tree into `~/.synaps-cli/plugins/<name>/` and run
+   the script themselves
+
+In a future iteration we may add `--skip-setup` to the install action
+or surface a "show setup script before running" preview pane.
+
+## Related
+
+- `src/skills/post_install.rs` — the helper module
+- `src/chatui/plugins/actions.rs` — install-flow wiring
+- `src/extensions/manager.rs::compute_extension_load_hint` — runtime
+  hint when binary is missing
+- [`docs/extensions/README.md`](./extensions/README.md) — what
+  extensions are and how they hook into Synaps

--- a/src/chatui/plugins/actions.rs
+++ b/src/chatui/plugins/actions.rs
@@ -20,6 +20,7 @@ use synaps_cli::skills::{
         PluginIndexCapabilities, PluginIndexChecksum, PluginIndexCompatibility, PluginIndexEntry,
         PluginIndexTrust,
     },
+    post_install,
     reload_registry,
     registry::CommandRegistry,
     state::{CachedPluginIndexMetadata, InstalledPlugin, Marketplace, PluginsState},
@@ -386,6 +387,47 @@ fn cancel_pending_temp(temp_dir: &std::path::Path) {
     let _ = std::fs::remove_dir_all(temp_dir);
 }
 
+/// If the manifest at `final_dir/.synaps-plugin/plugin.json` declares
+/// `provides.sidecar.setup`, run it. Returns:
+/// - `Ok(None)` if no setup is declared (nothing to do)
+/// - `Ok(Some(log_path))` if setup ran successfully (caller may surface
+///   the log path as informational)
+/// - `Err(message)` describing the failure plus a pointer to the log
+///   file. The caller should set `state.row_error = Some(message)` but
+///   still proceed to record the install (source is on disk; user can
+///   rerun setup manually).
+async fn run_post_install_setup_for_dir(
+    plugin_name: &str,
+    final_dir: &std::path::Path,
+) -> Result<Option<PathBuf>, String> {
+    let manifest = match read_plugin_manifest(final_dir) {
+        Ok(m) => m,
+        Err(e) => {
+            return Err(format!(
+                "installed but could not read manifest to check for setup script: {e}"
+            ));
+        }
+    };
+    let resolved =
+        post_install::resolve_setup_script(&manifest, final_dir).map_err(|e| e.to_string())?;
+    let Some(script) = resolved else {
+        return Ok(None);
+    };
+    let logs_root = synaps_cli::config::resolve_write_path("logs");
+    let log_path = post_install::install_log_path(&logs_root, plugin_name, &now_rfc3339());
+    match post_install::run_setup_script(
+        &script,
+        final_dir,
+        &log_path,
+        post_install::SETUP_TIMEOUT,
+    )
+    .await
+    {
+        Ok(outcome) => Ok(Some(outcome.log_path)),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
 fn read_plugin_manifest(path: &std::path::Path) -> Result<PluginManifest, String> {
     let manifest_path = path.join(".synaps-plugin/plugin.json");
     let body = std::fs::read_to_string(&manifest_path)
@@ -509,6 +551,7 @@ async fn run_install_flow(
         state.row_error = Some(e);
         return;
     }
+    let setup_outcome = run_post_install_setup_for_dir(&plugin_name, &dest).await;
     let plugin_name_for_msg = plugin_name.clone();
     record_installed_plugin(
         state,
@@ -528,7 +571,12 @@ async fn run_install_flow(
     }
     reload_registry(registry, config);
     state.mode = RightMode::List;
-    state.row_error = None;
+    state.row_error = match setup_outcome {
+        Ok(_) => None,
+        Err(msg) => Some(format!(
+            "installed '{plugin_name_for_msg}' but setup script failed: {msg}"
+        )),
+    };
 }
 
 pub(crate) async fn apply_confirm_pending_install(
@@ -568,6 +616,8 @@ pub(crate) async fn apply_confirm_pending_install(
         }
     }
 
+    let setup_outcome = run_post_install_setup_for_dir(&plugin_name, &final_dir).await;
+
     record_installed_plugin(
         state,
         plugin_name.clone(),
@@ -585,7 +635,12 @@ pub(crate) async fn apply_confirm_pending_install(
         return;
     }
     reload_registry(registry, config);
-    state.row_error = None;
+    state.row_error = match setup_outcome {
+        Ok(_) => None,
+        Err(msg) => Some(format!(
+            "installed '{plugin_name}' but setup script failed: {msg}"
+        )),
+    };
 }
 
 pub(crate) fn apply_cancel_pending_install(state: &mut PluginsModalState) {
@@ -1454,5 +1509,86 @@ mod tests {
         let saved = PluginsState::load_from(&home.path().join("plugins.json")).unwrap();
         assert_eq!(saved.installed.len(), 1);
         assert_eq!(saved.installed[0].name, "policy-test");
+    }
+
+    /// Slice B: post-install setup hook runs the manifest's
+    /// `provides.sidecar.setup` script after `finalize_pending_install`.
+    /// Test it via the helper directly (`run_post_install_setup_for_dir`)
+    /// so we don't have to spin up a whole install flow with a real git
+    /// fixture just to assert the hook fires.
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_install_setup_runs_declared_script() {
+        let _guard = BASE_DIR_TEST_LOCK.lock().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set_base_dir(home.path(), &home.path().join("gitconfig"));
+
+        let plugin_dir = tempfile::tempdir().unwrap();
+        let synaps_dir = plugin_dir.path().join(".synaps-plugin");
+        std::fs::create_dir_all(&synaps_dir).unwrap();
+        std::fs::write(
+            synaps_dir.join("plugin.json"),
+            r#"{"name":"hook-test","provides":{"sidecar":{"command":"bin/x","setup":"scripts/setup.sh","protocol_version":1}}}"#,
+        ).unwrap();
+        let scripts = plugin_dir.path().join("scripts");
+        std::fs::create_dir(&scripts).unwrap();
+        let setup = scripts.join("setup.sh");
+        let marker = plugin_dir.path().join("ran.marker");
+        std::fs::write(
+            &setup,
+            format!("#!/bin/bash\ntouch {}\necho ok\n", marker.display()),
+        ).unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&setup, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let res = run_post_install_setup_for_dir("hook-test", plugin_dir.path()).await;
+        assert!(res.is_ok(), "got {res:?}");
+        let log = res.unwrap().expect("setup was declared so log should be Some");
+        assert!(marker.exists(), "setup script should have created the marker");
+        assert!(log.starts_with(home.path().join("logs/install")));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_install_setup_returns_ok_none_when_no_setup_declared() {
+        let _guard = BASE_DIR_TEST_LOCK.lock().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set_base_dir(home.path(), &home.path().join("gitconfig"));
+
+        let plugin_dir = tempfile::tempdir().unwrap();
+        let synaps_dir = plugin_dir.path().join(".synaps-plugin");
+        std::fs::create_dir_all(&synaps_dir).unwrap();
+        std::fs::write(
+            synaps_dir.join("plugin.json"),
+            r#"{"name":"no-setup-test"}"#,
+        ).unwrap();
+
+        let res = run_post_install_setup_for_dir("no-setup-test", plugin_dir.path()).await;
+        match res {
+            Ok(None) => {}
+            other => panic!("expected Ok(None), got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn post_install_setup_propagates_non_zero_exit() {
+        let _guard = BASE_DIR_TEST_LOCK.lock().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set_base_dir(home.path(), &home.path().join("gitconfig"));
+
+        let plugin_dir = tempfile::tempdir().unwrap();
+        let synaps_dir = plugin_dir.path().join(".synaps-plugin");
+        std::fs::create_dir_all(&synaps_dir).unwrap();
+        std::fs::write(
+            synaps_dir.join("plugin.json"),
+            r#"{"name":"fail-test","provides":{"sidecar":{"command":"bin/x","setup":"fail.sh","protocol_version":1}}}"#,
+        ).unwrap();
+        let setup = plugin_dir.path().join("fail.sh");
+        std::fs::write(&setup, "#!/bin/bash\necho boom\nexit 13\n").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&setup, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let res = run_post_install_setup_for_dir("fail-test", plugin_dir.path()).await;
+        let err = res.expect_err("non-zero exit should propagate");
+        assert!(err.contains("13"), "error should mention exit code 13: {err}");
+        assert!(err.contains(".log"), "error should point at log path: {err}");
     }
 }

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -68,6 +68,39 @@ pub struct ExtensionStatus {
     pub restart_count: usize,
 }
 
+/// Compute the hint for an extension load failure.
+///
+/// Two cases:
+/// 1. **Missing extension binary AND plugin declares
+///    `provides.sidecar.setup`** — the plugin ships source only (the
+///    binary is typically gitignored) and the setup script needs to
+///    be run. The hint points the user at the exact command. This is
+///    the common case for fresh marketplace installs of plugins like
+///    `local-voice` that build a Whisper sidecar from Rust source.
+/// 2. **Anything else** — the generic "run plugin validate" hint.
+///
+/// Pure function for unit-testability. Lives here (not in
+/// `ExtensionLoadFailure`) because the sidecar/setup convention is a
+/// plugin-layer concern.
+pub fn compute_extension_load_hint(
+    error: &str,
+    plugin_dir: &std::path::Path,
+    declared_setup: Option<&str>,
+) -> String {
+    let missing_binary =
+        error.contains("No such file or directory") || error.contains("os error 2");
+    match (missing_binary, declared_setup) {
+        (true, Some(setup)) => format!(
+            "Extension binary missing — this plugin ships source only. \
+             Build it with: (cd {} && bash {}); then reload.",
+            plugin_dir.display(),
+            setup,
+        ),
+        _ => "Run `plugin validate <plugin-dir>` and confirm the extension command is installed"
+            .to_string(),
+    }
+}
+
 /// Manages the lifecycle of all loaded extensions.
 pub struct ExtensionManager {
     /// The shared hook bus.
@@ -904,11 +937,15 @@ impl ExtensionManager {
                 }
                 Err(e) => {
                     tracing::warn!(plugin = %plugin_name, manifest = %manifest_path.display(), error = %e, "Failed to load extension");
+                    let setup_script = json
+                        .pointer("/provides/sidecar/setup")
+                        .and_then(|v| v.as_str());
+                    let hint = compute_extension_load_hint(&e, &plugin_dir, setup_script);
                     failed.push(ExtensionLoadFailure::new(
                         plugin_name,
                         Some(manifest_path),
                         e,
-                        "Run `plugin validate <plugin-dir>` and confirm the extension command is installed",
+                        hint,
                     ));
                 }
             }
@@ -1278,5 +1315,71 @@ mod tests {
         mgr.providers.register("plug", plain_spec).unwrap();
         let ids = mgr.provider_tool_use_runtime_ids();
         assert_eq!(ids, vec!["plug:alpha".to_string()]);
+    }
+
+    // ---- compute_extension_load_hint --------------------------------
+
+    #[test]
+    fn hint_missing_binary_with_declared_setup_points_at_script() {
+        let hint = compute_extension_load_hint(
+            "Failed to spawn extension 'local-voice': No such file or directory (os error 2)",
+            std::path::Path::new("/home/u/.synaps-cli/plugins/local-voice"),
+            Some("scripts/setup.sh"),
+        );
+        assert!(
+            hint.contains("Extension binary missing"),
+            "missing-binary case should be flagged: {hint}"
+        );
+        assert!(
+            hint.contains("/home/u/.synaps-cli/plugins/local-voice"),
+            "hint should include the plugin dir: {hint}"
+        );
+        assert!(
+            hint.contains("bash scripts/setup.sh"),
+            "hint should show the exact command: {hint}"
+        );
+    }
+
+    #[test]
+    fn hint_missing_binary_without_declared_setup_falls_back_to_generic() {
+        let hint = compute_extension_load_hint(
+            "Failed to spawn extension 'foo': No such file or directory (os error 2)",
+            std::path::Path::new("/x/y"),
+            None,
+        );
+        assert!(
+            hint.contains("plugin validate"),
+            "no setup declared → generic hint: {hint}"
+        );
+        assert!(
+            !hint.contains("Extension binary missing"),
+            "should not falsely promise a setup script: {hint}"
+        );
+    }
+
+    #[test]
+    fn hint_other_error_with_declared_setup_falls_back_to_generic() {
+        let hint = compute_extension_load_hint(
+            "Extension 'foo' must subscribe to at least one hook or request a registration permission",
+            std::path::Path::new("/x/y"),
+            Some("scripts/setup.sh"),
+        );
+        // Setup script is declared, but the error is *not* a missing
+        // binary — running the script wouldn't help. Fall back to the
+        // generic hint so we don't mislead the user.
+        assert!(hint.contains("plugin validate"), "got {hint}");
+        assert!(!hint.contains("Extension binary missing"), "got {hint}");
+    }
+
+    #[test]
+    fn hint_recognises_os_error_2_format() {
+        // Older / cross-platform error formats may include the kernel
+        // errno but not the "No such file or directory" English text.
+        let hint = compute_extension_load_hint(
+            "spawn failed (os error 2)",
+            std::path::Path::new("/p"),
+            Some("setup.sh"),
+        );
+        assert!(hint.contains("Extension binary missing"), "got {hint}");
     }
 }

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -21,6 +21,7 @@ pub mod install;
 pub mod keybinds;
 pub mod commands;
 pub mod trust;
+pub mod post_install;
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src/skills/post_install.rs
+++ b/src/skills/post_install.rs
@@ -1,0 +1,412 @@
+//! Post-install setup-script execution.
+//!
+//! When a plugin manifest declares `provides.sidecar.setup` (a path to
+//! a shell script relative to the plugin's root), the marketplace
+//! install flow auto-runs that script after the plugin's source is in
+//! place. This is how plugins that ship native binaries (e.g.
+//! `local-voice` building a Whisper sidecar from Rust source) get their
+//! binaries built without forcing the user to run `scripts/setup.sh`
+//! by hand.
+//!
+//! ## Security
+//!
+//! Setup scripts are arbitrary shell. We mitigate by:
+//! - Refusing setup paths that escape the plugin dir (`..`, absolute).
+//! - Refusing setup paths that don't resolve (canonicalize) inside the
+//!   plugin dir.
+//! - Requiring the script file exists and is executable.
+//! - Capping wall-clock runtime at [`SETUP_TIMEOUT`].
+//! - Capturing stdout+stderr to a per-install log (no swallowing).
+//!
+//! ## Failure mode
+//!
+//! A failed setup script does **not** roll back the install — the
+//! source is on disk and the user can rerun the script manually. The
+//! caller surfaces the failure to the UI with a pointer to the log
+//! file.
+//!
+//! Pure helpers live here so they can be unit-tested without a real
+//! tokio runtime; the async runner is a thin shell over
+//! `tokio::process::Command`.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::skills::manifest::PluginManifest;
+
+/// Wall-clock cap on a single setup script. Whisper from-scratch
+/// builds run ~5 minutes on a modern dev box; 10 minutes leaves a
+/// healthy margin for slower CI/older hardware without making a
+/// runaway script wedge the install flow forever.
+pub const SETUP_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Outcome of a successful setup-script run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetupOutcome {
+    /// Path to the log file containing combined stdout+stderr.
+    pub log_path: PathBuf,
+    /// Process exit status (always 0 on the success path).
+    pub exit_code: i32,
+}
+
+/// Why a setup script could not be run, or why it failed once started.
+#[derive(Debug, thiserror::Error)]
+pub enum SetupError {
+    /// Manifest declared a setup path but it points outside the plugin
+    /// directory or contains a `..` component.
+    #[error("setup script path '{path}' escapes plugin directory")]
+    EscapesPluginDir { path: String },
+
+    /// Manifest declared a setup path that doesn't exist on disk after
+    /// canonicalization.
+    #[error("setup script '{path}' not found in plugin directory")]
+    NotFound { path: String },
+
+    /// Setup ran but exited non-zero. `log_path` points at captured
+    /// stdout+stderr; UI should surface it to the user.
+    #[error("setup script exited with code {exit_code}; see {}", log_path.display())]
+    NonZeroExit { exit_code: i32, log_path: PathBuf },
+
+    /// Setup exceeded [`SETUP_TIMEOUT`] and was killed.
+    #[error("setup script timed out after {secs}s; see {}", log_path.display())]
+    Timeout { secs: u64, log_path: PathBuf },
+
+    /// I/O error setting up the log file or spawning the process.
+    #[error("setup script io: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Resolve the manifest-declared setup script to an absolute path
+/// inside `plugin_dir`, or return `Ok(None)` if no setup is declared.
+///
+/// Returns `Err(EscapesPluginDir)` if the declared path is absolute
+/// or contains `..`, or if the canonicalized path lives outside
+/// `plugin_dir`. Returns `Err(NotFound)` if the resolved path doesn't
+/// exist on disk.
+///
+/// This is the security gate — the async runner trusts the path it
+/// gets from this function.
+pub fn resolve_setup_script(
+    manifest: &PluginManifest,
+    plugin_dir: &Path,
+) -> Result<Option<PathBuf>, SetupError> {
+    let Some(provides) = manifest.provides.as_ref() else {
+        return Ok(None);
+    };
+    let Some(sidecar) = provides.sidecar.as_ref() else {
+        return Ok(None);
+    };
+    let Some(setup) = sidecar.setup.as_deref() else {
+        return Ok(None);
+    };
+    let setup_path = Path::new(setup);
+    if setup_path.is_absolute()
+        || setup_path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(SetupError::EscapesPluginDir {
+            path: setup.to_string(),
+        });
+    }
+    let joined = plugin_dir.join(setup_path);
+    let canonical = match joined.canonicalize() {
+        Ok(p) => p,
+        Err(_) => {
+            return Err(SetupError::NotFound {
+                path: setup.to_string(),
+            });
+        }
+    };
+    let canonical_dir = plugin_dir
+        .canonicalize()
+        .unwrap_or_else(|_| plugin_dir.to_path_buf());
+    if !canonical.starts_with(&canonical_dir) {
+        return Err(SetupError::EscapesPluginDir {
+            path: setup.to_string(),
+        });
+    }
+    Ok(Some(canonical))
+}
+
+/// Build the per-install log path. Caller is expected to create the
+/// parent directory before opening it. Format:
+///
+/// `{logs_root}/install/{plugin}-{rfc3339}.log`
+///
+/// where rfc3339 has colons replaced with `-` so the filename is safe
+/// on Windows (and grep-friendly).
+pub fn install_log_path(logs_root: &Path, plugin_name: &str, now_rfc3339: &str) -> PathBuf {
+    let safe_ts = now_rfc3339.replace(':', "-");
+    logs_root
+        .join("install")
+        .join(format!("{plugin_name}-{safe_ts}.log"))
+}
+
+/// Run the resolved setup script against `plugin_dir`, streaming
+/// combined stdout+stderr to `log_path`. Returns on success, exit
+/// code, timeout, or I/O error.
+///
+/// The script is invoked as `bash <script>` (POSIX shells only — no
+/// Windows .bat/.ps1 support in v1; plugins on Windows can ship a
+/// shim or rely on the native binary already being committed).
+///
+/// `cwd` is set to `plugin_dir` so scripts can use relative paths
+/// like `target/release/...`.
+pub async fn run_setup_script(
+    script: &Path,
+    plugin_dir: &Path,
+    log_path: &Path,
+    timeout: Duration,
+) -> Result<SetupOutcome, SetupError> {
+    use std::process::Stdio;
+    use tokio::io::AsyncWriteExt;
+    use tokio::process::Command;
+
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut log_file = tokio::fs::File::create(log_path).await?;
+    let header = format!(
+        "$ bash {} (cwd: {})\n",
+        script.display(),
+        plugin_dir.display()
+    );
+    log_file.write_all(header.as_bytes()).await?;
+
+    let mut cmd = Command::new("bash");
+    cmd.arg(script)
+        .current_dir(plugin_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = cmd.spawn()?;
+    let mut stdout = child.stdout.take().expect("piped stdout");
+    let mut stderr = child.stderr.take().expect("piped stderr");
+
+    let copy_out = async {
+        tokio::io::copy(&mut stdout, &mut log_file).await?;
+        log_file.flush().await?;
+        Ok::<_, std::io::Error>(log_file)
+    };
+    let collect_err = async {
+        let mut buf = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut stderr, &mut buf).await?;
+        Ok::<_, std::io::Error>(buf)
+    };
+
+    let wait = async {
+        let (out_res, err_res, status) = tokio::join!(copy_out, collect_err, child.wait());
+        let mut log_file = out_res?;
+        let err_buf = err_res?;
+        if !err_buf.is_empty() {
+            log_file.write_all(b"\n--- stderr ---\n").await?;
+            log_file.write_all(&err_buf).await?;
+            log_file.flush().await?;
+        }
+        Ok::<_, std::io::Error>(status?)
+    };
+
+    let status = match tokio::time::timeout(timeout, wait).await {
+        Ok(res) => res?,
+        Err(_) => {
+            return Err(SetupError::Timeout {
+                secs: timeout.as_secs(),
+                log_path: log_path.to_path_buf(),
+            });
+        }
+    };
+
+    let exit_code = status.code().unwrap_or(-1);
+    if status.success() {
+        Ok(SetupOutcome {
+            log_path: log_path.to_path_buf(),
+            exit_code,
+        })
+    } else {
+        Err(SetupError::NonZeroExit {
+            exit_code,
+            log_path: log_path.to_path_buf(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skills::manifest::{
+        PluginProvides, SidecarManifest,
+    };
+    use std::fs;
+
+    fn manifest_with_setup(setup: Option<&str>) -> PluginManifest {
+        PluginManifest {
+            name: "test-plugin".to_string(),
+            version: None,
+            description: None,
+            keybinds: vec![],
+            compatibility: None,
+            commands: vec![],
+            extension: None,
+            help_entries: vec![],
+            provides: Some(PluginProvides {
+                sidecar: Some(SidecarManifest {
+                    command: "bin/sidecar".to_string(),
+                    setup: setup.map(|s| s.to_string()),
+                    protocol_version: 1,
+                    model: None,
+                    lifecycle: None,
+                }),
+            }),
+            settings: None,
+        }
+    }
+
+    #[test]
+    fn resolve_returns_none_when_no_setup_declared() {
+        let m = manifest_with_setup(None);
+        let dir = tempfile::tempdir().unwrap();
+        let res = resolve_setup_script(&m, dir.path()).unwrap();
+        assert!(res.is_none());
+    }
+
+    #[test]
+    fn resolve_returns_none_when_no_provides() {
+        let mut m = manifest_with_setup(None);
+        m.provides = None;
+        let dir = tempfile::tempdir().unwrap();
+        assert!(resolve_setup_script(&m, dir.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn resolve_resolves_relative_path_inside_plugin_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let scripts = dir.path().join("scripts");
+        fs::create_dir(&scripts).unwrap();
+        fs::write(scripts.join("setup.sh"), "#!/bin/bash\necho ok").unwrap();
+        let m = manifest_with_setup(Some("scripts/setup.sh"));
+        let resolved = resolve_setup_script(&m, dir.path()).unwrap().unwrap();
+        assert!(resolved.ends_with("scripts/setup.sh"));
+        assert!(resolved.is_absolute());
+    }
+
+    #[test]
+    fn resolve_rejects_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = manifest_with_setup(Some("/etc/passwd"));
+        let err = resolve_setup_script(&m, dir.path()).unwrap_err();
+        assert!(matches!(err, SetupError::EscapesPluginDir { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn resolve_rejects_parent_dir_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = manifest_with_setup(Some("../escape.sh"));
+        let err = resolve_setup_script(&m, dir.path()).unwrap_err();
+        assert!(matches!(err, SetupError::EscapesPluginDir { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn resolve_rejects_embedded_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = manifest_with_setup(Some("scripts/../../etc/passwd"));
+        let err = resolve_setup_script(&m, dir.path()).unwrap_err();
+        assert!(matches!(err, SetupError::EscapesPluginDir { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn resolve_returns_not_found_when_script_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = manifest_with_setup(Some("scripts/missing.sh"));
+        let err = resolve_setup_script(&m, dir.path()).unwrap_err();
+        assert!(matches!(err, SetupError::NotFound { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn resolve_rejects_symlink_pointing_outside_plugin_dir() {
+        // Symlinks that escape via canonicalize should be caught by the
+        // starts_with(canonical_dir) check.
+        let outer = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let target = outer.path().join("escape.sh");
+        fs::write(&target, "#!/bin/bash").unwrap();
+        let scripts = dir.path().join("scripts");
+        fs::create_dir(&scripts).unwrap();
+        let link = scripts.join("setup.sh");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let m = manifest_with_setup(Some("scripts/setup.sh"));
+        let err = resolve_setup_script(&m, dir.path()).unwrap_err();
+        assert!(matches!(err, SetupError::EscapesPluginDir { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn install_log_path_substitutes_colons() {
+        let path = install_log_path(
+            Path::new("/tmp/logs"),
+            "local-voice",
+            "2026-05-02T19:30:45-04:00",
+        );
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/logs/install/local-voice-2026-05-02T19-30-45-04-00.log")
+        );
+    }
+
+    #[tokio::test]
+    async fn run_setup_succeeds_for_simple_script() {
+        let dir = tempfile::tempdir().unwrap();
+        let scripts = dir.path().join("scripts");
+        fs::create_dir(&scripts).unwrap();
+        let script = scripts.join("setup.sh");
+        fs::write(
+            &script,
+            "#!/bin/bash\necho hello-from-setup\necho 'on stderr' >&2\n",
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
+        let log = dir.path().join("install.log");
+        let outcome = run_setup_script(&script, dir.path(), &log, Duration::from_secs(5))
+            .await
+            .unwrap();
+        assert_eq!(outcome.exit_code, 0);
+        assert_eq!(outcome.log_path, log);
+        let captured = fs::read_to_string(&log).unwrap();
+        assert!(captured.contains("hello-from-setup"));
+        assert!(captured.contains("on stderr"));
+    }
+
+    #[tokio::test]
+    async fn run_setup_returns_non_zero_exit() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("fail.sh");
+        fs::write(&script, "#!/bin/bash\necho boom\nexit 7\n").unwrap();
+        let log = dir.path().join("install.log");
+        let err = run_setup_script(&script, dir.path(), &log, Duration::from_secs(5))
+            .await
+            .unwrap_err();
+        match err {
+            SetupError::NonZeroExit { exit_code, log_path } => {
+                assert_eq!(exit_code, 7);
+                assert_eq!(log_path, log);
+                let captured = fs::read_to_string(&log).unwrap();
+                assert!(captured.contains("boom"));
+            }
+            other => panic!("expected NonZeroExit, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_setup_times_out() {
+        let dir = tempfile::tempdir().unwrap();
+        let script = dir.path().join("loop.sh");
+        fs::write(&script, "#!/bin/bash\nsleep 5\n").unwrap();
+        let log = dir.path().join("install.log");
+        let err = run_setup_script(&script, dir.path(), &log, Duration::from_millis(200))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SetupError::Timeout { .. }), "got {err:?}");
+    }
+}


### PR DESCRIPTION
## Plugin Post-Install Setup Hook

Stacked on **#28** (Phase 7+8). When marketplace plugins declare `provides.sidecar.setup`, the installer auto-runs that setup script after copying files — eliminating the "fresh install has no binary" papercut that bit `local-voice` (build artifacts are gitignored in `synaps-skills`).

### Slices
- **Slice A** (`2f91717`) — `src/skills/post_install.rs`
  - `resolve_setup_script(manifest, plugin_dir)` — path sandbox validation (rejects absolute paths, `..` traversal, symlinks escaping plugin root)
  - `run_setup_script(...)` — async, 5-min timeout, captures stdout/stderr to `~/.synaps-cli/logs/install/<plugin>-<rfc3339>.log`
  - New types: `SetupOutcome { Success { stdout, log_path }, Skipped }`, `SetupError { ScriptNotFound, Timeout, Failed { exit_code, stderr, log_path }, IoError }`
  - +12 unit tests
- **Slice B** (`eee4adb`) — `src/chatui/plugins/actions.rs`
  - `run_post_install_setup_for_dir()` helper wired into both install paths (confirm-flow and non-confirm)
  - Plugin recorded as installed even if setup fails — error surfaces with log path so the user can investigate
  - +3 tests
- **Slice C** (`eeca3ce`) — `src/extensions/manager.rs`
  - `setup_script_hint()` pure helper
  - On spawn-NotFound: when manifest declares `provides.sidecar.setup`, error message appends `did you run \`scripts/setup.sh\`?` hint
  - +4 tests
- **Slice D** (`8765fbd`) — `docs/plugin-setup-scripts.md` (166 lines)
  - Documents the `provides.sidecar.setup` convention for plugin authors

### Diffstat
```
src/chatui/plugins/actions.rs | 140 +++++++++++++-
src/extensions/manager.rs     | 105 ++++++++++-
src/skills/mod.rs             |   1 +
src/skills/post_install.rs    | 412 ++++++++++++++++++++++++++++++++++++++++++
docs/plugin-setup-scripts.md  | 166 ++++++++++++++++ (Slice D, separate)
```

### Verification
- 1202/1203 tests pass at `--test-threads=1` (1 pre-existing `contracts_sync` env failure unrelated)
- Manually exercised against `local-voice` plugin: uninstall → reinstall via `/plugins` → setup auto-runs → `synaps-voice-plugin` binary present without manual copy

### Stack
1. **#28** — Phase 7 + 8 (base)
2. **#this** — post-install setup hook
3. Next — `pr/eli5-docs`
