### PR TITLE
release: v0.4.0 — credential broker + #137 test-isolation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Shared credentials via a broker (`auth.remote_endpoint` + `synaps auth-broker`).**
+  Many machines can share ONE OAuth credential without copying it to each disk.
+  On a client, set `auth.remote_endpoint` (+ `auth.machine_token`, or env
+  `SYNAPS_AUTH_ENDPOINT` / `SYNAPS_MACHINE_TOKEN`) and it fetches short-lived
+  access tokens from a broker instead of reading/refreshing the local `auth.json`.
+  Run the broker with `synaps auth-broker --bind <addr> --machine-token <secret>`
+  on a trusted host (behind WireGuard). Clients hold only access tokens in memory
+  — never a refresh token, never written to disk; the broker is the single
+  refresher (Anthropic rotates the refresh token, so exactly one party may
+  refresh). Degrades gracefully on a broker blip (serves a still-valid cached
+  token). Closes the agentic-VM bootstrap: guests authenticate with zero
+  credentials on their own disk.
+
 ## [0.3.10] — 2026-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,24 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - **Shared credentials via a broker (`auth.remote_endpoint` + `synaps auth-broker`).**
-  Many machines can share ONE OAuth credential without copying it to each disk.
-  On a client, set `auth.remote_endpoint` (+ `auth.machine_token`, or env
-  `SYNAPS_AUTH_ENDPOINT` / `SYNAPS_MACHINE_TOKEN`) and it fetches short-lived
-  access tokens from a broker instead of reading/refreshing the local `auth.json`.
-  Run the broker with `synaps auth-broker --bind <addr> --machine-token <secret>`
-  on a trusted host (behind WireGuard). Clients hold only access tokens in memory
-  — never a refresh token, never written to disk; the broker is the single
-  refresher (Anthropic rotates the refresh token, so exactly one party may
-  refresh). Degrades gracefully on a broker blip (serves a still-valid cached
-  token). Closes the agentic-VM bootstrap: guests authenticate with zero
-  credentials on their own disk.
+  Many machines share ONE OAuth credential without copying it to each disk — both
+  **Anthropic and OpenAI/codex** tokens route through the broker. On a client, set
+  `auth.remote_endpoint` (+ `auth.machine_token`, or env `SYNAPS_AUTH_ENDPOINT` /
+  `SYNAPS_MACHINE_TOKEN`) and it fetches short-lived access tokens from a broker
+  instead of reading/refreshing the local `auth.json`. Clients hold only access
+  tokens in memory — never a refresh token, never written to disk; the broker is
+  the single refresher. Run the broker with `synaps auth-broker` on a trusted
+  host (`--machine-token-file`, behind WireGuard or a TLS-terminating proxy).
+  Closes the agentic-VM bootstrap: guests authenticate with zero credentials on
+  their own disk.
+  - **Security:** constant-time machine-token compare, provider allowlist,
+    in-flight rate cap, refuses unauthenticated non-loopback start, graceful
+    shutdown, redacting `Debug` on secrets, on-401 refetch+retry, clock-skew
+    defense (`ttl_ms`), token validation, and a `systemd` unit at
+    `deploy/synaps-auth-broker.service`.
+  - **ToS:** intended for sharing one account across YOUR OWN machines. Sharing a
+    subscription seat across users / a large fleet risks account suspension — use
+    org/enterprise API keys at scale. See the README.
 
 ## [0.3.10] — 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-06-29
+
 ### Added
 - **Shared credentials via a broker (`auth.remote_endpoint` + `synaps auth-broker`).**
   Many machines share ONE OAuth credential without copying it to each disk — both
@@ -24,6 +26,13 @@ All notable changes to this project will be documented in this file.
   - **ToS:** intended for sharing one account across YOUR OWN machines. Sharing a
     subscription seat across users / a large fleet risks account suspension — use
     org/enterprise API keys at scale. See the README.
+
+### Fixed
+- **Flaky test isolation in `synaps-tui` (#137).** Config-env tests (config
+  migration + plugin actions) raced on `SYNAPS_BASE_DIR`/`HOME` through two
+  independent locks, causing intermittent failures in parallel `cargo test` runs
+  only. Unified all config-env tests under one shared test lock; verified green
+  across repeated parallel runs.
 
 ## [0.3.10] — 2026-06-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "synaps"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3035,7 +3035,7 @@ dependencies = [
 
 [[package]]
 name = "synaps-core"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "axum",
  "base64",
