### PR TITLE
release: v0.1.7 — Extension Widgets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synaps"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["Haseeb Khalid <haseebkhalid1507@gmail.com>"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -193,6 +193,23 @@ keybind.F5 = /compact
 
 That's it. No YAML. No TOML. No JSON. Key = value. Done.
 
+### Bridge mirror (optional)
+
+When the bridge daemon (synaps-skills) is running locally, the watcher
+can mirror per-agent heartbeats over its UDS `ControlSocket`
+(`heartbeat_emit` op). Off by default. Enable with:
+
+```ini
+bridge.heartbeat_mirror = true
+# bridge.uds_path = /custom/path/control.sock     # default: ~/.synaps-cli/bridge/control.sock
+# bridge.heartbeat_timeout_ms = 250               # connect+write+read budget
+```
+
+Mirroring is best-effort — the watcher never blocks or fails an agent
+if the bridge UDS is missing. See
+[`docs/smoke/watcher-bridge.md`](docs/smoke/watcher-bridge.md) for the
+verification playbook.
+
 ---
 
 ## Extensions & Plugins

--- a/docs/smoke/watcher-bridge.md
+++ b/docs/smoke/watcher-bridge.md
@@ -1,0 +1,90 @@
+# Smoke: watcher → bridge UDS heartbeat mirror
+
+This playbook verifies that the SynapsCLI watcher mirrors per-agent
+heartbeats over the bridge daemon's `ControlSocket` (`heartbeat_emit`
+op) when `[bridge].heartbeat_mirror` is enabled.
+
+## Prereqs
+
+- Bridge daemon (synaps-skills, Phase 5+) running and exposing a UDS
+  control socket. Default path: `~/.synaps-cli/bridge/control.sock`.
+- At least one watcher agent configured under `~/.synaps-cli/watcher/<name>/`.
+- `socat` installed (for the manual UDS probe in step 4).
+
+## Steps
+
+### 1. Enable the mirror
+
+Edit `~/.config/synaps/config.toml` (or the file referenced by
+`SYNAPS_CONFIG`) and add:
+
+```toml
+[bridge]
+heartbeat_mirror = true
+# Optional overrides:
+# uds_path = "/custom/path/control.sock"
+# heartbeat_timeout_ms = 250
+```
+
+When unset, `uds_path` resolves to `<base_dir>/bridge/control.sock`
+(usually `~/.synaps-cli/bridge/control.sock`).
+
+### 2. Start the watcher supervisor
+
+```bash
+synaps watcher start
+```
+
+You should see this line in the watcher log within the first second:
+
+```
+[watcher] bridge heartbeat mirror ENABLED (uds=…/control.sock, timeout=250ms)
+```
+
+### 3. Confirm bridge sees per-agent heartbeats
+
+Within ~30 s of any agent posting a heartbeat (default
+`interval_secs = 30`), the bridge `/health` endpoint should report a
+component entry per agent. With the bridge daemon's HTTP probe:
+
+```bash
+curl -s http://127.0.0.1:<bridge-port>/health | jq '.components[] | select(.component=="agent")'
+```
+
+Expected: one object per running watcher agent, with `healthy: true`
+and a `lastSeen` timestamp newer than the watcher's heartbeat
+interval.
+
+### 4. (Optional) Manual UDS probe
+
+Send a one-off `heartbeat_emit` directly to the bridge to validate
+framing without involving the watcher:
+
+```bash
+echo '{"op":"heartbeat_emit","component":"agent","id":"smoke-test","healthy":true,"details":{},"synaps_user_id":"local"}' \
+  | socat - UNIX-CONNECT:$HOME/.synaps-cli/bridge/control.sock
+```
+
+Expected response (one line):
+
+```json
+{"ok":true,"ts":"2025-…"}
+```
+
+### 5. Verify graceful degradation
+
+Stop the bridge daemon and watch the SynapsCLI log with
+`RUST_LOG=watcher::bridge=debug`. The watcher must keep running.
+You should see lines like:
+
+```
+DEBUG watcher::bridge: bridge heartbeat mirror failed (non-fatal) agent=… error=bridge socket unavailable: …
+```
+
+Agents must continue to spawn, restart, and heartbeat normally — the
+bridge being offline is never fatal.
+
+## Tear-down
+
+Set `heartbeat_mirror = false` (or remove the `[bridge]` block) and
+restart the watcher to disable mirroring.

--- a/src/cmd/rpc.rs
+++ b/src/cmd/rpc.rs
@@ -29,7 +29,7 @@ use synaps_cli::{
     Runtime, Session, SessionEvent, StreamEvent,
     core::rpc_protocol::{RpcAttachment, RpcCommand, RpcEvent, TurnUsage, RPC_PROTOCOL_VERSION},
     core::rpc_dispatch::{
-        accumulate_usage, build_user_content, map_stream_event, parse_frame, MAX_FRAME_BYTES,
+        accumulate_usage, build_user_content, build_tools_list_body, map_stream_event, parse_frame, MAX_FRAME_BYTES,
     },
     engine::setup::{self, EngineOpts},
 };
@@ -544,6 +544,39 @@ async fn handle_get_state(
         .await;
 }
 
+/// Handle the `ToolsList` command.
+///
+/// Reads the current tool schema from the runtime's shared `ToolRegistry`
+/// (built-ins + any MCP / extension tools loaded at boot time) and returns
+/// `{ ok: true, tools: [{name, description, input_schema}, ...] }`.
+///
+/// The response uses the existing [`RpcEvent::Response`] frame with
+/// `command: "tools_list"`, which the bridge Phase 8
+/// `SynapsRpcSessionRouter.listTools()` validates as:
+///   `response.ok === true && Array.isArray(response.tools)`.
+async fn handle_tools_list(
+    id: Option<String>,
+    state: Arc<Mutex<RpcState>>,
+    writer_tx: mpsc::Sender<RpcEvent>,
+) {
+    let schema = {
+        let st = state.lock().await;
+        let registry = st.runtime.tools_shared();
+        let guard = registry.read().await;
+        guard.tools_schema().as_ref().clone()
+    };
+
+    let body = build_tools_list_body(&schema);
+    let response_id = id.unwrap_or_default();
+    let _ = writer_tx
+        .send(RpcEvent::Response {
+            id: response_id,
+            command: "tools_list".to_string(),
+            body,
+        })
+        .await;
+}
+
 // ─── Entry point ──────────────────────────────────────────────────────────────
 
 /// Run the `synaps rpc` headless server.
