### PR TITLE
feat(auth): credential broker — share one OAuth cred across machines (epic #155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Shared credentials via a broker (`auth.remote_endpoint` + `synaps auth-broker`).**
+  Many machines can share ONE OAuth credential without copying it to each disk.
+  On a client, set `auth.remote_endpoint` (+ `auth.machine_token`, or env
+  `SYNAPS_AUTH_ENDPOINT` / `SYNAPS_MACHINE_TOKEN`) and it fetches short-lived
+  access tokens from a broker instead of reading/refreshing the local `auth.json`.
+  Run the broker with `synaps auth-broker --bind <addr> --machine-token <secret>`
+  on a trusted host (behind WireGuard). Clients hold only access tokens in memory
+  — never a refresh token, never written to disk; the broker is the single
+  refresher (Anthropic rotates the refresh token, so exactly one party may
+  refresh). Degrades gracefully on a broker blip (serves a still-valid cached
+  token). Closes the agentic-VM bootstrap: guests authenticate with zero
+  credentials on their own disk.
+
 ## [0.3.10] — 2026-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,24 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - **Shared credentials via a broker (`auth.remote_endpoint` + `synaps auth-broker`).**
-  Many machines can share ONE OAuth credential without copying it to each disk.
-  On a client, set `auth.remote_endpoint` (+ `auth.machine_token`, or env
-  `SYNAPS_AUTH_ENDPOINT` / `SYNAPS_MACHINE_TOKEN`) and it fetches short-lived
-  access tokens from a broker instead of reading/refreshing the local `auth.json`.
-  Run the broker with `synaps auth-broker --bind <addr> --machine-token <secret>`
-  on a trusted host (behind WireGuard). Clients hold only access tokens in memory
-  — never a refresh token, never written to disk; the broker is the single
-  refresher (Anthropic rotates the refresh token, so exactly one party may
-  refresh). Degrades gracefully on a broker blip (serves a still-valid cached
-  token). Closes the agentic-VM bootstrap: guests authenticate with zero
-  credentials on their own disk.
+  Many machines share ONE OAuth credential without copying it to each disk — both
+  **Anthropic and OpenAI/codex** tokens route through the broker. On a client, set
+  `auth.remote_endpoint` (+ `auth.machine_token`, or env `SYNAPS_AUTH_ENDPOINT` /
+  `SYNAPS_MACHINE_TOKEN`) and it fetches short-lived access tokens from a broker
+  instead of reading/refreshing the local `auth.json`. Clients hold only access
+  tokens in memory — never a refresh token, never written to disk; the broker is
+  the single refresher. Run the broker with `synaps auth-broker` on a trusted
+  host (`--machine-token-file`, behind WireGuard or a TLS-terminating proxy).
+  Closes the agentic-VM bootstrap: guests authenticate with zero credentials on
+  their own disk.
+  - **Security:** constant-time machine-token compare, provider allowlist,
+    in-flight rate cap, refuses unauthenticated non-loopback start, graceful
+    shutdown, redacting `Debug` on secrets, on-401 refetch+retry, clock-skew
+    defense (`ttl_ms`), token validation, and a `systemd` unit at
+    `deploy/synaps-auth-broker.service`.
+  - **ToS:** intended for sharing one account across YOUR OWN machines. Sharing a
+    subscription seat across users / a large fleet risks account suspension — use
+    org/enterprise API keys at scale. See the README.
 
 ## [0.3.10] — 2026-06-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "tower 0.4.13",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -3535,6 +3536,10 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ signal-hook = { version = "0.3", features = ["iterator"] }
 
 # Server deps
 axum = { version = "0.7", features = ["ws"] }
+tower = { version = "0.4", features = ["limit"] }
 unicode-width = "0.2.0"
 
 # Shell / PTY deps

--- a/README.md
+++ b/README.md
@@ -218,6 +218,33 @@ if the bridge UDS is missing. See
 [`docs/smoke/watcher-bridge.md`](docs/smoke/watcher-bridge.md) for the
 verification playbook.
 
+### Shared credentials via a broker (`auth.*`)
+
+By default each machine reads and refreshes its own `~/.synaps-cli/auth.json`
+(`auth.remote_endpoint` unset). To share ONE OAuth credential across many
+machines without copying it to each disk, run a broker on one trusted host and
+point the others at it:
+
+```ini
+# on a CLIENT machine — fetch short-lived access tokens from the broker
+auth.remote_endpoint = http://broker-host:8181
+auth.machine_token   = <shared-secret>
+# env overrides (win over config): SYNAPS_AUTH_ENDPOINT / SYNAPS_MACHINE_TOKEN
+```
+
+```bash
+# on the BROKER host — holds the credential, refreshes centrally, serves tokens
+synaps auth-broker --bind 0.0.0.0:8181 --machine-token <shared-secret>
+#   GET /healthz            -> { status, fresh_until }
+#   GET /token?provider=X   -> { access_token, expires }   (Authorization: Bearer)
+```
+
+A Remote client **never stores the credential**: it holds only short-lived
+access tokens in memory, never a refresh token, and never writes `auth.json`.
+The broker is the single refresher (Anthropic rotates the refresh token, so
+exactly one party may refresh). Run the broker behind WireGuard / a private
+network — the machine token gates who may fetch.
+
 ---
 
 ## Extensions & Plugins

--- a/README.md
+++ b/README.md
@@ -223,27 +223,64 @@ verification playbook.
 By default each machine reads and refreshes its own `~/.synaps-cli/auth.json`
 (`auth.remote_endpoint` unset). To share ONE OAuth credential across many
 machines without copying it to each disk, run a broker on one trusted host and
-point the others at it:
+point the others at it. Anthropic **and** OpenAI/codex tokens both route through
+the broker.
 
 ```ini
 # on a CLIENT machine — fetch short-lived access tokens from the broker
-auth.remote_endpoint = http://broker-host:8181
+auth.remote_endpoint = https://broker-host:8181
 auth.machine_token   = <shared-secret>
 # env overrides (win over config): SYNAPS_AUTH_ENDPOINT / SYNAPS_MACHINE_TOKEN
 ```
 
 ```bash
 # on the BROKER host — holds the credential, refreshes centrally, serves tokens
-synaps auth-broker --bind 0.0.0.0:8181 --machine-token <shared-secret>
-#   GET /healthz            -> { status, fresh_until }
-#   GET /token?provider=X   -> { access_token, expires }   (Authorization: Bearer)
+synaps auth-broker --bind 0.0.0.0:8181 --machine-token-file /etc/synaps/broker.token
+#   GET /healthz            -> { status }                  (non-200 if cred missing)
+#   GET /token?provider=X   -> { access_token, expires, ttl_ms }  (Bearer machine token)
 ```
 
 A Remote client **never stores the credential**: it holds only short-lived
 access tokens in memory, never a refresh token, and never writes `auth.json`.
-The broker is the single refresher (Anthropic rotates the refresh token, so
-exactly one party may refresh). Run the broker behind WireGuard / a private
-network — the machine token gates who may fetch.
+The broker is the single refresher (Anthropic rotates the refresh token on every
+refresh, so exactly one party may refresh).
+
+**Token config (note the three env vars):**
+
+| Role | config key | env var |
+|---|---|---|
+| client → broker URL | `auth.remote_endpoint` | `SYNAPS_AUTH_ENDPOINT` |
+| client → its identity to the broker | `auth.machine_token` | `SYNAPS_MACHINE_TOKEN` |
+| broker → secret it requires of clients | `--machine-token` / `--machine-token-file` | `SYNAPS_BROKER_TOKEN` |
+
+Prefer `--machine-token-file` over `--machine-token` so the secret isn't exposed
+in `argv`/`ps`.
+
+**Security model — read before exposing it:**
+- The broker constant-time-compares the machine token, allowlists providers,
+  rate-limits in-flight requests, and refuses to start unauthenticated on a
+  non-loopback bind (override with `--insecure-no-auth`, don't).
+- **TLS is terminated externally** — the broker speaks plain HTTP to stay a lean
+  single static binary. Run it **behind WireGuard** (private overlay) **or front
+  it with a TLS-terminating reverse proxy / load balancer / service mesh.** A
+  bare non-loopback HTTP bind ships your machine token and access tokens in
+  cleartext — a DNS-spoof/MITM then harvests them. Example with Caddy:
+  ```
+  # Caddyfile — terminates TLS, proxies to the loopback broker
+  broker.internal {
+      reverse_proxy 127.0.0.1:8181
+  }
+  ```
+  Then run `synaps auth-broker --bind 127.0.0.1:8181 ...` and point clients at
+  `https://broker.internal`. (systemd unit: `deploy/synaps-auth-broker.service`.)
+
+> **⚠ Terms of Service.** This is for sharing ONE account's credential across
+> **your own** machines (a personal homelab / your own fleet). Sharing a Claude
+> Pro/Max or ChatGPT **subscription seat** across multiple distinct users — or
+> fanning one seat out across a large machine fleet — likely violates Anthropic's
+> / OpenAI's Terms and risks **account suspension**. At real scale use **org/
+> enterprise API keys**, not subscription-seat OAuth. Check the current ToS
+> before deploying beyond your own boxes.
 
 ---
 

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -16,9 +16,10 @@ use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Where a client gets its provider credentials.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub enum CredentialSource {
     /// Read + refresh the local `auth.json` (default — unchanged behavior).
+    #[default]
     Local,
     /// Fetch short-lived access tokens from a broker over the network.
     Remote {
@@ -46,6 +47,20 @@ impl CredentialSource {
 
     pub fn is_remote(&self) -> bool {
         matches!(self, CredentialSource::Remote { .. })
+    }
+}
+
+/// Redacting Debug — never print the machine token (board M3/B3).
+impl std::fmt::Debug for CredentialSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CredentialSource::Local => write!(f, "Local"),
+            CredentialSource::Remote { endpoint, .. } => f
+                .debug_struct("Remote")
+                .field("endpoint", endpoint)
+                .field("machine_token", &"***")
+                .finish(),
+        }
     }
 }
 
@@ -89,6 +104,18 @@ pub const DEFAULT_MARGIN_MS: u64 = 5 * 60 * 1000;
 #[derive(Clone, Default)]
 pub struct TokenCache {
     inner: Arc<RwLock<HashMap<String, BrokerToken>>>,
+}
+
+/// Redacting Debug — print only the cached provider names, never the tokens.
+impl std::fmt::Debug for TokenCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let providers: Vec<String> = self
+            .inner
+            .read()
+            .map(|m| m.keys().cloned().collect())
+            .unwrap_or_default();
+        f.debug_struct("TokenCache").field("providers", &providers).finish()
+    }
 }
 
 impl TokenCache {

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -227,7 +227,15 @@ pub struct BrokerClient {
 
 impl BrokerClient {
     pub fn new(endpoint: impl Into<String>, machine_token: impl Into<String>) -> Self {
-        Self { http: reqwest::Client::new(), endpoint: endpoint.into(), machine_token: machine_token.into() }
+        // D1: bound the request so a hung/unreachable broker can't stall the
+        // caller's whole turn. (The runtime path uses `with_client` and inherits
+        // the runtime's configured client; this is the standalone fallback.)
+        let http = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .timeout(std::time::Duration::from_secs(20))
+            .build()
+            .unwrap_or_default();
+        Self { http, endpoint: endpoint.into(), machine_token: machine_token.into() }
     }
 
     /// Like `new` but reuses an existing `reqwest::Client` (shared connection

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -197,6 +197,16 @@ impl BrokerClient {
         Self { http: reqwest::Client::new(), endpoint: endpoint.into(), machine_token: machine_token.into() }
     }
 
+    /// Like `new` but reuses an existing `reqwest::Client` (shared connection
+    /// pool) instead of building a fresh one per call. (#158 A5)
+    pub fn with_client(
+        endpoint: impl Into<String>,
+        machine_token: impl Into<String>,
+        http: reqwest::Client,
+    ) -> Self {
+        Self { http, endpoint: endpoint.into(), machine_token: machine_token.into() }
+    }
+
     /// Build from a `CredentialSource`. `None` for `Local`.
     pub fn from_source(source: &CredentialSource) -> Option<Self> {
         match source {
@@ -204,6 +214,35 @@ impl BrokerClient {
                 Some(Self::new(endpoint.clone(), machine_token.clone()))
             }
             CredentialSource::Local => None,
+        }
+    }
+}
+
+/// Provider-aware token resolution honoring the credential source — the single
+/// entry point both the Anthropic and the OpenAI/codex paths use. (#158 C4)
+///
+/// - `Local`: refresh the provider's own local credential (`ensure_fresh_*`).
+/// - `Remote`: fetch a short-lived access token from the broker, keyed by
+///   provider. Reuses the caller's `http` client (no per-call pool — A5), and
+///   never holds a refresh token / never writes `auth.json` (invariant 1).
+pub async fn resolve_access_token(
+    provider: &str,
+    source: &CredentialSource,
+    cache: &TokenCache,
+    http: &reqwest::Client,
+) -> Result<String, String> {
+    match source {
+        CredentialSource::Remote { endpoint, machine_token } => {
+            let broker = BrokerClient::with_client(endpoint.clone(), machine_token.clone(), http.clone());
+            Ok(resolve_remote(&broker, cache, provider, DEFAULT_MARGIN_MS).await?.access_token)
+        }
+        CredentialSource::Local => {
+            let creds = if provider == "anthropic" {
+                super::ensure_fresh_token(http).await?
+            } else {
+                super::ensure_fresh_provider_token(http, provider).await?
+            };
+            Ok(creds.access)
         }
     }
 }
@@ -458,6 +497,23 @@ mod tests {
         let c = BrokerClient::new(url, "WRONG-token");
         let err = c.fetch_token("anthropic").await.unwrap_err();
         assert!(err.contains("401"), "expected 401 error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn resolve_access_token_remote_fetches_from_broker() {
+        let url = spawn_broker(
+            r#"{"access_token":"sk-broker","expires":9999999999999}"#,
+            "m",
+        )
+        .await;
+        let source = CredentialSource::Remote { endpoint: url, machine_token: "m".into() };
+        let cache = TokenCache::new();
+        let http = reqwest::Client::new();
+        let t = resolve_access_token("anthropic", &source, &cache, &http).await.unwrap();
+        assert_eq!(t, "sk-broker");
+        // second call hits the cache (shared http client reused, no new pool)
+        let t2 = resolve_access_token("anthropic", &source, &cache, &http).await.unwrap();
+        assert_eq!(t2, "sk-broker");
     }
 
     // ── invariant: a Remote client can NEVER hold a refresh token ─────────

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -130,24 +130,31 @@ pub trait TokenFetcher {
     async fn fetch_token(&self, provider: &str) -> Result<BrokerToken, String>;
 }
 
-/// Resolve a provider access token via cache-or-fetch. Returns the cached token
-/// if fresh; otherwise fetches from `fetcher`, caches it, and returns it.
-///
-/// This is the entire Remote credential path. It NEVER reads or holds a refresh
-/// token, NEVER writes `auth.json`, NEVER refreshes client-side — `fetcher` only
-/// ever yields a short-lived `BrokerToken` (which structurally has no refresh).
+/// Resolve a provider token via cache-or-fetch, returning the full
+/// `BrokerToken` (access + expiry). The runtime needs the expiry to drive its
+/// in-memory refresh trigger. NEVER touches a refresh token or `auth.json`.
+pub async fn resolve_remote<F: TokenFetcher>(
+    fetcher: &F,
+    cache: &TokenCache,
+    provider: &str,
+    margin_ms: u64,
+) -> Result<BrokerToken, String> {
+    if let Some(tok) = cache.get_fresh(provider, margin_ms) {
+        return Ok(tok);
+    }
+    let tok = fetcher.fetch_token(provider).await?;
+    cache.put(provider, tok.clone());
+    Ok(tok)
+}
+
+/// Like [`resolve_remote`] but returns only the access token string.
 pub async fn resolve_remote_token<F: TokenFetcher>(
     fetcher: &F,
     cache: &TokenCache,
     provider: &str,
     margin_ms: u64,
 ) -> Result<String, String> {
-    if let Some(tok) = cache.get_fresh(provider, margin_ms) {
-        return Ok(tok.access_token);
-    }
-    let tok = fetcher.fetch_token(provider).await?;
-    cache.put(provider, tok.clone());
-    Ok(tok.access_token)
+    Ok(resolve_remote(fetcher, cache, provider, margin_ms).await?.access_token)
 }
 
 // ── Broker HTTP client ───────────────────────────────────────────────────────

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -119,6 +119,19 @@ impl TokenCache {
             map.remove(provider);
         }
     }
+
+    /// Cached token if present and not PAST hard expiry (ignores the refetch
+    /// margin). Used as a degraded-mode fallback when the broker is unreachable:
+    /// a token slightly inside its refetch window is still better than failing.
+    pub fn get_unexpired(&self, provider: &str) -> Option<BrokerToken> {
+        let map = self.inner.read().ok()?;
+        let tok = map.get(provider)?;
+        if is_expired_with_margin(tok.expires, 0) {
+            None
+        } else {
+            Some(tok.clone())
+        }
+    }
 }
 
 // ── Fetcher abstraction + resolver ───────────────────────────────────────────
@@ -142,9 +155,21 @@ pub async fn resolve_remote<F: TokenFetcher>(
     if let Some(tok) = cache.get_fresh(provider, margin_ms) {
         return Ok(tok);
     }
-    let tok = fetcher.fetch_token(provider).await?;
-    cache.put(provider, tok.clone());
-    Ok(tok)
+    match fetcher.fetch_token(provider).await {
+        Ok(tok) => {
+            cache.put(provider, tok.clone());
+            Ok(tok)
+        }
+        Err(e) => {
+            // Degraded mode: the broker is unreachable, but if we still hold a
+            // token that hasn't hit hard expiry, serve it rather than failing
+            // the turn. Self-heals on the next call once the broker is back.
+            if let Some(tok) = cache.get_unexpired(provider) {
+                return Ok(tok);
+            }
+            Err(e)
+        }
+    }
 }
 
 /// Like [`resolve_remote`] but returns only the access token string.
@@ -350,6 +375,39 @@ mod tests {
         resolve_remote_token(&f, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
         resolve_remote_token(&f, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
         assert_eq!(f.calls.load(Ordering::SeqCst), 1, "second resolve should hit the cache");
+    }
+
+    // ── broker-down degradation ───────────────────────────────────────────
+    struct FailFetcher;
+    impl TokenFetcher for FailFetcher {
+        async fn fetch_token(&self, _provider: &str) -> Result<BrokerToken, String> {
+            Err("broker unreachable".into())
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_serves_stale_cache_when_broker_down() {
+        // Token expires in 2 min; margin is 5 min -> get_fresh misses (would
+        // refetch), the broker is down, but it's not HARD-expired, so we serve it.
+        let cache = TokenCache::new();
+        cache.put("anthropic", tok(now_millis() + 2 * 60 * 1000));
+        let t = resolve_remote(&FailFetcher, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
+        assert_eq!(t.access_token, "sk-live");
+    }
+
+    #[tokio::test]
+    async fn resolve_errors_when_broker_down_and_no_cache() {
+        let cache = TokenCache::new();
+        let err = resolve_remote(&FailFetcher, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap_err();
+        assert!(err.contains("unreachable"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn resolve_errors_when_broker_down_and_cache_hard_expired() {
+        let cache = TokenCache::new();
+        cache.put("anthropic", tok(now_millis().saturating_sub(1000))); // already expired
+        let err = resolve_remote(&FailFetcher, &cache, "anthropic", 0).await.unwrap_err();
+        assert!(err.contains("unreachable"), "got: {err}");
     }
 
     // ── BrokerClient against a tiny in-test axum server ──────────────────

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -1,0 +1,159 @@
+//! Remote credential source — Option C (task #157, epic #155).
+//!
+//! A Synaps client can resolve its provider **access token** from a broker over
+//! the network instead of the local `auth.json`. This lets many machines share
+//! one OAuth credential without copying the secret to each disk.
+//!
+//! INVARIANT (the whole point — enforced by construction + tests):
+//! the `Remote` path NEVER reads or holds a refresh token, NEVER writes
+//! `auth.json`, and NEVER refreshes client-side. It only fetches short-lived
+//! access tokens from the broker and caches them in memory. The single
+//! refresher is the broker (Anthropic rotates the refresh token on every
+//! refresh, so exactly one party may refresh).
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Where a client gets its provider credentials.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CredentialSource {
+    /// Read + refresh the local `auth.json` (default — unchanged behavior).
+    Local,
+    /// Fetch short-lived access tokens from a broker over the network.
+    Remote {
+        /// Broker base URL, e.g. `https://jade.jade:8181` (no trailing slash).
+        endpoint: String,
+        /// Per-machine bearer presented TO the broker. This is the machine's own
+        /// identity, NOT the provider credential.
+        machine_token: String,
+    },
+}
+
+impl CredentialSource {
+    /// Build from explicit config values. Returns `Remote` iff a non-empty
+    /// endpoint is given; otherwise `Local`. Trailing slashes on the endpoint
+    /// are trimmed so callers can join paths uniformly.
+    pub fn from_parts(endpoint: Option<String>, machine_token: Option<String>) -> Self {
+        match endpoint {
+            Some(e) if !e.trim().is_empty() => CredentialSource::Remote {
+                endpoint: e.trim().trim_end_matches('/').to_string(),
+                machine_token: machine_token.unwrap_or_default().trim().to_string(),
+            },
+            _ => CredentialSource::Local,
+        }
+    }
+
+    pub fn is_remote(&self) -> bool {
+        matches!(self, CredentialSource::Remote { .. })
+    }
+}
+
+/// An access token as returned by the broker's `GET /token`.
+///
+/// Deliberately has **no** refresh-token field: a Remote client must never
+/// receive or hold one. This is the invariant made structural — there is no
+/// place to put a refresh token even if the broker mistakenly sent one.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct BrokerToken {
+    pub access_token: String,
+    /// Absolute expiry, unix-epoch **milliseconds** (matches
+    /// `OAuthCredentials.expires`).
+    pub expires: u64,
+}
+
+/// Current unix time in milliseconds.
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// True if `expires_ms` is already past, or within `margin_ms` of now.
+///
+/// The margin absorbs clock skew + request latency so a client refetches
+/// slightly early rather than presenting a token that dies mid-flight.
+pub fn is_expired_with_margin(expires_ms: u64, margin_ms: u64) -> bool {
+    now_millis().saturating_add(margin_ms) >= expires_ms
+}
+
+/// Default refetch margin: 5 minutes (mirrors `is_token_expired`).
+pub const DEFAULT_MARGIN_MS: u64 = 5 * 60 * 1000;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_parts_local_when_no_endpoint() {
+        assert_eq!(CredentialSource::from_parts(None, None), CredentialSource::Local);
+        assert_eq!(
+            CredentialSource::from_parts(Some("   ".into()), Some("m".into())),
+            CredentialSource::Local
+        );
+    }
+
+    #[test]
+    fn from_parts_remote_when_endpoint_set() {
+        let s = CredentialSource::from_parts(Some("https://jade.jade:8181".into()), Some("tok".into()));
+        assert_eq!(
+            s,
+            CredentialSource::Remote {
+                endpoint: "https://jade.jade:8181".into(),
+                machine_token: "tok".into()
+            }
+        );
+        assert!(s.is_remote());
+    }
+
+    #[test]
+    fn from_parts_trims_trailing_slash_and_whitespace() {
+        let s = CredentialSource::from_parts(Some("  https://b/  ".into()), Some("  tok  ".into()));
+        assert_eq!(
+            s,
+            CredentialSource::Remote { endpoint: "https://b".into(), machine_token: "tok".into() }
+        );
+    }
+
+    #[test]
+    fn remote_with_missing_machine_token_defaults_empty() {
+        let s = CredentialSource::from_parts(Some("https://b".into()), None);
+        assert_eq!(
+            s,
+            CredentialSource::Remote { endpoint: "https://b".into(), machine_token: String::new() }
+        );
+    }
+
+    #[test]
+    fn local_is_not_remote() {
+        assert!(!CredentialSource::Local.is_remote());
+    }
+
+    #[test]
+    fn expiry_far_future_not_expired() {
+        let far = now_millis() + 60 * 60 * 1000; // +1h
+        assert!(!is_expired_with_margin(far, DEFAULT_MARGIN_MS));
+    }
+
+    #[test]
+    fn expiry_past_is_expired() {
+        let past = now_millis().saturating_sub(1000);
+        assert!(is_expired_with_margin(past, 0));
+    }
+
+    #[test]
+    fn expiry_within_margin_is_expired() {
+        // expires in 2 minutes, margin 5 minutes -> treated as expired (refetch early)
+        let soon = now_millis() + 2 * 60 * 1000;
+        assert!(is_expired_with_margin(soon, DEFAULT_MARGIN_MS));
+        // ...but with a 1-minute margin it is NOT yet expired
+        assert!(!is_expired_with_margin(soon, 60 * 1000));
+    }
+
+    #[test]
+    fn broker_token_deserializes_without_refresh_field() {
+        let json = r#"{"access_token":"sk-abc","expires":1750000000000}"#;
+        let t: BrokerToken = serde_json::from_str(json).unwrap();
+        assert_eq!(t.access_token, "sk-abc");
+        assert_eq!(t.expires, 1_750_000_000_000);
+    }
+}

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -73,8 +73,14 @@ impl std::fmt::Debug for CredentialSource {
 pub struct BrokerToken {
     pub access_token: String,
     /// Absolute expiry, unix-epoch **milliseconds** (matches
-    /// `OAuthCredentials.expires`).
+    /// `OAuthCredentials.expires`). When `ttl_ms` is present the client
+    /// overwrites this with its own clock + ttl to defeat clock skew.
     pub expires: u64,
+    /// Optional relative TTL in ms. When the broker sends it, the client
+    /// recomputes `expires = client_now + ttl_ms`, eliminating broker↔client
+    /// clock skew on suspend/resume VMs (board C3). Absent → use `expires`.
+    #[serde(default)]
+    pub ttl_ms: Option<u64>,
 }
 
 /// Current unix time in milliseconds.
@@ -292,9 +298,23 @@ impl TokenFetcher for BrokerClient {
         if !status.is_success() {
             return Err(format!("broker returned HTTP {status}"));
         }
-        resp.json::<BrokerToken>()
+        let mut tok = resp
+            .json::<BrokerToken>()
             .await
-            .map_err(|e| format!("invalid broker token response: {e}"))
+            .map_err(|e| format!("invalid broker token response: {e}"))?;
+        // C3: prefer the broker's relative TTL over its absolute clock.
+        if let Some(ttl) = tok.ttl_ms {
+            tok.expires = now_millis().saturating_add(ttl);
+        }
+        // C2: reject a malformed/dead token rather than caching it (which would
+        // cause a permanent refetch storm or a dud bearer).
+        if tok.access_token.is_empty() {
+            return Err("broker returned an empty access_token".to_string());
+        }
+        if tok.expires <= now_millis() {
+            return Err("broker returned an already-expired token".to_string());
+        }
+        Ok(tok)
     }
 }
 
@@ -378,7 +398,7 @@ mod tests {
 
     // ── cache ────────────────────────────────────────────────────────────
     fn tok(expires: u64) -> BrokerToken {
-        BrokerToken { access_token: "sk-live".into(), expires }
+        BrokerToken { access_token: "sk-live".into(), expires, ttl_ms: None }
     }
 
     #[test]
@@ -524,6 +544,30 @@ mod tests {
         let c = BrokerClient::new(url, "WRONG-token");
         let err = c.fetch_token("anthropic").await.unwrap_err();
         assert!(err.contains("401"), "expected 401 error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn fetch_token_recomputes_expiry_from_ttl_ms() {
+        // Broker sends a STALE absolute `expires` but a fresh `ttl_ms`; the
+        // client must recompute from its own clock (clock-skew defense, C3).
+        let url = spawn_broker(r#"{"access_token":"sk","expires":1,"ttl_ms":3600000}"#, "m").await;
+        let c = BrokerClient::new(url, "m");
+        let t = c.fetch_token("anthropic").await.unwrap();
+        assert!(t.expires > now_millis(), "expires must come from ttl_ms, got {}", t.expires);
+    }
+
+    #[tokio::test]
+    async fn fetch_token_rejects_empty_access_token() {
+        let url = spawn_broker(r#"{"access_token":"","expires":9999999999999}"#, "m").await;
+        let c = BrokerClient::new(url, "m");
+        assert!(c.fetch_token("anthropic").await.unwrap_err().contains("empty"));
+    }
+
+    #[tokio::test]
+    async fn fetch_token_rejects_already_expired() {
+        let url = spawn_broker(r#"{"access_token":"sk","expires":1}"#, "m").await;
+        let c = BrokerClient::new(url, "m");
+        assert!(c.fetch_token("anthropic").await.unwrap_err().contains("expired"));
     }
 
     #[tokio::test]

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -394,4 +394,19 @@ mod tests {
         let err = c.fetch_token("anthropic").await.unwrap_err();
         assert!(err.contains("401"), "expected 401 error, got: {err}");
     }
+
+    // ── invariant: a Remote client can NEVER hold a refresh token ─────────
+    #[test]
+    fn broker_token_structurally_drops_any_refresh_field() {
+        // Even a misbehaving/compromised broker that leaks a refresh token in
+        // the JSON cannot make a client hold one: BrokerToken has no field for
+        // it, so serde silently drops it. The "clients never hold a refresh
+        // token" invariant is structural, not a runtime check.
+        let json = r#"{"access_token":"a","expires":1,"refresh_token":"LEAK","refresh":"LEAK"}"#;
+        let t: BrokerToken = serde_json::from_str(json).unwrap();
+        assert_eq!(t.access_token, "a");
+        assert_eq!(t.expires, 1);
+        // There is no `refresh`/`refresh_token` field to even read — confirmed
+        // at compile time by the struct definition above.
+    }
 }

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -11,6 +11,8 @@
 //! refresher is the broker (Anthropic rotates the refresh token on every
 //! refresh, so exactly one party may refresh).
 
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Where a client gets its provider credentials.
@@ -78,6 +80,125 @@ pub fn is_expired_with_margin(expires_ms: u64, margin_ms: u64) -> bool {
 
 /// Default refetch margin: 5 minutes (mirrors `is_token_expired`).
 pub const DEFAULT_MARGIN_MS: u64 = 5 * 60 * 1000;
+
+// ── In-memory token cache ────────────────────────────────────────────────────
+
+/// Thread-safe, per-provider cache of broker access tokens. Cloneable handle
+/// over shared state. Holds ONLY short-lived access tokens, never a refresh
+/// token, never persisted to disk.
+#[derive(Clone, Default)]
+pub struct TokenCache {
+    inner: Arc<RwLock<HashMap<String, BrokerToken>>>,
+}
+
+impl TokenCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the cached token for `provider` only if present AND not within
+    /// `margin_ms` of expiry. Otherwise `None` (caller should fetch).
+    pub fn get_fresh(&self, provider: &str, margin_ms: u64) -> Option<BrokerToken> {
+        let map = self.inner.read().ok()?;
+        let tok = map.get(provider)?;
+        if is_expired_with_margin(tok.expires, margin_ms) {
+            None
+        } else {
+            Some(tok.clone())
+        }
+    }
+
+    pub fn put(&self, provider: &str, token: BrokerToken) {
+        if let Ok(mut map) = self.inner.write() {
+            map.insert(provider.to_string(), token);
+        }
+    }
+
+    pub fn invalidate(&self, provider: &str) {
+        if let Ok(mut map) = self.inner.write() {
+            map.remove(provider);
+        }
+    }
+}
+
+// ── Fetcher abstraction + resolver ───────────────────────────────────────────
+
+/// "Get a fresh access token from somewhere." Abstracted so the cache/resolve
+/// logic is unit-testable without real HTTP. The real impl is `BrokerClient`.
+#[allow(async_fn_in_trait)]
+pub trait TokenFetcher {
+    async fn fetch_token(&self, provider: &str) -> Result<BrokerToken, String>;
+}
+
+/// Resolve a provider access token via cache-or-fetch. Returns the cached token
+/// if fresh; otherwise fetches from `fetcher`, caches it, and returns it.
+///
+/// This is the entire Remote credential path. It NEVER reads or holds a refresh
+/// token, NEVER writes `auth.json`, NEVER refreshes client-side — `fetcher` only
+/// ever yields a short-lived `BrokerToken` (which structurally has no refresh).
+pub async fn resolve_remote_token<F: TokenFetcher>(
+    fetcher: &F,
+    cache: &TokenCache,
+    provider: &str,
+    margin_ms: u64,
+) -> Result<String, String> {
+    if let Some(tok) = cache.get_fresh(provider, margin_ms) {
+        return Ok(tok.access_token);
+    }
+    let tok = fetcher.fetch_token(provider).await?;
+    cache.put(provider, tok.clone());
+    Ok(tok.access_token)
+}
+
+// ── Broker HTTP client ───────────────────────────────────────────────────────
+
+/// HTTP client for a credential broker. Presents the machine's own bearer token
+/// (NOT the provider credential) and receives a short-lived access token.
+pub struct BrokerClient {
+    http: reqwest::Client,
+    endpoint: String,
+    machine_token: String,
+}
+
+impl BrokerClient {
+    pub fn new(endpoint: impl Into<String>, machine_token: impl Into<String>) -> Self {
+        Self { http: reqwest::Client::new(), endpoint: endpoint.into(), machine_token: machine_token.into() }
+    }
+
+    /// Build from a `CredentialSource`. `None` for `Local`.
+    pub fn from_source(source: &CredentialSource) -> Option<Self> {
+        match source {
+            CredentialSource::Remote { endpoint, machine_token } => {
+                Some(Self::new(endpoint.clone(), machine_token.clone()))
+            }
+            CredentialSource::Local => None,
+        }
+    }
+}
+
+impl TokenFetcher for BrokerClient {
+    async fn fetch_token(&self, provider: &str) -> Result<BrokerToken, String> {
+        let url = format!("{}/token", self.endpoint);
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[("provider", provider)])
+            .bearer_auth(&self.machine_token)
+            .send()
+            .await
+            .map_err(|e| format!("broker request failed: {e}"))?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err("broker rejected machine auth (401)".to_string());
+        }
+        if !status.is_success() {
+            return Err(format!("broker returned HTTP {status}"));
+        }
+        resp.json::<BrokerToken>()
+            .await
+            .map_err(|e| format!("invalid broker token response: {e}"))
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -155,5 +276,122 @@ mod tests {
         let t: BrokerToken = serde_json::from_str(json).unwrap();
         assert_eq!(t.access_token, "sk-abc");
         assert_eq!(t.expires, 1_750_000_000_000);
+    }
+
+    // ── cache ────────────────────────────────────────────────────────────
+    fn tok(expires: u64) -> BrokerToken {
+        BrokerToken { access_token: "sk-live".into(), expires }
+    }
+
+    #[test]
+    fn cache_get_fresh_returns_unexpired() {
+        let c = TokenCache::new();
+        c.put("anthropic", tok(now_millis() + 60 * 60 * 1000));
+        assert!(c.get_fresh("anthropic", DEFAULT_MARGIN_MS).is_some());
+    }
+
+    #[test]
+    fn cache_get_fresh_none_when_expired() {
+        let c = TokenCache::new();
+        c.put("anthropic", tok(now_millis().saturating_sub(1000)));
+        assert!(c.get_fresh("anthropic", 0).is_none());
+    }
+
+    #[test]
+    fn cache_invalidate_removes() {
+        let c = TokenCache::new();
+        c.put("anthropic", tok(now_millis() + 60 * 60 * 1000));
+        c.invalidate("anthropic");
+        assert!(c.get_fresh("anthropic", 0).is_none());
+    }
+
+    #[test]
+    fn cache_providers_isolated() {
+        let c = TokenCache::new();
+        c.put("anthropic", tok(now_millis() + 60 * 60 * 1000));
+        assert!(c.get_fresh("openai", 0).is_none());
+    }
+
+    // ── resolve with a fake fetcher (counts calls) ───────────────────────
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct FakeFetcher {
+        token: BrokerToken,
+        calls: AtomicUsize,
+    }
+    impl TokenFetcher for FakeFetcher {
+        async fn fetch_token(&self, _provider: &str) -> Result<BrokerToken, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.token.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_cache_hit_does_not_fetch() {
+        let cache = TokenCache::new();
+        cache.put("anthropic", tok(now_millis() + 60 * 60 * 1000));
+        let f = FakeFetcher { token: tok(0), calls: AtomicUsize::new(0) };
+        let t = resolve_remote_token(&f, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
+        assert_eq!(t, "sk-live");
+        assert_eq!(f.calls.load(Ordering::SeqCst), 0, "must not fetch on a cache hit");
+    }
+
+    #[tokio::test]
+    async fn resolve_miss_fetches_then_caches() {
+        let cache = TokenCache::new();
+        let f = FakeFetcher { token: tok(now_millis() + 60 * 60 * 1000), calls: AtomicUsize::new(0) };
+        resolve_remote_token(&f, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
+        resolve_remote_token(&f, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
+        assert_eq!(f.calls.load(Ordering::SeqCst), 1, "second resolve should hit the cache");
+    }
+
+    // ── BrokerClient against a tiny in-test axum server ──────────────────
+    async fn spawn_broker(token_json: &'static str, require_token: &'static str) -> String {
+        use axum::{http::HeaderMap, http::StatusCode, routing::get, Router};
+        let app = Router::new().route(
+            "/token",
+            get(move |headers: HeaderMap| async move {
+                let auth = headers
+                    .get("authorization")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("");
+                if auth == format!("Bearer {require_token}") {
+                    (StatusCode::OK, token_json.to_string())
+                } else {
+                    (StatusCode::UNAUTHORIZED, String::new())
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn broker_client_fetches_and_parses() {
+        let url = spawn_broker(
+            r#"{"access_token":"sk-from-broker","expires":9999999999999}"#,
+            "machine-xyz",
+        )
+        .await;
+        let c = BrokerClient::new(url, "machine-xyz");
+        let t = c.fetch_token("anthropic").await.unwrap();
+        assert_eq!(t.access_token, "sk-from-broker");
+        assert_eq!(t.expires, 9_999_999_999_999);
+    }
+
+    #[tokio::test]
+    async fn broker_client_401_on_bad_machine_auth() {
+        let url = spawn_broker(
+            r#"{"access_token":"x","expires":9999999999999}"#,
+            "right-token",
+        )
+        .await;
+        let c = BrokerClient::new(url, "WRONG-token");
+        let err = c.fetch_token("anthropic").await.unwrap_err();
+        assert!(err.contains("401"), "expected 401 error, got: {err}");
     }
 }

--- a/crates/agent-core/src/core/auth/mod.rs
+++ b/crates/agent-core/src/core/auth/mod.rs
@@ -72,7 +72,12 @@ pub struct CallbackResult {
     pub state: String,
 }
 
-/// Check if the current token is expired (or will expire within 5 minutes).
+/// Check if the current token is expired.
+///
+/// Note the effective ~5-minute safety margin lives in the stored value, not
+/// here: `refresh_token`/`exchange_code_for_tokens` bake a 5-minute buffer into
+/// `expires` (`now + expires_in*1000 - 5min`). So a bare `now >= expires` check
+/// already fires ~5 minutes before the credential actually dies at the provider.
 pub fn is_token_expired(creds: &OAuthCredentials) -> bool {
     now_millis() >= creds.expires
 }

--- a/crates/agent-core/src/core/auth/mod.rs
+++ b/crates/agent-core/src/core/auth/mod.rs
@@ -17,6 +17,7 @@ mod token;
 mod storage;
 mod browser;
 mod openai_codex;
+mod credential_source;
 
 // ── Re-exports ──────────────────────────────────────────────────────────────────
 
@@ -26,6 +27,7 @@ pub use token::{exchange_code_for_tokens, refresh_token, ensure_fresh_token, ens
 pub use storage::{auth_file_path, load_auth, load_provider_auth, save_auth, save_provider_auth};
 pub use browser::open_browser;
 pub use openai_codex::{extract_account_id as extract_codex_account_id, login as login_openai_codex};
+pub use credential_source::{CredentialSource, BrokerToken, is_expired_with_margin, DEFAULT_MARGIN_MS};
 
 // ── Constants (match Claude Code / Pi) ──────────────────────────────────────
 

--- a/crates/agent-core/src/core/auth/mod.rs
+++ b/crates/agent-core/src/core/auth/mod.rs
@@ -27,7 +27,7 @@ pub use token::{exchange_code_for_tokens, refresh_token, ensure_fresh_token, ens
 pub use storage::{auth_file_path, load_auth, load_provider_auth, save_auth, save_provider_auth};
 pub use browser::open_browser;
 pub use openai_codex::{extract_account_id as extract_codex_account_id, login as login_openai_codex};
-pub use credential_source::{CredentialSource, BrokerToken, BrokerClient, TokenCache, TokenFetcher, resolve_remote_token, is_expired_with_margin, DEFAULT_MARGIN_MS};
+pub use credential_source::{CredentialSource, BrokerToken, BrokerClient, TokenCache, TokenFetcher, resolve_remote, resolve_remote_token, is_expired_with_margin, DEFAULT_MARGIN_MS};
 
 // ── Constants (match Claude Code / Pi) ──────────────────────────────────────
 

--- a/crates/agent-core/src/core/auth/mod.rs
+++ b/crates/agent-core/src/core/auth/mod.rs
@@ -27,7 +27,7 @@ pub use token::{exchange_code_for_tokens, refresh_token, ensure_fresh_token, ens
 pub use storage::{auth_file_path, load_auth, load_provider_auth, save_auth, save_provider_auth};
 pub use browser::open_browser;
 pub use openai_codex::{extract_account_id as extract_codex_account_id, login as login_openai_codex};
-pub use credential_source::{CredentialSource, BrokerToken, BrokerClient, TokenCache, TokenFetcher, resolve_remote, resolve_remote_token, is_expired_with_margin, DEFAULT_MARGIN_MS};
+pub use credential_source::{CredentialSource, BrokerToken, BrokerClient, TokenCache, TokenFetcher, resolve_remote, resolve_remote_token, resolve_access_token, is_expired_with_margin, DEFAULT_MARGIN_MS};
 
 // ── Constants (match Claude Code / Pi) ──────────────────────────────────────
 

--- a/crates/agent-core/src/core/auth/mod.rs
+++ b/crates/agent-core/src/core/auth/mod.rs
@@ -27,7 +27,7 @@ pub use token::{exchange_code_for_tokens, refresh_token, ensure_fresh_token, ens
 pub use storage::{auth_file_path, load_auth, load_provider_auth, save_auth, save_provider_auth};
 pub use browser::open_browser;
 pub use openai_codex::{extract_account_id as extract_codex_account_id, login as login_openai_codex};
-pub use credential_source::{CredentialSource, BrokerToken, is_expired_with_margin, DEFAULT_MARGIN_MS};
+pub use credential_source::{CredentialSource, BrokerToken, BrokerClient, TokenCache, TokenFetcher, resolve_remote_token, is_expired_with_margin, DEFAULT_MARGIN_MS};
 
 // ── Constants (match Claude Code / Pi) ──────────────────────────────────────
 

--- a/crates/agent-core/src/core/config.rs
+++ b/crates/agent-core/src/core/config.rs
@@ -152,6 +152,37 @@ impl BridgeConfig {
     }
 }
 
+/// Auth configuration parsed from `auth.*` keys. Controls whether this client
+/// resolves provider tokens from the local `auth.json` (default) or from a
+/// remote credential broker. See task #157 / `auth::credential_source`.
+#[derive(Debug, Clone, Default)]
+pub struct AuthConfig {
+    /// Broker base URL. When set (here, or via `SYNAPS_AUTH_ENDPOINT`), the
+    /// client fetches short-lived access tokens from the broker instead of
+    /// reading/refreshing the local `auth.json`.
+    pub remote_endpoint: Option<String>,
+    /// Per-machine bearer presented to the broker (or `SYNAPS_MACHINE_TOKEN`).
+    /// This is the machine's own identity, never the provider credential.
+    pub machine_token: Option<String>,
+}
+
+impl AuthConfig {
+    /// Resolve the credential source. Environment variables take precedence over
+    /// config-file values: `SYNAPS_AUTH_ENDPOINT` / `SYNAPS_MACHINE_TOKEN`.
+    /// Returns `Remote` iff an endpoint is set (env or config), else `Local`.
+    pub fn credential_source(&self) -> crate::core::auth::CredentialSource {
+        let endpoint = std::env::var("SYNAPS_AUTH_ENDPOINT")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| self.remote_endpoint.clone());
+        let machine_token = std::env::var("SYNAPS_MACHINE_TOKEN")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| self.machine_token.clone());
+        crate::core::auth::CredentialSource::from_parts(endpoint, machine_token)
+    }
+}
+
 /// Prompt-cache TTL strategy for Anthropic requests.
 ///
 /// Controls the `cache_control` value emitted at every cache marker site:
@@ -214,6 +245,7 @@ pub struct SynapsConfig {
     pub shell: ShellConfig,
     pub server: ServerConfig,
     pub bridge: BridgeConfig,
+    pub auth: AuthConfig,
     pub provider_keys: BTreeMap<String, String>,
     pub keybinds: std::collections::HashMap<String, String>,
     /// Non-fatal problems found while parsing the config file (unknown keys,
@@ -247,6 +279,7 @@ impl Default for SynapsConfig {
             shell: ShellConfig::default(),
             server: ServerConfig::default(),
             bridge: BridgeConfig::default(),
+            auth: AuthConfig::default(),
             provider_keys: BTreeMap::new(),
             keybinds: std::collections::HashMap::new(),
             warnings: Vec::new(),
@@ -435,6 +468,21 @@ fn parse_bridge_config_key(bridge_config: &mut BridgeConfig, key: &str, val: &st
     }
 }
 
+/// Parse auth.* configuration keys and update the AuthConfig.
+fn parse_auth_config_key(auth_config: &mut AuthConfig, key: &str, val: &str) {
+    let v = val.trim();
+    match key {
+        "auth.remote_endpoint" => {
+            auth_config.remote_endpoint = if v.is_empty() { None } else { Some(v.to_string()) };
+        }
+        "auth.machine_token" => {
+            auth_config.machine_token = if v.is_empty() { None } else { Some(v.to_string()) };
+        }
+        _ => {
+            // Unknown auth.* keys preserved (not rejected)
+        }
+    }
+}
 /// Parse the config file at ~/.synaps-cli/config (or profile variant).
 /// Returns default config if file doesn't exist or can't be read.
 pub fn load_config() -> SynapsConfig {
@@ -545,6 +593,8 @@ pub fn load_config() -> SynapsConfig {
                     parse_server_config_key(&mut config.server, key, val);
                 } else if key.starts_with("bridge.") {
                     parse_bridge_config_key(&mut config.bridge, key, val);
+                } else if key.starts_with("auth.") {
+                    parse_auth_config_key(&mut config.auth, key, val);
                 } else if let Some(provider_key) = key.strip_prefix("provider.") {
                     config.provider_keys.insert(provider_key.to_string(), val.to_string());
                 } else if let Some(keybind_key) = key.strip_prefix("keybind.") {
@@ -1223,5 +1273,69 @@ api_retries = 5
         assert_eq!(config.bash_max_timeout, 600);
         assert_eq!(config.subagent_timeout, 120);
         assert_eq!(config.api_retries, 5);
+    }
+
+    // ── auth.* config + credential source (#157) ──
+
+    #[test]
+    #[serial]
+    fn test_auth_config_parses_endpoint_and_token() {
+        let home = std::env::temp_dir().join(format!("synaps-auth-test-{}", std::process::id()));
+        let dir = home.join(".synaps-cli");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("config"),
+            "auth.remote_endpoint = https://jade.jade:8181\nauth.machine_token = machine-abc\n",
+        )
+        .unwrap();
+        with_home(&home, || {
+            let config = load_config();
+            assert_eq!(config.auth.remote_endpoint.as_deref(), Some("https://jade.jade:8181"));
+            assert_eq!(config.auth.machine_token.as_deref(), Some("machine-abc"));
+            // auth.* are namespaced -> must NOT warn as unknown keys
+            assert!(!config.warnings.iter().any(|w| w.contains("auth.")), "{:?}", config.warnings);
+        });
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    #[serial]
+    fn test_credential_source_local_by_default() {
+        std::env::remove_var("SYNAPS_AUTH_ENDPOINT");
+        std::env::remove_var("SYNAPS_MACHINE_TOKEN");
+        assert!(!AuthConfig::default().credential_source().is_remote());
+    }
+
+    #[test]
+    #[serial]
+    fn test_credential_source_remote_from_config() {
+        std::env::remove_var("SYNAPS_AUTH_ENDPOINT");
+        std::env::remove_var("SYNAPS_MACHINE_TOKEN");
+        let auth = AuthConfig {
+            remote_endpoint: Some("https://b".into()),
+            machine_token: Some("m".into()),
+        };
+        assert_eq!(
+            auth.credential_source(),
+            crate::core::auth::CredentialSource::Remote { endpoint: "https://b".into(), machine_token: "m".into() }
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_credential_source_env_overrides_config() {
+        let auth = AuthConfig {
+            remote_endpoint: Some("https://config-host".into()),
+            machine_token: Some("config-tok".into()),
+        };
+        std::env::set_var("SYNAPS_AUTH_ENDPOINT", "https://env-host");
+        std::env::set_var("SYNAPS_MACHINE_TOKEN", "env-tok");
+        let src = auth.credential_source();
+        std::env::remove_var("SYNAPS_AUTH_ENDPOINT");
+        std::env::remove_var("SYNAPS_MACHINE_TOKEN");
+        assert_eq!(
+            src,
+            crate::core::auth::CredentialSource::Remote { endpoint: "https://env-host".into(), machine_token: "env-tok".into() }
+        );
     }
 }

--- a/crates/agent-engine/src/runtime/api.rs
+++ b/crates/agent-engine/src/runtime/api.rs
@@ -606,6 +606,12 @@ pub struct ApiOptions {
     /// the downgrade notice on healthy Hybrid turns where the 1h prefix is
     /// already cached (1h == 0, 5m > 0). Shared via Arc like the notice latch.
     pub saw_1h_honored: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Credential source for provider auth (Local/Remote). Carried here so the
+    /// OpenAI/codex routing path can resolve tokens through the broker on
+    /// Remote, same as the Anthropic path. (#158 C4)
+    pub credential_source: crate::auth::CredentialSource,
+    /// Shared broker token cache (Remote only).
+    pub token_cache: crate::auth::TokenCache,
 }
 
 pub(super) struct ApiMethods;
@@ -651,6 +657,7 @@ impl ApiMethods {
         if let Some(result) = crate::runtime::openai::try_route(
             model, client, &tools_schema, system_prompt, messages, &tx,
             None, None, thinking_budget, cancel,
+            &options.credential_source, &options.token_cache,
         ).await {
             return result.map_err(|e| RuntimeError::Config(format!("openai provider: {e}")));
         }

--- a/crates/agent-engine/src/runtime/api.rs
+++ b/crates/agent-engine/src/runtime/api.rs
@@ -663,7 +663,9 @@ impl ApiMethods {
         }
 
         // Read auth state for this API call
-        let (auth_header_name, auth_header_value, auth_type) = Self::build_auth_header(auth).await;
+        let (mut auth_header_name, mut auth_header_value, auth_type) = Self::build_auth_header(auth).await;
+        // C1: allow a single on-401 token refetch+retry for Remote clients.
+        let mut auth_retried = false;
 
         // Fail early with a clear message if no Anthropic credentials
         if auth_type == "none" {
@@ -805,6 +807,35 @@ impl ApiMethods {
                         if status.is_success() {
                             response = Some(resp);
                             break;
+                        }
+
+                        // C1: a 401 with a Remote source means the broker token
+                        // was rejected (revoked, or rotated at the broker before
+                        // our cache thought it expired). Invalidate, refetch from
+                        // the broker, and retry ONCE with the fresh token.
+                        if status.as_u16() == 401
+                            && options.credential_source.is_remote()
+                            && !auth_retried
+                        {
+                            auth_retried = true;
+                            let _ = resp.text().await; // drain body
+                            options.token_cache.invalidate("anthropic");
+                            {
+                                let mut g = auth.write().await;
+                                g.auth_token.clear();
+                                g.token_expires = None;
+                            }
+                            super::auth::AuthMethods::refresh_if_needed(
+                                std::sync::Arc::clone(auth),
+                                client,
+                                &options.credential_source,
+                                &options.token_cache,
+                            )
+                            .await?;
+                            let (n, v, _t) = Self::build_auth_header(auth).await;
+                            auth_header_name = n;
+                            auth_header_value = v;
+                            continue;
                         }
 
                         let is_429    = status.as_u16() == 429;

--- a/crates/agent-engine/src/runtime/api_sync.rs
+++ b/crates/agent-engine/src/runtime/api_sync.rs
@@ -50,6 +50,7 @@ impl ApiMethods {
         if let Some(result) = crate::runtime::openai::try_route(
             model, client, &tools_schema, system_prompt, messages, &tx,
             None, None, thinking_budget, &tokio_util::sync::CancellationToken::new(),
+            &options.credential_source, &options.token_cache,
         ).await {
             drop(tx);
             while rx.recv().await.is_some() {}
@@ -267,6 +268,10 @@ impl ApiMethods {
             None,
             thinking_budget,
             &tokio_util::sync::CancellationToken::new(),
+            // call_api_simple is an internal helper without ApiOptions; codex here
+            // uses the Local credential. (Broker-routed codex goes via the stream path.)
+            &crate::auth::CredentialSource::Local,
+            &crate::auth::TokenCache::new(),
         )
         .await
         {

--- a/crates/agent-engine/src/runtime/auth.rs
+++ b/crates/agent-engine/src/runtime/auth.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use crate::{Result, RuntimeError};
 use reqwest::Client;
-use crate::auth::{BrokerClient, CredentialSource, TokenCache, resolve_remote, DEFAULT_MARGIN_MS};
+use crate::auth::{BrokerClient, CredentialSource, TokenCache, resolve_remote, is_expired_with_margin, DEFAULT_MARGIN_MS};
 use super::types::{AuthState, PiAuth};
 
 pub(super) struct AuthMethods;
@@ -33,11 +33,17 @@ impl AuthMethods {
     ) -> Result<()> {
         // ── Remote credential source: resolve via the broker. ──
         if let CredentialSource::Remote { .. } = source {
-            // Fast path: in-memory broker token still fresh?
+            // Fast path: in-memory broker token still outside the refetch margin?
+            // Must use the SAME predicate as the cache (is_expired_with_margin +
+            // DEFAULT_MARGIN_MS) so the fast-path and TokenCache agree on freshness
+            // — otherwise the fast-path serves a token the cache would refetch,
+            // and a >margin tool step can expire it mid-flight (board finding #1).
             {
                 let auth_guard = auth.read().await;
                 if let Some(exp) = auth_guard.token_expires {
-                    if !auth_guard.auth_token.is_empty() && crate::epoch_millis() < exp {
+                    if !auth_guard.auth_token.is_empty()
+                        && !is_expired_with_margin(exp, DEFAULT_MARGIN_MS)
+                    {
                         return Ok(());
                     }
                 }
@@ -202,6 +208,30 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(auth.read().await.auth_token, "sk-1");
+    }
+
+    #[tokio::test]
+    async fn remote_fast_path_refetches_a_token_inside_the_margin() {
+        // AuthState holds a token that is valid but within the 5-min refetch
+        // margin. The fast path must NOT serve it — it must refetch (board #1).
+        let url = spawn_broker(r#"{"access_token":"sk-FRESH","expires":9999999999999}"#).await;
+        let source = CredentialSource::Remote { endpoint: url, machine_token: "m".into() };
+        let cache = TokenCache::new();
+        let near = crate::epoch_millis() + 2 * 60 * 1000; // 2 min — inside the 5-min margin
+        let auth = Arc::new(RwLock::new(AuthState {
+            auth_token: "sk-STALE".into(),
+            auth_type: "oauth".into(),
+            refresh_token: None,
+            token_expires: Some(near),
+        }));
+        AuthMethods::refresh_if_needed(Arc::clone(&auth), &Client::new(), &source, &cache)
+            .await
+            .unwrap();
+        assert_eq!(
+            auth.read().await.auth_token,
+            "sk-FRESH",
+            "a token inside the refetch margin must be refetched, not served stale"
+        );
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/runtime/auth.rs
+++ b/crates/agent-engine/src/runtime/auth.rs
@@ -2,13 +2,21 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use crate::{Result, RuntimeError};
 use reqwest::Client;
+use crate::auth::{BrokerClient, CredentialSource, TokenCache, resolve_remote, DEFAULT_MARGIN_MS};
 use super::types::{AuthState, PiAuth};
 
 pub(super) struct AuthMethods;
 
 impl AuthMethods {
     /// Check if the OAuth token is expired and refresh it if needed.
-    /// Uses Pi-style file locking for cross-process safety:
+    ///
+    /// Two credential sources:
+    /// - `Remote` (#157): fetch a short-lived access token from the broker.
+    ///   Independent of the local auth.json. NEVER holds a refresh token,
+    ///   NEVER writes auth.json, NEVER refreshes client-side.
+    /// - `Local` (default): the original Pi-style file-locked refresh below.
+    ///
+    /// Local path detail (unchanged):
     /// - Acquires exclusive lock on auth.json
     /// - Re-reads inside the lock (another instance may have refreshed)
     /// - Refreshes via API only if still expired
@@ -17,7 +25,39 @@ impl AuthMethods {
     /// Multiple SynapsCLI instances (or Avante/Jade) can safely call this
     /// simultaneously — they'll serialize on the lock and only one will
     /// actually hit the token endpoint.
-    pub(super) async fn refresh_if_needed(auth: Arc<RwLock<AuthState>>, client: &Client) -> Result<()> {
+    pub(super) async fn refresh_if_needed(
+        auth: Arc<RwLock<AuthState>>,
+        client: &Client,
+        source: &CredentialSource,
+        cache: &TokenCache,
+    ) -> Result<()> {
+        // ── Remote credential source: resolve via the broker. ──
+        if let CredentialSource::Remote { .. } = source {
+            // Fast path: in-memory broker token still fresh?
+            {
+                let auth_guard = auth.read().await;
+                if let Some(exp) = auth_guard.token_expires {
+                    if !auth_guard.auth_token.is_empty() && crate::epoch_millis() < exp {
+                        return Ok(());
+                    }
+                }
+            }
+            let broker = BrokerClient::from_source(source)
+                .expect("CredentialSource::Remote always yields a BrokerClient");
+            let tok = resolve_remote(&broker, cache, "anthropic", DEFAULT_MARGIN_MS)
+                .await
+                .map_err(|e| RuntimeError::Auth(format!(
+                    "Broker token fetch failed: {}. Check auth.remote_endpoint, the machine token, and broker reachability.", e
+                )))?;
+            let mut auth_guard = auth.write().await;
+            auth_guard.auth_token = tok.access_token;
+            auth_guard.auth_type = "oauth".to_string();
+            auth_guard.refresh_token = None; // invariant: clients never hold a refresh token
+            auth_guard.token_expires = Some(tok.expires);
+            return Ok(());
+        }
+
+        // ── Local credential source (default — unchanged behavior). ──
         // Fast path: read lock to check expiry without blocking writers
         {
             let auth_guard = auth.read().await;
@@ -103,5 +143,84 @@ impl AuthMethods {
         // No Anthropic credentials — allow startup anyway for non-Anthropic providers.
         // Auth will fail lazily on the first actual Anthropic API call.
         Ok(("".to_string(), "none".to_string(), None, None))
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::TokenCache;
+
+    /// Tiny in-test broker that always returns `token_json` at GET /token.
+    async fn spawn_broker(token_json: &'static str) -> String {
+        use axum::{routing::get, Router};
+        let app = Router::new().route("/token", get(move || async move { token_json.to_string() }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    fn empty_auth() -> Arc<RwLock<AuthState>> {
+        Arc::new(RwLock::new(AuthState {
+            auth_token: String::new(),
+            auth_type: "none".into(),
+            refresh_token: Some("SHOULD-BE-CLEARED".into()),
+            token_expires: None,
+        }))
+    }
+
+    #[tokio::test]
+    async fn remote_source_fetches_and_populates_auth_state() {
+        let url = spawn_broker(r#"{"access_token":"sk-broker-xyz","expires":9999999999999}"#).await;
+        let source = CredentialSource::Remote { endpoint: url, machine_token: "m".into() };
+        let cache = TokenCache::new();
+        let auth = empty_auth();
+        AuthMethods::refresh_if_needed(Arc::clone(&auth), &Client::new(), &source, &cache)
+            .await
+            .unwrap();
+        let g = auth.read().await;
+        assert_eq!(g.auth_token, "sk-broker-xyz");
+        assert_eq!(g.auth_type, "oauth");
+        assert_eq!(g.refresh_token, None, "Remote must clear any refresh token (invariant)");
+        assert_eq!(g.token_expires, Some(9_999_999_999_999));
+    }
+
+    #[tokio::test]
+    async fn remote_source_fast_path_when_token_still_fresh() {
+        let url = spawn_broker(r#"{"access_token":"sk-1","expires":9999999999999}"#).await;
+        let source = CredentialSource::Remote { endpoint: url, machine_token: "m".into() };
+        let cache = TokenCache::new();
+        let auth = empty_auth();
+        // First call fetches + sets a far-future expiry.
+        AuthMethods::refresh_if_needed(Arc::clone(&auth), &Client::new(), &source, &cache)
+            .await
+            .unwrap();
+        // Second call: in-memory token is fresh -> fast path returns without refetch.
+        AuthMethods::refresh_if_needed(Arc::clone(&auth), &Client::new(), &source, &cache)
+            .await
+            .unwrap();
+        assert_eq!(auth.read().await.auth_token, "sk-1");
+    }
+
+    #[tokio::test]
+    async fn local_source_api_key_is_noop_never_contacts_broker() {
+        // Local + non-oauth auth_type hits the original early-return: no broker,
+        // no error, state untouched. (Local path byte-for-byte unchanged.)
+        let source = CredentialSource::Local;
+        let cache = TokenCache::new();
+        let auth = Arc::new(RwLock::new(AuthState {
+            auth_token: "key".into(),
+            auth_type: "api_key".into(),
+            refresh_token: None,
+            token_expires: None,
+        }));
+        AuthMethods::refresh_if_needed(Arc::clone(&auth), &Client::new(), &source, &cache)
+            .await
+            .unwrap();
+        let g = auth.read().await;
+        assert_eq!(g.auth_token, "key");
+        assert_eq!(g.auth_type, "api_key");
     }
 }

--- a/crates/agent-engine/src/runtime/auth.rs
+++ b/crates/agent-engine/src/runtime/auth.rs
@@ -8,6 +8,18 @@ use super::types::{AuthState, PiAuth};
 pub(super) struct AuthMethods;
 
 impl AuthMethods {
+    /// Reset `AuthState` so a Remote client never *uses* or *holds* a credential
+    /// seeded from a local `auth.json`. Called from `apply_config` when the
+    /// source is Remote: clears the access token, drops any refresh token
+    /// (invariant 1), and forces the next `refresh_if_needed` to fetch from the
+    /// broker. `auth_type` stays "oauth" so the Local early-return is not taken.
+    pub(super) fn scrub_for_remote(s: &mut AuthState) {
+        s.auth_token.clear();
+        s.auth_type = "oauth".to_string();
+        s.refresh_token = None;
+        s.token_expires = None;
+    }
+
     /// Check if the OAuth token is expired and refresh it if needed.
     ///
     /// Two credential sources:
@@ -252,5 +264,20 @@ mod tests {
         let g = auth.read().await;
         assert_eq!(g.auth_token, "key");
         assert_eq!(g.auth_type, "api_key");
+    }
+
+    #[test]
+    fn scrub_for_remote_clears_local_credential_and_refresh_token() {
+        let mut s = AuthState {
+            auth_token: "local-token".into(),
+            auth_type: "oauth".into(),
+            refresh_token: Some("LEAKED-REFRESH".into()),
+            token_expires: Some(123),
+        };
+        AuthMethods::scrub_for_remote(&mut s);
+        assert!(s.auth_token.is_empty(), "access token must be cleared");
+        assert_eq!(s.refresh_token, None, "refresh token must be dropped (invariant 1)");
+        assert_eq!(s.token_expires, None, "expiry must be cleared to force a broker fetch");
+        assert_eq!(s.auth_type, "oauth", "auth_type stays oauth so Local early-return is skipped");
     }
 }

--- a/crates/agent-engine/src/runtime/auth.rs
+++ b/crates/agent-engine/src/runtime/auth.rs
@@ -7,6 +7,19 @@ use super::types::{AuthState, PiAuth};
 
 pub(super) struct AuthMethods;
 
+/// True if `model` routes to the Anthropic path (not OpenAI/codex/local). Used
+/// to skip the Anthropic pre-stream refresh for non-Anthropic models — they
+/// resolve their own provider auth (incl. via the broker), so fetching an
+/// Anthropic token first is wasteful and would FAIL on a codex-only Remote
+/// broker. (#158 C4/#7)
+pub(super) fn model_is_anthropic(model: &str) -> bool {
+    let keys = crate::core::config::get_provider_keys();
+    matches!(
+        crate::runtime::openai::resolve_route(model, &keys),
+        crate::runtime::openai::Provider::Anthropic
+    )
+}
+
 impl AuthMethods {
     /// Reset `AuthState` so a Remote client never *uses* or *holds* a credential
     /// seeded from a local `auth.json`. Called from `apply_config` when the

--- a/crates/agent-engine/src/runtime/auth.rs
+++ b/crates/agent-engine/src/runtime/auth.rs
@@ -44,7 +44,7 @@ impl AuthMethods {
         cache: &TokenCache,
     ) -> Result<()> {
         // ── Remote credential source: resolve via the broker. ──
-        if let CredentialSource::Remote { .. } = source {
+        if let CredentialSource::Remote { endpoint, machine_token } = source {
             // Fast path: in-memory broker token still outside the refetch margin?
             // Must use the SAME predicate as the cache (is_expired_with_margin +
             // DEFAULT_MARGIN_MS) so the fast-path and TokenCache agree on freshness
@@ -60,8 +60,9 @@ impl AuthMethods {
                     }
                 }
             }
-            let broker = BrokerClient::from_source(source)
-                .expect("CredentialSource::Remote always yields a BrokerClient");
+            // Reuse the runtime's shared reqwest::Client (shared connection
+            // pool) instead of building a fresh one per refresh. (#158 A5)
+            let broker = BrokerClient::with_client(endpoint.clone(), machine_token.clone(), client.clone());
             let tok = resolve_remote(&broker, cache, "anthropic", DEFAULT_MARGIN_MS)
                 .await
                 .map_err(|e| RuntimeError::Auth(format!(

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -356,7 +356,22 @@ impl Runtime {
         self.cache_ttl = config.cache_ttl;
         // Credential source: Local (auth.json) by default, or Remote (broker)
         // when auth.remote_endpoint / SYNAPS_AUTH_ENDPOINT is set. (#157)
-        self.credential_source = config.auth.credential_source();
+        let new_source = config.auth.credential_source();
+        // A6: switching source (or broker endpoint) must not serve a token minted
+        // by the previous broker/identity — drop any cached token.
+        if new_source != self.credential_source {
+            self.token_cache.invalidate("anthropic");
+        }
+        self.credential_source = new_source;
+        // A2: on Remote, NEVER use a credential seeded from a local auth.json.
+        // Scrub AuthState so the first refresh fetches from the broker and the
+        // client never holds a refresh token (invariant 1). try_write is safe:
+        // apply_config runs at boot before AuthState is shared with stream tasks.
+        if self.credential_source.is_remote() {
+            if let Ok(mut auth) = self.auth.try_write() {
+                AuthMethods::scrub_for_remote(&mut auth);
+            }
+        }
 
         // Remove any built-in tools the user disabled via `disabled_tools`.
         // try_write is safe here: apply_config runs at boot before the registry

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -769,6 +769,8 @@ impl Runtime {
         // same AuthState so mid-loop token refreshes are visible immediately.
         let auth = Arc::clone(&self.auth);
         let client = self.client.clone();
+        let credential_source = self.credential_source.clone();
+        let token_cache = self.token_cache.clone();
         let model = self.model.clone();
         let tools = self.tools.clone();
         let system_prompt = self.system_prompt.clone();
@@ -793,7 +795,7 @@ impl Runtime {
         };
 
         let session = crate::runtime::stream::StreamSession {
-            auth, client, options, api_retries,
+            auth, client, credential_source, token_cache, options, api_retries,
             model, tools, system_prompt, thinking_budget,
             tx: tx.clone(), cancel, steering_rx,
             watcher_exit_path, max_tool_output,

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -192,6 +192,13 @@ pub struct Runtime {
     reaper_handle: Option<tokio::task::JoinHandle<()>>,
     #[allow(dead_code)]
     reaper_cancel: Option<tokio_util::sync::CancellationToken>,
+    /// How provider credentials are resolved: `Local` (read/refresh auth.json —
+    /// the default) or `Remote` (fetch short-lived access tokens from a broker).
+    /// Set from config in `apply_config`. See task #157.
+    credential_source: crate::auth::CredentialSource,
+    /// In-memory cache of broker-fetched access tokens (Remote source only).
+    /// Cheap to clone (Arc inside). Never persisted to disk.
+    token_cache: crate::auth::TokenCache,
 }
 
 impl Runtime {
@@ -248,6 +255,8 @@ impl Runtime {
             hook_bus: Arc::new(crate::extensions::hooks::HookBus::new()),
             reaper_handle: Some(reaper_handle),
             reaper_cancel: Some(cancel),
+            credential_source: crate::auth::CredentialSource::Local,
+            token_cache: crate::auth::TokenCache::new(),
         })
     }
 
@@ -345,6 +354,9 @@ impl Runtime {
         self.telemetry_level = crate::runtime::telemetry::TelemetryLevel::from_str_key(&config.telemetry);
         self.cache_diagnostics = config.cache_diagnostics;
         self.cache_ttl = config.cache_ttl;
+        // Credential source: Local (auth.json) by default, or Remote (broker)
+        // when auth.remote_endpoint / SYNAPS_AUTH_ENDPOINT is set. (#157)
+        self.credential_source = config.auth.credential_source();
 
         // Remove any built-in tools the user disabled via `disabled_tools`.
         // try_write is safe here: apply_config runs at boot before the registry
@@ -433,7 +445,13 @@ impl Runtime {
 
     /// Check if the OAuth token is expired and refresh it if needed.
     pub async fn refresh_if_needed(&self) -> Result<()> {
-        AuthMethods::refresh_if_needed(Arc::clone(&self.auth), &self.client).await
+        AuthMethods::refresh_if_needed(
+            Arc::clone(&self.auth),
+            &self.client,
+            &self.credential_source,
+            &self.token_cache,
+        )
+        .await
     }
 
     /// Make a simple non-streaming API call for compaction (no tools).
@@ -831,6 +849,8 @@ impl Clone for Runtime {
             hook_bus: self.hook_bus.clone(),
             reaper_handle: None,  // Cloned runtimes don't own the reaper
             reaper_cancel: None,  // Cloned runtimes don't own the reaper
+            credential_source: self.credential_source.clone(),
+            token_cache: self.token_cache.clone(), // shares the same cache (Arc inside)
         }
     }
 }

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -516,6 +516,8 @@ impl Runtime {
                     cache_ttl: self.cache_ttl,
                     ttl_downgrade_notified: self.ttl_downgrade_notified.clone(),
                     saw_1h_honored: self.saw_1h_honored.clone(),
+                    credential_source: self.credential_source.clone(),
+                    token_cache: self.token_cache.clone(),
                 },
             ).await?;
             
@@ -810,6 +812,8 @@ impl Runtime {
             cache_ttl: self.cache_ttl,
             ttl_downgrade_notified: self.ttl_downgrade_notified.clone(),
             saw_1h_honored: self.saw_1h_honored.clone(),
+            credential_source: self.credential_source.clone(),
+            token_cache: self.token_cache.clone(),
         };
 
         let session = crate::runtime::stream::StreamSession {

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -463,6 +463,11 @@ impl Runtime {
 
     /// Check if the OAuth token is expired and refresh it if needed.
     pub async fn refresh_if_needed(&self) -> Result<()> {
+        // Non-Anthropic models resolve their own provider auth in the OpenAI
+        // path (incl. via the broker), so skip the Anthropic pre-fetch. (#158 #7)
+        if !crate::runtime::auth::model_is_anthropic(&self.model) {
+            return Ok(());
+        }
         AuthMethods::refresh_if_needed(
             Arc::clone(&self.auth),
             &self.client,

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -354,24 +354,7 @@ impl Runtime {
         self.telemetry_level = crate::runtime::telemetry::TelemetryLevel::from_str_key(&config.telemetry);
         self.cache_diagnostics = config.cache_diagnostics;
         self.cache_ttl = config.cache_ttl;
-        // Credential source: Local (auth.json) by default, or Remote (broker)
-        // when auth.remote_endpoint / SYNAPS_AUTH_ENDPOINT is set. (#157)
-        let new_source = config.auth.credential_source();
-        // A6: switching source (or broker endpoint) must not serve a token minted
-        // by the previous broker/identity — drop any cached token.
-        if new_source != self.credential_source {
-            self.token_cache.invalidate("anthropic");
-        }
-        self.credential_source = new_source;
-        // A2: on Remote, NEVER use a credential seeded from a local auth.json.
-        // Scrub AuthState so the first refresh fetches from the broker and the
-        // client never holds a refresh token (invariant 1). try_write is safe:
-        // apply_config runs at boot before AuthState is shared with stream tasks.
-        if self.credential_source.is_remote() {
-            if let Ok(mut auth) = self.auth.try_write() {
-                AuthMethods::scrub_for_remote(&mut auth);
-            }
-        }
+        self.apply_auth_config(config);
 
         // Remove any built-in tools the user disabled via `disabled_tools`.
         // try_write is safe here: apply_config runs at boot before the registry
@@ -379,6 +362,26 @@ impl Runtime {
         if !config.disabled_tools.is_empty() {
             if let Ok(mut reg) = self.tools.try_write() {
                 reg.disable(&config.disabled_tools);
+            }
+        }
+    }
+
+    /// Apply only the credential-source portion of config. Used by subagent
+    /// spawns that build a fresh `Runtime::new()` (which defaults to Local) and
+    /// must inherit the user's Remote/broker setup. (#158 A3)
+    ///
+    /// A6: invalidates the token cache if the source/endpoint changed.
+    /// A2: scrubs `AuthState` when Remote so no local `auth.json` credential is
+    /// used or held (invariant 1).
+    pub fn apply_auth_config(&mut self, config: &crate::config::SynapsConfig) {
+        let new_source = config.auth.credential_source();
+        if new_source != self.credential_source {
+            self.token_cache.invalidate("anthropic");
+        }
+        self.credential_source = new_source;
+        if self.credential_source.is_remote() {
+            if let Ok(mut auth) = self.auth.try_write() {
+                AuthMethods::scrub_for_remote(&mut auth);
             }
         }
     }

--- a/crates/agent-engine/src/runtime/openai/catalog/mod.rs
+++ b/crates/agent-engine/src/runtime/openai/catalog/mod.rs
@@ -294,7 +294,13 @@ async fn read_catalog_response(resp: reqwest::Response) -> Result<String, String
 async fn fetch_anthropic_catalog_models(
     client: &reqwest::Client,
 ) -> Result<Vec<CatalogModel>, String> {
-    let creds = crate::auth::ensure_fresh_token(client)
+    // Honor the credential source so a Remote client lists models via a
+    // broker-issued token instead of refreshing (and rotating) auth.json
+    // client-side — which would lock the broker out. (#158 A4)
+    let config = crate::config::load_config();
+    let source = config.auth.credential_source();
+    let cache = crate::auth::TokenCache::new();
+    let access = crate::auth::resolve_access_token("anthropic", &source, &cache, client)
         .await
         .map_err(|e| format!("Anthropic is not configured: {e}"))?;
     let mut pages = Vec::new();
@@ -303,8 +309,8 @@ async fn fetch_anthropic_catalog_models(
     for _ in 0..ANTHROPIC_MODELS_MAX_PAGES {
         let url = anthropic_models_url(after_id.as_deref());
         let resp = catalog_get(client, &url)
-            .bearer_auth(&creds.access)
-            .header("x-api-key", &creds.access)
+            .bearer_auth(&access)
+            .header("x-api-key", &access)
             .header("anthropic-version", "2023-06-01")
             .send()
             .await

--- a/crates/agent-engine/src/runtime/openai/mod.rs
+++ b/crates/agent-engine/src/runtime/openai/mod.rs
@@ -101,6 +101,8 @@ pub async fn try_route(
     max_tokens: Option<u32>,
     thinking_budget: u32,
     cancel: &tokio_util::sync::CancellationToken,
+    source: &crate::auth::CredentialSource,
+    cache: &crate::auth::TokenCache,
 ) -> Option<Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>>> {
     if let Some((plugin_id, provider_id, model_id)) = ProviderRegistry::parse_model_id(model) {
         if let Some(manager) = extension_manager_for_routing() {
@@ -325,7 +327,7 @@ pub async fn try_route(
         Provider::Codex(cfg) => {
             let result = stream::call_codex_stream_inner(
                 &cfg, client, tools_schema, system_prompt, messages, tx,
-                temperature, max_tokens, cancel,
+                temperature, max_tokens, cancel, source, cache,
             ).await;
             Some(result)
         }

--- a/crates/agent-engine/src/runtime/openai/stream.rs
+++ b/crates/agent-engine/src/runtime/openai/stream.rs
@@ -157,23 +157,31 @@ pub(crate) async fn call_codex_stream_inner(
     temperature: Option<f32>,
     max_tokens: Option<u32>,
     cancel: &tokio_util::sync::CancellationToken,
+    source: &crate::auth::CredentialSource,
+    cache: &crate::auth::TokenCache,
 ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
-    let creds = if cfg.api_key.is_empty() {
-        crate::auth::ensure_fresh_provider_token(client, "openai-codex").await?
+    // Resolve the codex access token honoring the credential source: Remote
+    // fetches from the broker, Local refreshes the openai-codex auth.json. (#158 C4)
+    let (access, account_id) = if !cfg.api_key.is_empty() {
+        (cfg.api_key.clone(), crate::auth::extract_codex_account_id(&cfg.api_key))
     } else {
-        crate::auth::OAuthCredentials {
-            auth_type: "oauth".to_string(),
-            refresh: String::new(),
-            access: cfg.api_key.clone(),
-            expires: 0,
-            account_id: None,
+        match source {
+            crate::auth::CredentialSource::Remote { .. } => {
+                let access = crate::auth::resolve_access_token("openai-codex", source, cache, client).await?;
+                let acct = crate::auth::extract_codex_account_id(&access);
+                (access, acct)
+            }
+            crate::auth::CredentialSource::Local => {
+                let creds = crate::auth::ensure_fresh_provider_token(client, "openai-codex").await?;
+                let acct = creds
+                    .account_id
+                    .clone()
+                    .or_else(|| crate::auth::extract_codex_account_id(&creds.access));
+                (creds.access, acct)
+            }
         }
     };
-    let account_id = creds
-        .account_id
-        .clone()
-        .or_else(|| crate::auth::extract_codex_account_id(&creds.access))
-        .ok_or("Failed to extract ChatGPT account id from Codex token")?;
+    let account_id = account_id.ok_or("Failed to extract ChatGPT account id from Codex token")?;
 
     let (oai_tools, name_map) = translate::tools_to_oai(tools_schema);
     let oai_messages = translate::messages_to_oai(messages, system_prompt, &name_map);
@@ -218,7 +226,7 @@ pub(crate) async fn call_codex_stream_inner(
 
     let resp = client
         .post(&url)
-        .bearer_auth(&creds.access)
+        .bearer_auth(&access)
         .header("chatgpt-account-id", account_id)
         .header("originator", "synaps")
         .header("OpenAI-Beta", "responses=experimental")

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -94,13 +94,17 @@ impl StreamMethods {
             // tokens in long-running agentic sessions. Unified path: branches
             // Local (auth.json) vs Remote (broker) so Remote clients refresh
             // mid-stream FROM THE BROKER, never the (absent) local auth.json. (#157)
-            super::auth::AuthMethods::refresh_if_needed(
-                Arc::clone(&auth),
-                &client,
-                &credential_source,
-                &token_cache,
-            )
-            .await?;
+            // Skip for non-Anthropic models — the OpenAI/codex path self-serves
+            // its provider token (incl. via the broker). (#158 #7)
+            if super::auth::model_is_anthropic(&model) {
+                super::auth::AuthMethods::refresh_if_needed(
+                    Arc::clone(&auth),
+                    &client,
+                    &credential_source,
+                    &token_cache,
+                )
+                .await?;
+            }
 
             let tools_snapshot = tools.read().await.clone();
 

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -17,6 +17,11 @@ pub(super) struct StreamSession {
     // Auth & network
     pub(super) auth: Arc<RwLock<AuthState>>,
     pub(super) client: Client,
+    /// Credential source (Local/Remote) — threaded in so the mid-stream refresh
+    /// uses the broker for Remote clients, not the local auth.json. (#157)
+    pub(super) credential_source: crate::auth::CredentialSource,
+    /// Shared broker token cache (Remote source only).
+    pub(super) token_cache: crate::auth::TokenCache,
     pub(super) options: super::api::ApiOptions,
     pub(super) api_retries: u32,
 
@@ -68,7 +73,7 @@ impl StreamMethods {
         initial_messages: Vec<Value>,
     ) -> Result<()> {
         let StreamSession {
-            auth, client, options, api_retries,
+            auth, client, credential_source, token_cache, options, api_retries,
             model, tools, system_prompt, thinking_budget,
             tx, cancel, mut steering_rx,
             watcher_exit_path, max_tool_output,
@@ -85,36 +90,17 @@ impl StreamMethods {
                 return Ok(());
             }
 
-            // Refresh token before each API call in the tool loop — this is
-            // the fix for stale tokens in long-running agentic sessions.
-            {
-                let auth_state = auth.read().await;
-                if auth_state.auth_type == "oauth" {
-                    let expired = match auth_state.token_expires {
-                        Some(exp) => {
-                            let now = crate::epoch_millis();
-                            now >= exp
-                        }
-                        None => false,
-                    };
-                    if expired {
-                        // Drop read lock before acquiring write
-                        drop(auth_state);
-
-                        tracing::info!("Refreshing token mid-stream");
-                        let creds = crate::auth::ensure_fresh_token(&client)
-                            .await
-                            .map_err(|e| RuntimeError::Auth(format!(
-                                "Token refresh failed mid-stream: {}. Run `synaps login` to re-authenticate.", e
-                            )))?;
-
-                        let mut auth_w = auth.write().await;
-                        auth_w.auth_token = creds.access;
-                        auth_w.refresh_token = Some(creds.refresh);
-                        auth_w.token_expires = Some(creds.expires);
-                    }
-                }
-            }
+            // Refresh token before each API call in the tool loop — fixes stale
+            // tokens in long-running agentic sessions. Unified path: branches
+            // Local (auth.json) vs Remote (broker) so Remote clients refresh
+            // mid-stream FROM THE BROKER, never the (absent) local auth.json. (#157)
+            super::auth::AuthMethods::refresh_if_needed(
+                Arc::clone(&auth),
+                &client,
+                &credential_source,
+                &token_cache,
+            )
+            .await?;
 
             let tools_snapshot = tools.read().await.clone();
 

--- a/crates/agent-engine/src/tools/subagent/oneshot.rs
+++ b/crates/agent-engine/src/tools/subagent/oneshot.rs
@@ -124,6 +124,9 @@ impl Tool for SubagentTool {
                         Err(e) => return Err(format!("Failed to create subagent runtime: {}", e)),
                     };
 
+                    // Inherit the user's credential source (Remote/broker) — a
+                    // fresh Runtime::new() defaults to Local. (#158 A3)
+                    runtime.apply_auth_config(&crate::config::load_config());
                     runtime.set_system_prompt(system_prompt);
                     runtime.set_model(model);
                     runtime.set_tools(crate::ToolRegistry::without_subagent());

--- a/crates/agent-engine/src/tools/subagent/resume.rs
+++ b/crates/agent-engine/src/tools/subagent/resume.rs
@@ -162,6 +162,8 @@ impl Tool for SubagentResumeTool {
                         Err(e) => return Err(format!("Failed to create subagent runtime: {}", e)),
                     };
 
+                    // Inherit the user's credential source (Remote/broker). (#158 A3)
+                    runtime.apply_auth_config(&crate::config::load_config());
                     runtime.set_system_prompt(system_prompt);
                     runtime.set_model(model_a.clone());
                     runtime.set_tools(crate::ToolRegistry::without_subagent());

--- a/crates/agent-engine/src/tools/subagent/start.rs
+++ b/crates/agent-engine/src/tools/subagent/start.rs
@@ -158,6 +158,8 @@ impl Tool for SubagentStartTool {
                         Err(e) => return Err(format!("Failed to create subagent runtime: {}", e)),
                     };
 
+                    // Inherit the user's credential source (Remote/broker). (#158 A3)
+                    runtime.apply_auth_config(&crate::config::load_config());
                     runtime.set_system_prompt(system_prompt);
                     runtime.set_model(model_a.clone());
                     let tools = if let Some(ext_mgr) = crate::runtime::openai::extension_manager_for_routing() {

--- a/deploy/synaps-auth-broker.service
+++ b/deploy/synaps-auth-broker.service
@@ -1,0 +1,26 @@
+# synaps auth-broker — credential broker (see README "Shared credentials via a broker")
+# Install: cp deploy/synaps-auth-broker.service /etc/systemd/system/
+#          put the machine token in /etc/synaps/broker.token (chmod 600)
+#          systemctl enable --now synaps-auth-broker
+[Unit]
+Description=synaps credential broker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=synaps
+# auth.json lives under this user's ~/.synaps-cli/
+ExecStart=/usr/local/bin/synaps auth-broker --bind 0.0.0.0:8181 --machine-token-file /etc/synaps/broker.token
+Restart=always
+RestartSec=5
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=true
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cmd/auth_broker.rs
+++ b/src/cmd/auth_broker.rs
@@ -185,8 +185,15 @@ async fn token(
 
     match creds {
         Ok(c) => {
+            // C3: send a relative TTL so clients compute expiry on their own
+            // clock (kills broker↔client skew on suspend/resume VMs).
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+            let ttl_ms = c.expires.saturating_sub(now);
             eprintln!("[auth-broker] issued {provider} token to {} (expires {})", peer.ip(), c.expires);
-            (StatusCode::OK, Json(json!({ "access_token": c.access, "expires": c.expires })))
+            (StatusCode::OK, Json(json!({ "access_token": c.access, "expires": c.expires, "ttl_ms": ttl_ms })))
                 .into_response()
         }
         Err(e) => {

--- a/src/cmd/auth_broker.rs
+++ b/src/cmd/auth_broker.rs
@@ -17,7 +17,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use axum::{
-    extract::{Query, State},
+    extract::{ConnectInfo, Query, State},
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::get,
@@ -53,7 +53,24 @@ pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<
         .timeout(Duration::from_secs(60))
         .build()?;
 
-    let state = BrokerState { machine_token: machine_token.clone(), client };
+    let state = BrokerState { machine_token: machine_token.clone(), client: client.clone() };
+
+    // Proactive refresh: keep the credential warm so clients always get a
+    // fresh token instantly, and so the single refresher runs even when no
+    // client is calling. ensure_fresh_token only hits the network when the
+    // token is within its expiry margin (file-locked — still the only refresher).
+    {
+        let refresh_client = client;
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                tick.tick().await;
+                if let Err(e) = auth::ensure_fresh_token(&refresh_client).await {
+                    eprintln!("[auth-broker] proactive refresh failed: {e}");
+                }
+            }
+        });
+    }
 
     let app = Router::new()
         .route("/healthz", get(healthz))
@@ -68,8 +85,11 @@ pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<
         "synaps auth-broker listening on http://{addr}  (machine auth: {})",
         if machine_token.is_some() { "ON" } else { "OFF — trusted-network only!" }
     );
+    if !addr.ip().is_loopback() {
+        eprintln!("  ⚠ bound to a non-loopback address — run this behind WireGuard / a private network (no TLS termination here).");
+    }
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
     Ok(())
 }
 
@@ -86,6 +106,7 @@ async fn healthz() -> impl IntoResponse {
 /// The broker refreshes centrally if needed (file-locked — the single refresher).
 async fn token(
     State(st): State<BrokerState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Query(q): Query<TokenQuery>,
 ) -> impl IntoResponse {
@@ -96,6 +117,7 @@ async fn token(
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
         if got != format!("Bearer {expected}") {
+            eprintln!("[auth-broker] DENIED token request from {} (bad machine auth)", peer.ip());
             return (StatusCode::UNAUTHORIZED, Json(json!({ "error": "bad machine auth" })))
                 .into_response();
         }
@@ -110,12 +132,12 @@ async fn token(
 
     match creds {
         Ok(c) => {
-            eprintln!("[auth-broker] issued {} token (expires {})", provider, c.expires);
+            eprintln!("[auth-broker] issued {} token to {} (expires {})", provider, peer.ip(), c.expires);
             (StatusCode::OK, Json(json!({ "access_token": c.access, "expires": c.expires })))
                 .into_response()
         }
         Err(e) => {
-            eprintln!("[auth-broker] refresh failed for {}: {}", provider, e);
+            eprintln!("[auth-broker] refresh failed for {} ({}): {}", provider, peer.ip(), e);
             (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e }))).into_response()
         }
     }

--- a/src/cmd/auth_broker.rs
+++ b/src/cmd/auth_broker.rs
@@ -10,8 +10,8 @@
 //! behind WireGuard / a private network — `--machine-token` gates who may fetch.
 //!
 //! Endpoints:
-//!   GET /healthz            -> { status, fresh_until }   (no secret)
-//!   GET /token?provider=X   -> { access_token, expires }  (machine-auth required)
+//!   GET /healthz            -> { status }                 (no secret, non-200 if cred missing)
+//!   GET /token?provider=X   -> { access_token, expires }  (machine-auth required, allowlisted)
 
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -27,10 +27,15 @@ use serde::Deserialize;
 use serde_json::json;
 use synaps_cli::auth;
 
+/// Providers the broker will vend. Anything else is rejected before any work or
+/// logging — prevents probing for configured providers and log injection via an
+/// arbitrary provider string. (#158 B4)
+const ALLOWED_PROVIDERS: &[&str] = &["anthropic", "openai-codex"];
+
 #[derive(Clone)]
 struct BrokerState {
     /// Token clients must present as `Authorization: Bearer <token>`. `None`
-    /// disables auth (only safe on a fully trusted/private network).
+    /// disables auth (only safe on loopback or with explicit `--insecure-no-auth`).
     machine_token: Option<String>,
     /// HTTP client used for the (central, single) token refresh to the provider.
     client: reqwest::Client,
@@ -41,10 +46,50 @@ struct TokenQuery {
     provider: Option<String>,
 }
 
-pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<()> {
+/// Constant-time byte comparison — avoids a timing oracle on the machine token.
+/// (#158 B1 / CWE-208.) Length mismatch short-circuits; token length is not the
+/// secret. Equal-length inputs are compared in constant time.
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) -> anyhow::Result<()> {
     let machine_token = machine_token
         .or_else(|| std::env::var("SYNAPS_BROKER_TOKEN").ok())
         .filter(|s| !s.trim().is_empty());
+
+    let addr: SocketAddr = bind
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid --bind '{}': {}", bind, e))?;
+
+    // B2: refuse to start unauthenticated on a non-loopback bind unless the
+    // operator explicitly opts in. A silent auth-OFF on the LAN is an open
+    // credential tap, not a convenience.
+    if machine_token.is_none() && !addr.ip().is_loopback() && !insecure {
+        anyhow::bail!(
+            "refusing to start: no machine token (set --machine-token or SYNAPS_BROKER_TOKEN) while \
+             bound to non-loopback {addr}. That would serve credentials unauthenticated to the network. \
+             Pass --insecure-no-auth to override (NOT recommended), or bind 127.0.0.1."
+        );
+    }
+
+    // D1: fail fast if the credential isn't present/readable, rather than
+    // starting a broker that 500s every request.
+    match auth::load_auth() {
+        Ok(Some(_)) => {}
+        Ok(None) => anyhow::bail!(
+            "no credential at {}. Run `synaps login` on the broker host first.",
+            auth::auth_file_path().display()
+        ),
+        Err(e) => anyhow::bail!("credential unreadable/corrupt: {e}"),
+    }
 
     let client = reqwest::Client::builder()
         .tls_built_in_webpki_certs(true)
@@ -55,10 +100,10 @@ pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<
 
     let state = BrokerState { machine_token: machine_token.clone(), client: client.clone() };
 
-    // Proactive refresh: keep the credential warm so clients always get a
-    // fresh token instantly, and so the single refresher runs even when no
-    // client is calling. ensure_fresh_token only hits the network when the
-    // token is within its expiry margin (file-locked — still the only refresher).
+    // Proactive refresh: keep the credential warm so clients always get a fresh
+    // token instantly, and so the single refresher runs even with no traffic.
+    // ensure_fresh_token only hits the network within the expiry margin
+    // (file-locked — still the only refresher).
     {
         let refresh_client = client;
         tokio::spawn(async move {
@@ -77,32 +122,30 @@ pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<
         .route("/token", get(token))
         .with_state(state);
 
-    let addr: SocketAddr = bind
-        .parse()
-        .map_err(|e| anyhow::anyhow!("invalid --bind '{}': {}", bind, e))?;
-
     eprintln!(
         "synaps auth-broker listening on http://{addr}  (machine auth: {})",
-        if machine_token.is_some() { "ON" } else { "OFF — trusted-network only!" }
+        if machine_token.is_some() { "ON" } else { "OFF — loopback/insecure only!" }
     );
     if !addr.ip().is_loopback() {
-        eprintln!("  ⚠ bound to a non-loopback address — run this behind WireGuard / a private network (no TLS termination here).");
+        eprintln!("  ⚠ non-loopback bind — run behind WireGuard / a private network (no in-process TLS yet).");
     }
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
     Ok(())
 }
 
-/// Liveness + credential freshness, without leaking any secret.
+/// Liveness + credential readiness. Returns non-200 when the credential is
+/// missing/corrupt so monitors actually catch it. No secret, no expiry leak.
+/// (#158 B8 / M1.)
 async fn healthz() -> impl IntoResponse {
-    let fresh_until = match auth::load_auth() {
-        Ok(Some(f)) => Some(f.anthropic.expires),
-        _ => None,
-    };
-    (StatusCode::OK, Json(json!({ "status": "ok", "fresh_until": fresh_until })))
+    match auth::load_auth() {
+        Ok(Some(_)) => (StatusCode::OK, Json(json!({ "status": "ok" }))),
+        Ok(None) => (StatusCode::SERVICE_UNAVAILABLE, Json(json!({ "status": "no_credential" }))),
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "status": "error" }))),
+    }
 }
 
-/// Issue a current access token for `provider` (default: anthropic).
+/// Issue a current access token for `provider` (default: anthropic, allowlisted).
 /// The broker refreshes centrally if needed (file-locked — the single refresher).
 async fn token(
     State(st): State<BrokerState>,
@@ -110,20 +153,30 @@ async fn token(
     headers: HeaderMap,
     Query(q): Query<TokenQuery>,
 ) -> impl IntoResponse {
-    // ── machine auth ──
+    // ── machine auth (constant-time) ──
     if let Some(ref expected) = st.machine_token {
         let got = headers
             .get("authorization")
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
-        if got != format!("Bearer {expected}") {
-            eprintln!("[auth-broker] DENIED token request from {} (bad machine auth)", peer.ip());
+        let expected_header = format!("Bearer {expected}");
+        if !ct_eq(got.as_bytes(), expected_header.as_bytes()) {
+            eprintln!("[auth-broker] DENIED from {} (bad machine auth)", peer.ip());
             return (StatusCode::UNAUTHORIZED, Json(json!({ "error": "bad machine auth" })))
                 .into_response();
         }
     }
 
+    // ── provider allowlist (before any work, refresh, or logging of the value) ──
     let provider = q.provider.unwrap_or_else(|| "anthropic".to_string());
+    if !ALLOWED_PROVIDERS.contains(&provider.as_str()) {
+        // Never log the raw (attacker-controlled) provider — only its length,
+        // so a `?provider=...%0A...` can't forge audit lines. (#158 B4 / CWE-117)
+        eprintln!("[auth-broker] DENIED from {} (provider not allowed, {} chars)", peer.ip(), provider.len());
+        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "unknown provider" }))).into_response();
+    }
+
+    // `provider` is now a known-safe allowlisted value — safe to log verbatim.
     let creds = if provider == "anthropic" {
         auth::ensure_fresh_token(&st.client).await
     } else {
@@ -132,13 +185,31 @@ async fn token(
 
     match creds {
         Ok(c) => {
-            eprintln!("[auth-broker] issued {} token to {} (expires {})", provider, peer.ip(), c.expires);
+            eprintln!("[auth-broker] issued {provider} token to {} (expires {})", peer.ip(), c.expires);
             (StatusCode::OK, Json(json!({ "access_token": c.access, "expires": c.expires })))
                 .into_response()
         }
         Err(e) => {
-            eprintln!("[auth-broker] refresh failed for {} ({}): {}", provider, peer.ip(), e);
-            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e }))).into_response()
+            // B5: log the detail server-side; return a generic message — the
+            // error can contain fs paths or raw provider responses. (CWE-209)
+            eprintln!("[auth-broker] refresh failed for {provider} from {}: {}", peer.ip(), e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": "token refresh failed" })))
+                .into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ct_eq;
+
+    #[test]
+    fn ct_eq_matches_only_identical() {
+        assert!(ct_eq(b"Bearer secret", b"Bearer secret"));
+        assert!(!ct_eq(b"Bearer secret", b"Bearer secreT"));
+        assert!(!ct_eq(b"Bearer secret", b"Bearer wrong"));
+        assert!(!ct_eq(b"short", b"longer-value"));
+        assert!(!ct_eq(b"", b"x"));
+        assert!(ct_eq(b"", b""));
     }
 }

--- a/src/cmd/auth_broker.rs
+++ b/src/cmd/auth_broker.rs
@@ -60,10 +60,26 @@ fn ct_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
-pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) -> anyhow::Result<()> {
-    let machine_token = machine_token
-        .or_else(|| std::env::var("SYNAPS_BROKER_TOKEN").ok())
-        .filter(|s| !s.trim().is_empty());
+pub async fn run(
+    bind: String,
+    machine_token: Option<String>,
+    machine_token_file: Option<std::path::PathBuf>,
+    insecure: bool,
+) -> anyhow::Result<()> {
+    // B3: token precedence — flag > file (read once, not in argv) > env.
+    let machine_token = match machine_token {
+        Some(t) => Some(t),
+        None => match machine_token_file {
+            Some(ref path) => Some(
+                std::fs::read_to_string(path)
+                    .map_err(|e| anyhow::anyhow!("could not read --machine-token-file {}: {e}", path.display()))?
+                    .trim()
+                    .to_string(),
+            ),
+            None => std::env::var("SYNAPS_BROKER_TOKEN").ok(),
+        },
+    }
+    .filter(|s| !s.trim().is_empty());
 
     let addr: SocketAddr = bind
         .parse()
@@ -74,9 +90,9 @@ pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) ->
     // credential tap, not a convenience.
     if machine_token.is_none() && !addr.ip().is_loopback() && !insecure {
         anyhow::bail!(
-            "refusing to start: no machine token (set --machine-token or SYNAPS_BROKER_TOKEN) while \
-             bound to non-loopback {addr}. That would serve credentials unauthenticated to the network. \
-             Pass --insecure-no-auth to override (NOT recommended), or bind 127.0.0.1."
+            "refusing to start: no machine token (set --machine-token / --machine-token-file / \
+             SYNAPS_BROKER_TOKEN) while bound to non-loopback {addr}. That would serve credentials \
+             unauthenticated to the network. Pass --insecure-no-auth to override, or bind 127.0.0.1."
         );
     }
 
@@ -100,13 +116,11 @@ pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) ->
 
     let state = BrokerState { machine_token: machine_token.clone(), client: client.clone() };
 
-    // Proactive refresh: keep the credential warm so clients always get a fresh
-    // token instantly, and so the single refresher runs even with no traffic.
-    // ensure_fresh_token only hits the network within the expiry margin
-    // (file-locked — still the only refresher).
+    // Proactive refresh, SUPERVISED: keep the credential warm and surface task
+    // death loudly (a silently-dead refresher = unmonitored credential expiry).
     {
         let refresh_client = client;
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let mut tick = tokio::time::interval(Duration::from_secs(60));
             loop {
                 tick.tick().await;
@@ -115,11 +129,21 @@ pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) ->
                 }
             }
         });
+        // D1: if the refresh task ever exits/panics, log loudly (it should run forever).
+        tokio::spawn(async move {
+            if let Err(e) = handle.await {
+                eprintln!("[auth-broker] FATAL: proactive refresh task died: {e:?} — tokens will go stale; restart the broker.");
+            }
+        });
     }
 
     let app = Router::new()
         .route("/healthz", get(healthz))
         .route("/token", get(token))
+        // B7: cap concurrent in-flight requests to bound resource use under a
+        // flooding/crash-looping client (each /token can take a file lock + an
+        // upstream refresh).
+        .layer(tower::limit::ConcurrencyLimitLayer::new(64))
         .with_state(state);
 
     eprintln!(
@@ -130,8 +154,34 @@ pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) ->
         eprintln!("  ⚠ non-loopback bind — run behind WireGuard / a private network (no in-process TLS yet).");
     }
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
+    // D1: drain in-flight requests on SIGTERM/Ctrl-C instead of dropping them.
+    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
     Ok(())
+}
+
+/// Resolve on Ctrl-C or SIGTERM so the broker drains cleanly.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(_) => std::future::pending::<()>().await,
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+    eprintln!("[auth-broker] shutting down (draining in-flight requests)…");
 }
 
 /// Liveness + credential readiness. Returns non-200 when the credential is

--- a/src/cmd/auth_broker.rs
+++ b/src/cmd/auth_broker.rs
@@ -1,0 +1,122 @@
+//! `synaps auth-broker` — credential broker (epic #155, task #156).
+//!
+//! Holds ONE OAuth credential (this machine's `auth.json`), is the SINGLE
+//! refresher (Anthropic rotates the refresh token on every refresh, so exactly
+//! one party may refresh), and serves short-lived **access** tokens to authorized
+//! client machines over HTTP.
+//!
+//! Clients run `synaps` with `auth.remote_endpoint` pointed here; they fetch a
+//! token per request and never store the credential on their own disk. Run this
+//! behind WireGuard / a private network — `--machine-token` gates who may fetch.
+//!
+//! Endpoints:
+//!   GET /healthz            -> { status, fresh_until }   (no secret)
+//!   GET /token?provider=X   -> { access_token, expires }  (machine-auth required)
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use axum::{
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use serde::Deserialize;
+use serde_json::json;
+use synaps_cli::auth;
+
+#[derive(Clone)]
+struct BrokerState {
+    /// Token clients must present as `Authorization: Bearer <token>`. `None`
+    /// disables auth (only safe on a fully trusted/private network).
+    machine_token: Option<String>,
+    /// HTTP client used for the (central, single) token refresh to the provider.
+    client: reqwest::Client,
+}
+
+#[derive(Deserialize)]
+struct TokenQuery {
+    provider: Option<String>,
+}
+
+pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<()> {
+    let machine_token = machine_token
+        .or_else(|| std::env::var("SYNAPS_BROKER_TOKEN").ok())
+        .filter(|s| !s.trim().is_empty());
+
+    let client = reqwest::Client::builder()
+        .tls_built_in_webpki_certs(true)
+        .tls_built_in_native_certs(true)
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(60))
+        .build()?;
+
+    let state = BrokerState { machine_token: machine_token.clone(), client };
+
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/token", get(token))
+        .with_state(state);
+
+    let addr: SocketAddr = bind
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid --bind '{}': {}", bind, e))?;
+
+    eprintln!(
+        "synaps auth-broker listening on http://{addr}  (machine auth: {})",
+        if machine_token.is_some() { "ON" } else { "OFF — trusted-network only!" }
+    );
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Liveness + credential freshness, without leaking any secret.
+async fn healthz() -> impl IntoResponse {
+    let fresh_until = match auth::load_auth() {
+        Ok(Some(f)) => Some(f.anthropic.expires),
+        _ => None,
+    };
+    (StatusCode::OK, Json(json!({ "status": "ok", "fresh_until": fresh_until })))
+}
+
+/// Issue a current access token for `provider` (default: anthropic).
+/// The broker refreshes centrally if needed (file-locked — the single refresher).
+async fn token(
+    State(st): State<BrokerState>,
+    headers: HeaderMap,
+    Query(q): Query<TokenQuery>,
+) -> impl IntoResponse {
+    // ── machine auth ──
+    if let Some(ref expected) = st.machine_token {
+        let got = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if got != format!("Bearer {expected}") {
+            return (StatusCode::UNAUTHORIZED, Json(json!({ "error": "bad machine auth" })))
+                .into_response();
+        }
+    }
+
+    let provider = q.provider.unwrap_or_else(|| "anthropic".to_string());
+    let creds = if provider == "anthropic" {
+        auth::ensure_fresh_token(&st.client).await
+    } else {
+        auth::ensure_fresh_provider_token(&st.client, &provider).await
+    };
+
+    match creds {
+        Ok(c) => {
+            eprintln!("[auth-broker] issued {} token (expires {})", provider, c.expires);
+            (StatusCode::OK, Json(json!({ "access_token": c.access, "expires": c.expires })))
+                .into_response()
+        }
+        Err(e) => {
+            eprintln!("[auth-broker] refresh failed for {}: {}", provider, e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e }))).into_response()
+        }
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod agent;
+pub(crate) mod auth_broker;
 pub(crate) mod chat;
 pub(crate) mod login;
 pub(crate) mod rpc;

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -1,15 +1,20 @@
 //! `synaps status` — show account usage and reset times.
 
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    // Refresh-if-needed via the shared auth machinery (honors profiles,
-    // fs4 file locking, and persists the rotated token). Previously this
-    // read auth.json raw from the base dir — expired tokens produced a
-    // useless HTTP 401 even though the user was logged in.
+    // Resolve the access token honoring the credential source: Local refreshes
+    // auth.json (fs4-locked, persisted) exactly as before; Remote fetches from
+    // the broker WITHOUT rotating the refresh token client-side — a stray
+    // `synaps status` on a Remote client must never rotate the broker's token
+    // out from under the fleet. (#158 A4)
     let client = reqwest::Client::new();
-    let creds = synaps_cli::auth::ensure_fresh_token(&client)
+    let config = synaps_cli::config::load_config();
+    let source = config.auth.credential_source();
+    let cache = synaps_cli::auth::TokenCache::new();
+    let access = synaps_cli::auth::resolve_access_token("anthropic", &source, &cache, &client)
         .await
-        .map_err(|e| format!("Not logged in ({}). Run `synaps login` first.", e))?;
-    let access = creds.access;
+        .map_err(|e| format!(
+            "Could not get a token ({}). Run `synaps login`, or check auth.remote_endpoint / broker reachability.", e
+        ))?;
 
     let resp = client.get("https://api.anthropic.com/api/oauth/usage")
         .header("Authorization", format!("Bearer {}", access))

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,9 +123,12 @@ enum Command {
         #[arg(long, default_value = "127.0.0.1:8181")]
         bind: String,
         /// Token clients must present (`Authorization: Bearer <token>`). Falls
-        /// back to `SYNAPS_BROKER_TOKEN`; if unset, auth is OFF (loopback only).
+        /// back to `--machine-token-file`, then `SYNAPS_BROKER_TOKEN`.
         #[arg(long)]
         machine_token: Option<String>,
+        /// Read the machine token from a file (avoids exposing it in argv/`ps`).
+        #[arg(long)]
+        machine_token_file: Option<std::path::PathBuf>,
         /// Allow starting with auth OFF on a non-loopback bind (serves
         /// credentials unauthenticated to the network — NOT recommended).
         #[arg(long)]
@@ -215,8 +218,8 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Status) => {
             cmd::status::run().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
         }
-        Some(Command::AuthBroker { bind, machine_token, insecure_no_auth }) => {
-            cmd::auth_broker::run(bind, machine_token, insecure_no_auth).await?;
+        Some(Command::AuthBroker { bind, machine_token, machine_token_file, insecure_no_auth }) => {
+            cmd::auth_broker::run(bind, machine_token, machine_token_file, insecure_no_auth).await?;
         }
         Some(Command::Completions { shell }) => {
             use clap::CommandFactory;

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,9 +123,13 @@ enum Command {
         #[arg(long, default_value = "127.0.0.1:8181")]
         bind: String,
         /// Token clients must present (`Authorization: Bearer <token>`). Falls
-        /// back to `SYNAPS_BROKER_TOKEN`; if unset, auth is OFF (trusted net only).
+        /// back to `SYNAPS_BROKER_TOKEN`; if unset, auth is OFF (loopback only).
         #[arg(long)]
         machine_token: Option<String>,
+        /// Allow starting with auth OFF on a non-loopback bind (serves
+        /// credentials unauthenticated to the network — NOT recommended).
+        #[arg(long)]
+        insecure_no_auth: bool,
     },
     /// Headless line-JSON RPC server on stdin/stdout (synaps-bridge IPC)
     Rpc {
@@ -211,8 +215,8 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Status) => {
             cmd::status::run().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
         }
-        Some(Command::AuthBroker { bind, machine_token }) => {
-            cmd::auth_broker::run(bind, machine_token).await?;
+        Some(Command::AuthBroker { bind, machine_token, insecure_no_auth }) => {
+            cmd::auth_broker::run(bind, machine_token, insecure_no_auth).await?;
         }
         Some(Command::Completions { shell }) => {
             use clap::CommandFactory;

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,17 @@ enum Command {
     },
     /// Show account usage and reset times
     Status,
+    /// Credential broker — serve short-lived access tokens to client machines
+    /// over HTTP so they can share one OAuth credential without storing it.
+    AuthBroker {
+        /// Address to bind, e.g. `0.0.0.0:8181` or `127.0.0.1:8181`.
+        #[arg(long, default_value = "127.0.0.1:8181")]
+        bind: String,
+        /// Token clients must present (`Authorization: Bearer <token>`). Falls
+        /// back to `SYNAPS_BROKER_TOKEN`; if unset, auth is OFF (trusted net only).
+        #[arg(long)]
+        machine_token: Option<String>,
+    },
     /// Headless line-JSON RPC server on stdin/stdout (synaps-bridge IPC)
     Rpc {
         /// Resume an existing session by ID, name, or prefix.
@@ -199,6 +210,9 @@ async fn main() -> anyhow::Result<()> {
         },
         Some(Command::Status) => {
             cmd::status::run().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        }
+        Some(Command::AuthBroker { bind, machine_token }) => {
+            cmd::auth_broker::run(bind, machine_token).await?;
         }
         Some(Command::Completions { shell }) => {
             use clap::CommandFactory;

--- a/tests/extension_provider_stream_route.rs
+++ b/tests/extension_provider_stream_route.rs
@@ -51,6 +51,8 @@ async fn try_route_streams_text_deltas_when_provider_supports_streaming() {
         None,
         0,
         &tokio_util::sync::CancellationToken::new(),
+        &synaps_cli::auth::CredentialSource::Local,
+        &synaps_cli::auth::TokenCache::new(),
     )
     .await
     .expect("extension route")

--- a/tests/extensions_e2e.rs
+++ b/tests/extensions_e2e.rs
@@ -618,6 +618,8 @@ async fn extension_provider_complete_routes_to_process() {
         None,
         0,
         &tokio_util::sync::CancellationToken::new(),
+        &synaps_cli::auth::CredentialSource::Local,
+        &synaps_cli::auth::TokenCache::new(),
     ).await.expect("extension route").unwrap();
 
     assert_eq!(result["content"][0]["text"], "echo:hello");
@@ -694,6 +696,8 @@ async fn provider_disabled_in_trust_state_blocks_route() {
         None,
         0,
         &tokio_util::sync::CancellationToken::new(),
+        &synaps_cli::auth::CredentialSource::Local,
+        &synaps_cli::auth::TokenCache::new(),
     )
     .await
     .expect("route returned Some");
@@ -758,6 +762,8 @@ async fn extension_provider_tool_use_is_executed_by_router_before_final_response
         None,
         0,
         &tokio_util::sync::CancellationToken::new(),
+        &synaps_cli::auth::CredentialSource::Local,
+        &synaps_cli::auth::TokenCache::new(),
     ).await.expect("extension route").unwrap();
 
     assert_eq!(result["content"][0]["text"], "final:from-provider");
@@ -1140,6 +1146,8 @@ async fn audit_log_records_disabled_route() {
         None,
         0,
         &tokio_util::sync::CancellationToken::new(),
+        &synaps_cli::auth::CredentialSource::Local,
+        &synaps_cli::auth::TokenCache::new(),
     )
     .await
     .expect("route returned Some");


### PR DESCRIPTION
Epic #155. Lets many machines share ONE OAuth credential without copying it to each disk: a broker holds the cred + serves short-lived access tokens; clients fetch tokens instead of storing the credential. **Validated live, cross-machine (Avante↔Jade), for BOTH anthropic and openai-codex** — a credential-less client pulled each provider's token from the broker and made real API calls.

## What's in it
- **#157 client** — `CredentialSource::{Local,Remote}` seam, `TokenCache`, `BrokerClient`, unified `resolve_access_token`. Remote never holds a refresh token / writes auth.json / refreshes client-side (invariant by construction — `BrokerToken` has no refresh field). Wired into `refresh_if_needed` (pre-stream + mid-stream).
- **#156 broker** — `synaps auth-broker` subcommand: `/token` (machine-auth gated, provider-keyed), `/healthz`, central refresh (single refresher — Anthropic rotates the refresh token), proactive timer, per-IP audit log.
- **C4** — codex/OpenAI routes through the broker too (not just anthropic); non-anthropic models skip the anthropic pre-fetch.
- Config: `auth.remote_endpoint` / `auth.machine_token` (+ env `SYNAPS_AUTH_ENDPOINT` / `SYNAPS_MACHINE_TOKEN`). Docs in README + CHANGELOG.

## ⚠️ DRAFT — hardening in progress (12-agent board review)
A 12-agent review found real issues; tracked in **#158** (`~/Jawz/workspace/credential-source-review-board.md`). **Done so far (Batch A correctness + C4):**
- A1 fast-path margin mismatch (7-agent consensus bug) · A2 scrub AuthState on Remote (no local-auth.json leak) · A3 subagents inherit Remote source · A5 reuse shared client · A6 cache-clear on source change · C4 codex-through-broker · redacting Debug on secrets.

**Still open before merge-ready (security/robustness/ops):**
- B: TLS, constant-time Bearer compare, `--machine-token-file`, provider allowlist + log-injection, rate-limit, /healthz status codes
- C: on-401 invalidation, token validation, clock-skew (ttl_ms)
- A4: route `status`/model-catalog through the source
- D: systemd unit, graceful shutdown, startup validation, task supervision
- E: ToS warning, env-var naming

**Do not deploy off localhost/WireGuard until the B (security) items land.**