@@ -3063,7 +3063,7 @@ dependencies = [
 
 [[package]]
 name = "synaps-engine"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3110,7 +3110,7 @@ dependencies = [
 
 [[package]]
 name = "synaps-tui"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "tower 0.4.13",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -3535,6 +3536,10 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anpa"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d032745fe46100dbcb28ee6e30f12c4b148786f8889e07cd0a3445eeb54970f"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,7 +140,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -215,12 +239,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -236,9 +275,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -271,7 +310,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -289,6 +328,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -313,12 +358,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -411,7 +450,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -436,16 +475,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "colorsys"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54261aba646433cb567ec89844be4c4825ca92a4f8afba52fc4dd88436e31bbd"
-
-[[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -453,6 +486,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -490,6 +532,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,16 +554,18 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
+ "derive_more",
+ "document-features",
  "futures-core",
  "mio 1.2.0",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -547,6 +597,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,7 +626,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -577,7 +637,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -587,12 +647,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -632,7 +720,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
@@ -644,7 +732,16 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -682,15 +779,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -741,6 +863,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +897,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,7 +917,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -846,7 +986,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -894,7 +1034,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
  "windows-link",
 ]
 
@@ -968,9 +1108,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -978,12 +1127,23 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1295,7 +1455,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1312,9 +1472,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1338,6 +1498,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1353,9 +1524,15 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -1376,6 +1553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,10 +1568,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1401,6 +1587,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1419,11 +1611,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1431,6 +1623,16 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
 
 [[package]]
 name = "matchers"
@@ -1454,10 +1656,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "micromath"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1509,10 +1738,33 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1521,7 +1773,7 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -1550,12 +1802,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1573,7 +1845,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -1585,7 +1857,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -1596,7 +1868,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -1615,7 +1887,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1626,7 +1898,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1656,6 +1928,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,16 +1984,105 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1702,12 +2096,18 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-pty"
@@ -1722,7 +2122,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.28.0",
  "serial2",
  "shared_library",
  "shell-words",
@@ -1761,7 +2161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1922,23 +2322,103 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.29.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
- "bitflags 2.11.1",
- "cassowary",
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
  "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
  "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
  "strum",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1947,7 +2427,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -2053,16 +2533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags 2.11.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "semver",
 ]
 
 [[package]]
@@ -2071,10 +2547,10 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -2182,7 +2658,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2232,7 +2708,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2314,7 +2790,7 @@ checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2408,10 +2884,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simple-easing"
-version = "1.0.2"
+name = "siphasher"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82d449ab1bccfeec125893c6875008206f038d4eb8a09e1e10caf86f44d574e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2455,24 +2931,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2486,6 +2961,17 @@ name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2540,7 +3026,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "unicode-width 0.2.0",
+ "unicode-width",
  "url",
  "urlencoding",
  "uuid",
@@ -2649,7 +3135,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "unicode-width 0.2.0",
+ "unicode-width",
  "uuid",
 ]
 
@@ -2670,7 +3156,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2680,7 +3166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode",
- "fancy-regex",
+ "fancy-regex 0.16.2",
  "flate2",
  "fnv",
  "once_cell",
@@ -2693,14 +3179,17 @@ dependencies = [
 
 [[package]]
 name = "tachyonfx"
-version = "0.9.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7bb70be127291790236fd45169b17a3be4aeb1902c8691f23fd02f49d174b7b"
+checksum = "c144c687e9f3628c06add1b6db585a68d3cd285a9d7213b9bca836771e337592"
 dependencies = [
+ "anpa",
  "bon",
- "colorsys",
- "ratatui",
- "simple-easing",
+ "compact_str",
+ "micromath",
+ "ratatui-core",
+ "thiserror 2.0.18",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2712,8 +3201,84 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.0",
+ "fancy-regex 0.11.0",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -2742,7 +3307,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2753,7 +3318,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2787,7 +3352,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -2860,7 +3427,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2995,7 +3562,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "http",
  "http-body",
@@ -3011,7 +3578,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -3068,7 +3635,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3160,6 +3727,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3173,20 +3746,14 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -3248,6 +3815,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
@@ -3264,6 +3832,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "walkdir"
@@ -3350,7 +3927,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3404,7 +3981,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3444,6 +4021,78 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
 
 [[package]]
 name = "winapi"
@@ -3497,7 +4146,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3508,7 +4157,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3820,7 +4469,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3836,7 +4485,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3848,7 +4497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -3891,7 +4540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix 1.1.4",
+ "rustix",
  "x11rb-protocol",
 ]
 
@@ -3920,7 +4569,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3941,7 +4590,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3961,7 +4610,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4001,7 +4650,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ signal-hook = { version = "0.3", features = ["iterator"] }
 
 # Server deps
 axum = { version = "0.7", features = ["ws"] }
+tower = { version = "0.4", features = ["limit"] }
 unicode-width = "0.2.0"
 
 # Shell / PTY deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synaps"
-version = "0.3.10"
+version = "0.4.0"
 edition = "2021"
 authors = ["Haseeb Khalid <haseebkhalid1507@gmail.com>"]
 license = "Apache-2.0"
@@ -13,9 +13,9 @@ exclude = [".github/", "docs/", "tests/fixtures/", "examples/"]
 rust-version = "1.80"
 
 [dependencies]
-agent-core = { path = "crates/agent-core", version = "0.3.10", package = "synaps-core" }
-agent-engine = { path = "crates/agent-engine", version = "0.3.10", package = "synaps-engine" }
-agent-tui = { path = "crates/agent-tui", version = "0.3.10", package = "synaps-tui" }
+agent-core = { path = "crates/agent-core", version = "0.4.0", package = "synaps-core" }
+agent-engine = { path = "crates/agent-engine", version = "0.4.0", package = "synaps-engine" }
+agent-tui = { path = "crates/agent-tui", version = "0.4.0", package = "synaps-tui" }
 arc-swap = "1"
 tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls-webpki-roots", "rustls-tls-native-roots"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ async-trait = "0.1.89"
 futures = "0.3"
 tokio-stream = "0.1"
 tokio-util = "0.7"
-ratatui = "0.29"
-crossterm = { version = "0.28", features = ["event-stream"] }
+ratatui = "0.30"
+crossterm = { version = "0.29", features = ["event-stream"] }
 sha2 = "0.10"
 rand = "0.9"
 base64 = "0.22"

--- a/README.md
+++ b/README.md
@@ -218,6 +218,33 @@ if the bridge UDS is missing. See
 [`docs/smoke/watcher-bridge.md`](docs/smoke/watcher-bridge.md) for the
 verification playbook.
 
+### Shared credentials via a broker (`auth.*`)
+
+By default each machine reads and refreshes its own `~/.synaps-cli/auth.json`
+(`auth.remote_endpoint` unset). To share ONE OAuth credential across many
+machines without copying it to each disk, run a broker on one trusted host and
+point the others at it:
+
+```ini
+# on a CLIENT machine — fetch short-lived access tokens from the broker
+auth.remote_endpoint = http://broker-host:8181
+auth.machine_token   = <shared-secret>
+# env overrides (win over config): SYNAPS_AUTH_ENDPOINT / SYNAPS_MACHINE_TOKEN
+```
+
+```bash
+# on the BROKER host — holds the credential, refreshes centrally, serves tokens
+synaps auth-broker --bind 0.0.0.0:8181 --machine-token <shared-secret>
+#   GET /healthz            -> { status, fresh_until }
+#   GET /token?provider=X   -> { access_token, expires }   (Authorization: Bearer)
+```
+
+A Remote client **never stores the credential**: it holds only short-lived
+access tokens in memory, never a refresh token, and never writes `auth.json`.
+The broker is the single refresher (Anthropic rotates the refresh token, so
+exactly one party may refresh). Run the broker behind WireGuard / a private
+network — the machine token gates who may fetch.
+
 ---
 
 ## Extensions & Plugins

--- a/README.md
+++ b/README.md
@@ -223,27 +223,64 @@ verification playbook.
 By default each machine reads and refreshes its own `~/.synaps-cli/auth.json`
 (`auth.remote_endpoint` unset). To share ONE OAuth credential across many
 machines without copying it to each disk, run a broker on one trusted host and
-point the others at it:
+point the others at it. Anthropic **and** OpenAI/codex tokens both route through
+the broker.
 
 ```ini
 # on a CLIENT machine — fetch short-lived access tokens from the broker
-auth.remote_endpoint = http://broker-host:8181
+auth.remote_endpoint = https://broker-host:8181
 auth.machine_token   = <shared-secret>
 # env overrides (win over config): SYNAPS_AUTH_ENDPOINT / SYNAPS_MACHINE_TOKEN
 ```
 
 ```bash
 # on the BROKER host — holds the credential, refreshes centrally, serves tokens
-synaps auth-broker --bind 0.0.0.0:8181 --machine-token <shared-secret>
-#   GET /healthz            -> { status, fresh_until }
-#   GET /token?provider=X   -> { access_token, expires }   (Authorization: Bearer)
+synaps auth-broker --bind 0.0.0.0:8181 --machine-token-file /etc/synaps/broker.token
+#   GET /healthz            -> { status }                  (non-200 if cred missing)
+#   GET /token?provider=X   -> { access_token, expires, ttl_ms }  (Bearer machine token)
 ```
 
 A Remote client **never stores the credential**: it holds only short-lived
 access tokens in memory, never a refresh token, and never writes `auth.json`.
-The broker is the single refresher (Anthropic rotates the refresh token, so
-exactly one party may refresh). Run the broker behind WireGuard / a private
-network — the machine token gates who may fetch.
+The broker is the single refresher (Anthropic rotates the refresh token on every
+refresh, so exactly one party may refresh).
+
+**Token config (note the three env vars):**
+
+| Role | config key | env var |
+|---|---|---|
+| client → broker URL | `auth.remote_endpoint` | `SYNAPS_AUTH_ENDPOINT` |
+| client → its identity to the broker | `auth.machine_token` | `SYNAPS_MACHINE_TOKEN` |
+| broker → secret it requires of clients | `--machine-token` / `--machine-token-file` | `SYNAPS_BROKER_TOKEN` |
+
+Prefer `--machine-token-file` over `--machine-token` so the secret isn't exposed
+in `argv`/`ps`.
+
+**Security model — read before exposing it:**
+- The broker constant-time-compares the machine token, allowlists providers,
+  rate-limits in-flight requests, and refuses to start unauthenticated on a
+  non-loopback bind (override with `--insecure-no-auth`, don't).
+- **TLS is terminated externally** — the broker speaks plain HTTP to stay a lean
+  single static binary. Run it **behind WireGuard** (private overlay) **or front
+  it with a TLS-terminating reverse proxy / load balancer / service mesh.** A
+  bare non-loopback HTTP bind ships your machine token and access tokens in
+  cleartext — a DNS-spoof/MITM then harvests them. Example with Caddy:
+  ```
+  # Caddyfile — terminates TLS, proxies to the loopback broker
+  broker.internal {
+      reverse_proxy 127.0.0.1:8181
+  }
+  ```
+  Then run `synaps auth-broker --bind 127.0.0.1:8181 ...` and point clients at
+  `https://broker.internal`. (systemd unit: `deploy/synaps-auth-broker.service`.)
+
+> **⚠ Terms of Service.** This is for sharing ONE account's credential across
+> **your own** machines (a personal homelab / your own fleet). Sharing a Claude
+> Pro/Max or ChatGPT **subscription seat** across multiple distinct users — or
+> fanning one seat out across a large machine fleet — likely violates Anthropic's
+> / OpenAI's Terms and risks **account suspension**. At real scale use **org/
+> enterprise API keys**, not subscription-seat OAuth. Check the current ToS
+> before deploying beyond your own boxes.
 
 ---
 

--- a/crates/agent-core/Cargo.toml
+++ b/crates/agent-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synaps-core"
-version = "0.3.10"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Foundation types, config, session, auth, protocol — leaf crate for agent-runtime"

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -16,9 +16,10 @@ use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Where a client gets its provider credentials.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub enum CredentialSource {
     /// Read + refresh the local `auth.json` (default — unchanged behavior).
+    #[default]
     Local,
     /// Fetch short-lived access tokens from a broker over the network.
     Remote {
@@ -46,6 +47,20 @@ impl CredentialSource {
 
     pub fn is_remote(&self) -> bool {
         matches!(self, CredentialSource::Remote { .. })
+    }
+}
+
+/// Redacting Debug — never print the machine token (board M3/B3).
+impl std::fmt::Debug for CredentialSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CredentialSource::Local => write!(f, "Local"),
+            CredentialSource::Remote { endpoint, .. } => f
+                .debug_struct("Remote")
+                .field("endpoint", endpoint)
+                .field("machine_token", &"***")
+                .finish(),
+        }
     }
 }
 
@@ -89,6 +104,18 @@ pub const DEFAULT_MARGIN_MS: u64 = 5 * 60 * 1000;
 #[derive(Clone, Default)]
 pub struct TokenCache {
     inner: Arc<RwLock<HashMap<String, BrokerToken>>>,
+}
+
+/// Redacting Debug — print only the cached provider names, never the tokens.
+impl std::fmt::Debug for TokenCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let providers: Vec<String> = self
+            .inner
+            .read()
+            .map(|m| m.keys().cloned().collect())
+            .unwrap_or_default();
+        f.debug_struct("TokenCache").field("providers", &providers).finish()
+    }
 }
 
 impl TokenCache {

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -227,7 +227,15 @@ pub struct BrokerClient {
 
 impl BrokerClient {
     pub fn new(endpoint: impl Into<String>, machine_token: impl Into<String>) -> Self {
-        Self { http: reqwest::Client::new(), endpoint: endpoint.into(), machine_token: machine_token.into() }
+        // D1: bound the request so a hung/unreachable broker can't stall the
+        // caller's whole turn. (The runtime path uses `with_client` and inherits
+        // the runtime's configured client; this is the standalone fallback.)
+        let http = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .timeout(std::time::Duration::from_secs(20))
+            .build()
+            .unwrap_or_default();
+        Self { http, endpoint: endpoint.into(), machine_token: machine_token.into() }
     }
 
     /// Like `new` but reuses an existing `reqwest::Client` (shared connection

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -197,6 +197,16 @@ impl BrokerClient {
         Self { http: reqwest::Client::new(), endpoint: endpoint.into(), machine_token: machine_token.into() }
     }
 
+    /// Like `new` but reuses an existing `reqwest::Client` (shared connection
+    /// pool) instead of building a fresh one per call. (#158 A5)
+    pub fn with_client(
+        endpoint: impl Into<String>,
+        machine_token: impl Into<String>,
+        http: reqwest::Client,
+    ) -> Self {
+        Self { http, endpoint: endpoint.into(), machine_token: machine_token.into() }
+    }
+
     /// Build from a `CredentialSource`. `None` for `Local`.
     pub fn from_source(source: &CredentialSource) -> Option<Self> {
         match source {
@@ -204,6 +214,35 @@ impl BrokerClient {
                 Some(Self::new(endpoint.clone(), machine_token.clone()))
             }
             CredentialSource::Local => None,
+        }
+    }
+}
+
+/// Provider-aware token resolution honoring the credential source — the single
+/// entry point both the Anthropic and the OpenAI/codex paths use. (#158 C4)
+///
+/// - `Local`: refresh the provider's own local credential (`ensure_fresh_*`).
+/// - `Remote`: fetch a short-lived access token from the broker, keyed by
+///   provider. Reuses the caller's `http` client (no per-call pool — A5), and
+///   never holds a refresh token / never writes `auth.json` (invariant 1).
+pub async fn resolve_access_token(
+    provider: &str,
+    source: &CredentialSource,
+    cache: &TokenCache,
+    http: &reqwest::Client,
+) -> Result<String, String> {
+    match source {
+        CredentialSource::Remote { endpoint, machine_token } => {
+            let broker = BrokerClient::with_client(endpoint.clone(), machine_token.clone(), http.clone());
+            Ok(resolve_remote(&broker, cache, provider, DEFAULT_MARGIN_MS).await?.access_token)
+        }
+        CredentialSource::Local => {
+            let creds = if provider == "anthropic" {
+                super::ensure_fresh_token(http).await?
+            } else {
+                super::ensure_fresh_provider_token(http, provider).await?
+            };
+            Ok(creds.access)
         }
     }
 }
@@ -458,6 +497,23 @@ mod tests {
         let c = BrokerClient::new(url, "WRONG-token");
         let err = c.fetch_token("anthropic").await.unwrap_err();
         assert!(err.contains("401"), "expected 401 error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn resolve_access_token_remote_fetches_from_broker() {
+        let url = spawn_broker(
+            r#"{"access_token":"sk-broker","expires":9999999999999}"#,
+            "m",
+        )
+        .await;
+        let source = CredentialSource::Remote { endpoint: url, machine_token: "m".into() };
+        let cache = TokenCache::new();
+        let http = reqwest::Client::new();
+        let t = resolve_access_token("anthropic", &source, &cache, &http).await.unwrap();
+        assert_eq!(t, "sk-broker");
+        // second call hits the cache (shared http client reused, no new pool)
+        let t2 = resolve_access_token("anthropic", &source, &cache, &http).await.unwrap();
+        assert_eq!(t2, "sk-broker");
     }
 
     // ── invariant: a Remote client can NEVER hold a refresh token ─────────

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -130,24 +130,31 @@ pub trait TokenFetcher {
     async fn fetch_token(&self, provider: &str) -> Result<BrokerToken, String>;
 }
 
-/// Resolve a provider access token via cache-or-fetch. Returns the cached token
-/// if fresh; otherwise fetches from `fetcher`, caches it, and returns it.
-///
-/// This is the entire Remote credential path. It NEVER reads or holds a refresh
-/// token, NEVER writes `auth.json`, NEVER refreshes client-side — `fetcher` only
-/// ever yields a short-lived `BrokerToken` (which structurally has no refresh).
+/// Resolve a provider token via cache-or-fetch, returning the full
+/// `BrokerToken` (access + expiry). The runtime needs the expiry to drive its
+/// in-memory refresh trigger. NEVER touches a refresh token or `auth.json`.
+pub async fn resolve_remote<F: TokenFetcher>(
+    fetcher: &F,
+    cache: &TokenCache,
+    provider: &str,
+    margin_ms: u64,
+) -> Result<BrokerToken, String> {
+    if let Some(tok) = cache.get_fresh(provider, margin_ms) {
+        return Ok(tok);
+    }
+    let tok = fetcher.fetch_token(provider).await?;
+    cache.put(provider, tok.clone());
+    Ok(tok)
+}
+
+/// Like [`resolve_remote`] but returns only the access token string.
 pub async fn resolve_remote_token<F: TokenFetcher>(
     fetcher: &F,
     cache: &TokenCache,
     provider: &str,
     margin_ms: u64,
 ) -> Result<String, String> {
-    if let Some(tok) = cache.get_fresh(provider, margin_ms) {
-        return Ok(tok.access_token);
-    }
-    let tok = fetcher.fetch_token(provider).await?;
-    cache.put(provider, tok.clone());
-    Ok(tok.access_token)
+    Ok(resolve_remote(fetcher, cache, provider, margin_ms).await?.access_token)
 }
 
 // ── Broker HTTP client ───────────────────────────────────────────────────────

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -119,6 +119,19 @@ impl TokenCache {
             map.remove(provider);
         }
     }
+
+    /// Cached token if present and not PAST hard expiry (ignores the refetch
+    /// margin). Used as a degraded-mode fallback when the broker is unreachable:
+    /// a token slightly inside its refetch window is still better than failing.
+    pub fn get_unexpired(&self, provider: &str) -> Option<BrokerToken> {
+        let map = self.inner.read().ok()?;
+        let tok = map.get(provider)?;
+        if is_expired_with_margin(tok.expires, 0) {
+            None
+        } else {
+            Some(tok.clone())
+        }
+    }
 }
 
 // ── Fetcher abstraction + resolver ───────────────────────────────────────────
@@ -142,9 +155,21 @@ pub async fn resolve_remote<F: TokenFetcher>(
     if let Some(tok) = cache.get_fresh(provider, margin_ms) {
         return Ok(tok);
     }
-    let tok = fetcher.fetch_token(provider).await?;
-    cache.put(provider, tok.clone());
-    Ok(tok)
+    match fetcher.fetch_token(provider).await {
+        Ok(tok) => {
+            cache.put(provider, tok.clone());
+            Ok(tok)
+        }
+        Err(e) => {
+            // Degraded mode: the broker is unreachable, but if we still hold a
+            // token that hasn't hit hard expiry, serve it rather than failing
+            // the turn. Self-heals on the next call once the broker is back.
+            if let Some(tok) = cache.get_unexpired(provider) {
+                return Ok(tok);
+            }
+            Err(e)
+        }
+    }
 }
 
 /// Like [`resolve_remote`] but returns only the access token string.
@@ -350,6 +375,39 @@ mod tests {
         resolve_remote_token(&f, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
         resolve_remote_token(&f, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
         assert_eq!(f.calls.load(Ordering::SeqCst), 1, "second resolve should hit the cache");
+    }
+
+    // ── broker-down degradation ───────────────────────────────────────────
+    struct FailFetcher;
+    impl TokenFetcher for FailFetcher {
+        async fn fetch_token(&self, _provider: &str) -> Result<BrokerToken, String> {
+            Err("broker unreachable".into())
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_serves_stale_cache_when_broker_down() {
+        // Token expires in 2 min; margin is 5 min -> get_fresh misses (would
+        // refetch), the broker is down, but it's not HARD-expired, so we serve it.
+        let cache = TokenCache::new();
+        cache.put("anthropic", tok(now_millis() + 2 * 60 * 1000));
+        let t = resolve_remote(&FailFetcher, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
+        assert_eq!(t.access_token, "sk-live");
+    }
+
+    #[tokio::test]
+    async fn resolve_errors_when_broker_down_and_no_cache() {
+        let cache = TokenCache::new();
+        let err = resolve_remote(&FailFetcher, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap_err();
+        assert!(err.contains("unreachable"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn resolve_errors_when_broker_down_and_cache_hard_expired() {
+        let cache = TokenCache::new();
+        cache.put("anthropic", tok(now_millis().saturating_sub(1000))); // already expired
+        let err = resolve_remote(&FailFetcher, &cache, "anthropic", 0).await.unwrap_err();
+        assert!(err.contains("unreachable"), "got: {err}");
     }
 
     // ── BrokerClient against a tiny in-test axum server ──────────────────

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -1,0 +1,159 @@
+//! Remote credential source — Option C (task #157, epic #155).
+//!
+//! A Synaps client can resolve its provider **access token** from a broker over
+//! the network instead of the local `auth.json`. This lets many machines share
+//! one OAuth credential without copying the secret to each disk.
+//!
+//! INVARIANT (the whole point — enforced by construction + tests):
+//! the `Remote` path NEVER reads or holds a refresh token, NEVER writes
+//! `auth.json`, and NEVER refreshes client-side. It only fetches short-lived
+//! access tokens from the broker and caches them in memory. The single
+//! refresher is the broker (Anthropic rotates the refresh token on every
+//! refresh, so exactly one party may refresh).
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Where a client gets its provider credentials.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CredentialSource {
+    /// Read + refresh the local `auth.json` (default — unchanged behavior).
+    Local,
+    /// Fetch short-lived access tokens from a broker over the network.
+    Remote {
+        /// Broker base URL, e.g. `https://jade.jade:8181` (no trailing slash).
+        endpoint: String,
+        /// Per-machine bearer presented TO the broker. This is the machine's own
+        /// identity, NOT the provider credential.
+        machine_token: String,
+    },
+}
+
+impl CredentialSource {
+    /// Build from explicit config values. Returns `Remote` iff a non-empty
+    /// endpoint is given; otherwise `Local`. Trailing slashes on the endpoint
+    /// are trimmed so callers can join paths uniformly.
+    pub fn from_parts(endpoint: Option<String>, machine_token: Option<String>) -> Self {
+        match endpoint {
+            Some(e) if !e.trim().is_empty() => CredentialSource::Remote {
+                endpoint: e.trim().trim_end_matches('/').to_string(),
+                machine_token: machine_token.unwrap_or_default().trim().to_string(),
+            },
+            _ => CredentialSource::Local,
+        }
+    }
+
+    pub fn is_remote(&self) -> bool {
+        matches!(self, CredentialSource::Remote { .. })
+    }
+}
+
+/// An access token as returned by the broker's `GET /token`.
+///
+/// Deliberately has **no** refresh-token field: a Remote client must never
+/// receive or hold one. This is the invariant made structural — there is no
+/// place to put a refresh token even if the broker mistakenly sent one.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct BrokerToken {
+    pub access_token: String,
+    /// Absolute expiry, unix-epoch **milliseconds** (matches
+    /// `OAuthCredentials.expires`).
+    pub expires: u64,
+}
+
+/// Current unix time in milliseconds.
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// True if `expires_ms` is already past, or within `margin_ms` of now.
+///
+/// The margin absorbs clock skew + request latency so a client refetches
+/// slightly early rather than presenting a token that dies mid-flight.
+pub fn is_expired_with_margin(expires_ms: u64, margin_ms: u64) -> bool {
+    now_millis().saturating_add(margin_ms) >= expires_ms
+}
+
+/// Default refetch margin: 5 minutes (mirrors `is_token_expired`).
+pub const DEFAULT_MARGIN_MS: u64 = 5 * 60 * 1000;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_parts_local_when_no_endpoint() {
+        assert_eq!(CredentialSource::from_parts(None, None), CredentialSource::Local);
+        assert_eq!(
+            CredentialSource::from_parts(Some("   ".into()), Some("m".into())),
+            CredentialSource::Local
+        );
+    }
+
+    #[test]
+    fn from_parts_remote_when_endpoint_set() {
+        let s = CredentialSource::from_parts(Some("https://jade.jade:8181".into()), Some("tok".into()));
+        assert_eq!(
+            s,
+            CredentialSource::Remote {
+                endpoint: "https://jade.jade:8181".into(),
+                machine_token: "tok".into()
+            }
+        );
+        assert!(s.is_remote());
+    }
+
+    #[test]
+    fn from_parts_trims_trailing_slash_and_whitespace() {
+        let s = CredentialSource::from_parts(Some("  https://b/  ".into()), Some("  tok  ".into()));
+        assert_eq!(
+            s,
+            CredentialSource::Remote { endpoint: "https://b".into(), machine_token: "tok".into() }
+        );
+    }
+
+    #[test]
+    fn remote_with_missing_machine_token_defaults_empty() {
+        let s = CredentialSource::from_parts(Some("https://b".into()), None);
+        assert_eq!(
+            s,
+            CredentialSource::Remote { endpoint: "https://b".into(), machine_token: String::new() }
+        );
+    }
+
+    #[test]
+    fn local_is_not_remote() {
+        assert!(!CredentialSource::Local.is_remote());
+    }
+
+    #[test]
+    fn expiry_far_future_not_expired() {
+        let far = now_millis() + 60 * 60 * 1000; // +1h
+        assert!(!is_expired_with_margin(far, DEFAULT_MARGIN_MS));
+    }
+
+    #[test]
+    fn expiry_past_is_expired() {
+        let past = now_millis().saturating_sub(1000);
+        assert!(is_expired_with_margin(past, 0));
+    }
+
+    #[test]
+    fn expiry_within_margin_is_expired() {
+        // expires in 2 minutes, margin 5 minutes -> treated as expired (refetch early)
+        let soon = now_millis() + 2 * 60 * 1000;
+        assert!(is_expired_with_margin(soon, DEFAULT_MARGIN_MS));
+        // ...but with a 1-minute margin it is NOT yet expired
+        assert!(!is_expired_with_margin(soon, 60 * 1000));
+    }
+
+    #[test]
+    fn broker_token_deserializes_without_refresh_field() {
+        let json = r#"{"access_token":"sk-abc","expires":1750000000000}"#;
+        let t: BrokerToken = serde_json::from_str(json).unwrap();
+        assert_eq!(t.access_token, "sk-abc");
+        assert_eq!(t.expires, 1_750_000_000_000);
+    }
+}

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -73,8 +73,14 @@ impl std::fmt::Debug for CredentialSource {
 pub struct BrokerToken {
     pub access_token: String,
     /// Absolute expiry, unix-epoch **milliseconds** (matches
-    /// `OAuthCredentials.expires`).
+    /// `OAuthCredentials.expires`). When `ttl_ms` is present the client
+    /// overwrites this with its own clock + ttl to defeat clock skew.
     pub expires: u64,
+    /// Optional relative TTL in ms. When the broker sends it, the client
+    /// recomputes `expires = client_now + ttl_ms`, eliminating broker↔client
+    /// clock skew on suspend/resume VMs (board C3). Absent → use `expires`.
+    #[serde(default)]
+    pub ttl_ms: Option<u64>,
 }
 
 /// Current unix time in milliseconds.
@@ -292,9 +298,23 @@ impl TokenFetcher for BrokerClient {
         if !status.is_success() {
             return Err(format!("broker returned HTTP {status}"));
         }
-        resp.json::<BrokerToken>()
+        let mut tok = resp
+            .json::<BrokerToken>()
             .await
-            .map_err(|e| format!("invalid broker token response: {e}"))
+            .map_err(|e| format!("invalid broker token response: {e}"))?;
+        // C3: prefer the broker's relative TTL over its absolute clock.
+        if let Some(ttl) = tok.ttl_ms {
+            tok.expires = now_millis().saturating_add(ttl);
+        }
+        // C2: reject a malformed/dead token rather than caching it (which would
+        // cause a permanent refetch storm or a dud bearer).
+        if tok.access_token.is_empty() {
+            return Err("broker returned an empty access_token".to_string());
+        }
+        if tok.expires <= now_millis() {
+            return Err("broker returned an already-expired token".to_string());
+        }
+        Ok(tok)
     }
 }
 
@@ -378,7 +398,7 @@ mod tests {
 
     // ── cache ────────────────────────────────────────────────────────────
     fn tok(expires: u64) -> BrokerToken {
-        BrokerToken { access_token: "sk-live".into(), expires }
+        BrokerToken { access_token: "sk-live".into(), expires, ttl_ms: None }
     }
 
     #[test]
@@ -524,6 +544,30 @@ mod tests {
         let c = BrokerClient::new(url, "WRONG-token");
         let err = c.fetch_token("anthropic").await.unwrap_err();
         assert!(err.contains("401"), "expected 401 error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn fetch_token_recomputes_expiry_from_ttl_ms() {
+        // Broker sends a STALE absolute `expires` but a fresh `ttl_ms`; the
+        // client must recompute from its own clock (clock-skew defense, C3).
+        let url = spawn_broker(r#"{"access_token":"sk","expires":1,"ttl_ms":3600000}"#, "m").await;
+        let c = BrokerClient::new(url, "m");
+        let t = c.fetch_token("anthropic").await.unwrap();
+        assert!(t.expires > now_millis(), "expires must come from ttl_ms, got {}", t.expires);
+    }
+
+    #[tokio::test]
+    async fn fetch_token_rejects_empty_access_token() {
+        let url = spawn_broker(r#"{"access_token":"","expires":9999999999999}"#, "m").await;
+        let c = BrokerClient::new(url, "m");
+        assert!(c.fetch_token("anthropic").await.unwrap_err().contains("empty"));
+    }
+
+    #[tokio::test]
+    async fn fetch_token_rejects_already_expired() {
+        let url = spawn_broker(r#"{"access_token":"sk","expires":1}"#, "m").await;
+        let c = BrokerClient::new(url, "m");
+        assert!(c.fetch_token("anthropic").await.unwrap_err().contains("expired"));
     }
 
     #[tokio::test]

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -394,4 +394,19 @@ mod tests {
         let err = c.fetch_token("anthropic").await.unwrap_err();
         assert!(err.contains("401"), "expected 401 error, got: {err}");
     }
+
+    // ── invariant: a Remote client can NEVER hold a refresh token ─────────
+    #[test]
+    fn broker_token_structurally_drops_any_refresh_field() {
+        // Even a misbehaving/compromised broker that leaks a refresh token in
+        // the JSON cannot make a client hold one: BrokerToken has no field for
+        // it, so serde silently drops it. The "clients never hold a refresh
+        // token" invariant is structural, not a runtime check.
+        let json = r#"{"access_token":"a","expires":1,"refresh_token":"LEAK","refresh":"LEAK"}"#;
+        let t: BrokerToken = serde_json::from_str(json).unwrap();
+        assert_eq!(t.access_token, "a");
+        assert_eq!(t.expires, 1);
+        // There is no `refresh`/`refresh_token` field to even read — confirmed
+        // at compile time by the struct definition above.
+    }
 }

--- a/crates/agent-core/src/core/auth/credential_source.rs
+++ b/crates/agent-core/src/core/auth/credential_source.rs
@@ -11,6 +11,8 @@
 //! refresher is the broker (Anthropic rotates the refresh token on every
 //! refresh, so exactly one party may refresh).
 
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Where a client gets its provider credentials.
@@ -78,6 +80,125 @@ pub fn is_expired_with_margin(expires_ms: u64, margin_ms: u64) -> bool {
 
 /// Default refetch margin: 5 minutes (mirrors `is_token_expired`).
 pub const DEFAULT_MARGIN_MS: u64 = 5 * 60 * 1000;
+
+// ── In-memory token cache ────────────────────────────────────────────────────
+
+/// Thread-safe, per-provider cache of broker access tokens. Cloneable handle
+/// over shared state. Holds ONLY short-lived access tokens, never a refresh
+/// token, never persisted to disk.
+#[derive(Clone, Default)]
+pub struct TokenCache {
+    inner: Arc<RwLock<HashMap<String, BrokerToken>>>,
+}
+
+impl TokenCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the cached token for `provider` only if present AND not within
+    /// `margin_ms` of expiry. Otherwise `None` (caller should fetch).
+    pub fn get_fresh(&self, provider: &str, margin_ms: u64) -> Option<BrokerToken> {
+        let map = self.inner.read().ok()?;
+        let tok = map.get(provider)?;
+        if is_expired_with_margin(tok.expires, margin_ms) {
+            None
+        } else {
+            Some(tok.clone())
+        }
+    }
+
+    pub fn put(&self, provider: &str, token: BrokerToken) {
+        if let Ok(mut map) = self.inner.write() {
+            map.insert(provider.to_string(), token);
+        }
+    }
+
+    pub fn invalidate(&self, provider: &str) {
+        if let Ok(mut map) = self.inner.write() {
+            map.remove(provider);
+        }
+    }
+}
+
+// ── Fetcher abstraction + resolver ───────────────────────────────────────────
+
+/// "Get a fresh access token from somewhere." Abstracted so the cache/resolve
+/// logic is unit-testable without real HTTP. The real impl is `BrokerClient`.
+#[allow(async_fn_in_trait)]
+pub trait TokenFetcher {
+    async fn fetch_token(&self, provider: &str) -> Result<BrokerToken, String>;
+}
+
+/// Resolve a provider access token via cache-or-fetch. Returns the cached token
+/// if fresh; otherwise fetches from `fetcher`, caches it, and returns it.
+///
+/// This is the entire Remote credential path. It NEVER reads or holds a refresh
+/// token, NEVER writes `auth.json`, NEVER refreshes client-side — `fetcher` only
+/// ever yields a short-lived `BrokerToken` (which structurally has no refresh).
+pub async fn resolve_remote_token<F: TokenFetcher>(
+    fetcher: &F,
+    cache: &TokenCache,
+    provider: &str,
+    margin_ms: u64,
+) -> Result<String, String> {
+    if let Some(tok) = cache.get_fresh(provider, margin_ms) {
+        return Ok(tok.access_token);
+    }
+    let tok = fetcher.fetch_token(provider).await?;
+    cache.put(provider, tok.clone());
+    Ok(tok.access_token)
+}
+
+// ── Broker HTTP client ───────────────────────────────────────────────────────
+
+/// HTTP client for a credential broker. Presents the machine's own bearer token
+/// (NOT the provider credential) and receives a short-lived access token.
+pub struct BrokerClient {
+    http: reqwest::Client,
+    endpoint: String,
+    machine_token: String,
+}
+
+impl BrokerClient {
+    pub fn new(endpoint: impl Into<String>, machine_token: impl Into<String>) -> Self {
+        Self { http: reqwest::Client::new(), endpoint: endpoint.into(), machine_token: machine_token.into() }
+    }
+
+    /// Build from a `CredentialSource`. `None` for `Local`.
+    pub fn from_source(source: &CredentialSource) -> Option<Self> {
+        match source {
+            CredentialSource::Remote { endpoint, machine_token } => {
+                Some(Self::new(endpoint.clone(), machine_token.clone()))
+            }
+            CredentialSource::Local => None,
+        }
+    }
+}
+
+impl TokenFetcher for BrokerClient {
+    async fn fetch_token(&self, provider: &str) -> Result<BrokerToken, String> {
+        let url = format!("{}/token", self.endpoint);
+        let resp = self
+            .http
+            .get(&url)
+            .query(&[("provider", provider)])
+            .bearer_auth(&self.machine_token)
+            .send()
+            .await
+            .map_err(|e| format!("broker request failed: {e}"))?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED {
+            return Err("broker rejected machine auth (401)".to_string());
+        }
+        if !status.is_success() {
+            return Err(format!("broker returned HTTP {status}"));
+        }
+        resp.json::<BrokerToken>()
+            .await
+            .map_err(|e| format!("invalid broker token response: {e}"))
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -155,5 +276,122 @@ mod tests {
         let t: BrokerToken = serde_json::from_str(json).unwrap();
         assert_eq!(t.access_token, "sk-abc");
         assert_eq!(t.expires, 1_750_000_000_000);
+    }
+
+    // ── cache ────────────────────────────────────────────────────────────
+    fn tok(expires: u64) -> BrokerToken {
+        BrokerToken { access_token: "sk-live".into(), expires }
+    }
+
+    #[test]
+    fn cache_get_fresh_returns_unexpired() {
+        let c = TokenCache::new();
+        c.put("anthropic", tok(now_millis() + 60 * 60 * 1000));
+        assert!(c.get_fresh("anthropic", DEFAULT_MARGIN_MS).is_some());
+    }
+
+    #[test]
+    fn cache_get_fresh_none_when_expired() {
+        let c = TokenCache::new();
+        c.put("anthropic", tok(now_millis().saturating_sub(1000)));
+        assert!(c.get_fresh("anthropic", 0).is_none());
+    }
+
+    #[test]
+    fn cache_invalidate_removes() {
+        let c = TokenCache::new();
+        c.put("anthropic", tok(now_millis() + 60 * 60 * 1000));
+        c.invalidate("anthropic");
+        assert!(c.get_fresh("anthropic", 0).is_none());
+    }
+
+    #[test]
+    fn cache_providers_isolated() {
+        let c = TokenCache::new();
+        c.put("anthropic", tok(now_millis() + 60 * 60 * 1000));
+        assert!(c.get_fresh("openai", 0).is_none());
+    }
+
+    // ── resolve with a fake fetcher (counts calls) ───────────────────────
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct FakeFetcher {
+        token: BrokerToken,
+        calls: AtomicUsize,
+    }
+    impl TokenFetcher for FakeFetcher {
+        async fn fetch_token(&self, _provider: &str) -> Result<BrokerToken, String> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.token.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_cache_hit_does_not_fetch() {
+        let cache = TokenCache::new();
+        cache.put("anthropic", tok(now_millis() + 60 * 60 * 1000));
+        let f = FakeFetcher { token: tok(0), calls: AtomicUsize::new(0) };
+        let t = resolve_remote_token(&f, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
+        assert_eq!(t, "sk-live");
+        assert_eq!(f.calls.load(Ordering::SeqCst), 0, "must not fetch on a cache hit");
+    }
+
+    #[tokio::test]
+    async fn resolve_miss_fetches_then_caches() {
+        let cache = TokenCache::new();
+        let f = FakeFetcher { token: tok(now_millis() + 60 * 60 * 1000), calls: AtomicUsize::new(0) };
+        resolve_remote_token(&f, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
+        resolve_remote_token(&f, &cache, "anthropic", DEFAULT_MARGIN_MS).await.unwrap();
+        assert_eq!(f.calls.load(Ordering::SeqCst), 1, "second resolve should hit the cache");
+    }
+
+    // ── BrokerClient against a tiny in-test axum server ──────────────────
+    async fn spawn_broker(token_json: &'static str, require_token: &'static str) -> String {
+        use axum::{http::HeaderMap, http::StatusCode, routing::get, Router};
+        let app = Router::new().route(
+            "/token",
+            get(move |headers: HeaderMap| async move {
+                let auth = headers
+                    .get("authorization")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("");
+                if auth == format!("Bearer {require_token}") {
+                    (StatusCode::OK, token_json.to_string())
+                } else {
+                    (StatusCode::UNAUTHORIZED, String::new())
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn broker_client_fetches_and_parses() {
+        let url = spawn_broker(
+            r#"{"access_token":"sk-from-broker","expires":9999999999999}"#,
+            "machine-xyz",
+        )
+        .await;
+        let c = BrokerClient::new(url, "machine-xyz");
+        let t = c.fetch_token("anthropic").await.unwrap();
+        assert_eq!(t.access_token, "sk-from-broker");
+        assert_eq!(t.expires, 9_999_999_999_999);
+    }
+
+    #[tokio::test]
+    async fn broker_client_401_on_bad_machine_auth() {
+        let url = spawn_broker(
+            r#"{"access_token":"x","expires":9999999999999}"#,
+            "right-token",
+        )
+        .await;
+        let c = BrokerClient::new(url, "WRONG-token");
+        let err = c.fetch_token("anthropic").await.unwrap_err();
+        assert!(err.contains("401"), "expected 401 error, got: {err}");
     }
 }

--- a/crates/agent-core/src/core/auth/mod.rs
+++ b/crates/agent-core/src/core/auth/mod.rs
@@ -72,7 +72,12 @@ pub struct CallbackResult {
     pub state: String,
 }
 
-/// Check if the current token is expired (or will expire within 5 minutes).
+/// Check if the current token is expired.
+///
+/// Note the effective ~5-minute safety margin lives in the stored value, not
+/// here: `refresh_token`/`exchange_code_for_tokens` bake a 5-minute buffer into
+/// `expires` (`now + expires_in*1000 - 5min`). So a bare `now >= expires` check
+/// already fires ~5 minutes before the credential actually dies at the provider.
 pub fn is_token_expired(creds: &OAuthCredentials) -> bool {
     now_millis() >= creds.expires
 }

--- a/crates/agent-core/src/core/auth/mod.rs
+++ b/crates/agent-core/src/core/auth/mod.rs
@@ -17,6 +17,7 @@ mod token;
 mod storage;
 mod browser;
 mod openai_codex;
+mod credential_source;
 
 // ── Re-exports ──────────────────────────────────────────────────────────────────
 
@@ -26,6 +27,7 @@ pub use token::{exchange_code_for_tokens, refresh_token, ensure_fresh_token, ens
 pub use storage::{auth_file_path, load_auth, load_provider_auth, save_auth, save_provider_auth};
 pub use browser::open_browser;
 pub use openai_codex::{extract_account_id as extract_codex_account_id, login as login_openai_codex};
+pub use credential_source::{CredentialSource, BrokerToken, is_expired_with_margin, DEFAULT_MARGIN_MS};
 
 // ── Constants (match Claude Code / Pi) ──────────────────────────────────────
 

--- a/crates/agent-core/src/core/auth/mod.rs
+++ b/crates/agent-core/src/core/auth/mod.rs
@@ -27,7 +27,7 @@ pub use token::{exchange_code_for_tokens, refresh_token, ensure_fresh_token, ens
 pub use storage::{auth_file_path, load_auth, load_provider_auth, save_auth, save_provider_auth};
 pub use browser::open_browser;
 pub use openai_codex::{extract_account_id as extract_codex_account_id, login as login_openai_codex};
-pub use credential_source::{CredentialSource, BrokerToken, BrokerClient, TokenCache, TokenFetcher, resolve_remote_token, is_expired_with_margin, DEFAULT_MARGIN_MS};
+pub use credential_source::{CredentialSource, BrokerToken, BrokerClient, TokenCache, TokenFetcher, resolve_remote, resolve_remote_token, is_expired_with_margin, DEFAULT_MARGIN_MS};
 
 // ── Constants (match Claude Code / Pi) ──────────────────────────────────────
 

--- a/crates/agent-core/src/core/auth/mod.rs
+++ b/crates/agent-core/src/core/auth/mod.rs
@@ -27,7 +27,7 @@ pub use token::{exchange_code_for_tokens, refresh_token, ensure_fresh_token, ens
 pub use storage::{auth_file_path, load_auth, load_provider_auth, save_auth, save_provider_auth};
 pub use browser::open_browser;
 pub use openai_codex::{extract_account_id as extract_codex_account_id, login as login_openai_codex};
-pub use credential_source::{CredentialSource, BrokerToken, BrokerClient, TokenCache, TokenFetcher, resolve_remote, resolve_remote_token, is_expired_with_margin, DEFAULT_MARGIN_MS};
+pub use credential_source::{CredentialSource, BrokerToken, BrokerClient, TokenCache, TokenFetcher, resolve_remote, resolve_remote_token, resolve_access_token, is_expired_with_margin, DEFAULT_MARGIN_MS};
 
 // ── Constants (match Claude Code / Pi) ──────────────────────────────────────
 

--- a/crates/agent-core/src/core/auth/mod.rs
+++ b/crates/agent-core/src/core/auth/mod.rs
@@ -27,7 +27,7 @@ pub use token::{exchange_code_for_tokens, refresh_token, ensure_fresh_token, ens
 pub use storage::{auth_file_path, load_auth, load_provider_auth, save_auth, save_provider_auth};
 pub use browser::open_browser;
 pub use openai_codex::{extract_account_id as extract_codex_account_id, login as login_openai_codex};
-pub use credential_source::{CredentialSource, BrokerToken, is_expired_with_margin, DEFAULT_MARGIN_MS};
+pub use credential_source::{CredentialSource, BrokerToken, BrokerClient, TokenCache, TokenFetcher, resolve_remote_token, is_expired_with_margin, DEFAULT_MARGIN_MS};
 
 // ── Constants (match Claude Code / Pi) ──────────────────────────────────────
 

--- a/crates/agent-core/src/core/config.rs
+++ b/crates/agent-core/src/core/config.rs
@@ -152,6 +152,37 @@ impl BridgeConfig {
     }
 }
 
+/// Auth configuration parsed from `auth.*` keys. Controls whether this client
+/// resolves provider tokens from the local `auth.json` (default) or from a
+/// remote credential broker. See task #157 / `auth::credential_source`.
+#[derive(Debug, Clone, Default)]
+pub struct AuthConfig {
+    /// Broker base URL. When set (here, or via `SYNAPS_AUTH_ENDPOINT`), the
+    /// client fetches short-lived access tokens from the broker instead of
+    /// reading/refreshing the local `auth.json`.
+    pub remote_endpoint: Option<String>,
+    /// Per-machine bearer presented to the broker (or `SYNAPS_MACHINE_TOKEN`).
+    /// This is the machine's own identity, never the provider credential.
+    pub machine_token: Option<String>,
+}
+
+impl AuthConfig {
+    /// Resolve the credential source. Environment variables take precedence over
+    /// config-file values: `SYNAPS_AUTH_ENDPOINT` / `SYNAPS_MACHINE_TOKEN`.
+    /// Returns `Remote` iff an endpoint is set (env or config), else `Local`.
+    pub fn credential_source(&self) -> crate::core::auth::CredentialSource {
+        let endpoint = std::env::var("SYNAPS_AUTH_ENDPOINT")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| self.remote_endpoint.clone());
+        let machine_token = std::env::var("SYNAPS_MACHINE_TOKEN")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .or_else(|| self.machine_token.clone());
+        crate::core::auth::CredentialSource::from_parts(endpoint, machine_token)
+    }
+}
+
 /// Prompt-cache TTL strategy for Anthropic requests.
 ///
 /// Controls the `cache_control` value emitted at every cache marker site:
@@ -214,6 +245,7 @@ pub struct SynapsConfig {
     pub shell: ShellConfig,
     pub server: ServerConfig,
     pub bridge: BridgeConfig,
+    pub auth: AuthConfig,
     pub provider_keys: BTreeMap<String, String>,
     pub keybinds: std::collections::HashMap<String, String>,
     /// Non-fatal problems found while parsing the config file (unknown keys,
@@ -247,6 +279,7 @@ impl Default for SynapsConfig {
             shell: ShellConfig::default(),
             server: ServerConfig::default(),
             bridge: BridgeConfig::default(),
+            auth: AuthConfig::default(),
             provider_keys: BTreeMap::new(),
             keybinds: std::collections::HashMap::new(),
             warnings: Vec::new(),
@@ -435,6 +468,21 @@ fn parse_bridge_config_key(bridge_config: &mut BridgeConfig, key: &str, val: &st
     }
 }
 
+/// Parse auth.* configuration keys and update the AuthConfig.
+fn parse_auth_config_key(auth_config: &mut AuthConfig, key: &str, val: &str) {
+    let v = val.trim();
+    match key {
+        "auth.remote_endpoint" => {
+            auth_config.remote_endpoint = if v.is_empty() { None } else { Some(v.to_string()) };
+        }
+        "auth.machine_token" => {
+            auth_config.machine_token = if v.is_empty() { None } else { Some(v.to_string()) };
+        }
+        _ => {
+            // Unknown auth.* keys preserved (not rejected)
+        }
+    }
+}
 /// Parse the config file at ~/.synaps-cli/config (or profile variant).
 /// Returns default config if file doesn't exist or can't be read.
 pub fn load_config() -> SynapsConfig {
@@ -545,6 +593,8 @@ pub fn load_config() -> SynapsConfig {
                     parse_server_config_key(&mut config.server, key, val);
                 } else if key.starts_with("bridge.") {
                     parse_bridge_config_key(&mut config.bridge, key, val);
+                } else if key.starts_with("auth.") {
+                    parse_auth_config_key(&mut config.auth, key, val);
                 } else if let Some(provider_key) = key.strip_prefix("provider.") {
                     config.provider_keys.insert(provider_key.to_string(), val.to_string());
                 } else if let Some(keybind_key) = key.strip_prefix("keybind.") {
@@ -1223,5 +1273,69 @@ api_retries = 5
         assert_eq!(config.bash_max_timeout, 600);
         assert_eq!(config.subagent_timeout, 120);
         assert_eq!(config.api_retries, 5);
+    }
+
+    // ── auth.* config + credential source (#157) ──
+
+    #[test]
+    #[serial]
+    fn test_auth_config_parses_endpoint_and_token() {
+        let home = std::env::temp_dir().join(format!("synaps-auth-test-{}", std::process::id()));
+        let dir = home.join(".synaps-cli");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("config"),
+            "auth.remote_endpoint = https://jade.jade:8181\nauth.machine_token = machine-abc\n",
+        )
+        .unwrap();
+        with_home(&home, || {
+            let config = load_config();
+            assert_eq!(config.auth.remote_endpoint.as_deref(), Some("https://jade.jade:8181"));
+            assert_eq!(config.auth.machine_token.as_deref(), Some("machine-abc"));
+            // auth.* are namespaced -> must NOT warn as unknown keys
+            assert!(!config.warnings.iter().any(|w| w.contains("auth.")), "{:?}", config.warnings);
+        });
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    #[serial]
+    fn test_credential_source_local_by_default() {
+        std::env::remove_var("SYNAPS_AUTH_ENDPOINT");
+        std::env::remove_var("SYNAPS_MACHINE_TOKEN");
+        assert!(!AuthConfig::default().credential_source().is_remote());
+    }
+
+    #[test]
+    #[serial]
+    fn test_credential_source_remote_from_config() {
+        std::env::remove_var("SYNAPS_AUTH_ENDPOINT");
+        std::env::remove_var("SYNAPS_MACHINE_TOKEN");
+        let auth = AuthConfig {
+            remote_endpoint: Some("https://b".into()),
+            machine_token: Some("m".into()),
+        };
+        assert_eq!(
+            auth.credential_source(),
+            crate::core::auth::CredentialSource::Remote { endpoint: "https://b".into(), machine_token: "m".into() }
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_credential_source_env_overrides_config() {
+        let auth = AuthConfig {
+            remote_endpoint: Some("https://config-host".into()),
+            machine_token: Some("config-tok".into()),
+        };
+        std::env::set_var("SYNAPS_AUTH_ENDPOINT", "https://env-host");
+        std::env::set_var("SYNAPS_MACHINE_TOKEN", "env-tok");
+        let src = auth.credential_source();
+        std::env::remove_var("SYNAPS_AUTH_ENDPOINT");
+        std::env::remove_var("SYNAPS_MACHINE_TOKEN");
+        assert_eq!(
+            src,
+            crate::core::auth::CredentialSource::Remote { endpoint: "https://env-host".into(), machine_token: "env-tok".into() }
+        );
     }
 }

--- a/crates/agent-engine/Cargo.toml
+++ b/crates/agent-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synaps-engine"
-version = "0.3.10"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Runtime engine — streaming, tools, MCP, skills, extensions, sidecar"
@@ -11,7 +11,7 @@ name = "agent_engine"
 path = "src/lib.rs"
 
 [dependencies]
-agent-core = { path = "../agent-core", version = "0.3.9", package = "synaps-core" }
+agent-core = { path = "../agent-core", version = "0.4.0", package = "synaps-core" }
 
 # Async runtime + utilities
 tokio              = { version = "1.0", features = ["full"] }

--- a/crates/agent-engine/Cargo.toml
+++ b/crates/agent-engine/Cargo.toml
@@ -71,7 +71,7 @@ signal-hook        = { version = "0.3", features = ["iterator"] }
 portable-pty       = "0.9"
 
 # Terminal (skills/keybinds use crossterm)
-crossterm          = { version = "0.28", features = ["event-stream"] }
+crossterm          = { version = "0.29", features = ["event-stream"] }
 
 # Server
 axum               = { version = "0.7", features = ["ws"] }

--- a/crates/agent-engine/src/runtime/api.rs
+++ b/crates/agent-engine/src/runtime/api.rs
@@ -606,6 +606,12 @@ pub struct ApiOptions {
     /// the downgrade notice on healthy Hybrid turns where the 1h prefix is
     /// already cached (1h == 0, 5m > 0). Shared via Arc like the notice latch.
     pub saw_1h_honored: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Credential source for provider auth (Local/Remote). Carried here so the
+    /// OpenAI/codex routing path can resolve tokens through the broker on
+    /// Remote, same as the Anthropic path. (#158 C4)
+    pub credential_source: crate::auth::CredentialSource,
+    /// Shared broker token cache (Remote only).
+    pub token_cache: crate::auth::TokenCache,
 }
 
 pub(super) struct ApiMethods;
@@ -651,6 +657,7 @@ impl ApiMethods {
         if let Some(result) = crate::runtime::openai::try_route(
             model, client, &tools_schema, system_prompt, messages, &tx,
             None, None, thinking_budget, cancel,
+            &options.credential_source, &options.token_cache,
         ).await {
             return result.map_err(|e| RuntimeError::Config(format!("openai provider: {e}")));
         }

--- a/crates/agent-engine/src/runtime/api.rs
+++ b/crates/agent-engine/src/runtime/api.rs
@@ -663,7 +663,9 @@ impl ApiMethods {
         }
 
         // Read auth state for this API call
-        let (auth_header_name, auth_header_value, auth_type) = Self::build_auth_header(auth).await;
+        let (mut auth_header_name, mut auth_header_value, auth_type) = Self::build_auth_header(auth).await;
+        // C1: allow a single on-401 token refetch+retry for Remote clients.
+        let mut auth_retried = false;
 
         // Fail early with a clear message if no Anthropic credentials
         if auth_type == "none" {
@@ -805,6 +807,35 @@ impl ApiMethods {
                         if status.is_success() {
                             response = Some(resp);
                             break;
+                        }
+
+                        // C1: a 401 with a Remote source means the broker token
+                        // was rejected (revoked, or rotated at the broker before
+                        // our cache thought it expired). Invalidate, refetch from
+                        // the broker, and retry ONCE with the fresh token.
+                        if status.as_u16() == 401
+                            && options.credential_source.is_remote()
+                            && !auth_retried
+                        {
+                            auth_retried = true;
+                            let _ = resp.text().await; // drain body
+                            options.token_cache.invalidate("anthropic");
+                            {
+                                let mut g = auth.write().await;
+                                g.auth_token.clear();
+                                g.token_expires = None;
+                            }
+                            super::auth::AuthMethods::refresh_if_needed(
+                                std::sync::Arc::clone(auth),
+                                client,
+                                &options.credential_source,
+                                &options.token_cache,
+                            )
+                            .await?;
+                            let (n, v, _t) = Self::build_auth_header(auth).await;
+                            auth_header_name = n;
+                            auth_header_value = v;
+                            continue;
                         }
 
                         let is_429    = status.as_u16() == 429;

--- a/crates/agent-engine/src/runtime/api_sync.rs
+++ b/crates/agent-engine/src/runtime/api_sync.rs
@@ -50,6 +50,7 @@ impl ApiMethods {
         if let Some(result) = crate::runtime::openai::try_route(
             model, client, &tools_schema, system_prompt, messages, &tx,
             None, None, thinking_budget, &tokio_util::sync::CancellationToken::new(),
+            &options.credential_source, &options.token_cache,
         ).await {
             drop(tx);
             while rx.recv().await.is_some() {}
@@ -267,6 +268,10 @@ impl ApiMethods {
             None,
             thinking_budget,
             &tokio_util::sync::CancellationToken::new(),
+            // call_api_simple is an internal helper without ApiOptions; codex here
+            // uses the Local credential. (Broker-routed codex goes via the stream path.)
+            &crate::auth::CredentialSource::Local,
+            &crate::auth::TokenCache::new(),
         )
         .await
         {

--- a/crates/agent-engine/src/runtime/auth.rs
+++ b/crates/agent-engine/src/runtime/auth.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use crate::{Result, RuntimeError};
 use reqwest::Client;
-use crate::auth::{BrokerClient, CredentialSource, TokenCache, resolve_remote, DEFAULT_MARGIN_MS};
+use crate::auth::{BrokerClient, CredentialSource, TokenCache, resolve_remote, is_expired_with_margin, DEFAULT_MARGIN_MS};
 use super::types::{AuthState, PiAuth};
 
 pub(super) struct AuthMethods;
@@ -33,11 +33,17 @@ impl AuthMethods {
     ) -> Result<()> {
         // ── Remote credential source: resolve via the broker. ──
         if let CredentialSource::Remote { .. } = source {
-            // Fast path: in-memory broker token still fresh?
+            // Fast path: in-memory broker token still outside the refetch margin?
+            // Must use the SAME predicate as the cache (is_expired_with_margin +
+            // DEFAULT_MARGIN_MS) so the fast-path and TokenCache agree on freshness
+            // — otherwise the fast-path serves a token the cache would refetch,
+            // and a >margin tool step can expire it mid-flight (board finding #1).
             {
                 let auth_guard = auth.read().await;
                 if let Some(exp) = auth_guard.token_expires {
-                    if !auth_guard.auth_token.is_empty() && crate::epoch_millis() < exp {
+                    if !auth_guard.auth_token.is_empty()
+                        && !is_expired_with_margin(exp, DEFAULT_MARGIN_MS)
+                    {
                         return Ok(());
                     }
                 }
@@ -202,6 +208,30 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(auth.read().await.auth_token, "sk-1");
+    }
+
+    #[tokio::test]
+    async fn remote_fast_path_refetches_a_token_inside_the_margin() {
+        // AuthState holds a token that is valid but within the 5-min refetch
+        // margin. The fast path must NOT serve it — it must refetch (board #1).
+        let url = spawn_broker(r#"{"access_token":"sk-FRESH","expires":9999999999999}"#).await;
+        let source = CredentialSource::Remote { endpoint: url, machine_token: "m".into() };
+        let cache = TokenCache::new();
+        let near = crate::epoch_millis() + 2 * 60 * 1000; // 2 min — inside the 5-min margin
+        let auth = Arc::new(RwLock::new(AuthState {
+            auth_token: "sk-STALE".into(),
+            auth_type: "oauth".into(),
+            refresh_token: None,
+            token_expires: Some(near),
+        }));
+        AuthMethods::refresh_if_needed(Arc::clone(&auth), &Client::new(), &source, &cache)
+            .await
+            .unwrap();
+        assert_eq!(
+            auth.read().await.auth_token,
+            "sk-FRESH",
+            "a token inside the refetch margin must be refetched, not served stale"
+        );
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/runtime/auth.rs
+++ b/crates/agent-engine/src/runtime/auth.rs
@@ -2,13 +2,21 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use crate::{Result, RuntimeError};
 use reqwest::Client;
+use crate::auth::{BrokerClient, CredentialSource, TokenCache, resolve_remote, DEFAULT_MARGIN_MS};
 use super::types::{AuthState, PiAuth};
 
 pub(super) struct AuthMethods;
 
 impl AuthMethods {
     /// Check if the OAuth token is expired and refresh it if needed.
-    /// Uses Pi-style file locking for cross-process safety:
+    ///
+    /// Two credential sources:
+    /// - `Remote` (#157): fetch a short-lived access token from the broker.
+    ///   Independent of the local auth.json. NEVER holds a refresh token,
+    ///   NEVER writes auth.json, NEVER refreshes client-side.
+    /// - `Local` (default): the original Pi-style file-locked refresh below.
+    ///
+    /// Local path detail (unchanged):
     /// - Acquires exclusive lock on auth.json
     /// - Re-reads inside the lock (another instance may have refreshed)
     /// - Refreshes via API only if still expired
@@ -17,7 +25,39 @@ impl AuthMethods {
     /// Multiple SynapsCLI instances (or Avante/Jade) can safely call this
     /// simultaneously — they'll serialize on the lock and only one will
     /// actually hit the token endpoint.
-    pub(super) async fn refresh_if_needed(auth: Arc<RwLock<AuthState>>, client: &Client) -> Result<()> {
+    pub(super) async fn refresh_if_needed(
+        auth: Arc<RwLock<AuthState>>,
+        client: &Client,
+        source: &CredentialSource,
+        cache: &TokenCache,
+    ) -> Result<()> {
+        // ── Remote credential source: resolve via the broker. ──
+        if let CredentialSource::Remote { .. } = source {
+            // Fast path: in-memory broker token still fresh?
+            {
+                let auth_guard = auth.read().await;
+                if let Some(exp) = auth_guard.token_expires {
+                    if !auth_guard.auth_token.is_empty() && crate::epoch_millis() < exp {
+                        return Ok(());
+                    }
+                }
+            }
+            let broker = BrokerClient::from_source(source)
+                .expect("CredentialSource::Remote always yields a BrokerClient");
+            let tok = resolve_remote(&broker, cache, "anthropic", DEFAULT_MARGIN_MS)
+                .await
+                .map_err(|e| RuntimeError::Auth(format!(
+                    "Broker token fetch failed: {}. Check auth.remote_endpoint, the machine token, and broker reachability.", e
+                )))?;
+            let mut auth_guard = auth.write().await;
+            auth_guard.auth_token = tok.access_token;
+            auth_guard.auth_type = "oauth".to_string();
+            auth_guard.refresh_token = None; // invariant: clients never hold a refresh token
+            auth_guard.token_expires = Some(tok.expires);
+            return Ok(());
+        }
+
+        // ── Local credential source (default — unchanged behavior). ──
         // Fast path: read lock to check expiry without blocking writers
         {
             let auth_guard = auth.read().await;
@@ -103,5 +143,84 @@ impl AuthMethods {
         // No Anthropic credentials — allow startup anyway for non-Anthropic providers.
         // Auth will fail lazily on the first actual Anthropic API call.
         Ok(("".to_string(), "none".to_string(), None, None))
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::TokenCache;
+
+    /// Tiny in-test broker that always returns `token_json` at GET /token.
+    async fn spawn_broker(token_json: &'static str) -> String {
+        use axum::{routing::get, Router};
+        let app = Router::new().route("/token", get(move || async move { token_json.to_string() }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    fn empty_auth() -> Arc<RwLock<AuthState>> {
+        Arc::new(RwLock::new(AuthState {
+            auth_token: String::new(),
+            auth_type: "none".into(),
+            refresh_token: Some("SHOULD-BE-CLEARED".into()),
+            token_expires: None,
+        }))
+    }
+
+    #[tokio::test]
+    async fn remote_source_fetches_and_populates_auth_state() {
+        let url = spawn_broker(r#"{"access_token":"sk-broker-xyz","expires":9999999999999}"#).await;
+        let source = CredentialSource::Remote { endpoint: url, machine_token: "m".into() };
+        let cache = TokenCache::new();
+        let auth = empty_auth();
+        AuthMethods::refresh_if_needed(Arc::clone(&auth), &Client::new(), &source, &cache)
+            .await
+            .unwrap();
+        let g = auth.read().await;
+        assert_eq!(g.auth_token, "sk-broker-xyz");
+        assert_eq!(g.auth_type, "oauth");
+        assert_eq!(g.refresh_token, None, "Remote must clear any refresh token (invariant)");
+        assert_eq!(g.token_expires, Some(9_999_999_999_999));
+    }
+
+    #[tokio::test]
+    async fn remote_source_fast_path_when_token_still_fresh() {
+        let url = spawn_broker(r#"{"access_token":"sk-1","expires":9999999999999}"#).await;
+        let source = CredentialSource::Remote { endpoint: url, machine_token: "m".into() };
+        let cache = TokenCache::new();
+        let auth = empty_auth();
+        // First call fetches + sets a far-future expiry.
+        AuthMethods::refresh_if_needed(Arc::clone(&auth), &Client::new(), &source, &cache)
+            .await
+            .unwrap();
+        // Second call: in-memory token is fresh -> fast path returns without refetch.
+        AuthMethods::refresh_if_needed(Arc::clone(&auth), &Client::new(), &source, &cache)
+            .await
+            .unwrap();
+        assert_eq!(auth.read().await.auth_token, "sk-1");
+    }
+
+    #[tokio::test]
+    async fn local_source_api_key_is_noop_never_contacts_broker() {
+        // Local + non-oauth auth_type hits the original early-return: no broker,
+        // no error, state untouched. (Local path byte-for-byte unchanged.)
+        let source = CredentialSource::Local;
+        let cache = TokenCache::new();
+        let auth = Arc::new(RwLock::new(AuthState {
+            auth_token: "key".into(),
+            auth_type: "api_key".into(),
+            refresh_token: None,
+            token_expires: None,
+        }));
+        AuthMethods::refresh_if_needed(Arc::clone(&auth), &Client::new(), &source, &cache)
+            .await
+            .unwrap();
+        let g = auth.read().await;
+        assert_eq!(g.auth_token, "key");
+        assert_eq!(g.auth_type, "api_key");
     }
 }

--- a/crates/agent-engine/src/runtime/auth.rs
+++ b/crates/agent-engine/src/runtime/auth.rs
@@ -8,6 +8,18 @@ use super::types::{AuthState, PiAuth};
 pub(super) struct AuthMethods;
 
 impl AuthMethods {
+    /// Reset `AuthState` so a Remote client never *uses* or *holds* a credential
+    /// seeded from a local `auth.json`. Called from `apply_config` when the
+    /// source is Remote: clears the access token, drops any refresh token
+    /// (invariant 1), and forces the next `refresh_if_needed` to fetch from the
+    /// broker. `auth_type` stays "oauth" so the Local early-return is not taken.
+    pub(super) fn scrub_for_remote(s: &mut AuthState) {
+        s.auth_token.clear();
+        s.auth_type = "oauth".to_string();
+        s.refresh_token = None;
+        s.token_expires = None;
+    }
+
     /// Check if the OAuth token is expired and refresh it if needed.
     ///
     /// Two credential sources:
@@ -252,5 +264,20 @@ mod tests {
         let g = auth.read().await;
         assert_eq!(g.auth_token, "key");
         assert_eq!(g.auth_type, "api_key");
+    }
+
+    #[test]
+    fn scrub_for_remote_clears_local_credential_and_refresh_token() {
+        let mut s = AuthState {
+            auth_token: "local-token".into(),
+            auth_type: "oauth".into(),
+            refresh_token: Some("LEAKED-REFRESH".into()),
+            token_expires: Some(123),
+        };
+        AuthMethods::scrub_for_remote(&mut s);
+        assert!(s.auth_token.is_empty(), "access token must be cleared");
+        assert_eq!(s.refresh_token, None, "refresh token must be dropped (invariant 1)");
+        assert_eq!(s.token_expires, None, "expiry must be cleared to force a broker fetch");
+        assert_eq!(s.auth_type, "oauth", "auth_type stays oauth so Local early-return is skipped");
     }
 }

--- a/crates/agent-engine/src/runtime/auth.rs
+++ b/crates/agent-engine/src/runtime/auth.rs
@@ -7,6 +7,19 @@ use super::types::{AuthState, PiAuth};
 
 pub(super) struct AuthMethods;
 
+/// True if `model` routes to the Anthropic path (not OpenAI/codex/local). Used
+/// to skip the Anthropic pre-stream refresh for non-Anthropic models — they
+/// resolve their own provider auth (incl. via the broker), so fetching an
+/// Anthropic token first is wasteful and would FAIL on a codex-only Remote
+/// broker. (#158 C4/#7)
+pub(super) fn model_is_anthropic(model: &str) -> bool {
+    let keys = crate::core::config::get_provider_keys();
+    matches!(
+        crate::runtime::openai::resolve_route(model, &keys),
+        crate::runtime::openai::Provider::Anthropic
+    )
+}
+
 impl AuthMethods {
     /// Reset `AuthState` so a Remote client never *uses* or *holds* a credential
     /// seeded from a local `auth.json`. Called from `apply_config` when the

--- a/crates/agent-engine/src/runtime/auth.rs
+++ b/crates/agent-engine/src/runtime/auth.rs
@@ -44,7 +44,7 @@ impl AuthMethods {
         cache: &TokenCache,
     ) -> Result<()> {
         // ── Remote credential source: resolve via the broker. ──
-        if let CredentialSource::Remote { .. } = source {
+        if let CredentialSource::Remote { endpoint, machine_token } = source {
             // Fast path: in-memory broker token still outside the refetch margin?
             // Must use the SAME predicate as the cache (is_expired_with_margin +
             // DEFAULT_MARGIN_MS) so the fast-path and TokenCache agree on freshness
@@ -60,8 +60,9 @@ impl AuthMethods {
                     }
                 }
             }
-            let broker = BrokerClient::from_source(source)
-                .expect("CredentialSource::Remote always yields a BrokerClient");
+            // Reuse the runtime's shared reqwest::Client (shared connection
+            // pool) instead of building a fresh one per refresh. (#158 A5)
+            let broker = BrokerClient::with_client(endpoint.clone(), machine_token.clone(), client.clone());
             let tok = resolve_remote(&broker, cache, "anthropic", DEFAULT_MARGIN_MS)
                 .await
                 .map_err(|e| RuntimeError::Auth(format!(

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -356,7 +356,22 @@ impl Runtime {
         self.cache_ttl = config.cache_ttl;
         // Credential source: Local (auth.json) by default, or Remote (broker)
         // when auth.remote_endpoint / SYNAPS_AUTH_ENDPOINT is set. (#157)
-        self.credential_source = config.auth.credential_source();
+        let new_source = config.auth.credential_source();
+        // A6: switching source (or broker endpoint) must not serve a token minted
+        // by the previous broker/identity — drop any cached token.
+        if new_source != self.credential_source {
+            self.token_cache.invalidate("anthropic");
+        }
+        self.credential_source = new_source;
+        // A2: on Remote, NEVER use a credential seeded from a local auth.json.
+        // Scrub AuthState so the first refresh fetches from the broker and the
+        // client never holds a refresh token (invariant 1). try_write is safe:
+        // apply_config runs at boot before AuthState is shared with stream tasks.
+        if self.credential_source.is_remote() {
+            if let Ok(mut auth) = self.auth.try_write() {
+                AuthMethods::scrub_for_remote(&mut auth);
+            }
+        }
 
         // Remove any built-in tools the user disabled via `disabled_tools`.
         // try_write is safe here: apply_config runs at boot before the registry

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -769,6 +769,8 @@ impl Runtime {
         // same AuthState so mid-loop token refreshes are visible immediately.
         let auth = Arc::clone(&self.auth);
         let client = self.client.clone();
+        let credential_source = self.credential_source.clone();
+        let token_cache = self.token_cache.clone();
         let model = self.model.clone();
         let tools = self.tools.clone();
         let system_prompt = self.system_prompt.clone();
@@ -793,7 +795,7 @@ impl Runtime {
         };
 
         let session = crate::runtime::stream::StreamSession {
-            auth, client, options, api_retries,
+            auth, client, credential_source, token_cache, options, api_retries,
             model, tools, system_prompt, thinking_budget,
             tx: tx.clone(), cancel, steering_rx,
             watcher_exit_path, max_tool_output,

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -192,6 +192,13 @@ pub struct Runtime {
     reaper_handle: Option<tokio::task::JoinHandle<()>>,
     #[allow(dead_code)]
     reaper_cancel: Option<tokio_util::sync::CancellationToken>,
+    /// How provider credentials are resolved: `Local` (read/refresh auth.json —
+    /// the default) or `Remote` (fetch short-lived access tokens from a broker).
+    /// Set from config in `apply_config`. See task #157.
+    credential_source: crate::auth::CredentialSource,
+    /// In-memory cache of broker-fetched access tokens (Remote source only).
+    /// Cheap to clone (Arc inside). Never persisted to disk.
+    token_cache: crate::auth::TokenCache,
 }
 
 impl Runtime {
@@ -248,6 +255,8 @@ impl Runtime {
             hook_bus: Arc::new(crate::extensions::hooks::HookBus::new()),
             reaper_handle: Some(reaper_handle),
             reaper_cancel: Some(cancel),
+            credential_source: crate::auth::CredentialSource::Local,
+            token_cache: crate::auth::TokenCache::new(),
         })
     }
 
@@ -345,6 +354,9 @@ impl Runtime {
         self.telemetry_level = crate::runtime::telemetry::TelemetryLevel::from_str_key(&config.telemetry);
         self.cache_diagnostics = config.cache_diagnostics;
         self.cache_ttl = config.cache_ttl;
+        // Credential source: Local (auth.json) by default, or Remote (broker)
+        // when auth.remote_endpoint / SYNAPS_AUTH_ENDPOINT is set. (#157)
+        self.credential_source = config.auth.credential_source();
 
         // Remove any built-in tools the user disabled via `disabled_tools`.
         // try_write is safe here: apply_config runs at boot before the registry
@@ -433,7 +445,13 @@ impl Runtime {
 
     /// Check if the OAuth token is expired and refresh it if needed.
     pub async fn refresh_if_needed(&self) -> Result<()> {
-        AuthMethods::refresh_if_needed(Arc::clone(&self.auth), &self.client).await
+        AuthMethods::refresh_if_needed(
+            Arc::clone(&self.auth),
+            &self.client,
+            &self.credential_source,
+            &self.token_cache,
+        )
+        .await
     }
 
     /// Make a simple non-streaming API call for compaction (no tools).
@@ -831,6 +849,8 @@ impl Clone for Runtime {
             hook_bus: self.hook_bus.clone(),
             reaper_handle: None,  // Cloned runtimes don't own the reaper
             reaper_cancel: None,  // Cloned runtimes don't own the reaper
+            credential_source: self.credential_source.clone(),
+            token_cache: self.token_cache.clone(), // shares the same cache (Arc inside)
         }
     }
 }

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -516,6 +516,8 @@ impl Runtime {
                     cache_ttl: self.cache_ttl,
                     ttl_downgrade_notified: self.ttl_downgrade_notified.clone(),
                     saw_1h_honored: self.saw_1h_honored.clone(),
+                    credential_source: self.credential_source.clone(),
+                    token_cache: self.token_cache.clone(),
                 },
             ).await?;
             
@@ -810,6 +812,8 @@ impl Runtime {
             cache_ttl: self.cache_ttl,
             ttl_downgrade_notified: self.ttl_downgrade_notified.clone(),
             saw_1h_honored: self.saw_1h_honored.clone(),
+            credential_source: self.credential_source.clone(),
+            token_cache: self.token_cache.clone(),
         };
 
         let session = crate::runtime::stream::StreamSession {

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -463,6 +463,11 @@ impl Runtime {
 
     /// Check if the OAuth token is expired and refresh it if needed.
     pub async fn refresh_if_needed(&self) -> Result<()> {
+        // Non-Anthropic models resolve their own provider auth in the OpenAI
+        // path (incl. via the broker), so skip the Anthropic pre-fetch. (#158 #7)
+        if !crate::runtime::auth::model_is_anthropic(&self.model) {
+            return Ok(());
+        }
         AuthMethods::refresh_if_needed(
             Arc::clone(&self.auth),
             &self.client,

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -354,24 +354,7 @@ impl Runtime {
         self.telemetry_level = crate::runtime::telemetry::TelemetryLevel::from_str_key(&config.telemetry);
         self.cache_diagnostics = config.cache_diagnostics;
         self.cache_ttl = config.cache_ttl;
-        // Credential source: Local (auth.json) by default, or Remote (broker)
-        // when auth.remote_endpoint / SYNAPS_AUTH_ENDPOINT is set. (#157)
-        let new_source = config.auth.credential_source();
-        // A6: switching source (or broker endpoint) must not serve a token minted
-        // by the previous broker/identity — drop any cached token.
-        if new_source != self.credential_source {
-            self.token_cache.invalidate("anthropic");
-        }
-        self.credential_source = new_source;
-        // A2: on Remote, NEVER use a credential seeded from a local auth.json.
-        // Scrub AuthState so the first refresh fetches from the broker and the
-        // client never holds a refresh token (invariant 1). try_write is safe:
-        // apply_config runs at boot before AuthState is shared with stream tasks.
-        if self.credential_source.is_remote() {
-            if let Ok(mut auth) = self.auth.try_write() {
-                AuthMethods::scrub_for_remote(&mut auth);
-            }
-        }
+        self.apply_auth_config(config);
 
         // Remove any built-in tools the user disabled via `disabled_tools`.
         // try_write is safe here: apply_config runs at boot before the registry
@@ -379,6 +362,26 @@ impl Runtime {
         if !config.disabled_tools.is_empty() {
             if let Ok(mut reg) = self.tools.try_write() {
                 reg.disable(&config.disabled_tools);
+            }
+        }
+    }
+
+    /// Apply only the credential-source portion of config. Used by subagent
+    /// spawns that build a fresh `Runtime::new()` (which defaults to Local) and
+    /// must inherit the user's Remote/broker setup. (#158 A3)
+    ///
+    /// A6: invalidates the token cache if the source/endpoint changed.
+    /// A2: scrubs `AuthState` when Remote so no local `auth.json` credential is
+    /// used or held (invariant 1).
+    pub fn apply_auth_config(&mut self, config: &crate::config::SynapsConfig) {
+        let new_source = config.auth.credential_source();
+        if new_source != self.credential_source {
+            self.token_cache.invalidate("anthropic");
+        }
+        self.credential_source = new_source;
+        if self.credential_source.is_remote() {
+            if let Ok(mut auth) = self.auth.try_write() {
+                AuthMethods::scrub_for_remote(&mut auth);
             }
         }
     }

--- a/crates/agent-engine/src/runtime/openai/catalog/mod.rs
+++ b/crates/agent-engine/src/runtime/openai/catalog/mod.rs
@@ -294,7 +294,13 @@ async fn read_catalog_response(resp: reqwest::Response) -> Result<String, String
 async fn fetch_anthropic_catalog_models(
     client: &reqwest::Client,
 ) -> Result<Vec<CatalogModel>, String> {
-    let creds = crate::auth::ensure_fresh_token(client)
+    // Honor the credential source so a Remote client lists models via a
+    // broker-issued token instead of refreshing (and rotating) auth.json
+    // client-side — which would lock the broker out. (#158 A4)
+    let config = crate::config::load_config();
+    let source = config.auth.credential_source();
+    let cache = crate::auth::TokenCache::new();
+    let access = crate::auth::resolve_access_token("anthropic", &source, &cache, client)
         .await
         .map_err(|e| format!("Anthropic is not configured: {e}"))?;
     let mut pages = Vec::new();
@@ -303,8 +309,8 @@ async fn fetch_anthropic_catalog_models(
     for _ in 0..ANTHROPIC_MODELS_MAX_PAGES {
         let url = anthropic_models_url(after_id.as_deref());
         let resp = catalog_get(client, &url)
-            .bearer_auth(&creds.access)
-            .header("x-api-key", &creds.access)
+            .bearer_auth(&access)
+            .header("x-api-key", &access)
             .header("anthropic-version", "2023-06-01")
             .send()
             .await

--- a/crates/agent-engine/src/runtime/openai/mod.rs
+++ b/crates/agent-engine/src/runtime/openai/mod.rs
@@ -101,6 +101,8 @@ pub async fn try_route(
     max_tokens: Option<u32>,
     thinking_budget: u32,
     cancel: &tokio_util::sync::CancellationToken,
+    source: &crate::auth::CredentialSource,
+    cache: &crate::auth::TokenCache,
 ) -> Option<Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>>> {
     if let Some((plugin_id, provider_id, model_id)) = ProviderRegistry::parse_model_id(model) {
         if let Some(manager) = extension_manager_for_routing() {
@@ -325,7 +327,7 @@ pub async fn try_route(
         Provider::Codex(cfg) => {
             let result = stream::call_codex_stream_inner(
                 &cfg, client, tools_schema, system_prompt, messages, tx,
-                temperature, max_tokens, cancel,
+                temperature, max_tokens, cancel, source, cache,
             ).await;
             Some(result)
         }

--- a/crates/agent-engine/src/runtime/openai/stream.rs
+++ b/crates/agent-engine/src/runtime/openai/stream.rs
@@ -157,23 +157,31 @@ pub(crate) async fn call_codex_stream_inner(
     temperature: Option<f32>,
     max_tokens: Option<u32>,
     cancel: &tokio_util::sync::CancellationToken,
+    source: &crate::auth::CredentialSource,
+    cache: &crate::auth::TokenCache,
 ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
-    let creds = if cfg.api_key.is_empty() {
-        crate::auth::ensure_fresh_provider_token(client, "openai-codex").await?
+    // Resolve the codex access token honoring the credential source: Remote
+    // fetches from the broker, Local refreshes the openai-codex auth.json. (#158 C4)
+    let (access, account_id) = if !cfg.api_key.is_empty() {
+        (cfg.api_key.clone(), crate::auth::extract_codex_account_id(&cfg.api_key))
     } else {
-        crate::auth::OAuthCredentials {
-            auth_type: "oauth".to_string(),
-            refresh: String::new(),
-            access: cfg.api_key.clone(),
-            expires: 0,
-            account_id: None,
+        match source {
+            crate::auth::CredentialSource::Remote { .. } => {
+                let access = crate::auth::resolve_access_token("openai-codex", source, cache, client).await?;
+                let acct = crate::auth::extract_codex_account_id(&access);
+                (access, acct)
+            }
+            crate::auth::CredentialSource::Local => {
+                let creds = crate::auth::ensure_fresh_provider_token(client, "openai-codex").await?;
+                let acct = creds
+                    .account_id
+                    .clone()
+                    .or_else(|| crate::auth::extract_codex_account_id(&creds.access));
+                (creds.access, acct)
+            }
         }
     };
-    let account_id = creds
-        .account_id
-        .clone()
-        .or_else(|| crate::auth::extract_codex_account_id(&creds.access))
-        .ok_or("Failed to extract ChatGPT account id from Codex token")?;
+    let account_id = account_id.ok_or("Failed to extract ChatGPT account id from Codex token")?;
 
     let (oai_tools, name_map) = translate::tools_to_oai(tools_schema);
     let oai_messages = translate::messages_to_oai(messages, system_prompt, &name_map);
@@ -218,7 +226,7 @@ pub(crate) async fn call_codex_stream_inner(
 
     let resp = client
         .post(&url)
-        .bearer_auth(&creds.access)
+        .bearer_auth(&access)
         .header("chatgpt-account-id", account_id)
         .header("originator", "synaps")
         .header("OpenAI-Beta", "responses=experimental")

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -94,13 +94,17 @@ impl StreamMethods {
             // tokens in long-running agentic sessions. Unified path: branches
             // Local (auth.json) vs Remote (broker) so Remote clients refresh
             // mid-stream FROM THE BROKER, never the (absent) local auth.json. (#157)
-            super::auth::AuthMethods::refresh_if_needed(
-                Arc::clone(&auth),
-                &client,
-                &credential_source,
-                &token_cache,
-            )
-            .await?;
+            // Skip for non-Anthropic models — the OpenAI/codex path self-serves
+            // its provider token (incl. via the broker). (#158 #7)
+            if super::auth::model_is_anthropic(&model) {
+                super::auth::AuthMethods::refresh_if_needed(
+                    Arc::clone(&auth),
+                    &client,
+                    &credential_source,
+                    &token_cache,
+                )
+                .await?;
+            }
 
             let tools_snapshot = tools.read().await.clone();
 

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -17,6 +17,11 @@ pub(super) struct StreamSession {
     // Auth & network
     pub(super) auth: Arc<RwLock<AuthState>>,
     pub(super) client: Client,
+    /// Credential source (Local/Remote) — threaded in so the mid-stream refresh
+    /// uses the broker for Remote clients, not the local auth.json. (#157)
+    pub(super) credential_source: crate::auth::CredentialSource,
+    /// Shared broker token cache (Remote source only).
+    pub(super) token_cache: crate::auth::TokenCache,
     pub(super) options: super::api::ApiOptions,
     pub(super) api_retries: u32,
 
@@ -68,7 +73,7 @@ impl StreamMethods {
         initial_messages: Vec<Value>,
     ) -> Result<()> {
         let StreamSession {
-            auth, client, options, api_retries,
+            auth, client, credential_source, token_cache, options, api_retries,
             model, tools, system_prompt, thinking_budget,
             tx, cancel, mut steering_rx,
             watcher_exit_path, max_tool_output,
@@ -85,36 +90,17 @@ impl StreamMethods {
                 return Ok(());
             }
 
-            // Refresh token before each API call in the tool loop — this is
-            // the fix for stale tokens in long-running agentic sessions.
-            {
-                let auth_state = auth.read().await;
-                if auth_state.auth_type == "oauth" {
-                    let expired = match auth_state.token_expires {
-                        Some(exp) => {
-                            let now = crate::epoch_millis();
-                            now >= exp
-                        }
-                        None => false,
-                    };
-                    if expired {
-                        // Drop read lock before acquiring write
-                        drop(auth_state);
-
-                        tracing::info!("Refreshing token mid-stream");
-                        let creds = crate::auth::ensure_fresh_token(&client)
-                            .await
-                            .map_err(|e| RuntimeError::Auth(format!(
-                                "Token refresh failed mid-stream: {}. Run `synaps login` to re-authenticate.", e
-                            )))?;
-
-                        let mut auth_w = auth.write().await;
-                        auth_w.auth_token = creds.access;
-                        auth_w.refresh_token = Some(creds.refresh);
-                        auth_w.token_expires = Some(creds.expires);
-                    }
-                }
-            }
+            // Refresh token before each API call in the tool loop — fixes stale
+            // tokens in long-running agentic sessions. Unified path: branches
+            // Local (auth.json) vs Remote (broker) so Remote clients refresh
+            // mid-stream FROM THE BROKER, never the (absent) local auth.json. (#157)
+            super::auth::AuthMethods::refresh_if_needed(
+                Arc::clone(&auth),
+                &client,
+                &credential_source,
+                &token_cache,
+            )
+            .await?;
 
             let tools_snapshot = tools.read().await.clone();
 

--- a/crates/agent-engine/src/tools/subagent/oneshot.rs
+++ b/crates/agent-engine/src/tools/subagent/oneshot.rs
@@ -124,6 +124,9 @@ impl Tool for SubagentTool {
                         Err(e) => return Err(format!("Failed to create subagent runtime: {}", e)),
                     };
 
+                    // Inherit the user's credential source (Remote/broker) — a
+                    // fresh Runtime::new() defaults to Local. (#158 A3)
+                    runtime.apply_auth_config(&crate::config::load_config());
                     runtime.set_system_prompt(system_prompt);
                     runtime.set_model(model);
                     runtime.set_tools(crate::ToolRegistry::without_subagent());

--- a/crates/agent-engine/src/tools/subagent/resume.rs
+++ b/crates/agent-engine/src/tools/subagent/resume.rs
@@ -162,6 +162,8 @@ impl Tool for SubagentResumeTool {
                         Err(e) => return Err(format!("Failed to create subagent runtime: {}", e)),
                     };
 
+                    // Inherit the user's credential source (Remote/broker). (#158 A3)
+                    runtime.apply_auth_config(&crate::config::load_config());
                     runtime.set_system_prompt(system_prompt);
                     runtime.set_model(model_a.clone());
                     runtime.set_tools(crate::ToolRegistry::without_subagent());

--- a/crates/agent-engine/src/tools/subagent/start.rs
+++ b/crates/agent-engine/src/tools/subagent/start.rs
@@ -158,6 +158,8 @@ impl Tool for SubagentStartTool {
                         Err(e) => return Err(format!("Failed to create subagent runtime: {}", e)),
                     };
 
+                    // Inherit the user's credential source (Remote/broker). (#158 A3)
+                    runtime.apply_auth_config(&crate::config::load_config());
                     runtime.set_system_prompt(system_prompt);
                     runtime.set_model(model_a.clone());
                     let tools = if let Some(ext_mgr) = crate::runtime::openai::extension_manager_for_routing() {

--- a/crates/agent-tui/Cargo.toml
+++ b/crates/agent-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synaps-tui"
-version = "0.3.10"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.80"
 description = "Terminal UI layer — ratatui, crossterm, syntect, tachyonfx"
@@ -11,8 +11,8 @@ name = "agent_tui"
 path = "src/lib.rs"
 
 [dependencies]
-agent-core   = { path = "../agent-core", version = "0.3.9", package = "synaps-core" }
-agent-engine = { path = "../agent-engine", version = "0.3.9", package = "synaps-engine" }
+agent-core   = { path = "../agent-core", version = "0.4.0", package = "synaps-core" }
+agent-engine = { path = "../agent-engine", version = "0.4.0", package = "synaps-engine" }
 
 # Async runtime + utilities
 tokio        = { version = "1.0", features = ["full"] }

--- a/crates/agent-tui/Cargo.toml
+++ b/crates/agent-tui/Cargo.toml
@@ -39,9 +39,9 @@ anyhow       = "1.0"
 reqwest      = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls-webpki-roots", "rustls-tls-native-roots"] }
 
 # TUI render crates
-ratatui       = "0.29"
-crossterm     = { version = "0.28", features = ["event-stream"] }
-tachyonfx     = { version = "0.9", features = ["sendable"] }
+ratatui       = "0.30"
+crossterm     = { version = "0.29", features = ["event-stream"] }
+tachyonfx     = { version = "0.25", features = ["sendable"] }
 syntect       = { version = "5", default-features = false, features = ["default-themes", "default-syntaxes", "regex-fancy"] }
 arc-swap      = "1"
 unicode-width = "0.2.0"

--- a/crates/agent-tui/src/tui/draw.rs
+++ b/crates/agent-tui/src/tui/draw.rs
@@ -7,7 +7,7 @@ use ratatui::{
     Terminal,
 };
 use std::io;
-use tachyonfx::{fx, Effect, Interpolation, Shader};
+use tachyonfx::{fx, Effect, Interpolation};
 
 /// Build a single sidecar pill segment for one `SidecarUiState`.
 #[allow(dead_code)] // used in tests
@@ -335,7 +335,7 @@ pub(crate) fn tool_accent(tool_name: &str) -> Color {
 }
 
 pub(crate) fn boot_effect() -> Effect {
-    use tachyonfx::fx::Direction as FxDir;
+    use tachyonfx::Motion as FxDir;
     let Color::Rgb(r, g, b) = THEME.load().bg else {
         return fx::sleep(0);
     };
@@ -365,7 +365,7 @@ pub(crate) fn boot_effect() -> Effect {
 }
 
 pub(crate) fn quit_effect() -> Effect {
-    use tachyonfx::fx::Direction as FxDir;
+    use tachyonfx::Motion as FxDir;
     let Color::Rgb(r, g, b) = THEME.load().muted else {
         return fx::sleep(0);
     };

--- a/crates/agent-tui/src/tui/mod.rs
+++ b/crates/agent-tui/src/tui/mod.rs
@@ -24,6 +24,14 @@ mod theme;
 mod toast;
 mod viewport;
 
+/// Single process-global lock for ALL tests that mutate config-env vars
+/// (`SYNAPS_BASE_DIR`, `HOME`).  Both `migration_tests` (this file) and the
+/// `BASE_DIR_TEST_LOCK` tests in `plugins/actions.rs` must hold this lock for
+/// the duration of any test that sets or reads those vars, so the two groups
+/// can never interleave even when `cargo test` runs them on parallel threads.
+#[cfg(test)]
+pub(crate) static CONFIG_ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 use app::{App, ChatMessage, THINKING_PLACEHOLDER};
 use commands::CommandAction;
 use draw::{boot_effect, build_render_model, quit_effect};
@@ -2332,24 +2340,44 @@ fn pick_display_name_for_plugin(
 #[cfg(test)]
 mod migration_tests {
     use super::*;
-    use serial_test::serial;
     use synaps_cli::skills::registry::LifecycleClaim;
 
-    fn make_test_home(subdir: &str) -> std::path::PathBuf {
-        let dir = std::path::PathBuf::from(format!("/tmp/synaps-mig-test-{}", subdir));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(dir.join(".synaps-cli")).unwrap();
-        dir
+    // RAII guard: sets SYNAPS_BASE_DIR for the duration of the test, then
+    // restores the previous value (or removes the var) on drop.  This is the
+    // canonical override – base_dir() checks SYNAPS_BASE_DIR *before* HOME, so
+    // setting it here completely shadows the real ~/.synaps-cli regardless of
+    // what HOME is, and is immune to the HOME-vs-SYNAPS_BASE_DIR race that was
+    // the root cause of T137 flakiness.
+    struct BaseDir {
+        _dir: tempfile::TempDir,
+        old: Option<String>,
     }
 
-    fn with_home<F: FnOnce()>(home: &std::path::Path, f: F) {
-        let original = std::env::var("HOME").ok();
-        std::env::set_var("HOME", home);
-        f();
-        if let Some(h) = original {
-            std::env::set_var("HOME", h);
-        } else {
-            std::env::remove_var("HOME");
+    impl BaseDir {
+        /// Create a fresh TempDir, point SYNAPS_BASE_DIR at it, write the
+        /// given initial config content into `<tmpdir>/config`, and return the
+        /// guard.  The directory is removed automatically when the guard drops.
+        fn new(initial_config: &str) -> Self {
+            let dir = tempfile::TempDir::new().expect("tempdir");
+            let old = std::env::var("SYNAPS_BASE_DIR").ok();
+            synaps_cli::config::set_base_dir_for_tests(dir.path().to_path_buf());
+            std::fs::write(dir.path().join("config"), initial_config)
+                .expect("write test config");
+            Self { _dir: dir, old }
+        }
+
+        /// Path to the config file that base_dir() resolves to.
+        fn config_path(&self) -> std::path::PathBuf {
+            self._dir.path().join("config")
+        }
+    }
+
+    impl Drop for BaseDir {
+        fn drop(&mut self) {
+            match &self.old {
+                Some(v) => std::env::set_var("SYNAPS_BASE_DIR", v),
+                None    => std::env::remove_var("SYNAPS_BASE_DIR"),
+            }
         }
     }
 
@@ -2364,113 +2392,102 @@ mod migration_tests {
     }
 
     #[test]
-    #[serial]
     fn migrate_copies_legacy_into_namespaced_key() {
-        let home = make_test_home("copy-into-namespaced");
-        let cfg = home.join(".synaps-cli/config");
-        std::fs::write(&cfg, "sidecar_toggle_key = F2\n").unwrap();
-        with_home(&home, || {
-            migrate_sidecar_toggle_key_to_claimed_plugins(&[claim(
-                "sample-sidecar",
-                "capture",
-                Some("capture"),
-            )]);
-            let v = synaps_cli::config::read_config_value(
-                "plugins.sample-sidecar.capture._lifecycle_toggle_key",
-            );
-            assert_eq!(v.as_deref(), Some("F2"));
-        });
+        let _lock = crate::tui::CONFIG_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _base = BaseDir::new("sidecar_toggle_key = F2\n");
+
+        migrate_sidecar_toggle_key_to_claimed_plugins(&[claim(
+            "sample-sidecar",
+            "capture",
+            Some("capture"),
+        )]);
+        let v = synaps_cli::config::read_config_value(
+            "plugins.sample-sidecar.capture._lifecycle_toggle_key",
+        );
+        assert_eq!(v.as_deref(), Some("F2"));
     }
 
     #[test]
-    #[serial]
     fn migrate_skips_when_new_key_already_set() {
-        let home = make_test_home("skip-existing");
-        let cfg = home.join(".synaps-cli/config");
-        std::fs::write(
-            &cfg,
+        let _lock = crate::tui::CONFIG_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _base = BaseDir::new(
             "sidecar_toggle_key = F2\nplugins.sample-sidecar.capture._lifecycle_toggle_key = F12\n",
-        )
-        .unwrap();
-        with_home(&home, || {
-            migrate_sidecar_toggle_key_to_claimed_plugins(&[claim(
-                "sample-sidecar",
-                "capture",
-                Some("capture"),
-            )]);
-            let v = synaps_cli::config::read_config_value(
-                "plugins.sample-sidecar.capture._lifecycle_toggle_key",
-            );
-            assert_eq!(
-                v.as_deref(),
-                Some("F12"),
-                "must not overwrite a user-set value"
-            );
-        });
+        );
+
+        migrate_sidecar_toggle_key_to_claimed_plugins(&[claim(
+            "sample-sidecar",
+            "capture",
+            Some("capture"),
+        )]);
+        let v = synaps_cli::config::read_config_value(
+            "plugins.sample-sidecar.capture._lifecycle_toggle_key",
+        );
+        assert_eq!(v.as_deref(), Some("F12"), "must not overwrite a user-set value");
     }
 
     #[test]
-    #[serial]
     fn migrate_is_noop_when_legacy_unset() {
-        let home = make_test_home("noop-no-legacy");
-        let cfg = home.join(".synaps-cli/config");
-        std::fs::write(&cfg, "model = claude-sonnet-4-6\n").unwrap();
-        with_home(&home, || {
-            migrate_sidecar_toggle_key_to_claimed_plugins(&[claim(
-                "sample-sidecar",
-                "capture",
-                Some("capture"),
-            )]);
-            assert!(synaps_cli::config::read_config_value(
+        let _lock = crate::tui::CONFIG_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _base = BaseDir::new("model = claude-sonnet-4-6\n");
+
+        migrate_sidecar_toggle_key_to_claimed_plugins(&[claim(
+            "sample-sidecar",
+            "capture",
+            Some("capture"),
+        )]);
+        assert!(synaps_cli::config::read_config_value(
+            "plugins.sample-sidecar.capture._lifecycle_toggle_key"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn migrate_skips_claim_without_settings_category() {
+        let _lock = crate::tui::CONFIG_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let base = BaseDir::new("sidecar_toggle_key = F8\n");
+
+        migrate_sidecar_toggle_key_to_claimed_plugins(&[claim("p", "ocr", None)]);
+        // No namespaced key written for a claim with no category.
+        let contents = std::fs::read_to_string(base.config_path()).unwrap();
+        assert!(
+            !contents.contains("_lifecycle_toggle_key"),
+            "no namespaced key should be written when settings_category is None: {contents}"
+        );
+    }
+
+    #[test]
+    fn migrate_handles_multiple_claims_in_one_pass() {
+        let _lock = crate::tui::CONFIG_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _base = BaseDir::new("sidecar_toggle_key = C-V\n");
+
+        migrate_sidecar_toggle_key_to_claimed_plugins(&[
+            claim("sample-sidecar", "capture", Some("capture")),
+            claim("ocr-plugin", "ocr", Some("ocr")),
+        ]);
+        assert_eq!(
+            synaps_cli::config::read_config_value(
                 "plugins.sample-sidecar.capture._lifecycle_toggle_key"
             )
-            .is_none());
-        });
-    }
-
-    #[test]
-    #[serial]
-    fn migrate_skips_claim_without_settings_category() {
-        let home = make_test_home("skip-no-category");
-        let cfg = home.join(".synaps-cli/config");
-        std::fs::write(&cfg, "sidecar_toggle_key = F8\n").unwrap();
-        with_home(&home, || {
-            migrate_sidecar_toggle_key_to_claimed_plugins(&[claim("p", "ocr", None)]);
-            // No namespaced key written for a claim with no category.
-            let contents = std::fs::read_to_string(&cfg).unwrap();
-            assert!(
-                !contents.contains("_lifecycle_toggle_key"),
-                "no namespaced key should be written when settings_category is None: {contents}"
-            );
-        });
-    }
-
-    #[test]
-    #[serial]
-    fn migrate_handles_multiple_claims_in_one_pass() {
-        let home = make_test_home("multi-claim");
-        let cfg = home.join(".synaps-cli/config");
-        std::fs::write(&cfg, "sidecar_toggle_key = C-V\n").unwrap();
-        with_home(&home, || {
-            migrate_sidecar_toggle_key_to_claimed_plugins(&[
-                claim("sample-sidecar", "capture", Some("capture")),
-                claim("ocr-plugin", "ocr", Some("ocr")),
-            ]);
-            assert_eq!(
-                synaps_cli::config::read_config_value(
-                    "plugins.sample-sidecar.capture._lifecycle_toggle_key"
-                )
-                .as_deref(),
-                Some("C-V")
-            );
-            assert_eq!(
-                synaps_cli::config::read_config_value(
-                    "plugins.ocr-plugin.ocr._lifecycle_toggle_key"
-                )
-                .as_deref(),
-                Some("C-V")
-            );
-        });
+            .as_deref(),
+            Some("C-V")
+        );
+        assert_eq!(
+            synaps_cli::config::read_config_value(
+                "plugins.ocr-plugin.ocr._lifecycle_toggle_key"
+            )
+            .as_deref(),
+            Some("C-V")
+        );
     }
 }
 

--- a/crates/agent-tui/src/tui/plugins/actions.rs
+++ b/crates/agent-tui/src/tui/plugins/actions.rs
@@ -1271,7 +1271,11 @@ mod tests {
         PluginIndexCapabilities, PluginIndexChecksum, PluginIndexCompatibility, PluginIndexEntry,
     };
 
-    static BASE_DIR_TEST_LOCK: Mutex<()> = Mutex::new(());
+    // All config-env tests in agent-tui must share ONE lock so that the
+    // migration_tests (tui/mod.rs) and these async tests can never interleave.
+    // Re-export the crate-wide lock under the name already used below so no
+    // call sites need to change.
+    use crate::tui::CONFIG_ENV_TEST_LOCK as BASE_DIR_TEST_LOCK;
 
     struct EnvGuard {
         old_base_dir: Option<String>,

--- a/crates/agent-tui/src/tui/render_thread.rs
+++ b/crates/agent-tui/src/tui/render_thread.rs
@@ -54,7 +54,7 @@ use std::time::Instant;
 
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
-use tachyonfx::{Effect, Shader};
+use tachyonfx::Effect;
 
 use super::draw::render_frame;
 use super::lifecycle;

--- a/crates/agent-tui/src/tui/viewport.rs
+++ b/crates/agent-tui/src/tui/viewport.rs
@@ -69,7 +69,7 @@ pub(crate) fn edge_scrub_area(size: Rect, protected_bottom_rows: u16) -> Option<
 #[allow(dead_code)]
 pub(crate) fn scrub_terminal_edges<B>(terminal: &mut Terminal<B>, style: Style) -> io::Result<()>
 where
-    B: Backend,
+    B: Backend<Error = io::Error>,
 {
     let size = terminal.size()?;
     let area = Rect::new(0, 0, size.width, size.height);

--- a/deploy/synaps-auth-broker.service
+++ b/deploy/synaps-auth-broker.service
@@ -1,0 +1,26 @@
+# synaps auth-broker — credential broker (see README "Shared credentials via a broker")
+# Install: cp deploy/synaps-auth-broker.service /etc/systemd/system/
+#          put the machine token in /etc/synaps/broker.token (chmod 600)
+#          systemctl enable --now synaps-auth-broker
+[Unit]
+Description=synaps credential broker
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=synaps
+# auth.json lives under this user's ~/.synaps-cli/
+ExecStart=/usr/local/bin/synaps auth-broker --bind 0.0.0.0:8181 --machine-token-file /etc/synaps/broker.token
+Restart=always
+RestartSec=5
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=true
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/src/cmd/auth_broker.rs
+++ b/src/cmd/auth_broker.rs
@@ -185,8 +185,15 @@ async fn token(
 
     match creds {
         Ok(c) => {
+            // C3: send a relative TTL so clients compute expiry on their own
+            // clock (kills broker↔client skew on suspend/resume VMs).
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+            let ttl_ms = c.expires.saturating_sub(now);
             eprintln!("[auth-broker] issued {provider} token to {} (expires {})", peer.ip(), c.expires);
-            (StatusCode::OK, Json(json!({ "access_token": c.access, "expires": c.expires })))
+            (StatusCode::OK, Json(json!({ "access_token": c.access, "expires": c.expires, "ttl_ms": ttl_ms })))
                 .into_response()
         }
         Err(e) => {

--- a/src/cmd/auth_broker.rs
+++ b/src/cmd/auth_broker.rs
@@ -17,7 +17,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use axum::{
-    extract::{Query, State},
+    extract::{ConnectInfo, Query, State},
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::get,
@@ -53,7 +53,24 @@ pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<
         .timeout(Duration::from_secs(60))
         .build()?;
 
-    let state = BrokerState { machine_token: machine_token.clone(), client };
+    let state = BrokerState { machine_token: machine_token.clone(), client: client.clone() };
+
+    // Proactive refresh: keep the credential warm so clients always get a
+    // fresh token instantly, and so the single refresher runs even when no
+    // client is calling. ensure_fresh_token only hits the network when the
+    // token is within its expiry margin (file-locked — still the only refresher).
+    {
+        let refresh_client = client;
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                tick.tick().await;
+                if let Err(e) = auth::ensure_fresh_token(&refresh_client).await {
+                    eprintln!("[auth-broker] proactive refresh failed: {e}");
+                }
+            }
+        });
+    }
 
     let app = Router::new()
         .route("/healthz", get(healthz))
@@ -68,8 +85,11 @@ pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<
         "synaps auth-broker listening on http://{addr}  (machine auth: {})",
         if machine_token.is_some() { "ON" } else { "OFF — trusted-network only!" }
     );
+    if !addr.ip().is_loopback() {
+        eprintln!("  ⚠ bound to a non-loopback address — run this behind WireGuard / a private network (no TLS termination here).");
+    }
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
     Ok(())
 }
 
@@ -86,6 +106,7 @@ async fn healthz() -> impl IntoResponse {
 /// The broker refreshes centrally if needed (file-locked — the single refresher).
 async fn token(
     State(st): State<BrokerState>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Query(q): Query<TokenQuery>,
 ) -> impl IntoResponse {
@@ -96,6 +117,7 @@ async fn token(
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
         if got != format!("Bearer {expected}") {
+            eprintln!("[auth-broker] DENIED token request from {} (bad machine auth)", peer.ip());
             return (StatusCode::UNAUTHORIZED, Json(json!({ "error": "bad machine auth" })))
                 .into_response();
         }
@@ -110,12 +132,12 @@ async fn token(
 
     match creds {
         Ok(c) => {
-            eprintln!("[auth-broker] issued {} token (expires {})", provider, c.expires);
+            eprintln!("[auth-broker] issued {} token to {} (expires {})", provider, peer.ip(), c.expires);
             (StatusCode::OK, Json(json!({ "access_token": c.access, "expires": c.expires })))
                 .into_response()
         }
         Err(e) => {
-            eprintln!("[auth-broker] refresh failed for {}: {}", provider, e);
+            eprintln!("[auth-broker] refresh failed for {} ({}): {}", provider, peer.ip(), e);
             (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e }))).into_response()
         }
     }

--- a/src/cmd/auth_broker.rs
+++ b/src/cmd/auth_broker.rs
@@ -10,8 +10,8 @@
 //! behind WireGuard / a private network — `--machine-token` gates who may fetch.
 //!
 //! Endpoints:
-//!   GET /healthz            -> { status, fresh_until }   (no secret)
-//!   GET /token?provider=X   -> { access_token, expires }  (machine-auth required)
+//!   GET /healthz            -> { status }                 (no secret, non-200 if cred missing)
+//!   GET /token?provider=X   -> { access_token, expires }  (machine-auth required, allowlisted)
 
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -27,10 +27,15 @@ use serde::Deserialize;
 use serde_json::json;
 use synaps_cli::auth;
 
+/// Providers the broker will vend. Anything else is rejected before any work or
+/// logging — prevents probing for configured providers and log injection via an
+/// arbitrary provider string. (#158 B4)
+const ALLOWED_PROVIDERS: &[&str] = &["anthropic", "openai-codex"];
+
 #[derive(Clone)]
 struct BrokerState {
     /// Token clients must present as `Authorization: Bearer <token>`. `None`
-    /// disables auth (only safe on a fully trusted/private network).
+    /// disables auth (only safe on loopback or with explicit `--insecure-no-auth`).
     machine_token: Option<String>,
     /// HTTP client used for the (central, single) token refresh to the provider.
     client: reqwest::Client,
@@ -41,10 +46,50 @@ struct TokenQuery {
     provider: Option<String>,
 }
 
-pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<()> {
+/// Constant-time byte comparison — avoids a timing oracle on the machine token.
+/// (#158 B1 / CWE-208.) Length mismatch short-circuits; token length is not the
+/// secret. Equal-length inputs are compared in constant time.
+fn ct_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) -> anyhow::Result<()> {
     let machine_token = machine_token
         .or_else(|| std::env::var("SYNAPS_BROKER_TOKEN").ok())
         .filter(|s| !s.trim().is_empty());
+
+    let addr: SocketAddr = bind
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid --bind '{}': {}", bind, e))?;
+
+    // B2: refuse to start unauthenticated on a non-loopback bind unless the
+    // operator explicitly opts in. A silent auth-OFF on the LAN is an open
+    // credential tap, not a convenience.
+    if machine_token.is_none() && !addr.ip().is_loopback() && !insecure {
+        anyhow::bail!(
+            "refusing to start: no machine token (set --machine-token or SYNAPS_BROKER_TOKEN) while \
+             bound to non-loopback {addr}. That would serve credentials unauthenticated to the network. \
+             Pass --insecure-no-auth to override (NOT recommended), or bind 127.0.0.1."
+        );
+    }
+
+    // D1: fail fast if the credential isn't present/readable, rather than
+    // starting a broker that 500s every request.
+    match auth::load_auth() {
+        Ok(Some(_)) => {}
+        Ok(None) => anyhow::bail!(
+            "no credential at {}. Run `synaps login` on the broker host first.",
+            auth::auth_file_path().display()
+        ),
+        Err(e) => anyhow::bail!("credential unreadable/corrupt: {e}"),
+    }
 
     let client = reqwest::Client::builder()
         .tls_built_in_webpki_certs(true)
@@ -55,10 +100,10 @@ pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<
 
     let state = BrokerState { machine_token: machine_token.clone(), client: client.clone() };
 
-    // Proactive refresh: keep the credential warm so clients always get a
-    // fresh token instantly, and so the single refresher runs even when no
-    // client is calling. ensure_fresh_token only hits the network when the
-    // token is within its expiry margin (file-locked — still the only refresher).
+    // Proactive refresh: keep the credential warm so clients always get a fresh
+    // token instantly, and so the single refresher runs even with no traffic.
+    // ensure_fresh_token only hits the network within the expiry margin
+    // (file-locked — still the only refresher).
     {
         let refresh_client = client;
         tokio::spawn(async move {
@@ -77,32 +122,30 @@ pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<
         .route("/token", get(token))
         .with_state(state);
 
-    let addr: SocketAddr = bind
-        .parse()
-        .map_err(|e| anyhow::anyhow!("invalid --bind '{}': {}", bind, e))?;
-
     eprintln!(
         "synaps auth-broker listening on http://{addr}  (machine auth: {})",
-        if machine_token.is_some() { "ON" } else { "OFF — trusted-network only!" }
+        if machine_token.is_some() { "ON" } else { "OFF — loopback/insecure only!" }
     );
     if !addr.ip().is_loopback() {
-        eprintln!("  ⚠ bound to a non-loopback address — run this behind WireGuard / a private network (no TLS termination here).");
+        eprintln!("  ⚠ non-loopback bind — run behind WireGuard / a private network (no in-process TLS yet).");
     }
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
     Ok(())
 }
 
-/// Liveness + credential freshness, without leaking any secret.
+/// Liveness + credential readiness. Returns non-200 when the credential is
+/// missing/corrupt so monitors actually catch it. No secret, no expiry leak.
+/// (#158 B8 / M1.)
 async fn healthz() -> impl IntoResponse {
-    let fresh_until = match auth::load_auth() {
-        Ok(Some(f)) => Some(f.anthropic.expires),
-        _ => None,
-    };
-    (StatusCode::OK, Json(json!({ "status": "ok", "fresh_until": fresh_until })))
+    match auth::load_auth() {
+        Ok(Some(_)) => (StatusCode::OK, Json(json!({ "status": "ok" }))),
+        Ok(None) => (StatusCode::SERVICE_UNAVAILABLE, Json(json!({ "status": "no_credential" }))),
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "status": "error" }))),
+    }
 }
 
-/// Issue a current access token for `provider` (default: anthropic).
+/// Issue a current access token for `provider` (default: anthropic, allowlisted).
 /// The broker refreshes centrally if needed (file-locked — the single refresher).
 async fn token(
     State(st): State<BrokerState>,
@@ -110,20 +153,30 @@ async fn token(
     headers: HeaderMap,
     Query(q): Query<TokenQuery>,
 ) -> impl IntoResponse {
-    // ── machine auth ──
+    // ── machine auth (constant-time) ──
     if let Some(ref expected) = st.machine_token {
         let got = headers
             .get("authorization")
             .and_then(|v| v.to_str().ok())
             .unwrap_or("");
-        if got != format!("Bearer {expected}") {
-            eprintln!("[auth-broker] DENIED token request from {} (bad machine auth)", peer.ip());
+        let expected_header = format!("Bearer {expected}");
+        if !ct_eq(got.as_bytes(), expected_header.as_bytes()) {
+            eprintln!("[auth-broker] DENIED from {} (bad machine auth)", peer.ip());
             return (StatusCode::UNAUTHORIZED, Json(json!({ "error": "bad machine auth" })))
                 .into_response();
         }
     }
 
+    // ── provider allowlist (before any work, refresh, or logging of the value) ──
     let provider = q.provider.unwrap_or_else(|| "anthropic".to_string());
+    if !ALLOWED_PROVIDERS.contains(&provider.as_str()) {
+        // Never log the raw (attacker-controlled) provider — only its length,
+        // so a `?provider=...%0A...` can't forge audit lines. (#158 B4 / CWE-117)
+        eprintln!("[auth-broker] DENIED from {} (provider not allowed, {} chars)", peer.ip(), provider.len());
+        return (StatusCode::BAD_REQUEST, Json(json!({ "error": "unknown provider" }))).into_response();
+    }
+
+    // `provider` is now a known-safe allowlisted value — safe to log verbatim.
     let creds = if provider == "anthropic" {
         auth::ensure_fresh_token(&st.client).await
     } else {
@@ -132,13 +185,31 @@ async fn token(
 
     match creds {
         Ok(c) => {
-            eprintln!("[auth-broker] issued {} token to {} (expires {})", provider, peer.ip(), c.expires);
+            eprintln!("[auth-broker] issued {provider} token to {} (expires {})", peer.ip(), c.expires);
             (StatusCode::OK, Json(json!({ "access_token": c.access, "expires": c.expires })))
                 .into_response()
         }
         Err(e) => {
-            eprintln!("[auth-broker] refresh failed for {} ({}): {}", provider, peer.ip(), e);
-            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e }))).into_response()
+            // B5: log the detail server-side; return a generic message — the
+            // error can contain fs paths or raw provider responses. (CWE-209)
+            eprintln!("[auth-broker] refresh failed for {provider} from {}: {}", peer.ip(), e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": "token refresh failed" })))
+                .into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ct_eq;
+
+    #[test]
+    fn ct_eq_matches_only_identical() {
+        assert!(ct_eq(b"Bearer secret", b"Bearer secret"));
+        assert!(!ct_eq(b"Bearer secret", b"Bearer secreT"));
+        assert!(!ct_eq(b"Bearer secret", b"Bearer wrong"));
+        assert!(!ct_eq(b"short", b"longer-value"));
+        assert!(!ct_eq(b"", b"x"));
+        assert!(ct_eq(b"", b""));
     }
 }

--- a/src/cmd/auth_broker.rs
+++ b/src/cmd/auth_broker.rs
@@ -60,10 +60,26 @@ fn ct_eq(a: &[u8], b: &[u8]) -> bool {
     diff == 0
 }
 
-pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) -> anyhow::Result<()> {
-    let machine_token = machine_token
-        .or_else(|| std::env::var("SYNAPS_BROKER_TOKEN").ok())
-        .filter(|s| !s.trim().is_empty());
+pub async fn run(
+    bind: String,
+    machine_token: Option<String>,
+    machine_token_file: Option<std::path::PathBuf>,
+    insecure: bool,
+) -> anyhow::Result<()> {
+    // B3: token precedence — flag > file (read once, not in argv) > env.
+    let machine_token = match machine_token {
+        Some(t) => Some(t),
+        None => match machine_token_file {
+            Some(ref path) => Some(
+                std::fs::read_to_string(path)
+                    .map_err(|e| anyhow::anyhow!("could not read --machine-token-file {}: {e}", path.display()))?
+                    .trim()
+                    .to_string(),
+            ),
+            None => std::env::var("SYNAPS_BROKER_TOKEN").ok(),
+        },
+    }
+    .filter(|s| !s.trim().is_empty());
 
     let addr: SocketAddr = bind
         .parse()
@@ -74,9 +90,9 @@ pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) ->
     // credential tap, not a convenience.
     if machine_token.is_none() && !addr.ip().is_loopback() && !insecure {
         anyhow::bail!(
-            "refusing to start: no machine token (set --machine-token or SYNAPS_BROKER_TOKEN) while \
-             bound to non-loopback {addr}. That would serve credentials unauthenticated to the network. \
-             Pass --insecure-no-auth to override (NOT recommended), or bind 127.0.0.1."
+            "refusing to start: no machine token (set --machine-token / --machine-token-file / \
+             SYNAPS_BROKER_TOKEN) while bound to non-loopback {addr}. That would serve credentials \
+             unauthenticated to the network. Pass --insecure-no-auth to override, or bind 127.0.0.1."
         );
     }
 
@@ -100,13 +116,11 @@ pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) ->
 
     let state = BrokerState { machine_token: machine_token.clone(), client: client.clone() };
 
-    // Proactive refresh: keep the credential warm so clients always get a fresh
-    // token instantly, and so the single refresher runs even with no traffic.
-    // ensure_fresh_token only hits the network within the expiry margin
-    // (file-locked — still the only refresher).
+    // Proactive refresh, SUPERVISED: keep the credential warm and surface task
+    // death loudly (a silently-dead refresher = unmonitored credential expiry).
     {
         let refresh_client = client;
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let mut tick = tokio::time::interval(Duration::from_secs(60));
             loop {
                 tick.tick().await;
@@ -115,11 +129,21 @@ pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) ->
                 }
             }
         });
+        // D1: if the refresh task ever exits/panics, log loudly (it should run forever).
+        tokio::spawn(async move {
+            if let Err(e) = handle.await {
+                eprintln!("[auth-broker] FATAL: proactive refresh task died: {e:?} — tokens will go stale; restart the broker.");
+            }
+        });
     }
 
     let app = Router::new()
         .route("/healthz", get(healthz))
         .route("/token", get(token))
+        // B7: cap concurrent in-flight requests to bound resource use under a
+        // flooding/crash-looping client (each /token can take a file lock + an
+        // upstream refresh).
+        .layer(tower::limit::ConcurrencyLimitLayer::new(64))
         .with_state(state);
 
     eprintln!(
@@ -130,8 +154,34 @@ pub async fn run(bind: String, machine_token: Option<String>, insecure: bool) ->
         eprintln!("  ⚠ non-loopback bind — run behind WireGuard / a private network (no in-process TLS yet).");
     }
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
+    // D1: drain in-flight requests on SIGTERM/Ctrl-C instead of dropping them.
+    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
     Ok(())
+}
+
+/// Resolve on Ctrl-C or SIGTERM so the broker drains cleanly.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(_) => std::future::pending::<()>().await,
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+    tokio::select! {
+        _ = ctrl_c => {}
+        _ = terminate => {}
+    }
+    eprintln!("[auth-broker] shutting down (draining in-flight requests)…");
 }
 
 /// Liveness + credential readiness. Returns non-200 when the credential is

--- a/src/cmd/auth_broker.rs
+++ b/src/cmd/auth_broker.rs
@@ -1,0 +1,122 @@
+//! `synaps auth-broker` — credential broker (epic #155, task #156).
+//!
+//! Holds ONE OAuth credential (this machine's `auth.json`), is the SINGLE
+//! refresher (Anthropic rotates the refresh token on every refresh, so exactly
+//! one party may refresh), and serves short-lived **access** tokens to authorized
+//! client machines over HTTP.
+//!
+//! Clients run `synaps` with `auth.remote_endpoint` pointed here; they fetch a
+//! token per request and never store the credential on their own disk. Run this
+//! behind WireGuard / a private network — `--machine-token` gates who may fetch.
+//!
+//! Endpoints:
+//!   GET /healthz            -> { status, fresh_until }   (no secret)
+//!   GET /token?provider=X   -> { access_token, expires }  (machine-auth required)
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use axum::{
+    extract::{Query, State},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use serde::Deserialize;
+use serde_json::json;
+use synaps_cli::auth;
+
+#[derive(Clone)]
+struct BrokerState {
+    /// Token clients must present as `Authorization: Bearer <token>`. `None`
+    /// disables auth (only safe on a fully trusted/private network).
+    machine_token: Option<String>,
+    /// HTTP client used for the (central, single) token refresh to the provider.
+    client: reqwest::Client,
+}
+
+#[derive(Deserialize)]
+struct TokenQuery {
+    provider: Option<String>,
+}
+
+pub async fn run(bind: String, machine_token: Option<String>) -> anyhow::Result<()> {
+    let machine_token = machine_token
+        .or_else(|| std::env::var("SYNAPS_BROKER_TOKEN").ok())
+        .filter(|s| !s.trim().is_empty());
+
+    let client = reqwest::Client::builder()
+        .tls_built_in_webpki_certs(true)
+        .tls_built_in_native_certs(true)
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(60))
+        .build()?;
+
+    let state = BrokerState { machine_token: machine_token.clone(), client };
+
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/token", get(token))
+        .with_state(state);
+
+    let addr: SocketAddr = bind
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid --bind '{}': {}", bind, e))?;
+
+    eprintln!(
+        "synaps auth-broker listening on http://{addr}  (machine auth: {})",
+        if machine_token.is_some() { "ON" } else { "OFF — trusted-network only!" }
+    );
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// Liveness + credential freshness, without leaking any secret.
+async fn healthz() -> impl IntoResponse {
+    let fresh_until = match auth::load_auth() {
+        Ok(Some(f)) => Some(f.anthropic.expires),
+        _ => None,
+    };
+    (StatusCode::OK, Json(json!({ "status": "ok", "fresh_until": fresh_until })))
+}
+
+/// Issue a current access token for `provider` (default: anthropic).
+/// The broker refreshes centrally if needed (file-locked — the single refresher).
+async fn token(
+    State(st): State<BrokerState>,
+    headers: HeaderMap,
+    Query(q): Query<TokenQuery>,
+) -> impl IntoResponse {
+    // ── machine auth ──
+    if let Some(ref expected) = st.machine_token {
+        let got = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        if got != format!("Bearer {expected}") {
+            return (StatusCode::UNAUTHORIZED, Json(json!({ "error": "bad machine auth" })))
+                .into_response();
+        }
+    }
+
+    let provider = q.provider.unwrap_or_else(|| "anthropic".to_string());
+    let creds = if provider == "anthropic" {
+        auth::ensure_fresh_token(&st.client).await
+    } else {
+        auth::ensure_fresh_provider_token(&st.client, &provider).await
+    };
+
+    match creds {
+        Ok(c) => {
+            eprintln!("[auth-broker] issued {} token (expires {})", provider, c.expires);
+            (StatusCode::OK, Json(json!({ "access_token": c.access, "expires": c.expires })))
+                .into_response()
+        }
+        Err(e) => {
+            eprintln!("[auth-broker] refresh failed for {}: {}", provider, e);
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e }))).into_response()
+        }
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod agent;
+pub(crate) mod auth_broker;
 pub(crate) mod chat;
 pub(crate) mod login;
 pub(crate) mod rpc;

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -1,15 +1,20 @@
 //! `synaps status` — show account usage and reset times.
 
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    // Refresh-if-needed via the shared auth machinery (honors profiles,
-    // fs4 file locking, and persists the rotated token). Previously this
-    // read auth.json raw from the base dir — expired tokens produced a
-    // useless HTTP 401 even though the user was logged in.
+    // Resolve the access token honoring the credential source: Local refreshes
+    // auth.json (fs4-locked, persisted) exactly as before; Remote fetches from
+    // the broker WITHOUT rotating the refresh token client-side — a stray
+    // `synaps status` on a Remote client must never rotate the broker's token
+    // out from under the fleet. (#158 A4)
     let client = reqwest::Client::new();
-    let creds = synaps_cli::auth::ensure_fresh_token(&client)
+    let config = synaps_cli::config::load_config();
+    let source = config.auth.credential_source();
+    let cache = synaps_cli::auth::TokenCache::new();
+    let access = synaps_cli::auth::resolve_access_token("anthropic", &source, &cache, &client)
         .await
-        .map_err(|e| format!("Not logged in ({}). Run `synaps login` first.", e))?;
-    let access = creds.access;
+        .map_err(|e| format!(
+            "Could not get a token ({}). Run `synaps login`, or check auth.remote_endpoint / broker reachability.", e
+        ))?;
 
     let resp = client.get("https://api.anthropic.com/api/oauth/usage")
         .header("Authorization", format!("Bearer {}", access))

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,9 +123,12 @@ enum Command {
         #[arg(long, default_value = "127.0.0.1:8181")]
         bind: String,
         /// Token clients must present (`Authorization: Bearer <token>`). Falls
-        /// back to `SYNAPS_BROKER_TOKEN`; if unset, auth is OFF (loopback only).
+        /// back to `--machine-token-file`, then `SYNAPS_BROKER_TOKEN`.
         #[arg(long)]
         machine_token: Option<String>,
+        /// Read the machine token from a file (avoids exposing it in argv/`ps`).
+        #[arg(long)]
+        machine_token_file: Option<std::path::PathBuf>,
         /// Allow starting with auth OFF on a non-loopback bind (serves
         /// credentials unauthenticated to the network — NOT recommended).
         #[arg(long)]
@@ -215,8 +218,8 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Status) => {
             cmd::status::run().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
         }
-        Some(Command::AuthBroker { bind, machine_token, insecure_no_auth }) => {
-            cmd::auth_broker::run(bind, machine_token, insecure_no_auth).await?;
+        Some(Command::AuthBroker { bind, machine_token, machine_token_file, insecure_no_auth }) => {
+            cmd::auth_broker::run(bind, machine_token, machine_token_file, insecure_no_auth).await?;
         }
         Some(Command::Completions { shell }) => {
             use clap::CommandFactory;

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,9 +123,13 @@ enum Command {
         #[arg(long, default_value = "127.0.0.1:8181")]
         bind: String,
         /// Token clients must present (`Authorization: Bearer <token>`). Falls
-        /// back to `SYNAPS_BROKER_TOKEN`; if unset, auth is OFF (trusted net only).
+        /// back to `SYNAPS_BROKER_TOKEN`; if unset, auth is OFF (loopback only).
         #[arg(long)]
         machine_token: Option<String>,
+        /// Allow starting with auth OFF on a non-loopback bind (serves
+        /// credentials unauthenticated to the network — NOT recommended).
+        #[arg(long)]
+        insecure_no_auth: bool,
     },
     /// Headless line-JSON RPC server on stdin/stdout (synaps-bridge IPC)
     Rpc {
@@ -211,8 +215,8 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Status) => {
             cmd::status::run().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
         }
-        Some(Command::AuthBroker { bind, machine_token }) => {
-            cmd::auth_broker::run(bind, machine_token).await?;
+        Some(Command::AuthBroker { bind, machine_token, insecure_no_auth }) => {
+            cmd::auth_broker::run(bind, machine_token, insecure_no_auth).await?;
         }
         Some(Command::Completions { shell }) => {
             use clap::CommandFactory;

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,17 @@ enum Command {
     },
     /// Show account usage and reset times
     Status,
+    /// Credential broker — serve short-lived access tokens to client machines
+    /// over HTTP so they can share one OAuth credential without storing it.
+    AuthBroker {
+        /// Address to bind, e.g. `0.0.0.0:8181` or `127.0.0.1:8181`.
+        #[arg(long, default_value = "127.0.0.1:8181")]
+        bind: String,
+        /// Token clients must present (`Authorization: Bearer <token>`). Falls
+        /// back to `SYNAPS_BROKER_TOKEN`; if unset, auth is OFF (trusted net only).
+        #[arg(long)]
+        machine_token: Option<String>,
+    },
     /// Headless line-JSON RPC server on stdin/stdout (synaps-bridge IPC)
     Rpc {
         /// Resume an existing session by ID, name, or prefix.
@@ -199,6 +210,9 @@ async fn main() -> anyhow::Result<()> {
         },
         Some(Command::Status) => {
             cmd::status::run().await.map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        }
+        Some(Command::AuthBroker { bind, machine_token }) => {
+            cmd::auth_broker::run(bind, machine_token).await?;
         }
         Some(Command::Completions { shell }) => {
             use clap::CommandFactory;

--- a/tests/extension_provider_stream_route.rs
+++ b/tests/extension_provider_stream_route.rs
@@ -51,6 +51,8 @@ async fn try_route_streams_text_deltas_when_provider_supports_streaming() {
         None,
         0,
         &tokio_util::sync::CancellationToken::new(),
+        &synaps_cli::auth::CredentialSource::Local,
+        &synaps_cli::auth::TokenCache::new(),
     )
     .await
     .expect("extension route")

--- a/tests/extensions_e2e.rs
+++ b/tests/extensions_e2e.rs
@@ -618,6 +618,8 @@ async fn extension_provider_complete_routes_to_process() {
         None,
         0,
         &tokio_util::sync::CancellationToken::new(),
+        &synaps_cli::auth::CredentialSource::Local,
+        &synaps_cli::auth::TokenCache::new(),
     ).await.expect("extension route").unwrap();
 
     assert_eq!(result["content"][0]["text"], "echo:hello");
@@ -694,6 +696,8 @@ async fn provider_disabled_in_trust_state_blocks_route() {
         None,
         0,
         &tokio_util::sync::CancellationToken::new(),
+        &synaps_cli::auth::CredentialSource::Local,
+        &synaps_cli::auth::TokenCache::new(),
     )
     .await
     .expect("route returned Some");
@@ -758,6 +762,8 @@ async fn extension_provider_tool_use_is_executed_by_router_before_final_response
         None,
         0,
         &tokio_util::sync::CancellationToken::new(),
+        &synaps_cli::auth::CredentialSource::Local,
+        &synaps_cli::auth::TokenCache::new(),
     ).await.expect("extension route").unwrap();
 
     assert_eq!(result["content"][0]["text"], "final:from-provider");
@@ -1140,6 +1146,8 @@ async fn audit_log_records_disabled_route() {
         None,
         0,
         &tokio_util::sync::CancellationToken::new(),
+        &synaps_cli::auth::CredentialSource::Local,
+        &synaps_cli::auth::TokenCache::new(),
     )
     .await
     .expect("route returned Some");


### PR DESCRIPTION
Cuts **v0.4.0**.

**Headline:** the credential broker / Remote credential source epic (#155) — share one OAuth credential across machines; tokens via a broker, clients never hold a refresh token.

**Also:** #137 synaps-tui flaky test isolation fixed (unified config-env test lock; verified green across repeated parallel runs).

Version bumped 0.3.10 → 0.4.0 (root + 3 crates + inter-crate pins), Cargo.lock + CHANGELOG updated. Build ✅ clippy ✅ tests ✅ (3× parallel green). Tag v0.4.0 after merge triggers cargo-dist publish.