@@ -710,6 +743,9 @@ pub async fn run(
                     }
                     RpcCommand::GetState { id } => {
                         handle_get_state(id, state.clone(), writer_tx.clone()).await;
+                    }
+                    RpcCommand::ToolsList { id } => {
+                        handle_tools_list(id, state.clone(), writer_tx.clone()).await;
                     }
                     RpcCommand::Shutdown => {
                         tracing::info!("Shutdown received; draining and exiting");

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -106,6 +106,42 @@ pub struct ServerConfig {
     pub max_message_size: Option<usize>,
 }
 
+/// Bridge daemon configuration parsed from `bridge.*` keys.
+///
+/// Controls best-effort mirroring of watcher heartbeats over the bridge
+/// daemon's UDS `ControlSocket` (`heartbeat_emit` op). All keys are optional
+/// and the feature is OFF by default.
+#[derive(Debug, Clone)]
+pub struct BridgeConfig {
+    /// Path to the bridge daemon's UDS control socket.
+    /// When `None`, defaults to `base_dir().join("bridge/control.sock")`.
+    pub uds_path: Option<PathBuf>,
+    /// When true, every watcher heartbeat tick mirrors a `heartbeat_emit`
+    /// JSON-RPC call over the UDS socket. Errors are logged at debug only.
+    pub heartbeat_mirror: bool,
+    /// Per-call timeout in milliseconds (covers connect + write + read).
+    pub heartbeat_timeout_ms: u64,
+}
+
+impl Default for BridgeConfig {
+    fn default() -> Self {
+        Self {
+            uds_path: None,
+            heartbeat_mirror: false,
+            heartbeat_timeout_ms: 250,
+        }
+    }
+}
+
+impl BridgeConfig {
+    /// Resolve the UDS path, falling back to the default under `base_dir()`.
+    pub fn resolved_uds_path(&self) -> PathBuf {
+        self.uds_path
+            .clone()
+            .unwrap_or_else(|| base_dir().join("bridge/control.sock"))
+    }
+}
+
 /// Parsed configuration from the config file.
 #[derive(Debug, Clone)]
 pub struct SynapsConfig {
@@ -125,6 +161,7 @@ pub struct SynapsConfig {
     pub disabled_skills: Vec<String>,
     pub shell: ShellConfig,
     pub server: ServerConfig,
+    pub bridge: BridgeConfig,
     pub provider_keys: BTreeMap<String, String>,
     pub keybinds: std::collections::HashMap<String, String>,
 }
@@ -148,6 +185,7 @@ impl Default for SynapsConfig {
             disabled_skills: Vec::new(),
             shell: ShellConfig::default(),
             server: ServerConfig::default(),
+            bridge: BridgeConfig::default(),
             provider_keys: BTreeMap::new(),
             keybinds: std::collections::HashMap::new(),
         }
@@ -274,6 +312,32 @@ fn parse_server_config_key(server_config: &mut ServerConfig, key: &str, val: &st
     }
 }
 
+/// Parse bridge.* configuration keys and update the BridgeConfig.
+fn parse_bridge_config_key(bridge_config: &mut BridgeConfig, key: &str, val: &str) {
+    match key {
+        "bridge.uds_path" => {
+            if val.is_empty() {
+                bridge_config.uds_path = None;
+            } else {
+                bridge_config.uds_path = Some(PathBuf::from(val));
+            }
+        }
+        "bridge.heartbeat_mirror" => {
+            bridge_config.heartbeat_mirror = matches!(val, "true" | "1" | "yes");
+        }
+        "bridge.heartbeat_timeout_ms" => {
+            if let Ok(ms) = val.parse::<u64>() {
+                bridge_config.heartbeat_timeout_ms = ms;
+            } else {
+                eprintln!("Warning: invalid value for bridge.heartbeat_timeout_ms: '{}', using default", val);
+            }
+        }
+        _ => {
+            // Unknown bridge.* keys preserved (not rejected)
+        }
+    }
+}
+
 /// Parse the config file at ~/.synaps-cli/config (or profile variant).
 /// Returns default config if file doesn't exist or can't be read.
 pub fn load_config() -> SynapsConfig {
@@ -344,6 +408,8 @@ pub fn load_config() -> SynapsConfig {
                     parse_shell_config_key(&mut config.shell, key, val);
                 } else if key.starts_with("server.") {
                     parse_server_config_key(&mut config.server, key, val);
+                } else if key.starts_with("bridge.") {
+                    parse_bridge_config_key(&mut config.bridge, key, val);
                 } else if let Some(provider_key) = key.strip_prefix("provider.") {
                     config.provider_keys.insert(provider_key.to_string(), val.to_string());
                 } else if let Some(keybind_key) = key.strip_prefix("keybind.") {
@@ -534,6 +600,66 @@ mod tests {
         assert_eq!(config.server.token, None);
         assert!(!config.server.auto_approve_confirms);
         assert_eq!(config.server.max_message_size, None);
+        // Bridge config defaults
+        assert!(config.bridge.uds_path.is_none());
+        assert!(!config.bridge.heartbeat_mirror);
+        assert_eq!(config.bridge.heartbeat_timeout_ms, 250);
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_config_bridge_keys() {
+        let home = make_test_home("bridge-keys");
+        let cfg = home.join(".synaps-cli/config");
+        std::fs::write(&cfg, "\
+bridge.uds_path = /tmp/some/control.sock\n\
+bridge.heartbeat_mirror = true\n\
+bridge.heartbeat_timeout_ms = 750\n\
+").unwrap();
+
+        with_home(&home, || {
+            let config = load_config();
+            assert_eq!(
+                config.bridge.uds_path,
+                Some(std::path::PathBuf::from("/tmp/some/control.sock")),
+            );
+            assert!(config.bridge.heartbeat_mirror);
+            assert_eq!(config.bridge.heartbeat_timeout_ms, 750);
+            assert_eq!(
+                config.bridge.resolved_uds_path(),
+                std::path::PathBuf::from("/tmp/some/control.sock"),
+            );
+        });
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn test_bridge_config_defaults() {
+        let cfg = BridgeConfig::default();
+        assert!(cfg.uds_path.is_none());
+        assert!(!cfg.heartbeat_mirror);
+        assert_eq!(cfg.heartbeat_timeout_ms, 250);
+        // resolved path falls under base_dir()/bridge/control.sock
+        let resolved = cfg.resolved_uds_path();
+        assert!(resolved.ends_with("bridge/control.sock"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_bridge_heartbeat_mirror_defaults_off_when_unset() {
+        let home = make_test_home("bridge-default-off");
+        let cfg = home.join(".synaps-cli/config");
+        std::fs::write(&cfg, "model = claude-sonnet-4-6\n").unwrap();
+
+        with_home(&home, || {
+            let config = load_config();
+            assert!(!config.bridge.heartbeat_mirror);
+            assert!(config.bridge.uds_path.is_none());
+            assert_eq!(config.bridge.heartbeat_timeout_ms, 250);
+        });
+
+        let _ = std::fs::remove_dir_all(&home);
     }
 
     #[test]

--- a/src/core/rpc_dispatch.rs
+++ b/src/core/rpc_dispatch.rs
@@ -175,6 +175,22 @@ pub fn build_user_content(message: &str, attachments: &[RpcAttachment]) -> Strin
     format!("[user attached files: {}]\n{}", parts.join(", "), message)
 }
 
+// ─── tools_list helper ───────────────────────────────────────────────────────
+
+/// Build the `tools_list` response body from a `ToolRegistry` schema snapshot.
+///
+/// The schema entries produced by [`ToolRegistry::tools_schema`] already have
+/// the shape `{name, description, input_schema}` that the bridge Phase 8
+/// `SynapsRpcSessionRouter.listTools()` expects. This function wraps them in
+/// the top-level `{ ok: true, tools: [...] }` envelope that the bridge
+/// validates (router.js line 112).
+pub fn build_tools_list_body(tools_schema: &[serde_json::Value]) -> serde_json::Value {
+    serde_json::json!({
+        "ok": true,
+        "tools": tools_schema,
+    })
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -695,6 +711,45 @@ mod tests {
             msg.contains("\"/tmp/a\\\\b\""),
             "backslash in path must be doubled: {msg}"
         );
+    }
+
+    // ── build_tools_list_body ────────────────────────────────────────────────
+
+    #[test]
+    fn build_tools_list_body_empty() {
+        let body = super::build_tools_list_body(&[]);
+        assert_eq!(body["ok"], true);
+        assert!(body["tools"].is_array());
+        assert_eq!(body["tools"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn build_tools_list_body_with_entries() {
+        let schema = vec![
+            json!({"name": "bash", "description": "Run bash", "input_schema": {"type": "object"}}),
+            json!({"name": "read", "description": "Read file", "input_schema": {"type": "object"}}),
+        ];
+        let body = super::build_tools_list_body(&schema);
+        assert_eq!(body["ok"], true);
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0]["name"], "bash");
+        assert_eq!(tools[1]["name"], "read");
+    }
+
+    /// The bridge checks `response.ok === true && Array.isArray(response.tools)`.
+    /// Verify the body round-trips through serde and satisfies both conditions.
+    #[test]
+    fn build_tools_list_body_roundtrip_satisfies_bridge_contract() {
+        let schema = vec![
+            json!({"name": "bash", "description": "desc", "input_schema": {}}),
+        ];
+        let body = super::build_tools_list_body(&schema);
+        // Simulate serialise → deserialise (what the parent process and bridge each do).
+        let serialised = serde_json::to_string(&body).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&serialised).unwrap();
+        assert_eq!(parsed["ok"], true, "bridge check: ok===true");
+        assert!(parsed["tools"].is_array(), "bridge check: Array.isArray(tools)");
     }
 
     // ── handle_compact lock-release invariant ────────────────────────────────

--- a/src/core/rpc_protocol.rs
+++ b/src/core/rpc_protocol.rs
@@ -186,6 +186,21 @@ pub enum RpcCommand {
         id: String,
     },
 
+    /// Enumerate all tools currently registered in this rpc session's tool
+    /// registry (built-ins + any MCP / extension tools loaded at boot).
+    ///
+    /// The `id` field follows the same optional-correlation convention used by
+    /// other commands: when present it is echoed in the `Response` frame so the
+    /// bridge can match the reply to its pending probe.  The bridge Phase 8
+    /// router sends `{"type":"tools_list"}` without an `id`; both forms are
+    /// accepted.
+    #[serde(rename = "tools_list")]
+    ToolsList {
+        /// Optional correlation id; echoed in the corresponding `Response`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+
     /// Instruct the rpc child to exit cleanly.
     ///
     /// No `id` field — the child does not send a `Response` for shutdown.
@@ -359,4 +374,84 @@ pub enum AssistantEvent {
         /// The serialised tool result string.
         result: String,
     },
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{from_str, json, to_string};
+
+    // ── RpcCommand::ToolsList round-trip ────────────────────────────────────
+
+    #[test]
+    fn tools_list_no_id_serialises() {
+        let cmd = RpcCommand::ToolsList { id: None };
+        let json = to_string(&cmd).expect("serialise");
+        let val: serde_json::Value = from_str(&json).unwrap();
+        assert_eq!(val["type"], "tools_list");
+        assert!(val.get("id").is_none(), "absent id must be omitted (skip_serializing_if)");
+    }
+
+    #[test]
+    fn tools_list_with_id_serialises() {
+        let cmd = RpcCommand::ToolsList { id: Some("req-42".to_string()) };
+        let json = to_string(&cmd).expect("serialise");
+        let val: serde_json::Value = from_str(&json).unwrap();
+        assert_eq!(val["type"], "tools_list");
+        assert_eq!(val["id"], "req-42");
+    }
+
+    #[test]
+    fn tools_list_no_id_deserialises() {
+        let line = r#"{"type":"tools_list"}"#;
+        let cmd: RpcCommand = from_str(line).expect("deserialise");
+        match cmd {
+            RpcCommand::ToolsList { id } => assert!(id.is_none()),
+            other => panic!("expected ToolsList, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tools_list_with_id_deserialises() {
+        let line = r#"{"type":"tools_list","id":"abc-123"}"#;
+        let cmd: RpcCommand = from_str(line).expect("deserialise");
+        match cmd {
+            RpcCommand::ToolsList { id } => assert_eq!(id.as_deref(), Some("abc-123")),
+            other => panic!("expected ToolsList, got {other:?}"),
+        }
+    }
+
+    // ── Response body shape expected by the bridge ──────────────────────────
+
+    /// The bridge validates: `response.ok === true && Array.isArray(response.tools)`.
+    /// Verify the flattened RpcEvent::Response body produces exactly that shape.
+    #[test]
+    fn tools_list_response_body_shape_matches_bridge_expectation() {
+        let tools_json = json!([
+            {
+                "name": "bash",
+                "description": "Run a bash command",
+                "input_schema": {"type": "object", "properties": {"command": {"type": "string"}}}
+            }
+        ]);
+        let ev = RpcEvent::Response {
+            id: "req-1".to_string(),
+            command: "tools_list".to_string(),
+            body: json!({ "ok": true, "tools": tools_json }),
+        };
+        let serialised = to_string(&ev).expect("serialise");
+        let val: serde_json::Value = from_str(&serialised).unwrap();
+
+        assert_eq!(val["type"], "response");
+        assert_eq!(val["id"], "req-1");
+        assert_eq!(val["command"], "tools_list");
+        // Bridge checks these two fields at the top level (flattened):
+        assert_eq!(val["ok"], true, "bridge needs ok=true at top level");
+        assert!(val["tools"].is_array(), "bridge needs tools array at top level");
+        assert_eq!(val["tools"][0]["name"], "bash");
+    }
 }

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -501,6 +501,19 @@ impl ExtensionManager {
         self.extensions.keys().map(|s| s.as_str()).collect()
     }
 
+    /// Return Arc references to all running extension handlers, sorted by ID.
+    /// Intended for background notification watchers that need to hold onto
+    /// handlers beyond the lifetime of a manager lock.
+    pub fn handlers(&self) -> Vec<(String, Arc<dyn super::runtime::ExtensionHandler>)> {
+        let mut out: Vec<_> = self
+            .extensions
+            .iter()
+            .map(|(id, h)| (id.clone(), Arc::clone(h)))
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
     /// Number of running extensions.
     pub fn count(&self) -> usize {
         self.extensions.len()

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -25,6 +25,7 @@ pub mod info;
 pub mod commands;
 pub mod settings_editor;
 pub mod tasks;
+pub mod widgets;
 pub mod active_tasks;
 pub mod loader;
 pub mod providers;

--- a/src/extensions/runtime/mod.rs
+++ b/src/extensions/runtime/mod.rs
@@ -8,7 +8,7 @@ pub use restart::RestartPolicy;
 use async_trait::async_trait;
 use serde_json::Value;
 use crate::extensions::hooks::events::{HookEvent, HookResult};
-use self::process::{ProviderCompleteParams, ProviderCompleteResult, ProviderStreamEvent};
+use self::process::{ProviderCompleteParams, ProviderCompleteResult, ProviderStreamEvent, NotificationFrame};
 use crate::extensions::info::PluginInfo;
 use crate::extensions::commands::CommandOutputEvent;
 use crate::extensions::tasks::TaskEvent;
@@ -150,6 +150,17 @@ pub trait ExtensionHandler: Send + Sync {
 
     /// Gracefully shut down the extension.
     async fn shutdown(&self);
+
+    /// Subscribe to raw JSON-RPC notifications from this extension.
+    /// Returns a monotonic subscription id (for unsubscribing) and a
+    /// receiver that yields every notification frame. The default
+    /// implementation returns a channel whose sender is immediately
+    /// dropped, so the receiver yields `None` right away — effectively
+    /// a no-op for handler impls that don't support notifications.
+    async fn subscribe_notifications(&self) -> (usize, tokio::sync::mpsc::UnboundedReceiver<NotificationFrame>) {
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (0, rx)
+    }
 
     /// Current health state of this handler.
     async fn health(&self) -> ExtensionHealth {

--- a/src/extensions/runtime/process.rs
+++ b/src/extensions/runtime/process.rs
@@ -499,7 +499,16 @@ pub struct NotificationFrame {
 /// errors when the reader observes EOF or a transport failure.
 struct Inbox {
     pending: Mutex<HashMap<u64, oneshot::Sender<Result<Value, String>>>>,
-    notification_sink: Mutex<Option<mpsc::UnboundedSender<NotificationFrame>>>,
+    /// Fan-out notification subscribers. Each subscriber is keyed by a monotonic
+    /// id so it can unsubscribe itself without disturbing other concurrent
+    /// subscribers (e.g. background watchers that overlap with
+    /// `command.invoke` / `provider.stream`). Dead senders (receiver dropped)
+    /// are pruned lazily on dispatch and on `unsubscribe_notifications`.
+    notification_sinks: Mutex<Vec<(usize, mpsc::UnboundedSender<NotificationFrame>)>>,
+    /// Monotonic id allocator for `notification_sinks`. Wraparound is not a
+    /// concern in practice — `usize` is enormous relative to subscription
+    /// lifetimes — but uniqueness is only required among live subscribers.
+    next_sink_id: std::sync::atomic::AtomicUsize,
     /// Set to true when the reader task exits (EOF or error). Used to prevent
     /// callers from registering pending requests that will never be fulfilled.
     closed: std::sync::atomic::AtomicBool,
@@ -518,7 +527,8 @@ impl Inbox {
     fn new(extension_id: String) -> Self {
         Self {
             pending: Mutex::new(HashMap::new()),
-            notification_sink: Mutex::new(None),
+            notification_sinks: Mutex::new(Vec::new()),
+            next_sink_id: std::sync::atomic::AtomicUsize::new(0),
             closed: std::sync::atomic::AtomicBool::new(false),
             permissions: RwLock::new(None),
             inbound_stdin: Mutex::new(None),
@@ -703,8 +713,8 @@ impl ProcessExtension {
                             "Extension stdout closed (EOF); failing pending requests",
                         );
                         inbox.fail_all_pending("transport closed: EOF").await;
-                        // Drop notification subscriber on EOF.
-                        inbox.notification_sink.lock().await.take();
+                        // Drop all notification subscribers on EOF.
+                        inbox.notification_sinks.lock().await.clear();
                         return;
                     }
                     Err(error) => {
@@ -716,7 +726,7 @@ impl ProcessExtension {
                         inbox
                             .fail_all_pending(&format!("transport error: {}", error))
                             .await;
-                        inbox.notification_sink.lock().await.take();
+                        inbox.notification_sinks.lock().await.clear();
                         return;
                     }
                 }
@@ -913,18 +923,18 @@ impl ProcessExtension {
                 method: method.to_string(),
                 params,
             };
-            let mut sink_guard = inbox.notification_sink.lock().await;
-            if let Some(sink) = sink_guard.as_ref() {
-                if sink.send(frame).is_err() {
-                    // Receiver dropped; clear subscription.
-                    sink_guard.take();
-                }
-            } else {
+            let mut sinks = inbox.notification_sinks.lock().await;
+            if sinks.is_empty() {
                 tracing::trace!(
                     extension = %extension_id,
                     method = %method,
-                    "Notification with no active subscriber; dropping",
+                    "Notification with no active subscribers; dropping",
                 );
+            } else {
+                // Fan out to every live subscriber; prune any whose receiver
+                // has been dropped. `mpsc::UnboundedSender::send` only errors
+                // when the receiver is gone, so failure == dead subscriber.
+                sinks.retain(|(_, tx)| tx.send(frame.clone()).is_ok());
             }
         } else {
             tracing::trace!(
@@ -1507,28 +1517,47 @@ impl ProcessExtension {
 
     /// Subscribe to JSON-RPC notifications emitted by the extension.
     ///
-    /// Returns an unbounded receiver that will yield every notification
-    /// frame (no `id`, has `method`) the extension sends until either:
-    /// - the receiver is dropped,
-    /// - the reader observes EOF or a transport error, or
-    /// - another caller calls `subscribe_notifications`, in which case the
-    ///   previous subscriber's sender is dropped (only one subscription is
-    ///   supported at a time).
+    /// Returns `(subscription_id, receiver)`. The id must be passed back to
+    /// [`unsubscribe_notifications`] to cancel this subscription specifically
+    /// — concurrent subscribers (e.g. background widget watchers running
+    /// alongside `command.invoke` / `provider.stream`) coexist and each
+    /// receives every notification frame.
+    ///
+    /// The receiver yields every notification frame (no `id`, has `method`)
+    /// the extension sends until either:
+    /// - the receiver is dropped (its slot is pruned on the next dispatch),
+    /// - [`unsubscribe_notifications`] is called with this id, or
+    /// - the reader observes EOF or a transport error (all subscribers are
+    ///   dropped together).
     ///
     /// Internal API: exposed publicly with `#[doc(hidden)]` only so
     /// integration tests can exercise the bidirectional transport.
     #[doc(hidden)]
-    pub async fn subscribe_notifications(&self) -> mpsc::UnboundedReceiver<NotificationFrame> {
+    pub async fn subscribe_notifications(
+        &self,
+    ) -> (usize, mpsc::UnboundedReceiver<NotificationFrame>) {
         let (tx, rx) = mpsc::unbounded_channel();
-        let mut sink = self.inbox.notification_sink.lock().await;
-        *sink = Some(tx);
-        rx
+        let id = self
+            .inbox
+            .next_sink_id
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut sinks = self.inbox.notification_sinks.lock().await;
+        // Opportunistically prune any subscribers whose receivers have been
+        // dropped, so the Vec doesn't grow unboundedly across long-lived
+        // extensions if callers forget to unsubscribe.
+        sinks.retain(|(_, tx)| !tx.is_closed());
+        sinks.push((id, tx));
+        (id, rx)
     }
 
-    /// Drop the current notification subscription, if any.
+    /// Drop the notification subscription with the given id, if any.
+    /// Unknown ids are silently ignored (idempotent — safe to call on
+    /// belt-and-braces timeout paths even after the inner future already
+    /// unsubscribed).
     #[doc(hidden)]
-    pub async fn unsubscribe_notifications(&self) {
-        self.inbox.notification_sink.lock().await.take();
+    pub async fn unsubscribe_notifications(&self, id: usize) {
+        let mut sinks = self.inbox.notification_sinks.lock().await;
+        sinks.retain(|(sub_id, tx)| *sub_id != id && !tx.is_closed());
     }
 
     /// Forward one notification frame received during `command.invoke`.
@@ -1678,7 +1707,7 @@ impl ExtensionHandler for ProcessExtension {
     ) -> Result<ProviderCompleteResult, String> {
         // Subscribe BEFORE issuing the request so we don't miss early
         // notifications that may arrive before `call(...)` even starts polling.
-        let mut rx = self.subscribe_notifications().await;
+        let (sub_id, mut rx) = self.subscribe_notifications().await;
         let params_value =
             serde_json::to_value(params).map_err(|e| e.to_string())?;
 
@@ -1696,10 +1725,11 @@ impl ExtensionHandler for ProcessExtension {
                     }
                 }
             };
-            // Response received: clear the inbox's notification sender so the
-            // receiver yields `None` once buffered frames are drained, then
-            // flush any remaining notifications before returning.
-            self.unsubscribe_notifications().await;
+            // Response received: drop our subscription so this receiver yields
+            // `None` once buffered frames are drained, then flush any
+            // remaining notifications before returning. Other concurrent
+            // subscribers (if any) are untouched.
+            self.unsubscribe_notifications(sub_id).await;
             while let Some(frame) = rx.recv().await {
                 Self::forward_provider_stream_frame(
                     &extension_id, &sink, &mut sink_open, frame,
@@ -1714,8 +1744,9 @@ impl ExtensionHandler for ProcessExtension {
         )
         .await;
 
-        // Belt-and-braces: ensure the subscription is cleared on timeout too.
-        self.unsubscribe_notifications().await;
+        // Belt-and-braces: ensure our subscription is cleared on timeout too.
+        // Idempotent if the inner future already unsubscribed.
+        self.unsubscribe_notifications(sub_id).await;
 
         let value = outcome
             .map_err(|_| format!("Extension '{}' provider.stream timed out", self.id))??;
@@ -1737,7 +1768,7 @@ impl ExtensionHandler for ProcessExtension {
         sink: tokio::sync::mpsc::UnboundedSender<crate::extensions::runtime::InvokeCommandEvent>,
     ) -> Result<Value, String> {
         // Subscribe before issuing the request so we don't miss early events.
-        let mut rx = self.subscribe_notifications().await;
+        let (sub_id, mut rx) = self.subscribe_notifications().await;
         let params = serde_json::json!({
             "command": command,
             "args": args,
@@ -1762,7 +1793,7 @@ impl ExtensionHandler for ProcessExtension {
             // Drain any notifications already buffered after the response lands, but
             // do not wait for the subscriber channel to close (that would deadlock
             // while this invocation still owns `rx`).
-            self.unsubscribe_notifications().await;
+            self.unsubscribe_notifications(sub_id).await;
             while let Ok(frame) = rx.try_recv() {
                 let _ = Self::forward_invoke_command_frame(
                     &extension_id, &request_id_owned, &sink, &mut sink_open, frame,
@@ -1777,8 +1808,9 @@ impl ExtensionHandler for ProcessExtension {
         )
         .await;
 
-        // Belt-and-braces: ensure subscription is cleared on timeout too.
-        self.unsubscribe_notifications().await;
+        // Belt-and-braces: ensure our subscription is cleared on timeout too.
+        // Idempotent if the inner future already unsubscribed.
+        self.unsubscribe_notifications(sub_id).await;
 
         outcome
             .map_err(|_| format!("Extension '{}' command.invoke timed out", self.id))?
@@ -1909,8 +1941,8 @@ impl ExtensionHandler for ProcessExtension {
             let mut child = state.child;
             let _ = child.kill().await;
         }
-        // Drop any active notification subscriber and signal pending callers.
-        self.inbox.notification_sink.lock().await.take();
+        // Drop all active notification subscribers and signal pending callers.
+        self.inbox.notification_sinks.lock().await.clear();
         self.inbox
             .fail_all_pending("transport closed: extension shutdown")
             .await;

--- a/src/extensions/runtime/process.rs
+++ b/src/extensions/runtime/process.rs
@@ -1948,6 +1948,10 @@ impl ExtensionHandler for ProcessExtension {
             .await;
     }
 
+    async fn subscribe_notifications(&self) -> (usize, tokio::sync::mpsc::UnboundedReceiver<NotificationFrame>) {
+        ProcessExtension::subscribe_notifications(self).await
+    }
+
     async fn restart_count(&self) -> usize {
         self.restart_count()
     }

--- a/src/extensions/widgets.rs
+++ b/src/extensions/widgets.rs
@@ -1,0 +1,348 @@
+//! Plugin widget notification types and parser.
+//!
+//! Phase B Phase 3 contract — see
+//! `docs/plans/2026-05-03-extension-contracts-for-rich-plugins.md`.
+//!
+//! Plugins push spontaneous JSON-RPC notifications to create, update, or
+//! dismiss persistent on-screen widgets (HUD panels, status boxes, etc.)
+//! outside the slash-command request/response cycle.
+//! Method names: `widget.upsert`, `widget.dismiss`.
+//!
+//! Wire shapes (params per method):
+//!
+//! - `widget.upsert`:  `{ id, lines: string[], position?: string, title?: string, ttl_secs?: number | null }`
+//! - `widget.dismiss`: `{ id }`
+//!
+//! Valid `position` values: `"top_left"`, `"top_center"`, `"top_right"`,
+//! `"middle_left"`, `"center"`, `"middle_right"`, `"bottom_left"`,
+//! `"bottom_center"`, `"bottom_right"`. Defaults to `"top_right"`.
+//!
+//! `ttl_secs: None` means the widget is persistent (no auto-dismiss).
+//! `ttl_secs: Some(n)` means the widget auto-dismisses after `n` seconds.
+
+use serde_json::Value;
+
+/// Default widget position when the plugin omits the field.
+const DEFAULT_POSITION: &str = "top_right";
+
+/// All valid position string values accepted over the wire.
+const VALID_POSITIONS: &[&str] = &[
+    "top_left",
+    "top_center",
+    "top_right",
+    "middle_left",
+    "center",
+    "middle_right",
+    "bottom_left",
+    "bottom_center",
+    "bottom_right",
+];
+
+/// Parsed widget notification.
+#[derive(Debug, Clone, PartialEq)]
+pub enum WidgetEvent {
+    /// Create or update a widget. `position` is stored as a raw string; the
+    /// TUI layer is responsible for converting it to a `ToastPosition`.
+    Upsert {
+        id: String,
+        lines: Vec<String>,
+        /// One of the nine position strings; always present (defaults to
+        /// `"top_right"` when the plugin omits the field).
+        position: String,
+        title: Option<String>,
+        /// `None` → persistent widget; `Some(n)` → auto-dismiss after n secs.
+        ttl_secs: Option<u64>,
+    },
+    /// Remove a widget by id.
+    Dismiss { id: String },
+}
+
+impl WidgetEvent {
+    pub fn id(&self) -> &str {
+        match self {
+            WidgetEvent::Upsert { id, .. } | WidgetEvent::Dismiss { id } => id,
+        }
+    }
+}
+
+/// Returns true if `method` is one of the recognised widget notifications.
+pub fn is_widget_method(method: &str) -> bool {
+    matches!(method, "widget.upsert" | "widget.dismiss")
+}
+
+/// Parse a `widget.*` notification given the JSON-RPC method and params.
+pub fn parse_widget_event(method: &str, params: &Value) -> Result<WidgetEvent, String> {
+    let obj = params
+        .as_object()
+        .ok_or_else(|| format!("{method} params must be a JSON object"))?;
+
+    let id = obj
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("{method} missing 'id'"))?
+        .to_string();
+    if id.is_empty() {
+        return Err(format!("{method} 'id' must be non-empty"));
+    }
+
+    match method {
+        "widget.upsert" => {
+            // --- lines ---
+            let lines_raw = obj
+                .get("lines")
+                .ok_or_else(|| "widget.upsert missing 'lines'".to_string())?;
+            let lines_arr = lines_raw
+                .as_array()
+                .ok_or_else(|| "widget.upsert 'lines' must be an array".to_string())?;
+            let mut lines = Vec::with_capacity(lines_arr.len());
+            for (i, v) in lines_arr.iter().enumerate() {
+                let s = v.as_str().ok_or_else(|| {
+                    format!("widget.upsert 'lines[{i}]' must be a string")
+                })?;
+                lines.push(s.to_string());
+            }
+
+            // --- position ---
+            let position = match obj.get("position") {
+                None => DEFAULT_POSITION.to_string(),
+                Some(Value::Null) => DEFAULT_POSITION.to_string(),
+                Some(v) => {
+                    let s = v
+                        .as_str()
+                        .ok_or_else(|| "widget.upsert 'position' must be a string".to_string())?;
+                    if !VALID_POSITIONS.contains(&s) {
+                        return Err(format!("widget.upsert unknown position '{s}'"));
+                    }
+                    s.to_string()
+                }
+            };
+
+            // --- title ---
+            let title = match obj.get("title") {
+                None | Some(Value::Null) => None,
+                Some(v) => {
+                    let s = v
+                        .as_str()
+                        .ok_or_else(|| "widget.upsert 'title' must be a string".to_string())?;
+                    if s.is_empty() { None } else { Some(s.to_string()) }
+                }
+            };
+
+            // --- ttl_secs ---
+            let ttl_secs = match obj.get("ttl_secs") {
+                None | Some(Value::Null) => None,
+                Some(v) => {
+                    let n = v.as_u64().ok_or_else(|| {
+                        format!(
+                            "widget.upsert 'ttl_secs' must be a non-negative integer or null, got {v}"
+                        )
+                    })?;
+                    Some(n)
+                }
+            };
+
+            Ok(WidgetEvent::Upsert { id, lines, position, title, ttl_secs })
+        }
+
+        "widget.dismiss" => Ok(WidgetEvent::Dismiss { id }),
+
+        other => Err(format!("not a widget method: {other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── widget.upsert ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn parses_upsert_minimal() {
+        let ev = parse_widget_event(
+            "widget.upsert",
+            &json!({"id": "status", "lines": ["hello"]}),
+        )
+        .unwrap();
+        assert_eq!(
+            ev,
+            WidgetEvent::Upsert {
+                id: "status".into(),
+                lines: vec!["hello".into()],
+                position: "top_right".into(),
+                title: None,
+                ttl_secs: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_upsert_full() {
+        let ev = parse_widget_event(
+            "widget.upsert",
+            &json!({
+                "id": "hud",
+                "lines": ["line one", "line two"],
+                "position": "bottom_left",
+                "title": "My Widget",
+                "ttl_secs": 30
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            ev,
+            WidgetEvent::Upsert {
+                id: "hud".into(),
+                lines: vec!["line one".into(), "line two".into()],
+                position: "bottom_left".into(),
+                title: Some("My Widget".into()),
+                ttl_secs: Some(30),
+            }
+        );
+    }
+
+    #[test]
+    fn upsert_null_position_defaults_to_top_right() {
+        let ev = parse_widget_event(
+            "widget.upsert",
+            &json!({"id": "w", "lines": [], "position": null}),
+        )
+        .unwrap();
+        assert!(matches!(
+            ev,
+            WidgetEvent::Upsert { position, .. } if position == "top_right"
+        ));
+    }
+
+    #[test]
+    fn upsert_null_ttl_means_persistent() {
+        let ev = parse_widget_event(
+            "widget.upsert",
+            &json!({"id": "w", "lines": [], "ttl_secs": null}),
+        )
+        .unwrap();
+        assert!(matches!(ev, WidgetEvent::Upsert { ttl_secs: None, .. }));
+    }
+
+    #[test]
+    fn upsert_empty_lines_is_valid() {
+        let ev = parse_widget_event(
+            "widget.upsert",
+            &json!({"id": "w", "lines": []}),
+        )
+        .unwrap();
+        assert!(matches!(ev, WidgetEvent::Upsert { lines, .. } if lines.is_empty()));
+    }
+
+    #[test]
+    fn upsert_empty_title_coerces_to_none() {
+        let ev = parse_widget_event(
+            "widget.upsert",
+            &json!({"id": "w", "lines": [], "title": ""}),
+        )
+        .unwrap();
+        assert!(matches!(ev, WidgetEvent::Upsert { title: None, .. }));
+    }
+
+    #[test]
+    fn upsert_all_positions_accepted() {
+        for pos in VALID_POSITIONS {
+            let ev = parse_widget_event(
+                "widget.upsert",
+                &json!({"id": "w", "lines": [], "position": pos}),
+            )
+            .unwrap();
+            assert!(
+                matches!(&ev, WidgetEvent::Upsert { position, .. } if position == pos),
+                "position '{pos}' was rejected"
+            );
+        }
+    }
+
+    // ── widget.dismiss ────────────────────────────────────────────────────────
+
+    #[test]
+    fn parses_dismiss() {
+        let ev =
+            parse_widget_event("widget.dismiss", &json!({"id": "hud"})).unwrap();
+        assert_eq!(ev, WidgetEvent::Dismiss { id: "hud".into() });
+    }
+
+    // ── error cases ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn rejects_missing_id() {
+        assert!(parse_widget_event("widget.upsert", &json!({"lines": []})).is_err());
+        assert!(parse_widget_event("widget.dismiss", &json!({})).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_id() {
+        assert!(
+            parse_widget_event("widget.upsert", &json!({"id": "", "lines": []})).is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_missing_lines() {
+        assert!(parse_widget_event("widget.upsert", &json!({"id": "w"})).is_err());
+    }
+
+    #[test]
+    fn rejects_non_string_line_element() {
+        let err = parse_widget_event(
+            "widget.upsert",
+            &json!({"id": "w", "lines": ["ok", 42]}),
+        )
+        .unwrap_err();
+        assert!(err.contains("lines[1]"));
+    }
+
+    #[test]
+    fn rejects_unknown_position() {
+        let err = parse_widget_event(
+            "widget.upsert",
+            &json!({"id": "w", "lines": [], "position": "floating"}),
+        )
+        .unwrap_err();
+        assert!(err.contains("unknown position"));
+    }
+
+    #[test]
+    fn rejects_non_object_params() {
+        assert!(parse_widget_event("widget.upsert", &json!("bad")).is_err());
+        assert!(parse_widget_event("widget.dismiss", &json!(null)).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_method() {
+        let err =
+            parse_widget_event("widget.flash", &json!({"id": "w"})).unwrap_err();
+        assert!(err.contains("not a widget method"));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_widget_method_works() {
+        assert!(is_widget_method("widget.upsert"));
+        assert!(is_widget_method("widget.dismiss"));
+        assert!(!is_widget_method("widget.flash"));
+        assert!(!is_widget_method("task.start"));
+        assert!(!is_widget_method(""));
+    }
+
+    #[test]
+    fn event_id_helper() {
+        let upsert = parse_widget_event(
+            "widget.upsert",
+            &json!({"id": "my-widget", "lines": []}),
+        )
+        .unwrap();
+        assert_eq!(upsert.id(), "my-widget");
+
+        let dismiss =
+            parse_widget_event("widget.dismiss", &json!({"id": "my-widget"})).unwrap();
+        assert_eq!(dismiss.id(), "my-widget");
+    }
+}

--- a/src/extensions/widgets.rs
+++ b/src/extensions/widgets.rs
@@ -150,6 +150,14 @@ pub fn parse_widget_event(method: &str, params: &Value) -> Result<WidgetEvent, S
     }
 }
 
+/// Event sent from a background notification watcher to the TUI.
+/// Carries the source extension id and the parsed widget event.
+#[derive(Debug, Clone)]
+pub struct ExtensionWidgetEvent {
+    pub extension_id: String,
+    pub event: WidgetEvent,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/extensions/widgets.rs
+++ b/src/extensions/widgets.rs
@@ -38,6 +38,15 @@ const VALID_POSITIONS: &[&str] = &[
     "bottom_right",
 ];
 
+/// A single styled text span sent over the wire from an extension.
+/// Extensions specify colors as CSS-style hex strings (e.g. `"#ff0000"`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct StyledSpan {
+    pub text: String,
+    pub fg: Option<String>,
+    pub bg: Option<String>,
+}
+
 /// Parsed widget notification.
 #[derive(Debug, Clone, PartialEq)]
 pub enum WidgetEvent {
@@ -46,6 +55,10 @@ pub enum WidgetEvent {
     Upsert {
         id: String,
         lines: Vec<String>,
+        /// Optional per-span styled lines. Each inner Vec is one display line,
+        /// each `StyledSpan` carries text + optional fg/bg colors. When present,
+        /// the TUI renders these instead of plain `lines`.
+        styled_lines: Option<Vec<Vec<StyledSpan>>>,
         /// One of the nine position strings; always present (defaults to
         /// `"top_right"` when the plugin omits the field).
         position: String,
@@ -141,7 +154,44 @@ pub fn parse_widget_event(method: &str, params: &Value) -> Result<WidgetEvent, S
                 }
             };
 
-            Ok(WidgetEvent::Upsert { id, lines, position, title, ttl_secs })
+            // --- styled_lines (optional) ---
+            let styled_lines = match obj.get("styled_lines") {
+                None | Some(Value::Null) => None,
+                Some(v) => {
+                    let outer = v.as_array().ok_or_else(|| {
+                        "widget.upsert 'styled_lines' must be an array of arrays".to_string()
+                    })?;
+                    let mut result = Vec::with_capacity(outer.len());
+                    for (i, row) in outer.iter().enumerate() {
+                        let spans_arr = row.as_array().ok_or_else(|| {
+                            format!("widget.upsert 'styled_lines[{i}]' must be an array of span objects")
+                        })?;
+                        let mut spans = Vec::with_capacity(spans_arr.len());
+                        for (j, span_val) in spans_arr.iter().enumerate() {
+                            let span_obj = span_val.as_object().ok_or_else(|| {
+                                format!("widget.upsert 'styled_lines[{i}][{j}]' must be an object")
+                            })?;
+                            let text = span_obj.get("text")
+                                .and_then(Value::as_str)
+                                .ok_or_else(|| {
+                                    format!("widget.upsert 'styled_lines[{i}][{j}].text' must be a string")
+                                })?
+                                .to_string();
+                            let fg = span_obj.get("fg")
+                                .and_then(Value::as_str)
+                                .map(str::to_string);
+                            let bg = span_obj.get("bg")
+                                .and_then(Value::as_str)
+                                .map(str::to_string);
+                            spans.push(StyledSpan { text, fg, bg });
+                        }
+                        result.push(spans);
+                    }
+                    Some(result)
+                }
+            };
+
+            Ok(WidgetEvent::Upsert { id, lines, styled_lines, position, title, ttl_secs })
         }
 
         "widget.dismiss" => Ok(WidgetEvent::Dismiss { id }),
@@ -180,6 +230,7 @@ mod tests {
                 position: "top_right".into(),
                 title: None,
                 ttl_secs: None,
+                styled_lines: None,
             }
         );
     }
@@ -205,6 +256,7 @@ mod tests {
                 position: "bottom_left".into(),
                 title: Some("My Widget".into()),
                 ttl_secs: Some(30),
+                styled_lines: None,
             }
         );
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -165,6 +165,9 @@ pub(crate) struct App {
     pub(crate) extension_loader_rx: tokio::sync::mpsc::UnboundedReceiver<synaps_cli::extensions::loader::ExtensionLoaderEvent>,
     pub(crate) extension_loader_tx: tokio::sync::mpsc::UnboundedSender<synaps_cli::extensions::loader::ExtensionLoaderEvent>,
     pub(crate) extension_loader_running: bool,
+    /// Channel for receiving widget events from background extension notification watchers.
+    pub(crate) widget_rx: tokio::sync::mpsc::UnboundedReceiver<synaps_cli::extensions::widgets::ExtensionWidgetEvent>,
+    pub(crate) widget_tx: tokio::sync::mpsc::UnboundedSender<synaps_cli::extensions::widgets::ExtensionWidgetEvent>,
     /// Live keybind registry — held so /settings can hot-swap plugin toggle keys.
     pub(crate) keybinds: Option<std::sync::Arc<std::sync::RwLock<synaps_cli::skills::keybinds::KeybindRegistry>>>,
 }
@@ -187,6 +190,7 @@ impl App {
         let (ping_tx_init, ping_rx_init) = tokio::sync::mpsc::unbounded_channel();
         let (model_list_tx_init, model_list_rx_init) = tokio::sync::mpsc::unbounded_channel();
         let (extension_loader_tx_init, extension_loader_rx_init) = tokio::sync::mpsc::unbounded_channel();
+        let (widget_tx_init, widget_rx_init) = tokio::sync::mpsc::unbounded_channel();
         Self {
             messages: Vec::new(),
             input: String::new(),
@@ -254,6 +258,8 @@ impl App {
             extension_loader_rx: extension_loader_rx_init,
             extension_loader_tx: extension_loader_tx_init,
             extension_loader_running: false,
+            widget_rx: widget_rx_init,
+            widget_tx: widget_tx_init,
             keybinds: None,
         }
     }

--- a/src/tui/draw.rs
+++ b/src/tui/draw.rs
@@ -274,13 +274,17 @@ fn render_toasts(frame: &mut ratatui::Frame<'_>, provider: &super::toast::ToastP
             .border_style(Style::default().fg(THEME.load().border_active))
             .style(Style::default().bg(THEME.load().bg));
         frame.render_widget(Clear, rect);
-        frame.render_widget(
-            Paragraph::new(lines)
-                .block(block)
-                .wrap(Wrap { trim: true })
-                .style(Style::default().fg(THEME.load().help_fg)),
-            rect,
-        );
+        // Rich lines carry their own per-span styling — don't override fg.
+        // Plain lines get the default help_fg color.
+        let paragraph = Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: true });
+        let paragraph = if toast.has_rich_lines() {
+            paragraph.style(Style::default().bg(THEME.load().bg))
+        } else {
+            paragraph.style(Style::default().fg(THEME.load().help_fg))
+        };
+        frame.render_widget(paragraph, rect);
     }
 }
 

--- a/src/tui/draw.rs
+++ b/src/tui/draw.rs
@@ -276,13 +276,18 @@ fn render_toasts(frame: &mut ratatui::Frame<'_>, provider: &super::toast::ToastP
         frame.render_widget(Clear, rect);
         // Rich lines carry their own per-span styling — don't override fg.
         // Plain lines get the default help_fg color.
-        let paragraph = Paragraph::new(lines)
-            .block(block)
-            .wrap(Wrap { trim: true });
+        // Rich content also needs trim=false to preserve pixel art spacing.
         let paragraph = if toast.has_rich_lines() {
-            paragraph.style(Style::default().bg(THEME.load().bg))
+            Paragraph::new(lines)
+                .block(block)
+                .wrap(Wrap { trim: false })
+                .alignment(ratatui::layout::Alignment::Center)
+                .style(Style::default().bg(THEME.load().bg))
         } else {
-            paragraph.style(Style::default().fg(THEME.load().help_fg))
+            Paragraph::new(lines)
+                .block(block)
+                .wrap(Wrap { trim: true })
+                .style(Style::default().fg(THEME.load().help_fg))
         };
         frame.render_widget(paragraph, rect);
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1809,7 +1809,7 @@ pub async fn run(
 fn handle_widget_event(app: &mut App, event: synaps_cli::extensions::widgets::ExtensionWidgetEvent) {
     use synaps_cli::extensions::widgets::WidgetEvent;
     match event.event {
-        WidgetEvent::Upsert { id, lines, position, title, ttl_secs } => {
+        WidgetEvent::Upsert { id, lines, styled_lines, position, title, ttl_secs } => {
             let pos = match position.as_str() {
                 "top_left"      => toast::ToastPosition::TOP_LEFT,
                 "top_center"    => toast::ToastPosition::TOP_CENTER,
@@ -1830,6 +1830,28 @@ fn handle_widget_event(app: &mut App, event: synaps_cli::extensions::widgets::Ex
             .lines(lines)
             .at(pos)
             .ttl(ttl);
+            // Convert styled_lines → rich ratatui Lines if present.
+            if let Some(styled) = styled_lines {
+                use ratatui::style::Style;
+                use ratatui::text::{Line, Span};
+                let rich: Vec<Line<'static>> = styled.into_iter().map(|spans| {
+                    Line::from(spans.into_iter().map(|s| {
+                        let mut style = Style::default();
+                        if let Some(ref fg) = s.fg {
+                            if let Some(c) = parse_hex_color(fg) {
+                                style = style.fg(c);
+                            }
+                        }
+                        if let Some(ref bg) = s.bg {
+                            if let Some(c) = parse_hex_color(bg) {
+                                style = style.bg(c);
+                            }
+                        }
+                        Span::styled(s.text, style)
+                    }).collect::<Vec<_>>())
+                }).collect();
+                t = t.rich(rich);
+            }
             if let Some(title) = title {
                 t = t.titled(title);
             }
@@ -1839,6 +1861,16 @@ fn handle_widget_event(app: &mut App, event: synaps_cli::extensions::widgets::Ex
             app.toasts.dismiss(&format!("widget:{}", id));
         }
     }
+}
+
+/// Parse a CSS-style hex color string (e.g. "#ff0000") into a ratatui Color.
+fn parse_hex_color(s: &str) -> Option<ratatui::style::Color> {
+    let s = s.strip_prefix('#')?;
+    if s.len() != 6 { return None; }
+    let r = u8::from_str_radix(&s[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&s[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&s[4..6], 16).ok()?;
+    Some(ratatui::style::Color::Rgb(r, g, b))
 }
 
 fn handle_extension_loader_toast(app: &mut App, title: &str, lines: Vec<String>, persistent: bool) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -187,11 +187,16 @@ pub async fn run(
             // ── Async extension loader progress ──
             event = app.extension_loader_rx.recv(), if app.extension_loader_running => {
                 if let Some(event) = event {
-                    handle_extension_loader_event(&mut app, &runtime, event).await;
+                    handle_extension_loader_event(&mut app, &runtime, event, &ext_mgr_shared).await;
                 } else {
                     app.extension_loader_running = false;
                     app.toasts.dismiss("extension-loader");
                 }
+            }
+
+            // ── Widget events from background extension notification watchers ──
+            Some(widget_event) = app.widget_rx.recv() => {
+                handle_widget_event(&mut app, widget_event);
             }
 
             // ── Sidecar events — multiplexed across all hosted sidecars (Phase 8 8B) ──
@@ -1801,6 +1806,41 @@ pub async fn run(
     Ok(())
 }
 
+fn handle_widget_event(app: &mut App, event: synaps_cli::extensions::widgets::ExtensionWidgetEvent) {
+    use synaps_cli::extensions::widgets::WidgetEvent;
+    match event.event {
+        WidgetEvent::Upsert { id, lines, position, title, ttl_secs } => {
+            let pos = match position.as_str() {
+                "top_left"      => toast::ToastPosition::TOP_LEFT,
+                "top_center"    => toast::ToastPosition::TOP_CENTER,
+                "top_right"     => toast::ToastPosition::TOP_RIGHT,
+                "middle_left"   => toast::ToastPosition::MIDDLE_LEFT,
+                "center"        => toast::ToastPosition::CENTER,
+                "middle_right"  => toast::ToastPosition::MIDDLE_RIGHT,
+                "bottom_left"   => toast::ToastPosition::BOTTOM_LEFT,
+                "bottom_center" => toast::ToastPosition::BOTTOM_CENTER,
+                "bottom_right"  => toast::ToastPosition::BOTTOM_RIGHT,
+                _               => toast::ToastPosition::TOP_RIGHT,
+            };
+            let ttl = ttl_secs.map(std::time::Duration::from_secs);
+            let mut t = toast::Toast::new(
+                format!("widget:{}", id),
+                lines.first().cloned().unwrap_or_default(),
+            )
+            .lines(lines)
+            .at(pos)
+            .ttl(ttl);
+            if let Some(title) = title {
+                t = t.titled(title);
+            }
+            app.toasts.upsert(t);
+        }
+        WidgetEvent::Dismiss { id } => {
+            app.toasts.dismiss(&format!("widget:{}", id));
+        }
+    }
+}
+
 fn handle_extension_loader_toast(app: &mut App, title: &str, lines: Vec<String>, persistent: bool) {
     app.toasts.upsert(toast::Toast::new("extension-loader", "")
         .titled(title)
@@ -1814,6 +1854,7 @@ async fn handle_extension_loader_event(
     app: &mut App,
     runtime: &Runtime,
     event: synaps_cli::extensions::loader::ExtensionLoaderEvent,
+    ext_mgr: &std::sync::Arc<tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>>,
 ) {
     use synaps_cli::extensions::loader::ExtensionLoaderEvent;
     match event {
@@ -1854,6 +1895,35 @@ async fn handle_extension_loader_event(
                 ]
             };
             handle_extension_loader_toast(app, "Extensions", lines, false);
+
+            // Spawn a background notification watcher for each loaded extension.
+            // The watcher forwards widget.* notifications to the TUI via widget_tx.
+            let handlers = ext_mgr.read().await.handlers();
+            for (ext_id, handler) in handlers {
+                let widget_tx = app.widget_tx.clone();
+                tokio::spawn(async move {
+                    loop {
+                        let (_sub_id, mut rx) = handler.subscribe_notifications().await;
+                        while let Some(frame) = rx.recv().await {
+                            if synaps_cli::extensions::widgets::is_widget_method(&frame.method) {
+                                if let Ok(event) = synaps_cli::extensions::widgets::parse_widget_event(
+                                    &frame.method,
+                                    &frame.params,
+                                ) {
+                                    let _ = widget_tx.send(
+                                        synaps_cli::extensions::widgets::ExtensionWidgetEvent {
+                                            extension_id: ext_id.clone(),
+                                            event,
+                                        },
+                                    );
+                                }
+                            }
+                        }
+                        // rx closed (EOF/restart) — resubscribe after a brief delay
+                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    }
+                });
+            }
         }
     }
 }

--- a/src/tui/toast.rs
+++ b/src/tui/toast.rs
@@ -19,6 +19,10 @@ pub(crate) struct Toast {
     id: String,
     pub(crate) title: Option<String>,
     pub(crate) lines: Vec<String>,
+    /// Pre-styled rich lines. When set, `toast_lines()` returns these instead
+    /// of converting `lines` to plain `Line::from`. Enables per-character
+    /// colors for pixel art, status indicators, and themed widgets.
+    pub(crate) rich_lines: Option<Vec<Line<'static>>>,
     pub(crate) position: ToastPosition,
     created_at: Instant,
     ttl: Option<Duration>,
@@ -30,6 +34,7 @@ impl Toast {
             id: id.into(),
             title: None,
             lines: vec![line.into()],
+            rich_lines: None,
             position: ToastPosition::default(),
             created_at: Instant::now(),
             ttl: Some(Duration::from_secs(4)),
@@ -44,6 +49,18 @@ impl Toast {
     pub(crate) fn lines(mut self, lines: Vec<String>) -> Self {
         self.lines = lines;
         self
+    }
+
+    /// Set pre-styled rich lines. When present, these take priority over
+    /// plain `lines` in rendering — enabling per-character fg/bg colors.
+    pub(crate) fn rich(mut self, lines: Vec<Line<'static>>) -> Self {
+        self.rich_lines = Some(lines);
+        self
+    }
+
+    /// Whether this toast has rich (pre-styled) content.
+    pub(crate) fn has_rich_lines(&self) -> bool {
+        self.rich_lines.is_some()
     }
 
     pub(crate) fn at(mut self, position: ToastPosition) -> Self {
@@ -138,6 +155,15 @@ pub(crate) fn anchor_point(area: Rect, position: ToastPosition) -> Position {
 }
 
 pub(crate) fn toast_lines(toast: &Toast) -> Vec<Line<'static>> {
+    // Rich lines take priority — they carry per-span styling for pixel art etc.
+    if let Some(rich) = &toast.rich_lines {
+        let mut lines = Vec::new();
+        if let Some(title) = &toast.title {
+            lines.push(Line::from(title.clone()));
+        }
+        lines.extend(rich.iter().cloned());
+        return lines;
+    }
     let mut lines = Vec::new();
     if let Some(title) = &toast.title {
         lines.push(Line::from(title.clone()));

--- a/src/watcher/bridge_client.rs
+++ b/src/watcher/bridge_client.rs
@@ -138,6 +138,46 @@ pub async fn emit_heartbeat(
     }
 }
 
+/// Resolve the synaps_user_id for a heartbeat: env `SYNAPS_USER_ID` or `"local"`.
+pub fn resolve_synaps_user_id() -> String {
+    std::env::var("SYNAPS_USER_ID")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "local".to_string())
+}
+
+/// High-level helper used by the watcher supervisor.
+///
+/// Reads the `BridgeConfig` and:
+/// - returns `Ok(())` immediately when `heartbeat_mirror == false`
+///   (without touching the socket at all)
+/// - otherwise calls [`emit_heartbeat`] with the configured UDS path and timeout
+///
+/// Callers should `tokio::spawn` this and discard the result so the watcher
+/// loop is never blocked or failed by bridge unavailability.
+pub async fn mirror_heartbeat(
+    bridge_cfg: &synaps_cli::config::BridgeConfig,
+    agent_name: &str,
+    healthy: bool,
+    details: Value,
+) -> Result<(), BridgeClientError> {
+    if !bridge_cfg.heartbeat_mirror {
+        return Ok(());
+    }
+    let uds = bridge_cfg.resolved_uds_path();
+    let user_id = resolve_synaps_user_id();
+    emit_heartbeat(
+        &uds,
+        Duration::from_millis(bridge_cfg.heartbeat_timeout_ms),
+        "agent",
+        agent_name,
+        healthy,
+        details,
+        &user_id,
+    )
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -328,5 +368,72 @@ mod tests {
             other => panic!("expected Timeout, got {other:?}"),
         }
         task.abort();
+    }
+
+    #[tokio::test]
+    async fn mirror_heartbeat_skips_when_disabled() {
+        // Point at a non-existent socket; with mirror disabled this must NOT
+        // attempt to connect and must return Ok(()).
+        let bogus = std::path::PathBuf::from(
+            "/tmp/synaps-bridge-NEVER-EXISTS-disabled.sock",
+        );
+        let cfg = synaps_cli::config::BridgeConfig {
+            uds_path: Some(bogus),
+            heartbeat_mirror: false,
+            heartbeat_timeout_ms: 100,
+        };
+        let res = mirror_heartbeat(&cfg, "agent-x", true, json!({})).await;
+        assert!(res.is_ok(), "disabled mirror must short-circuit Ok, got {res:?}");
+    }
+
+    #[tokio::test]
+    async fn mirror_heartbeat_emits_when_enabled() {
+        let path = temp_sock("mirror-on");
+        let (task, recorded) =
+            spawn_fake_bridge(path.clone(), r#"{"ok":true}"#);
+
+        let cfg = synaps_cli::config::BridgeConfig {
+            uds_path: Some(path),
+            heartbeat_mirror: true,
+            heartbeat_timeout_ms: 1000,
+        };
+        let res = mirror_heartbeat(
+            &cfg,
+            "research-bot",
+            true,
+            json!({"session_count": 7}),
+        )
+        .await;
+        assert!(res.is_ok(), "expected Ok, got {res:?}");
+
+        let lines = recorded.lock().await.clone();
+        assert_eq!(lines.len(), 1);
+        let req: Value = serde_json::from_str(lines[0].trim_end()).unwrap();
+        assert_eq!(req["op"], "heartbeat_emit");
+        assert_eq!(req["component"], "agent");
+        assert_eq!(req["id"], "research-bot");
+        assert_eq!(req["healthy"], true);
+        assert_eq!(req["details"]["session_count"], 7);
+
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn mirror_heartbeat_returns_unavailable_when_socket_missing() {
+        let bogus = std::env::temp_dir().join(format!(
+            "synaps-bridge-mirror-missing-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&bogus);
+        let cfg = synaps_cli::config::BridgeConfig {
+            uds_path: Some(bogus),
+            heartbeat_mirror: true,
+            heartbeat_timeout_ms: 200,
+        };
+        let res = mirror_heartbeat(&cfg, "x", true, json!({})).await;
+        match res {
+            Err(BridgeClientError::Unavailable(_)) => {}
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
     }
 }

--- a/src/watcher/bridge_client.rs
+++ b/src/watcher/bridge_client.rs
@@ -1,0 +1,332 @@
+//! bridge_client — best-effort UDS client for the bridge daemon's
+//! `ControlSocket` (`heartbeat_emit` op).
+//!
+//! Wire format (newline-delimited JSON, one request -> one line response):
+//!
+//! Request:
+//! ```jsonc
+//! { "op": "heartbeat_emit",
+//!   "component": "agent",
+//!   "id": "<agent-name>",
+//!   "healthy": true,
+//!   "details": { /* arbitrary */ },
+//!   "synaps_user_id": "local" }
+//! ```
+//!
+//! Response:
+//! ```jsonc
+//! { "ok": true,  "ts": "2025-..." }
+//! { "ok": false, "code": "E_FOO", "error": "..." }
+//! ```
+//!
+//! All errors are explicit — callers (the watcher loop) MUST swallow them
+//! at debug level so the bridge being offline never blocks supervision.
+
+use std::path::Path;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use thiserror::Error;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::time::timeout;
+
+#[derive(Debug, Error)]
+pub enum BridgeClientError {
+    /// Socket file missing or refused the connection — bridge daemon not running.
+    #[error("bridge socket unavailable: {0}")]
+    Unavailable(String),
+    /// Connect, write, or read exceeded `heartbeat_timeout_ms`.
+    #[error("bridge call timed out")]
+    Timeout,
+    /// Underlying I/O failure (write, read, peer closed mid-frame).
+    #[error("bridge io error: {0}")]
+    Io(#[from] std::io::Error),
+    /// Response was not valid JSON or was missing the `ok` field.
+    #[error("bridge bad response: {0}")]
+    BadResponse(String),
+    /// Bridge replied `{ok:false, code, error}`.
+    #[error("bridge rejected: code={code} error={error}")]
+    Rejected { code: String, error: String },
+}
+
+/// Emit a single `heartbeat_emit` JSON-RPC call to the bridge daemon.
+///
+/// Best-effort: this function is intentionally **not retried**. Callers
+/// (the watcher heartbeat loop) should `tokio::spawn` it and log any
+/// error at debug level only.
+///
+/// `timeout` covers connect + write + read end-to-end.
+pub async fn emit_heartbeat(
+    uds_path: &Path,
+    call_timeout: Duration,
+    component: &str,
+    id: &str,
+    healthy: bool,
+    details: Value,
+    synaps_user_id: &str,
+) -> Result<(), BridgeClientError> {
+    let request = json!({
+        "op": "heartbeat_emit",
+        "component": component,
+        "id": id,
+        "healthy": healthy,
+        "details": details,
+        "synaps_user_id": synaps_user_id,
+    });
+
+    let mut payload = serde_json::to_vec(&request)
+        .map_err(|e| BridgeClientError::BadResponse(format!("encode: {e}")))?;
+    payload.push(b'\n');
+
+    let fut = async move {
+        let stream = UnixStream::connect(uds_path).await.map_err(|e| {
+            match e.kind() {
+                std::io::ErrorKind::NotFound
+                | std::io::ErrorKind::ConnectionRefused => {
+                    BridgeClientError::Unavailable(e.to_string())
+                }
+                _ => BridgeClientError::Io(e),
+            }
+        })?;
+
+        let (read_half, mut write_half) = stream.into_split();
+        write_half.write_all(&payload).await?;
+        write_half.flush().await?;
+        // Half-close write side so the peer can detect end-of-request if it
+        // chooses to wait for EOF; ControlSocket reads line-by-line so this
+        // is harmless.
+        drop(write_half);
+
+        let mut reader = BufReader::new(read_half);
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            return Err(BridgeClientError::BadResponse(
+                "empty response (peer closed)".to_string(),
+            ));
+        }
+
+        let parsed: Value = serde_json::from_str(line.trim_end()).map_err(|e| {
+            BridgeClientError::BadResponse(format!("invalid json: {e}"))
+        })?;
+
+        match parsed.get("ok").and_then(|v| v.as_bool()) {
+            Some(true) => Ok(()),
+            Some(false) => {
+                let code = parsed
+                    .get("code")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("E_UNKNOWN")
+                    .to_string();
+                let error = parsed
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                Err(BridgeClientError::Rejected { code, error })
+            }
+            None => Err(BridgeClientError::BadResponse(format!(
+                "missing 'ok' field: {line}"
+            ))),
+        }
+    };
+
+    match timeout(call_timeout, fut).await {
+        Ok(res) => res,
+        Err(_) => Err(BridgeClientError::Timeout),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::UnixListener;
+    use tokio::sync::Mutex;
+
+    fn temp_sock(name: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "synaps-bridge-client-{}-{}",
+            name,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.join("control.sock")
+    }
+
+    /// Spawn a fake bridge that responds with the supplied JSON line and
+    /// records every received request line. Returns the listener task and
+    /// the shared request log.
+    fn spawn_fake_bridge(
+        path: std::path::PathBuf,
+        response: &'static str,
+    ) -> (tokio::task::JoinHandle<()>, Arc<Mutex<Vec<String>>>) {
+        let listener = UnixListener::bind(&path).expect("bind temp UDS");
+        let recorded: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let recorded_clone = recorded.clone();
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let recorded = recorded_clone.clone();
+                tokio::spawn(async move {
+                    let (read_half, mut write_half) = stream.split();
+                    let mut reader = BufReader::new(read_half);
+                    let mut line = String::new();
+                    if reader.read_line(&mut line).await.is_ok() && !line.is_empty() {
+                        recorded.lock().await.push(line.clone());
+                        let _ = write_half.write_all(response.as_bytes()).await;
+                        let _ = write_half.write_all(b"\n").await;
+                        let _ = write_half.flush().await;
+                    }
+                    // Drain anything else then drop.
+                    let mut sink = Vec::new();
+                    let _ = reader.read_to_end(&mut sink).await;
+                });
+            }
+        });
+
+        (handle, recorded)
+    }
+
+    #[tokio::test]
+    async fn emit_heartbeat_happy_path() {
+        let path = temp_sock("happy");
+        let (task, recorded) =
+            spawn_fake_bridge(path.clone(), r#"{"ok":true,"ts":"2025-01-01T00:00:00Z"}"#);
+
+        let res = emit_heartbeat(
+            &path,
+            Duration::from_secs(2),
+            "agent",
+            "research-bot",
+            true,
+            json!({"session_count": 42}),
+            "local",
+        )
+        .await;
+        assert!(res.is_ok(), "expected Ok, got: {res:?}");
+
+        let lines = recorded.lock().await.clone();
+        assert_eq!(lines.len(), 1, "expected exactly one request");
+        let req: Value = serde_json::from_str(lines[0].trim_end()).unwrap();
+        assert_eq!(req["op"], "heartbeat_emit");
+        assert_eq!(req["component"], "agent");
+        assert_eq!(req["id"], "research-bot");
+        assert_eq!(req["healthy"], true);
+        assert_eq!(req["synaps_user_id"], "local");
+        assert_eq!(req["details"]["session_count"], 42);
+
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn emit_heartbeat_unavailable_when_socket_missing() {
+        let path = std::env::temp_dir().join(format!(
+            "synaps-bridge-client-missing-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        let res = emit_heartbeat(
+            &path,
+            Duration::from_secs(1),
+            "agent",
+            "x",
+            true,
+            json!({}),
+            "local",
+        )
+        .await;
+        match res {
+            Err(BridgeClientError::Unavailable(_)) => {}
+            other => panic!("expected Unavailable, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_heartbeat_rejected_when_bridge_says_no() {
+        let path = temp_sock("rejected");
+        let (task, _recorded) = spawn_fake_bridge(
+            path.clone(),
+            r#"{"ok":false,"code":"E_BAD","error":"nope"}"#,
+        );
+
+        let res = emit_heartbeat(
+            &path,
+            Duration::from_secs(2),
+            "agent",
+            "x",
+            true,
+            json!({}),
+            "local",
+        )
+        .await;
+        match res {
+            Err(BridgeClientError::Rejected { code, error }) => {
+                assert_eq!(code, "E_BAD");
+                assert_eq!(error, "nope");
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn emit_heartbeat_bad_response_when_not_json() {
+        let path = temp_sock("badjson");
+        let (task, _recorded) = spawn_fake_bridge(path.clone(), "not json at all");
+
+        let res = emit_heartbeat(
+            &path,
+            Duration::from_secs(2),
+            "agent",
+            "x",
+            true,
+            json!({}),
+            "local",
+        )
+        .await;
+        match res {
+            Err(BridgeClientError::BadResponse(_)) => {}
+            other => panic!("expected BadResponse, got {other:?}"),
+        }
+
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn emit_heartbeat_times_out_when_peer_silent() {
+        let path = temp_sock("timeout");
+        let listener = UnixListener::bind(&path).unwrap();
+        // Accept and hold the connection without responding.
+        let task = tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                drop(stream);
+            }
+        });
+
+        let res = emit_heartbeat(
+            &path,
+            Duration::from_millis(100),
+            "agent",
+            "x",
+            true,
+            json!({}),
+            "local",
+        )
+        .await;
+        match res {
+            Err(BridgeClientError::Timeout) => {}
+            other => panic!("expected Timeout, got {other:?}"),
+        }
+        task.abort();
+    }
+}

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -16,6 +16,7 @@
 mod ipc;
 mod supervisor;
 mod display;
+pub(crate) mod bridge_client;
 
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/src/watcher/supervisor.rs
+++ b/src/watcher/supervisor.rs
@@ -340,6 +340,18 @@ pub(crate) async fn run_supervisor() {
 
     log("starting supervisor");
 
+    // Load global SynapsConfig once for bridge mirror settings; failures here
+    // are non-fatal — we just default the BridgeConfig.
+    let synaps_cfg = synaps_cli::load_config();
+    let bridge_cfg = std::sync::Arc::new(synaps_cfg.bridge.clone());
+    if bridge_cfg.heartbeat_mirror {
+        log(&format!(
+            "bridge heartbeat mirror ENABLED (uds={}, timeout={}ms)",
+            bridge_cfg.resolved_uds_path().display(),
+            bridge_cfg.heartbeat_timeout_ms
+        ));
+    }
+
     let socket_path = watcher_dir().join("watcher.sock");
     let pid_path = watcher_dir().join("watcher.pid");
 
@@ -492,8 +504,39 @@ pub(crate) async fn run_supervisor() {
                         }
                         Ok(None) => {
                             let agent_dir = AgentConfig::agent_dir(&agent.config_path);
+                            let stale_threshold = agent.config.heartbeat.stale_threshold_secs;
+                            let fresh = check_heartbeat(&agent_dir, stale_threshold);
+
+                            // Best-effort: mirror heartbeat to bridge UDS. Never blocks
+                            // the supervisor loop or fails the agent.
+                            if bridge_cfg.heartbeat_mirror {
+                                let bridge_cfg_for_task = bridge_cfg.clone();
+                                let agent_name = name.clone();
+                                let session_count = agent.session_count;
+                                let pid = agent.pid;
+                                tokio::spawn(async move {
+                                    let details = serde_json::json!({
+                                        "session_count": session_count,
+                                        "pid": pid,
+                                    });
+                                    if let Err(e) = bridge_client::mirror_heartbeat(
+                                        &bridge_cfg_for_task,
+                                        &agent_name,
+                                        fresh,
+                                        details,
+                                    ).await {
+                                        tracing::debug!(
+                                            target: "watcher::bridge",
+                                            agent = %agent_name,
+                                            error = %e,
+                                            "bridge heartbeat mirror failed (non-fatal)"
+                                        );
+                                    }
+                                });
+                            }
+
                             if agent.last_start.map(|s| s.elapsed().as_secs()).unwrap_or(0) > 60
-                                && !check_heartbeat(&agent_dir, agent.config.heartbeat.stale_threshold_secs)
+                                && !fresh
                             {
                                 log(&format!("[{}] heartbeat stale — killing", name));
                                 let _ = child.kill().await;

--- a/tests/extension_provider_streaming_transport.rs
+++ b/tests/extension_provider_streaming_transport.rs
@@ -33,7 +33,7 @@ async fn process_extension_dispatches_notifications_to_subscriber() {
         .await
         .expect("initialize fixture");
 
-    let mut rx = handler.subscribe_notifications().await;
+    let (_sub_id, mut rx) = handler.subscribe_notifications().await;
 
     let result = handler
         .call_tool("trigger", serde_json::json!({}))


### PR DESCRIPTION
## What's New in v0.1.7

### Extension Widget System
Extensions can now render persistent, styled, positioned UI widgets on the TUI via JSON-RPC notifications.

- `widget.upsert` / `widget.dismiss` notification types + 17 tests
- Notification fan-out refactor (singleton → Vec) for concurrent subscribers  
- Background watcher per extension forwarding widget events to TUI
- Rich styled content with per-span fg/bg hex colors (pixel art support)
- Toast system extended with `rich_lines`, centered rendering
- `subscribe_notifications()` added to ExtensionHandler trait
- `ExtensionManager::handlers()` public accessor

### Other
- Watcher bridge client + heartbeat mirror
- RPC dispatch improvements
- Config module additions

**10 files changed, ~660 lines added for the widget system**