### PR TITLE
docs: add ELI5.md — plain-English overview of Synaps

### DIFF
--- a/ELI5.md
+++ b/ELI5.md
@@ -1,0 +1,56 @@
+# Synaps - ELI5
+
+## 🤖 Imagine you have a robot friend who lives in your computer
+
+You can talk to it by typing. It can read files, run commands, write code, and do tasks for you. Lots of robots like this exist (ChatGPT, Claude, etc.). But most of them are big and slow and only know how to do what their makers taught them.
+
+**Synaps is a robot harness that's tiny, super fast, and you can teach it new tricks by giving it plugins.** 🏷️
+
+## 🧱 It's built like LEGO
+
+Most robot apps are like a toy that comes glued together — you can't open it up. Synaps is like a LEGO set:
+
+- 🧠 The **brain** is one piece (it talks to AI models)
+- 🔧 The **tools** are little blocks (read a file, run a command, search the web)
+- 🎨 You can **swap the AI** behind it — Claude, or a free one from Groq, or one running on your own computer
+- 🏠 It all lives in **one tiny file** that starts in less than a blink
+
+## 🏷️ Plugins are like magic stickers you put on your robot
+
+Want your robot to also do voice? **Stick on a voice plugin.** 🎤
+Want it to check your code is safe? **Stick on a security plugin.** 🛡️
+Want it to remember things forever? **Stick on a memory plugin.** 🧠
+
+```
+   Your Robot 🤖
+      │
+   ┌──┴──┬─────┬─────┬─────┐
+   🎤    🛡️    🧠    📚    🎨
+  voice  safe  mem  skills theme
+```
+
+Each sticker is just a folder you drop in with its own programs for the robot to run. The cool part: stickers can talk to other stickers, but they can't do mean things — the robot has strict rules ("you can read files but not delete them," "you can listen but not see the chat").
+
+## 👯 You can have lots of robots working together
+
+The big robot can call **little helper robots** to do small jobs while it does the big job. It's like a chef with sous-chefs:
+
+```
+     🤖 Big Robot
+       │ "you chop, you stir, you watch the oven"
+   ┌───┼────┬──────┐
+   🤖   🤖   🤖    🤖
+  chop stir oven taste
+```
+
+You can even **poke a robot mid-task** ("wait, do it differently!") and it listens. And there's a **babysitter robot** 👶‍🦺 that watches the others so they don't crash or spend too much money.
+
+## 📬 Anything in the world can poke your robot
+
+Your monitoring system can yell *"the website is down!"* and your robot wakes up and fixes it. An alarm can say *"it's morning, check email."* It's a robot that **listens to the whole world**, not just to you.
+
+## 🎯 Why does this matter?
+
+Most AI tools are like a **fancy single toy**. Synaps is more like a **toy box with rails** — you can build whatever robot-shaped thing you want, share your stickers with friends, and snap them together. As AI models get cheaper and more common (some are already free!), the cool part stops being *which AI you have* and starts being *how cleverly you put your robot together*.
+
+**That's what Synaps is: not a robot, but a really good way to make robots work.** 🛠️🤖✨


### PR DESCRIPTION
## docs: ELI5.md — plain-English overview of Synaps

Stacked on **#29** (post-install setup) → **#28** (Phase 7+8).

Adds a single 56-line `ELI5.md` at the repo root that explains what Synaps is and how it works in plain English — for newcomers, non-engineers, and anyone deciding whether to read the deeper architecture docs.

No code changes. No test impact.

### Stack
1. **#28** — Phase 7 + 8
2. **#29** — post-install setup hook
3. **#this** — ELI5 docs
