### PR TITLE
feat: after_tool_call → Replace primitive (native tool-output transforms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Agents aren't anonymous forks. They're crew members with names, system prompts, 
 
 **📡 Event bus.** Push events into a running session from any script, cron, or service. The agent reacts in real time.
 
-**🔌 Extensions.** JSON-RPC 2.0 over stdio. Hook into `before_tool_call`, `after_tool_call`, `before_message`, `on_message_complete`, `on_compaction`, `on_session_start`, `on_session_end`. Build guardrails, inject context, modify tool calls.
+**🔌 Extensions.** JSON-RPC 2.0 over stdio. Hook into `before_tool_call`, `after_tool_call`, `before_message`, `on_message_complete`, `on_compaction`, `on_session_start`, `on_session_end`. Build guardrails, inject context, modify tool calls, and transform tool output (compression, redaction, summarization).
 
 **🧠 Context that lasts.** 90%+ prompt cache hit rate. `/compact` replaces history with a structured checkpoint. Chain sessions across days.
 

--- a/crates/agent-engine/src/extensions/audit.rs
+++ b/crates/agent-engine/src/extensions/audit.rs
@@ -108,6 +108,95 @@ pub(crate) fn append_audit_entry_to(
     Ok(())
 }
 
+// ── Tool-output intercept audit (HookResult::Replace) ───────────────────────
+
+/// Audit record for an extension rewriting a tool's output via
+/// `HookResult::Replace`. Captures WHO rewrote WHICH tool's output and WHEN,
+/// plus sizes — never the content (privacy), matching the provider-audit policy.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct InterceptAuditEntry {
+    /// RFC3339 UTC timestamp.
+    pub timestamp: String,
+    pub plugin_id: String,
+    /// Hook that fired (e.g. "after_tool_call").
+    pub hook: String,
+    /// Tool whose output was rewritten, when tool-specific.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    /// Action taken (currently always "replace").
+    pub action: String,
+    /// Length (bytes) of the output the extension observed. For large outputs
+    /// this is the 32 KB event preview, not the full original.
+    pub observed_len: usize,
+    /// Length (bytes) of the replacement the extension returned.
+    pub replacement_len: usize,
+}
+
+/// Path to the intercept audit file (`$SYNAPS_BASE_DIR/extensions/intercept.jsonl`).
+pub fn intercept_file_path() -> PathBuf {
+    intercept_file_path_for(&crate::config::base_dir())
+}
+
+pub(crate) fn intercept_file_path_for(base: &Path) -> PathBuf {
+    base.join("extensions").join("intercept.jsonl")
+}
+
+/// Record that an extension replaced a tool's output. Best-effort and
+/// metadata-only — auditing must never break or alter the tool flow, so
+/// callers typically ignore the result.
+pub fn record_tool_output_replace(
+    plugin_id: impl Into<String>,
+    hook: impl Into<String>,
+    tool_name: Option<String>,
+    observed_len: usize,
+    replacement_len: usize,
+) -> Result<(), String> {
+    record_tool_output_replace_to(
+        &crate::config::base_dir(),
+        plugin_id,
+        hook,
+        tool_name,
+        observed_len,
+        replacement_len,
+    )
+}
+
+pub(crate) fn record_tool_output_replace_to(
+    base: &Path,
+    plugin_id: impl Into<String>,
+    hook: impl Into<String>,
+    tool_name: Option<String>,
+    observed_len: usize,
+    replacement_len: usize,
+) -> Result<(), String> {
+    let entry = InterceptAuditEntry {
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        plugin_id: plugin_id.into(),
+        hook: hook.into(),
+        tool_name,
+        action: "replace".to_string(),
+        observed_len,
+        replacement_len,
+    };
+    let path = intercept_file_path_for(base);
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("intercept.jsonl path has no parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("failed to create dir {}: {}", parent.display(), e))?;
+    let mut line = serde_json::to_string(&entry)
+        .map_err(|e| format!("failed to serialize intercept entry: {}", e))?;
+    line.push('\n');
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .map_err(|e| format!("failed to open {}: {}", path.display(), e))?;
+    file.write_all(line.as_bytes())
+        .map_err(|e| format!("failed to append to {}: {}", path.display(), e))?;
+    Ok(())
+}
+
 /// Read all entries (one per line). Missing file → empty Vec. Malformed
 /// lines are skipped with a `tracing::warn!`.
 pub fn read_audit_entries() -> Result<Vec<ProviderAuditEntry>, String> {
@@ -254,6 +343,39 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let entries = read_audit_entries_from(dir.path()).unwrap();
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn intercept_path_is_under_extensions_dir() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(
+            intercept_file_path_for(dir.path()),
+            dir.path().join("extensions").join("intercept.jsonl")
+        );
+    }
+
+    #[test]
+    fn record_tool_output_replace_writes_metadata_only() {
+        let dir = TempDir::new().unwrap();
+        record_tool_output_replace_to(
+            dir.path(),
+            "headroom-bridge",
+            "after_tool_call",
+            Some("bash".to_string()),
+            45_000,
+            6_080,
+        )
+        .unwrap();
+        let raw = std::fs::read_to_string(intercept_file_path_for(dir.path())).unwrap();
+        let entry: InterceptAuditEntry = serde_json::from_str(raw.trim()).unwrap();
+        assert_eq!(entry.plugin_id, "headroom-bridge");
+        assert_eq!(entry.hook, "after_tool_call");
+        assert_eq!(entry.tool_name.as_deref(), Some("bash"));
+        assert_eq!(entry.action, "replace");
+        assert_eq!(entry.observed_len, 45_000);
+        assert_eq!(entry.replacement_len, 6_080);
+        // Privacy: the record carries sizes, never tool content.
+        assert!(!raw.contains("tool_output"), "audit line must not carry content");
     }
 
     #[test]

--- a/crates/agent-engine/src/extensions/hooks/events.rs
+++ b/crates/agent-engine/src/extensions/hooks/events.rs
@@ -344,6 +344,25 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// The extension wire format `{"action":"replace","output":"..."}`
+    /// deserializes to HookResult::Replace via the serde action tag — and
+    /// round-trips back. This locks the contract a transform extension speaks.
+    #[test]
+    fn replace_action_roundtrips_extension_wire_format() {
+        // Inbound: what a process extension sends on hook.handle.
+        let wire = json!({"action": "replace", "output": "compressed"});
+        let parsed: HookResult = serde_json::from_value(wire).expect("must deserialize");
+        match parsed {
+            HookResult::Replace { output } => assert_eq!(output, "compressed"),
+            other => panic!("expected Replace, got {other:?}"),
+        }
+
+        // Outbound: the action tag is exactly "replace".
+        let out = serde_json::to_value(HookResult::Replace { output: "x".into() }).unwrap();
+        assert_eq!(out["action"], "replace");
+        assert_eq!(out["output"], "x");
+    }
+
     // ── HookKind ──────────────────────────────────────────────────────────────
 
     /// after_tool_call may return Replace; other hooks may not, and

--- a/crates/agent-engine/src/extensions/hooks/events.rs
+++ b/crates/agent-engine/src/extensions/hooks/events.rs
@@ -307,7 +307,7 @@ impl HookEvent {
 /// - `Block`, `Confirm`, and `Modify` stop the handler chain for `before_tool_call`.
 /// - `Inject` results are accumulated for `before_message`.
 /// - `Continue` is the no-op default — processing continues normally.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum HookResult {
     /// Allow execution to proceed unchanged.
@@ -321,11 +321,16 @@ pub enum HookResult {
     /// Ask the runtime to get explicit user confirmation before proceeding.
     /// Only valid on before_tool_call hooks.
     Confirm { message: String },
-    /// Replace the tool input before execution. Only valid on before_tool_call hooks.
+    /// Replace the tool **input** before execution (structured JSON args).
+    /// Only valid on before_tool_call hooks. The output-side counterpart is
+    /// [`HookResult::Replace`]. The first modifier stops the handler chain.
     Modify { input: Value },
-    /// Replace the tool output after execution, before it enters history.
-    /// Only valid on after_tool_call hooks. Enables native output transforms
-    /// (compression, redaction, summarization) by extensions.
+    /// Replace the tool **output** after execution (flat string), before it
+    /// enters history. Only valid on after_tool_call hooks. The input-side
+    /// counterpart is [`HookResult::Modify`] — distinct name because the payload
+    /// is an unstructured `String`, not structured `Value`. Enables native
+    /// output transforms (compression, redaction, summarization) by extensions.
+    /// The first transform stops the handler chain.
     Replace { output: String },
 }
 

--- a/crates/agent-engine/src/extensions/hooks/events.rs
+++ b/crates/agent-engine/src/extensions/hooks/events.rs
@@ -76,7 +76,7 @@ impl HookKind {
     pub fn allowed_action_names(&self) -> &'static [&'static str] {
         match self {
             Self::BeforeToolCall => &["continue", "block", "confirm", "modify"],
-            Self::AfterToolCall => &["continue"],
+            Self::AfterToolCall => &["continue", "replace"],
             Self::BeforeMessage => &["continue", "inject"],
             Self::OnMessageComplete | Self::OnCompaction | Self::OnSessionStart | Self::OnSessionEnd => &["continue"],
         }
@@ -95,6 +95,7 @@ impl HookKind {
                 | (Self::BeforeToolCall, HookResult::Block { .. })
                 | (Self::BeforeToolCall, HookResult::Confirm { .. })
                 | (Self::BeforeToolCall, HookResult::Modify { .. })
+                | (Self::AfterToolCall, HookResult::Replace { .. })
                 | (Self::BeforeMessage, HookResult::Inject { .. })
         )
     }
@@ -322,6 +323,10 @@ pub enum HookResult {
     Confirm { message: String },
     /// Replace the tool input before execution. Only valid on before_tool_call hooks.
     Modify { input: Value },
+    /// Replace the tool output after execution, before it enters history.
+    /// Only valid on after_tool_call hooks. Enables native output transforms
+    /// (compression, redaction, summarization) by extensions.
+    Replace { output: String },
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -340,6 +345,35 @@ mod tests {
     use serde_json::json;
 
     // ── HookKind ──────────────────────────────────────────────────────────────
+
+    /// after_tool_call may return Replace; other hooks may not, and
+    /// after_tool_call advertises "replace" in its action contract.
+    #[test]
+    fn after_tool_call_allows_replace_output() {
+        let replace = HookResult::Replace { output: "compressed".into() };
+
+        // The transform seam: after_tool_call accepts Replace.
+        assert!(
+            HookKind::AfterToolCall.allows_result(&replace),
+            "after_tool_call must permit Replace to enable output transforms"
+        );
+
+        // Replace is scoped strictly to after_tool_call.
+        assert!(
+            !HookKind::BeforeToolCall.allows_result(&replace),
+            "before_tool_call must not permit Replace (input-only)"
+        );
+        assert!(
+            !HookKind::BeforeMessage.allows_result(&replace),
+            "before_message must not permit Replace"
+        );
+
+        // The extension-facing action contract advertises "replace".
+        assert!(
+            HookKind::AfterToolCall.allowed_action_names().contains(&"replace"),
+            "after_tool_call must advertise the 'replace' action"
+        );
+    }
 
     /// Every variant's as_str round-trips through from_str.
     #[test]

--- a/crates/agent-engine/src/extensions/hooks/mod.rs
+++ b/crates/agent-engine/src/extensions/hooks/mod.rs
@@ -288,14 +288,26 @@ impl HookBus {
     ///     fire-and-forget notification calls (deck, d20, jawz-widget,
     ///     synaps-tasks all write to their own stores independently).
     ///
-    /// **Do NOT use for** `before_tool_call` / `before_message` hooks where
-    /// `Block` / `Modify` / `Inject` semantics require a defined winner when
-    /// two handlers disagree.
+    /// **Do NOT use for** `before_tool_call` / `after_tool_call` / `before_message`
+    /// hooks where `Block` / `Modify` / `Replace` / `Inject` semantics require a
+    /// defined winner when two handlers disagree — `join_all` completion order is
+    /// nondeterministic, so the "winner" would be unstable. Those hooks must use
+    /// the sequential [`emit`](Self::emit), which enforces first-wins ordering.
     ///
     /// With N extensions and a 5 s per-handler timeout, serial emit takes up
     /// to N×5 s; concurrent emit collapses that to a single 5 s window
     /// regardless of N — critical for teardown budgets.
     pub async fn emit_concurrent(&self, event: &HookEvent) -> HookResult {
+        debug_assert!(
+            !matches!(
+                event.kind,
+                HookKind::BeforeToolCall | HookKind::AfterToolCall | HookKind::BeforeMessage
+            ),
+            "emit_concurrent must not be used for transform-capable hooks \
+             ({:?}); their Block/Modify/Replace/Inject results need the \
+             deterministic first-wins ordering of the sequential emit()",
+            event.kind,
+        );
         // Snapshot handler list (same as emit()).
         let registrations = {
             let handlers = self.handlers.read().await;
@@ -517,6 +529,31 @@ mod tests {
         .await;
 
         assert_eq!(recorded, "RAW", "no Replace → original output preserved");
+    }
+
+    /// First Replace wins: once an earlier after_tool_call handler returns
+    /// Replace, later handlers are never reached (mirrors block/modify
+    /// chain-stop). Proves the "first transform wins" comment in emit().
+    #[tokio::test]
+    async fn replace_stops_chain_for_after_tool_call() {
+        let bus = HookBus::new();
+        let first = TestHandler::new("first", HookResult::Replace { output: "FIRST".into() });
+        let second = TestHandler::new("second", HookResult::Replace { output: "SECOND".into() });
+        let perms = perms_with(&[Permission::ToolsIntercept]);
+
+        bus.subscribe(HookKind::AfterToolCall, first.clone(), None, None, perms.clone())
+            .await
+            .unwrap();
+        bus.subscribe(HookKind::AfterToolCall, second.clone(), None, None, perms)
+            .await
+            .unwrap();
+
+        let event = HookEvent::after_tool_call("bash", serde_json::json!({}), "RAW".to_string());
+        let result = bus.emit(&event).await;
+
+        assert_eq!(result, HookResult::Replace { output: "FIRST".into() });
+        assert_eq!(first.calls(), 1);
+        assert_eq!(second.calls(), 0); // never reached — first transform wins
     }
 
     #[test]

--- a/crates/agent-engine/src/extensions/hooks/mod.rs
+++ b/crates/agent-engine/src/extensions/hooks/mod.rs
@@ -236,10 +236,23 @@ impl HookBus {
                     return HookResult::Modify { input };
                 }
                 Ok(HookResult::Replace { output }) => {
+                    let observed_len = event.tool_output.as_ref().map_or(0, String::len);
                     tracing::info!(
                         hook = %event.kind.as_str(),
                         extension = %reg.handler.id(),
+                        observed_len,
+                        replacement_len = output.len(),
                         "Hook replaced tool output by extension"
+                    );
+                    // Persistent audit trail — who rewrote which tool's output
+                    // and when, plus sizes (never content). Best-effort: a
+                    // failed audit write must not break the tool flow.
+                    let _ = crate::extensions::audit::record_tool_output_replace(
+                        reg.handler.id(),
+                        event.kind.as_str(),
+                        event.tool_name.clone(),
+                        observed_len,
+                        output.len(),
                     );
                     // First transform wins (mirrors Modify). Chaining is a future enhancement.
                     return HookResult::Replace { output };

--- a/crates/agent-engine/src/extensions/hooks/mod.rs
+++ b/crates/agent-engine/src/extensions/hooks/mod.rs
@@ -471,6 +471,54 @@ mod tests {
         set
     }
 
+    /// emit_after_tool_call returns the substituted output when an
+    /// after_tool_call handler returns Replace — this is the seam that lets an
+    /// extension compress/redact tool output before it enters history.
+    #[tokio::test]
+    async fn after_tool_call_replace_substitutes_recorded_output() {
+        let bus = std::sync::Arc::new(HookBus::new());
+        let handler = TestHandler::new(
+            "compressor",
+            HookResult::Replace { output: "COMPRESSED".into() },
+        );
+        bus.subscribe(
+            HookKind::AfterToolCall,
+            handler,
+            None,
+            None,
+            perms_with(&[Permission::ToolsIntercept]),
+        )
+        .await
+        .unwrap();
+
+        let recorded = crate::runtime::emit_after_tool_call(
+            &bus,
+            "bash",
+            None,
+            serde_json::json!({"command": "cat huge.log"}),
+            "RAW 10k lines".to_string(),
+        )
+        .await;
+
+        assert_eq!(recorded, "COMPRESSED", "Replace output must reach history");
+    }
+
+    /// With no transform handler, the original output is preserved unchanged.
+    #[tokio::test]
+    async fn after_tool_call_without_replace_keeps_original_output() {
+        let bus = std::sync::Arc::new(HookBus::new());
+        let recorded = crate::runtime::emit_after_tool_call(
+            &bus,
+            "bash",
+            None,
+            serde_json::json!({}),
+            "RAW".to_string(),
+        )
+        .await;
+
+        assert_eq!(recorded, "RAW", "no Replace → original output preserved");
+    }
+
     #[test]
     fn trace_env_value_parser_accepts_common_truthy_values() {
         for value in ["1", "true", "TRUE", "yes", "on"] {

--- a/crates/agent-engine/src/extensions/hooks/mod.rs
+++ b/crates/agent-engine/src/extensions/hooks/mod.rs
@@ -37,6 +37,7 @@ fn hook_result_action(result: &HookResult) -> &'static str {
         HookResult::Inject { .. } => "inject",
         HookResult::Confirm { .. } => "confirm",
         HookResult::Modify { .. } => "modify",
+        HookResult::Replace { .. } => "replace",
     }
 }
 
@@ -234,6 +235,15 @@ impl HookBus {
                     );
                     return HookResult::Modify { input };
                 }
+                Ok(HookResult::Replace { output }) => {
+                    tracing::info!(
+                        hook = %event.kind.as_str(),
+                        extension = %reg.handler.id(),
+                        "Hook replaced tool output by extension"
+                    );
+                    // First transform wins (mirrors Modify). Chaining is a future enhancement.
+                    return HookResult::Replace { output };
+                }
                 Ok(HookResult::Confirm { message }) => {
                     tracing::info!(
                         hook = %event.kind.as_str(),
@@ -337,6 +347,9 @@ impl HookBus {
                 }
                 Ok(HookResult::Modify { input }) => {
                     return HookResult::Modify { input };
+                }
+                Ok(HookResult::Replace { output }) => {
+                    return HookResult::Replace { output };
                 }
                 Ok(HookResult::Confirm { message }) => {
                     return HookResult::Confirm { message };

--- a/crates/agent-engine/src/extensions/hooks/mod.rs
+++ b/crates/agent-engine/src/extensions/hooks/mod.rs
@@ -16,7 +16,7 @@ use tokio::sync::RwLock;
 
 use self::events::{HookEvent, HookKind, HookResult};
 use crate::extensions::manifest::HookMatcher;
-use crate::extensions::permissions::PermissionSet;
+use crate::extensions::permissions::{Permission, PermissionSet};
 
 /// Default timeout for a single hook handler call.
 const HANDLER_TIMEOUT: Duration = Duration::from_secs(5);
@@ -236,6 +236,19 @@ impl HookBus {
                     return HookResult::Modify { input };
                 }
                 Ok(HookResult::Replace { output }) => {
+                    // Two-key gate: subscribing to after_tool_call needs
+                    // `tools.intercept` (observe); rewriting the output
+                    // additionally needs `tools.transform_output`. Without it,
+                    // ignore this handler's Replace (fail-safe: original output
+                    // preserved) and continue the chain.
+                    if !reg.permissions.has(Permission::ToolsTransformOutput) {
+                        tracing::warn!(
+                            hook = %event.kind.as_str(),
+                            extension = %reg.handler.id(),
+                            "Extension returned Replace without tools.transform_output permission — ignoring transform"
+                        );
+                        continue;
+                    }
                     let observed_len = event.tool_output.as_ref().map_or(0, String::len);
                     tracing::info!(
                         hook = %event.kind.as_str(),
@@ -511,7 +524,7 @@ mod tests {
             handler,
             None,
             None,
-            perms_with(&[Permission::ToolsIntercept]),
+            perms_with(&[Permission::ToolsIntercept, Permission::ToolsTransformOutput]),
         )
         .await
         .unwrap();
@@ -552,7 +565,7 @@ mod tests {
         let bus = HookBus::new();
         let first = TestHandler::new("first", HookResult::Replace { output: "FIRST".into() });
         let second = TestHandler::new("second", HookResult::Replace { output: "SECOND".into() });
-        let perms = perms_with(&[Permission::ToolsIntercept]);
+        let perms = perms_with(&[Permission::ToolsIntercept, Permission::ToolsTransformOutput]);
 
         bus.subscribe(HookKind::AfterToolCall, first.clone(), None, None, perms.clone())
             .await
@@ -567,6 +580,43 @@ mod tests {
         assert_eq!(result, HookResult::Replace { output: "FIRST".into() });
         assert_eq!(first.calls(), 1);
         assert_eq!(second.calls(), 0); // never reached — first transform wins
+    }
+
+    /// Two-key gate: an extension may subscribe to after_tool_call with only
+    /// `tools.intercept` (observe), but its Replace is IGNORED without the
+    /// additional `tools.transform_output` — the original output is preserved.
+    #[tokio::test]
+    async fn replace_without_transform_permission_is_ignored() {
+        let bus = std::sync::Arc::new(HookBus::new());
+        let handler = TestHandler::new(
+            "observer-only",
+            HookResult::Replace { output: "SNEAKY".into() },
+        );
+        // Only the observe key — NOT tools.transform_output.
+        bus.subscribe(
+            HookKind::AfterToolCall,
+            handler.clone(),
+            None,
+            None,
+            perms_with(&[Permission::ToolsIntercept]),
+        )
+        .await
+        .unwrap();
+
+        let recorded = crate::runtime::emit_after_tool_call(
+            &bus,
+            "bash",
+            None,
+            serde_json::json!({}),
+            "ORIGINAL".to_string(),
+        )
+        .await;
+
+        assert_eq!(handler.calls(), 1, "handler still runs (it's subscribed)");
+        assert_eq!(
+            recorded, "ORIGINAL",
+            "Replace without tools.transform_output must be ignored — original preserved"
+        );
     }
 
     #[test]

--- a/crates/agent-engine/src/extensions/permissions.rs
+++ b/crates/agent-engine/src/extensions/permissions.rs
@@ -14,6 +14,11 @@ use serde::{Deserialize, Serialize};
 pub enum Permission {
     /// Can subscribe to before_tool_call / after_tool_call hooks.
     ToolsIntercept,
+    /// Can rewrite tool OUTPUT via `after_tool_call` → `HookResult::Replace`.
+    /// Distinct from (and additional to) `tools.intercept`: observing a tool's
+    /// output is a weaker capability than silently rewriting what the model
+    /// believes the tool returned, so it requires explicit, separate consent.
+    ToolsTransformOutput,
     /// Can override built-in tools.
     ToolsOverride,
     /// Can read LLM input/output (before_message hook).
@@ -43,6 +48,7 @@ impl Permission {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::ToolsIntercept => "tools.intercept",
+            Self::ToolsTransformOutput => "tools.transform_output",
             Self::ToolsOverride => "tools.override",
             Self::LlmContent => "privacy.llm_content",
             Self::SessionLifecycle => "session.lifecycle",
@@ -61,6 +67,7 @@ impl Permission {
     pub fn parse(s: &str) -> Option<Self> {
         match s {
             "tools.intercept" => Some(Self::ToolsIntercept),
+            "tools.transform_output" => Some(Self::ToolsTransformOutput),
             "tools.override" => Some(Self::ToolsOverride),
             "privacy.llm_content" => Some(Self::LlmContent),
             "session.lifecycle" => Some(Self::SessionLifecycle),

--- a/crates/agent-engine/src/extensions/runtime/process.rs
+++ b/crates/agent-engine/src/extensions/runtime/process.rs
@@ -265,12 +265,12 @@ pub async fn execute_provider_tool_use(
         Ok(output) => (output, false),
         Err(error) => (format!("Tool execution failed: {}", error), true),
     };
-    let _ = crate::runtime::emit_after_tool_call(
+    let result = crate::runtime::emit_after_tool_call(
         hook_bus,
         &tool_name,
         Some(&runtime_name),
         input_for_hook,
-        result.clone(),
+        result,
     ).await;
 
     let mut response = serde_json::json!({

--- a/crates/agent-engine/src/extensions/runtime/process.rs
+++ b/crates/agent-engine/src/extensions/runtime/process.rs
@@ -1851,12 +1851,18 @@ impl ExtensionHandler for ProcessExtension {
                         response = %value,
                         "Extension hook handler returned invalid result",
                     );
-                    if value.get("action").and_then(Value::as_str) == Some("modify") {
-                        HookResult::Block {
+                    match value.get("action").and_then(Value::as_str) {
+                        // A malformed `modify` is dangerous — it would let an
+                        // unknown/partial input through. Fail safe by blocking.
+                        Some("modify") => HookResult::Block {
                             reason: "Extension returned malformed modify result".to_string(),
-                        }
-                    } else {
-                        HookResult::Continue
+                        },
+                        // A malformed `replace` is safe to ignore: the original
+                        // tool output is preserved by emit_after_tool_call.
+                        // Explicit arm so this intent can't be silently changed
+                        // by a future edit to the catch-all below.
+                        Some("replace") => HookResult::Continue,
+                        _ => HookResult::Continue,
                     }
                 }
             },

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -117,13 +117,26 @@ pub async fn resolve_before_tool_call_decision(
     }
 }
 
-/// Emit an `after_tool_call` event and include the runtime tool name when it
-/// differs from the API-safe name.
+/// Maximum size (bytes) of a `Replace` output an extension may substitute.
+/// A transform returning more than this is clamped (with a warning) to bound
+/// memory between deserialization and the downstream tool-output truncation.
+/// Generous on purpose — legitimate compression/redaction shrinks output.
+const MAX_REPLACE_OUTPUT: usize = 1024 * 1024; // 1 MiB
+
 /// Emit an `after_tool_call` event and return the tool output to record in
 /// history — either the original `output`, or a `Replace { output }`
 /// substituted by an extension transform hook (compression, redaction,
 /// summarization). The runtime tool name is included when it differs from the
 /// API-safe name.
+///
+/// Fail-safe: any non-`Replace` result — `Continue`, a result rejected by the
+/// permission matrix, a crashed/timed-out handler, or any future variant —
+/// returns the original `output` unchanged. A misbehaving extension can never
+/// drop or corrupt a tool's output.
+///
+/// Note: the event delivered to the extension carries `tool_output` truncated
+/// to 32 KB (see [`HookEvent::after_tool_call`]); a transform therefore decides
+/// based on a preview of large outputs, not the full bytes.
 pub async fn emit_after_tool_call(
     hook_bus: &Arc<crate::extensions::hooks::HookBus>,
     tool_name: &str,
@@ -131,17 +144,44 @@ pub async fn emit_after_tool_call(
     input: Value,
     output: String,
 ) -> String {
+    use crate::extensions::hooks::events::HookResult;
+    // Keep the original to return verbatim if no transform fires.
+    let original = output.clone();
     let mut event = crate::extensions::hooks::events::HookEvent::after_tool_call(
         tool_name,
         input,
-        output.clone(),
+        output,
     );
     if let Some(runtime_tool_name) = runtime_tool_name {
         event.tool_runtime_name = Some(runtime_tool_name.to_string());
     }
     match hook_bus.emit(&event).await {
-        crate::extensions::hooks::events::HookResult::Replace { output } => output,
-        _ => output,
+        HookResult::Replace { mut output } => {
+            if output.len() > MAX_REPLACE_OUTPUT {
+                tracing::warn!(
+                    tool = %tool_name,
+                    len = output.len(),
+                    cap = MAX_REPLACE_OUTPUT,
+                    "Extension Replace output exceeds cap — clamping",
+                );
+                // Floor to a UTF-8 char boundary before truncating.
+                let mut boundary = MAX_REPLACE_OUTPUT;
+                while boundary > 0 && !output.is_char_boundary(boundary) {
+                    boundary -= 1;
+                }
+                output.truncate(boundary);
+            }
+            output
+        }
+        HookResult::Continue => original,
+        other => {
+            tracing::warn!(
+                tool = %tool_name,
+                ?other,
+                "Unexpected after_tool_call result — using original output",
+            );
+            original
+        }
     }
 }
 

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -119,22 +119,30 @@ pub async fn resolve_before_tool_call_decision(
 
 /// Emit an `after_tool_call` event and include the runtime tool name when it
 /// differs from the API-safe name.
+/// Emit an `after_tool_call` event and return the tool output to record in
+/// history — either the original `output`, or a `Replace { output }`
+/// substituted by an extension transform hook (compression, redaction,
+/// summarization). The runtime tool name is included when it differs from the
+/// API-safe name.
 pub async fn emit_after_tool_call(
     hook_bus: &Arc<crate::extensions::hooks::HookBus>,
     tool_name: &str,
     runtime_tool_name: Option<&str>,
     input: Value,
     output: String,
-) -> crate::extensions::hooks::events::HookResult {
+) -> String {
     let mut event = crate::extensions::hooks::events::HookEvent::after_tool_call(
         tool_name,
         input,
-        output,
+        output.clone(),
     );
     if let Some(runtime_tool_name) = runtime_tool_name {
         event.tool_runtime_name = Some(runtime_tool_name.to_string());
     }
-    hook_bus.emit(&event).await
+    match hook_bus.emit(&event).await {
+        crate::extensions::hooks::events::HookResult::Replace { output } => output,
+        _ => output,
+    }
 }
 
 /// The core runtime — manages API communication, tool execution, authentication,
@@ -612,12 +620,12 @@ impl Runtime {
                                         Ok(output) => output,
                                         Err(e) => format!("Tool execution failed: {}", e),
                                     };
-                                    let _ = emit_after_tool_call(
+                                    let output = emit_after_tool_call(
                                         &self.hook_bus,
                                         tool_name,
                                         Some(&runtime_name),
                                         input_for_hook,
-                                        output.clone(),
+                                        output,
                                     ).await;
                                     output
                                 }
@@ -706,12 +714,12 @@ impl Runtime {
                                             Ok(output) => output,
                                             Err(e) => format!("Tool execution failed: {}", e),
                                         };
-                                        let _ = crate::runtime::emit_after_tool_call(
+                                        let output = crate::runtime::emit_after_tool_call(
                                             &hook_bus_inner,
                                             &tool_name_for_hook,
                                             Some(&runtime_name_for_hook),
                                             input_for_hook,
-                                            output.clone(),
+                                            output,
                                         ).await;
                                         output
                                         }

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -134,9 +134,11 @@ const MAX_REPLACE_OUTPUT: usize = 1024 * 1024; // 1 MiB
 /// returns the original `output` unchanged. A misbehaving extension can never
 /// drop or corrupt a tool's output.
 ///
-/// Note: the event delivered to the extension carries `tool_output` truncated
-/// to 32 KB (see [`HookEvent::after_tool_call`]); a transform therefore decides
-/// based on a preview of large outputs, not the full bytes.
+/// Note: the event delivered to the extension carries `tool_output` as a
+/// size-limited preview for large outputs — a ~32 KB prefix plus a
+/// `…[truncated, N total bytes]` marker (see [`HookEvent::after_tool_call`]),
+/// so the delivered string can slightly exceed 32 KB. A transform therefore
+/// decides based on a preview, not the full bytes.
 pub async fn emit_after_tool_call(
     hook_bus: &Arc<crate::extensions::hooks::HookBus>,
     tool_name: &str,

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -307,12 +307,12 @@ impl StreamMethods {
                                             Ok(output) => output,
                                             Err(e) => format!("Tool execution failed: {}", e),
                                         };
-                                        let _ = emit_after_tool_call(
+                                        let output = emit_after_tool_call(
                                             &hook_bus,
                                             &tool_name,
                                             Some(&runtime_name),
                                             input_for_hook,
-                                            output.clone(),
+                                            output,
                                         ).await;
                                         output
                                     }
@@ -422,12 +422,12 @@ impl StreamMethods {
                                                 Ok(output) => output,
                                                 Err(e) => format!("Tool execution failed: {}", e),
                                             };
-                                            let _ = emit_after_tool_call(
+                                            let output = emit_after_tool_call(
                                                 &hook_bus_inner,
                                                 &tool_name_for_hook,
                                                 Some(&runtime_name_for_hook),
                                                 input_for_hook,
-                                                output.clone(),
+                                                output,
                                             ).await;
                                             (false, output)
                                         }

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -16,6 +16,7 @@ Extensions can:
 - **Block** — prevent a `before_tool_call` event from proceeding
 - **Confirm** — ask for explicit user approval before a tool call proceeds
 - **Modify** — replace `before_tool_call` input before execution
+- **Replace** — rewrite `after_tool_call` output before it enters history (compression, redaction, summarization; requires `tools.transform_output`)
 - **Inject** — prepend context into the system prompt before a request reaches the LLM
 
 Future protocol phases reserve names for tool/provider registration, but phase 1 does not grant those capabilities yet.
@@ -103,8 +104,9 @@ The `extension` field is what distinguishes a plugin that provides an extension 
 - `before_tool_call` supports `block`; if any extension blocks, the tool is not executed and later handlers are skipped.
 - `before_tool_call` also supports `confirm`, which requests explicit user approval before proceeding. Interactive TUI streams prompt the user; headless/non-interactive call sites fail closed by blocking the tool call.
 - `before_tool_call` supports `modify`, which replaces the tool input before execution. Trace logs record that modification occurred without logging the modified input.
+- `after_tool_call` supports `replace`, which rewrites the tool **output** before it enters history (compression, redaction, summarization). It requires `tools.transform_output` *in addition to* `tools.intercept`; the first `replace` wins and stops the chain. A `replace` from an extension lacking the permission, or a malformed/crashed handler, is ignored and the original output is preserved.
 - `before_message` supports `inject`; injected content from matching extensions is accumulated.
-- Other hooks are observation-oriented today. Returning an unsupported action is ignored by the current call site.
+- The remaining hooks are observation-oriented today. Returning an unsupported action is ignored by the current call site.
 
 ---
 
@@ -156,7 +158,8 @@ Extensions must declare the permissions they require. SynapsCLI rejects unknown 
 
 | Permission           | What it grants                                                                 |
 |----------------------|--------------------------------------------------------------------------------|
-| `tools.intercept`    | Ability to receive `before_tool_call` / `after_tool_call` events               |
+| `tools.intercept`    | Subscribe to `before_tool_call` / `after_tool_call` (observe, block, confirm, modify input) |
+| `tools.transform_output` | Rewrite tool output via `after_tool_call` → `replace` (required in addition to `tools.intercept`) |
 | `privacy.llm_content`| Access to message content for `before_message`                                 |
 | `session.lifecycle`  | Receipt of `on_session_start` and `on_session_end` events                      |
 | `tools.register`    | Register extension-provided tools during initialization                         |

--- a/docs/extensions/contract.json
+++ b/docs/extensions/contract.json
@@ -62,6 +62,7 @@
   },
   "permissions": [
     "tools.intercept",
+    "tools.transform_output",
     "privacy.llm_content",
     "session.lifecycle",
     "tools.register",

--- a/docs/extensions/contract.json
+++ b/docs/extensions/contract.json
@@ -19,7 +19,8 @@
       "permission": "tools.intercept",
       "tool_filter": true,
       "actions": [
-        "continue"
+        "continue",
+        "replace"
       ]
     },
     "before_message": {

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -26,7 +26,7 @@ name.
 | Hook | Required permission | Tool filter? | Allowed result actions | Purpose |
 |---|---|---:|---|---|
 | `before_tool_call` | `tools.intercept` | yes | `continue`, `block`, `confirm`, `modify` | Inspect/block/confirm/modify a tool call before execution |
-| `after_tool_call` | `tools.intercept` | yes | `continue` | Observe tool input/output after execution |
+| `after_tool_call` | `tools.intercept` | yes | `continue`, `replace` | Observe or rewrite tool output after execution |
 | `before_message` | `privacy.llm_content` | no | `continue`, `inject` | Inspect the user message and optionally inject context |
 | `on_message_complete` | `privacy.llm_content` | no | `continue` | Observe completed assistant responses |
 | `on_compaction` | `privacy.llm_content` | no | `continue` | Observe completed conversation compaction summaries |
@@ -47,6 +47,18 @@ Unsupported result actions are ignored fail-open and logged as warnings.
   model context. It is accepted only on `before_message`.
 - `modify` replaces the tool input before execution. It is accepted only on
   `before_tool_call`; the first modifier stops the handler chain.
+- `replace` substitutes the tool **output** after execution, before it enters
+  conversation history. It is accepted only on `after_tool_call`. Return
+  `{"action": "replace", "output": "<string>"}`. The first handler to return
+  `replace` wins and stops the chain (later handlers are skipped). Use it for
+  compression, redaction, or summarization. Notes:
+  - The `tool_output` delivered in the event is **truncated to 32 KB**, so a
+    transform decides based on a preview of large outputs.
+  - A malformed `replace` (missing/invalid `output`) or a crashed/timed-out
+    handler is fail-safe: the **original output is preserved unchanged**.
+  - `replace` does **not** clear the `is_error` flag — replacing the content of
+    a failed tool call leaves it marked as an error.
+  - Replacement output larger than 1 MiB is clamped.
 
 `on_message_complete` fires after an assistant response is added to session
 history. It requires `privacy.llm_content` and is observe-only. The `message`

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -48,7 +48,11 @@ Unsupported result actions are ignored fail-open and logged as warnings.
 - `modify` replaces the tool input before execution. It is accepted only on
   `before_tool_call`; the first modifier stops the handler chain.
 - `replace` substitutes the tool **output** after execution, before it enters
-  conversation history. It is accepted only on `after_tool_call`. Return
+  conversation history. It is accepted only on `after_tool_call`, and requires
+  the **`tools.transform_output`** permission **in addition to** `tools.intercept`
+  (subscribing/observing needs `tools.intercept`; rewriting the output needs the
+  second key — a Replace from an extension lacking `tools.transform_output` is
+  ignored and the original output is preserved). Return
   `{"action": "replace", "output": "<string>"}`. The first handler to return
   `replace` wins and stops the chain (later handlers are skipped). Use it for
   compression, redaction, or summarization. Notes:

--- a/docs/extensions/hooks.md
+++ b/docs/extensions/hooks.md
@@ -56,8 +56,10 @@ Unsupported result actions are ignored fail-open and logged as warnings.
   `{"action": "replace", "output": "<string>"}`. The first handler to return
   `replace` wins and stops the chain (later handlers are skipped). Use it for
   compression, redaction, or summarization. Notes:
-  - The `tool_output` delivered in the event is **truncated to 32 KB**, so a
-    transform decides based on a preview of large outputs.
+  - The `tool_output` delivered in the event is a **size-limited preview** for
+    large outputs — a ~32 KB prefix plus a `…[truncated, N total bytes]` marker,
+    so it can slightly exceed 32 KB. A transform decides on this preview, not
+    the full bytes.
   - A malformed `replace` (missing/invalid `output`) or a crashed/timed-out
     handler is fail-safe: the **original output is preserved unchanged**.
   - `replace` does **not** clear the `is_error` flag — replacing the content of

--- a/docs/extensions/permissions.md
+++ b/docs/extensions/permissions.md
@@ -11,7 +11,8 @@ These are the only permissions currently accepted in `extension.permissions`:
 
 | Permission | Allows |
 |---|---|
-| `tools.intercept` | Subscribe to `before_tool_call` and `after_tool_call` |
+| `tools.intercept` | Subscribe to `before_tool_call` and `after_tool_call` (observe, block, confirm, modify input) |
+| `tools.transform_output` | Rewrite tool **output** via `after_tool_call` → `replace`. Required *in addition to* `tools.intercept`; without it a `replace` is ignored |
 | `privacy.llm_content` | Subscribe to `before_message`, `on_message_complete`, and `on_compaction`; receive message/summary content |
 | `session.lifecycle` | Subscribe to `on_session_start` and `on_session_end` |
 | `tools.register` | Register extension-provided tools during initialization |

--- a/docs/extensions/protocol.md
+++ b/docs/extensions/protocol.md
@@ -314,7 +314,7 @@ The `params` field of a `hook.handle` request is a `HookEvent` object.
 | `tool_name`         | string \| null  | `before_tool_call`, `after_tool_call`         | API-safe name of the tool being called                           |
 | `tool_runtime_name` | string \| null  | `before_tool_call`, `after_tool_call`         | Original runtime tool name (before API sanitization)             |
 | `tool_input`        | object \| null  | `before_tool_call`, `after_tool_call`         | The raw input arguments passed to the tool                       |
-| `tool_output`       | string \| null  | `after_tool_call`                             | The result returned by the tool (truncated at 32 KB)             |
+| `tool_output`       | string \| null  | `after_tool_call`                             | The result returned by the tool (size-limited preview: ~32 KB prefix + marker) |
 | `message`           | string \| null  | `before_message`, `on_message_complete`, `on_compaction` | User/assistant/summary message content for message hooks         |
 | `session_id`        | string \| null  | `on_compaction`, `on_session_start`, `on_session_end` | Stable identifier for the current or newly-created session       |
 | `transcript`        | array \| null   | `on_session_end`                              | Conversation transcript delivered at session end                 |
@@ -434,6 +434,34 @@ Replace the tool input before execution. Only valid on `before_tool_call`; on ot
 | Field   | Type   | Required | Description                       |
 |---------|--------|----------|-----------------------------------|
 | `input` | object | yes      | Replacement tool input JSON value |
+
+### `replace`
+
+Rewrite the tool **output** after execution, before it enters conversation
+history (compression, redaction, summarization). Only valid on `after_tool_call`;
+on other hooks it is treated as `continue` and logged as an unsupported action.
+The first `replace` stops the handler chain. Trace logs record `action=replace`
+and the observed/replacement lengths, but never the content.
+
+Requires the **`tools.transform_output`** permission *in addition to*
+`tools.intercept`. A `replace` from an extension lacking it is ignored and the
+original output is preserved (fail-safe). Each replacement is recorded to
+`extensions/intercept.jsonl` (metadata only: plugin id, tool, sizes — never
+content). Replacement output is clamped at 1 MiB.
+
+> The `tool_output` an extension sees is a size-limited preview (~32 KB prefix +
+> truncation marker), so a transform decides on a preview of large outputs.
+
+```json
+{
+  "action": "replace",
+  "output": "compressed/redacted/summarized tool output"
+}
+```
+
+| Field    | Type   | Required | Description                          |
+|----------|--------|----------|--------------------------------------|
+| `output` | string | yes      | Replacement tool output (≤ 1 MiB)    |
 
 ### `inject`
 

--- a/tests/extensions_contract.rs
+++ b/tests/extensions_contract.rs
@@ -19,8 +19,9 @@ const ALL_HOOK_KINDS: [HookKind; 7] = [
     HookKind::OnSessionEnd,
 ];
 
-const ALL_PERMISSIONS: [Permission; 5] = [
+const ALL_PERMISSIONS: [Permission; 6] = [
     Permission::ToolsIntercept,
+    Permission::ToolsTransformOutput,
     Permission::LlmContent,
     Permission::SessionLifecycle,
     Permission::ToolsRegister,

--- a/tests/extensions_e2e.rs
+++ b/tests/extensions_e2e.rs
@@ -241,7 +241,7 @@ async fn after_tool_call_replace_substitutes_output_via_real_extension() {
         setup: None,
         prebuilt: ::std::collections::HashMap::new(),
         args: vec![fixture],
-        permissions: vec!["tools.intercept".to_string()],
+        permissions: vec!["tools.intercept".to_string(), "tools.transform_output".to_string()],
         hooks: vec![synaps_cli::extensions::manifest::HookSubscription {
             hook: "after_tool_call".to_string(),
             tool: Some("bash".to_string()),

--- a/tests/extensions_e2e.rs
+++ b/tests/extensions_e2e.rs
@@ -212,7 +212,8 @@ async fn modify_hook_replaces_tool_input_and_after_hook_sees_modified_input() {
         input,
         output,
     ).await;
-    assert!(matches!(after, HookResult::Continue));
+    // No after_tool_call transform handler registered → output unchanged.
+    assert_eq!(after, "modified");
 
     manager.shutdown_all().await;
 }

--- a/tests/extensions_e2e.rs
+++ b/tests/extensions_e2e.rs
@@ -218,6 +218,59 @@ async fn modify_hook_replaces_tool_input_and_after_hook_sees_modified_input() {
     manager.shutdown_all().await;
 }
 
+/// End-to-end proof of HookResult::Replace: a real process extension subscribed
+/// to after_tool_call returns {"action":"replace","output":...}, and the engine
+/// substitutes that transformed string in place of the raw tool output before it
+/// enters history. This exercises the full path — subprocess spawn, JSON-RPC
+/// initialize handshake, hook.handle dispatch, serde deserialization of the new
+/// `replace` action, and resolution inside emit_after_tool_call.
+#[tokio::test]
+async fn after_tool_call_replace_substitutes_output_via_real_extension() {
+    let fixture = std::env::current_dir()
+        .unwrap()
+        .join("tests/fixtures/replace_extension.py")
+        .to_string_lossy()
+        .to_string();
+
+    let hook_bus = Arc::new(HookBus::new());
+    let mut manager = ExtensionManager::new(hook_bus.clone());
+    let manifest = synaps_cli::extensions::manifest::ExtensionManifest {
+        protocol_version: synaps_cli::extensions::manifest::CURRENT_EXTENSION_PROTOCOL_VERSION,
+        runtime: synaps_cli::extensions::manifest::ExtensionRuntime::Process,
+        command: "python3".to_string(),
+        setup: None,
+        prebuilt: ::std::collections::HashMap::new(),
+        args: vec![fixture],
+        permissions: vec!["tools.intercept".to_string()],
+        hooks: vec![synaps_cli::extensions::manifest::HookSubscription {
+            hook: "after_tool_call".to_string(),
+            tool: Some("bash".to_string()),
+            matcher: None,
+        }],
+        config: vec![],
+    };
+    manager.load("replace-test", &manifest).await.unwrap();
+
+    // 32-byte raw output the tool "produced"; the fixture clamps it deterministically
+    // to "[clamped:<len>] <first 8 chars>".
+    let raw = "DEADBEEFDEADBEEFDEADBEEFDEADBEEF".to_string();
+    let result = synaps_cli::runtime::emit_after_tool_call(
+        &hook_bus,
+        "bash",
+        None,
+        json!({"command": "echo big"}),
+        raw,
+    )
+    .await;
+
+    assert_eq!(
+        result, "[clamped:32] DEADBEEF",
+        "the extension's Replace output must be substituted for the raw tool output"
+    );
+
+    manager.shutdown_all().await;
+}
+
 #[tokio::test]
 async fn malformed_modify_result_blocks_instead_of_failing_open() {
     let fixture = std::env::current_dir()

--- a/tests/fixtures/replace_extension.py
+++ b/tests/fixtures/replace_extension.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Test fixture: an after_tool_call extension that REPLACES tool output.
+
+Proves the HookResult::Replace path end-to-end through a real process
+extension: initialize handshake → hook.handle(after_tool_call) → returns
+{"action": "replace", "output": ...} → engine substitutes it into history.
+
+Transform is deterministic so the test can assert exact bytes:
+    output  ->  "[clamped:<len>] <first 8 chars>"
+"""
+import json
+import sys
+
+
+def read_message():
+    content_length = None
+    while True:
+        line = sys.stdin.buffer.readline()
+        if line == b"":
+            return None
+        if line in (b"\r\n", b"\n"):
+            break
+        name, _, value = line.decode("ascii").partition(":")
+        if name.lower() == "content-length":
+            content_length = int(value.strip())
+    if content_length is None:
+        raise RuntimeError("missing Content-Length")
+    return json.loads(sys.stdin.buffer.read(content_length))
+
+
+def write_message(request, result=None, error=None):
+    payload = {"jsonrpc": "2.0", "id": request.get("id")}
+    if error is None:
+        payload["result"] = result
+    else:
+        payload["error"] = error
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    sys.stdout.buffer.write(f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body)
+    sys.stdout.buffer.flush()
+
+
+def main():
+    while True:
+        request = read_message()
+        if request is None:
+            break
+        method = request.get("method")
+        if method == "initialize":
+            write_message(request, {"protocol_version": 1, "capabilities": {}})
+        elif method == "hook.handle":
+            event = request.get("params") or {}
+            if event.get("kind") == "after_tool_call":
+                out = event.get("tool_output") or ""
+                clamped = f"[clamped:{len(out)}] {out[:8]}"
+                write_message(request, {"action": "replace", "output": clamped})
+            else:
+                write_message(request, {"action": "continue"})
+        elif method == "shutdown":
+            write_message(request, {})
+            break
+        else:
+            write_message(request, error={"code": -32601, "message": f"unknown method: {method}"})
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds `HookResult::Replace { output }` — a generic seam that lets an
`after_tool_call` extension **rewrite a tool's output before it enters
conversation history**. Upgrades `after_tool_call` from read-only to read-write.

This is the platform primitive for native tool-output transforms — compression
(headroom), redaction, secret-scrubbing, summarization. Pi already had this
(`ToolResultEvent` transform); Synaps didn't.

## How

- New `HookResult::Replace { output }`, gated to `after_tool_call` only
  (`allowed_action_names` + `allows_result`).
- Wire format `{"action":"replace","output":"..."}` rides the existing serde
  `tag = "action"` — no parser change.
- Honored at all 5 `emit_after_tool_call` sites (runtime/mod.rs ×2,
  stream.rs ×2, process.rs). The helper resolves Replace → final `String`.
- **Provider-agnostic**: the OpenAI path normalizes to Anthropic content-blocks
  *before* tools execute, so the shared sites cover both providers — zero
  provider-specific code.

## Security model — two keys

- `tools.intercept` — subscribe to `after_tool_call` and **observe** (unchanged).
- `tools.transform_output` (**new**) — required to actually **return Replace**.

A Replace from an extension lacking `tools.transform_output` is ignored
(fail-safe → original output preserved) and warn-logged. Output rewriting edits
what the model *believes* a tool returned, so it requires explicit, separate
consent from mere interception.

## Audit

Every Replace is recorded to `$SYNAPS_BASE_DIR/extensions/intercept.jsonl`
(timestamp, plugin_id, hook, tool, observed_len → replacement_len) — **metadata
only, never content** (matches provider-audit privacy policy).

## Safety invariant

A misbehaving extension can never drop or corrupt a tool's output. Every error
path — `Continue`, rejected result, crash, timeout, malformed `replace`, missing
permission, oversized output (clamped at 1 MiB) — falls back to the original.

## Review

Reviewed from 8 angles (correctness, security, architecture, perf/caching,
integration, error-handling, quality, spec). All findings resolved, nothing
deferred. Notable: cache-safe (Replace fires before message assembly, can't
disrupt prompt-cache prefixes); −5 net clones vs. before.

## Tests

37 hooks + 7 contract + 22 e2e + 9 audit tests green; full workspace build
clean; clippy clean. Includes a real-process-extension e2e proof and a negative
test for the permission gate.

🎲 Generated with Jawz
