### PR TITLE
fix(runtime): compress-then-truncate tool output (Fork 1)

### DIFF
--- a/crates/agent-engine/src/extensions/hooks/events.rs
+++ b/crates/agent-engine/src/extensions/hooks/events.rs
@@ -78,7 +78,10 @@ impl HookKind {
             Self::BeforeToolCall => &["continue", "block", "confirm", "modify"],
             Self::AfterToolCall => &["continue", "replace"],
             Self::BeforeMessage => &["continue", "inject"],
-            Self::OnMessageComplete | Self::OnCompaction | Self::OnSessionStart | Self::OnSessionEnd => &["continue"],
+            Self::OnMessageComplete
+            | Self::OnCompaction
+            | Self::OnSessionStart
+            | Self::OnSessionEnd => &["continue"],
         }
     }
 
@@ -108,7 +111,9 @@ impl HookKind {
     pub fn required_permission(&self) -> Permission {
         match self {
             Self::BeforeToolCall | Self::AfterToolCall => Permission::ToolsIntercept,
-            Self::BeforeMessage | Self::OnMessageComplete | Self::OnCompaction => Permission::LlmContent,
+            Self::BeforeMessage | Self::OnMessageComplete | Self::OnCompaction => {
+                Permission::LlmContent
+            }
             Self::OnSessionStart | Self::OnSessionEnd => Permission::SessionLifecycle,
         }
     }
@@ -177,10 +182,14 @@ impl HookEvent {
     }
 
     /// Construct an `after_tool_call` event carrying both input and output.
-    /// Output is truncated to MAX_HOOK_OUTPUT_SIZE to prevent sending
-    /// megabytes of bash output over the JSON-RPC pipe.
+    /// Output is truncated to MAX_HOOK_OUTPUT to bound the JSON-RPC payload
+    /// to extensions. This cap matches the runtime's `max_tool_buffer`
+    /// (the OOM safety net) so transform extensions see the FULL buffered
+    /// tool output and can decide what to keep — the final context-budget
+    /// truncation to `max_tool_output` happens AFTER the hook in
+    /// `emit_after_tool_call` (compress-then-truncate).
     pub fn after_tool_call(tool_name: &str, input: Value, output: String) -> Self {
-        const MAX_HOOK_OUTPUT: usize = 32 * 1024; // 32 KB
+        const MAX_HOOK_OUTPUT: usize = 256 * 1024; // 256 KB — matches max_tool_buffer
         let truncated_output = if output.len() > MAX_HOOK_OUTPUT {
             let boundary = output
                 .char_indices()
@@ -251,9 +260,18 @@ impl HookEvent {
             data = Value::Object(Default::default());
         }
         if let Some(object) = data.as_object_mut() {
-            object.insert("old_session_id".to_string(), Value::String(old_session_id.to_string()));
-            object.insert("new_session_id".to_string(), Value::String(new_session_id.to_string()));
-            object.insert("message_count".to_string(), Value::Number(message_count.into()));
+            object.insert(
+                "old_session_id".to_string(),
+                Value::String(old_session_id.to_string()),
+            );
+            object.insert(
+                "new_session_id".to_string(),
+                Value::String(new_session_id.to_string()),
+            );
+            object.insert(
+                "message_count".to_string(),
+                Value::Number(message_count.into()),
+            );
         }
         Self {
             kind: HookKind::OnCompaction,
@@ -374,7 +392,9 @@ mod tests {
     /// after_tool_call advertises "replace" in its action contract.
     #[test]
     fn after_tool_call_allows_replace_output() {
-        let replace = HookResult::Replace { output: "compressed".into() };
+        let replace = HookResult::Replace {
+            output: "compressed".into(),
+        };
 
         // The transform seam: after_tool_call accepts Replace.
         assert!(
@@ -394,7 +414,9 @@ mod tests {
 
         // The extension-facing action contract advertises "replace".
         assert!(
-            HookKind::AfterToolCall.allowed_action_names().contains(&"replace"),
+            HookKind::AfterToolCall
+                .allowed_action_names()
+                .contains(&"replace"),
             "after_tool_call must advertise the 'replace' action"
         );
     }
@@ -491,8 +513,7 @@ mod tests {
     #[test]
     fn hook_event_after_tool_call() {
         let input = json!({"query": "select 1"});
-        let ev =
-            HookEvent::after_tool_call("sql_query", input.clone(), "1 row".to_string());
+        let ev = HookEvent::after_tool_call("sql_query", input.clone(), "1 row".to_string());
 
         assert_eq!(ev.kind, HookKind::AfterToolCall);
         assert_eq!(ev.tool_name.as_deref(), Some("sql_query"));
@@ -609,7 +630,10 @@ mod tests {
             message: "Run this command?".to_string(),
         };
         let json = serde_json::to_string(&r).unwrap();
-        assert_eq!(json, r#"{"action":"confirm","message":"Run this command?"}"#);
+        assert_eq!(
+            json,
+            r#"{"action":"confirm","message":"Run this command?"}"#
+        );
 
         let back: HookResult = serde_json::from_str(&json).unwrap();
         assert!(matches!(back, HookResult::Confirm { message } if message == "Run this command?"));
@@ -618,12 +642,19 @@ mod tests {
     /// Modify carries replacement input through serialization.
     #[test]
     fn hook_result_modify_serde() {
-        let r = HookResult::Modify { input: json!({"command": "echo safe"}) };
+        let r = HookResult::Modify {
+            input: json!({"command": "echo safe"}),
+        };
         let json = serde_json::to_string(&r).unwrap();
-        assert_eq!(json, r#"{"action":"modify","input":{"command":"echo safe"}}"#);
+        assert_eq!(
+            json,
+            r#"{"action":"modify","input":{"command":"echo safe"}}"#
+        );
 
         let back: HookResult = serde_json::from_str(&json).unwrap();
-        assert!(matches!(back, HookResult::Modify { input } if input == json!({"command": "echo safe"})));
+        assert!(
+            matches!(back, HookResult::Modify { input } if input == json!({"command": "echo safe"}))
+        );
     }
 
     /// Continue serialises as {"action":"continue"}.

--- a/crates/agent-engine/src/extensions/hooks/mod.rs
+++ b/crates/agent-engine/src/extensions/hooks/mod.rs
@@ -154,11 +154,7 @@ impl HookBus {
             let event_clone = event.clone();
             let trace_enabled = extensions_trace_enabled();
             let started_at = trace_enabled.then(Instant::now);
-            let result = tokio::time::timeout(
-                HANDLER_TIMEOUT,
-                handler.handle(&event_clone),
-            )
-            .await;
+            let result = tokio::time::timeout(HANDLER_TIMEOUT, handler.handle(&event_clone)).await;
 
             if trace_enabled {
                 let health = reg.handler.health().await;
@@ -344,32 +340,31 @@ impl HookBus {
         };
 
         // Dispatch all handlers simultaneously.
-        let futures: Vec<_> = registrations
-            .iter()
-            .filter(|reg| {
-                // Apply tool filter before spawning.
-                if let Some(ref filter) = reg.tool_filter {
-                    match (&event.tool_name, &event.tool_runtime_name) {
-                        (Some(api), Some(runtime)) => filter == api || filter == runtime,
-                        (Some(api), None) => filter == api,
-                        (None, Some(runtime)) => filter == runtime,
-                        (None, None) => false,
+        let futures: Vec<_> =
+            registrations
+                .iter()
+                .filter(|reg| {
+                    // Apply tool filter before spawning.
+                    if let Some(ref filter) = reg.tool_filter {
+                        match (&event.tool_name, &event.tool_runtime_name) {
+                            (Some(api), Some(runtime)) => filter == api || filter == runtime,
+                            (Some(api), None) => filter == api,
+                            (None, Some(runtime)) => filter == runtime,
+                            (None, None) => false,
+                        }
+                    } else {
+                        true
                     }
-                } else {
-                    true
-                }
-            })
-            .filter(|reg| {
-                reg.matcher.as_ref().map_or(true, |m| m.matches(event))
-            })
-            .map(|reg| {
-                let handler = reg.handler.clone();
-                let event_clone = event.clone();
-                async move {
-                    tokio::time::timeout(HANDLER_TIMEOUT, handler.handle(&event_clone)).await
-                }
-            })
-            .collect();
+                })
+                .filter(|reg| reg.matcher.as_ref().map_or(true, |m| m.matches(event)))
+                .map(|reg| {
+                    let handler = reg.handler.clone();
+                    let event_clone = event.clone();
+                    async move {
+                        tokio::time::timeout(HANDLER_TIMEOUT, handler.handle(&event_clone)).await
+                    }
+                })
+                .collect();
 
         let results = join_all(futures).await;
 
@@ -443,11 +438,7 @@ impl HookBus {
                 }
             }
         }
-        out.sort_by(|a, b| {
-            a.0.as_str()
-                .cmp(b.0.as_str())
-                .then_with(|| a.1.cmp(&b.1))
-        });
+        out.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()).then_with(|| a.1.cmp(&b.1)));
         out
     }
 }
@@ -517,7 +508,9 @@ mod tests {
         let bus = std::sync::Arc::new(HookBus::new());
         let handler = TestHandler::new(
             "compressor",
-            HookResult::Replace { output: "COMPRESSED".into() },
+            HookResult::Replace {
+                output: "COMPRESSED".into(),
+            },
         );
         bus.subscribe(
             HookKind::AfterToolCall,
@@ -535,6 +528,7 @@ mod tests {
             None,
             serde_json::json!({"command": "cat huge.log"}),
             "RAW 10k lines".to_string(),
+            30_000,
         )
         .await;
 
@@ -551,6 +545,7 @@ mod tests {
             None,
             serde_json::json!({}),
             "RAW".to_string(),
+            30_000,
         )
         .await;
 
@@ -563,13 +558,29 @@ mod tests {
     #[tokio::test]
     async fn replace_stops_chain_for_after_tool_call() {
         let bus = HookBus::new();
-        let first = TestHandler::new("first", HookResult::Replace { output: "FIRST".into() });
-        let second = TestHandler::new("second", HookResult::Replace { output: "SECOND".into() });
+        let first = TestHandler::new(
+            "first",
+            HookResult::Replace {
+                output: "FIRST".into(),
+            },
+        );
+        let second = TestHandler::new(
+            "second",
+            HookResult::Replace {
+                output: "SECOND".into(),
+            },
+        );
         let perms = perms_with(&[Permission::ToolsIntercept, Permission::ToolsTransformOutput]);
 
-        bus.subscribe(HookKind::AfterToolCall, first.clone(), None, None, perms.clone())
-            .await
-            .unwrap();
+        bus.subscribe(
+            HookKind::AfterToolCall,
+            first.clone(),
+            None,
+            None,
+            perms.clone(),
+        )
+        .await
+        .unwrap();
         bus.subscribe(HookKind::AfterToolCall, second.clone(), None, None, perms)
             .await
             .unwrap();
@@ -577,7 +588,12 @@ mod tests {
         let event = HookEvent::after_tool_call("bash", serde_json::json!({}), "RAW".to_string());
         let result = bus.emit(&event).await;
 
-        assert_eq!(result, HookResult::Replace { output: "FIRST".into() });
+        assert_eq!(
+            result,
+            HookResult::Replace {
+                output: "FIRST".into()
+            }
+        );
         assert_eq!(first.calls(), 1);
         assert_eq!(second.calls(), 0); // never reached — first transform wins
     }
@@ -590,7 +606,9 @@ mod tests {
         let bus = std::sync::Arc::new(HookBus::new());
         let handler = TestHandler::new(
             "observer-only",
-            HookResult::Replace { output: "SNEAKY".into() },
+            HookResult::Replace {
+                output: "SNEAKY".into(),
+            },
         );
         // Only the observe key — NOT tools.transform_output.
         bus.subscribe(
@@ -609,6 +627,7 @@ mod tests {
             None,
             serde_json::json!({}),
             "ORIGINAL".to_string(),
+            30_000,
         )
         .await;
 
@@ -623,12 +642,18 @@ mod tests {
     fn trace_env_value_parser_accepts_common_truthy_values() {
         for value in ["1", "true", "TRUE", "yes", "on"] {
             std::env::set_var("SYNAPS_EXTENSIONS_TRACE", value);
-            assert!(extensions_trace_enabled(), "{value} should enable trace mode");
+            assert!(
+                extensions_trace_enabled(),
+                "{value} should enable trace mode"
+            );
         }
 
         for value in ["", "0", "false", "off", "no"] {
             std::env::set_var("SYNAPS_EXTENSIONS_TRACE", value);
-            assert!(!extensions_trace_enabled(), "{value:?} should not enable trace mode");
+            assert!(
+                !extensions_trace_enabled(),
+                "{value:?} should not enable trace mode"
+            );
         }
         std::env::remove_var("SYNAPS_EXTENSIONS_TRACE");
     }
@@ -636,7 +661,12 @@ mod tests {
     #[tokio::test]
     async fn matcher_skips_handler_when_input_does_not_contain_value() {
         let bus = HookBus::new();
-        let handler = TestHandler::new("matcher", HookResult::Block { reason: "matched".into() });
+        let handler = TestHandler::new(
+            "matcher",
+            HookResult::Block {
+                reason: "matched".into(),
+            },
+        );
         let mut perms = PermissionSet::new();
         perms.grant(Permission::ToolsIntercept);
         bus.subscribe(
@@ -648,12 +678,15 @@ mod tests {
                 input_equals: None,
             }),
             perms,
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
         let safe = HookEvent::before_tool_call("bash", serde_json::json!({"command": "echo safe"}));
         assert!(matches!(bus.emit(&safe).await, HookResult::Continue));
 
-        let danger = HookEvent::before_tool_call("bash", serde_json::json!({"command": "echo danger"}));
+        let danger =
+            HookEvent::before_tool_call("bash", serde_json::json!({"command": "echo danger"}));
         assert!(matches!(bus.emit(&danger).await, HookResult::Block { .. }));
     }
 
@@ -713,15 +746,24 @@ mod tests {
     #[tokio::test]
     async fn confirm_stops_chain_for_before_tool_call() {
         let bus = HookBus::new();
-        let confirmer = TestHandler::new("confirmer", HookResult::Confirm {
-            message: "Run this command?".into(),
-        });
+        let confirmer = TestHandler::new(
+            "confirmer",
+            HookResult::Confirm {
+                message: "Run this command?".into(),
+            },
+        );
         let after = TestHandler::new("after", HookResult::Continue);
         let perms = perms_with(&[Permission::ToolsIntercept]);
 
-        bus.subscribe(HookKind::BeforeToolCall, confirmer.clone(), None, None, perms.clone())
-            .await
-            .unwrap();
+        bus.subscribe(
+            HookKind::BeforeToolCall,
+            confirmer.clone(),
+            None,
+            None,
+            perms.clone(),
+        )
+        .await
+        .unwrap();
         bus.subscribe(HookKind::BeforeToolCall, after.clone(), None, None, perms)
             .await
             .unwrap();
@@ -737,14 +779,23 @@ mod tests {
     #[tokio::test]
     async fn confirm_is_ignored_for_non_tool_hooks() {
         let bus = HookBus::new();
-        let confirmer = TestHandler::new("confirmer", HookResult::Confirm {
-            message: "Not allowed here".into(),
-        });
+        let confirmer = TestHandler::new(
+            "confirmer",
+            HookResult::Confirm {
+                message: "Not allowed here".into(),
+            },
+        );
         let perms = perms_with(&[Permission::LlmContent]);
 
-        bus.subscribe(HookKind::BeforeMessage, confirmer.clone(), None, None, perms)
-            .await
-            .unwrap();
+        bus.subscribe(
+            HookKind::BeforeMessage,
+            confirmer.clone(),
+            None,
+            None,
+            perms,
+        )
+        .await
+        .unwrap();
 
         let event = HookEvent::before_message("hello");
         let result = bus.emit(&event).await;
@@ -756,15 +807,24 @@ mod tests {
     #[tokio::test]
     async fn block_stops_chain() {
         let bus = HookBus::new();
-        let blocker = TestHandler::new("blocker", HookResult::Block {
-            reason: "dangerous".into(),
-        });
+        let blocker = TestHandler::new(
+            "blocker",
+            HookResult::Block {
+                reason: "dangerous".into(),
+            },
+        );
         let after = TestHandler::new("after", HookResult::Continue);
         let perms = perms_with(&[Permission::ToolsIntercept]);
 
-        bus.subscribe(HookKind::BeforeToolCall, blocker.clone(), None, None, perms.clone())
-            .await
-            .unwrap();
+        bus.subscribe(
+            HookKind::BeforeToolCall,
+            blocker.clone(),
+            None,
+            None,
+            perms.clone(),
+        )
+        .await
+        .unwrap();
         bus.subscribe(HookKind::BeforeToolCall, after.clone(), None, None, perms)
             .await
             .unwrap();
@@ -780,17 +840,29 @@ mod tests {
     #[tokio::test]
     async fn modify_stops_chain() {
         let bus = HookBus::new();
-        let modifier = TestHandler::new("modifier", HookResult::Modify {
-            input: serde_json::json!({"command": "echo safe"}),
-        });
-        let after = TestHandler::new("after", HookResult::Block {
-            reason: "should not run".into(),
-        });
+        let modifier = TestHandler::new(
+            "modifier",
+            HookResult::Modify {
+                input: serde_json::json!({"command": "echo safe"}),
+            },
+        );
+        let after = TestHandler::new(
+            "after",
+            HookResult::Block {
+                reason: "should not run".into(),
+            },
+        );
         let perms = perms_with(&[Permission::ToolsIntercept]);
 
-        bus.subscribe(HookKind::BeforeToolCall, modifier.clone(), None, None, perms.clone())
-            .await
-            .unwrap();
+        bus.subscribe(
+            HookKind::BeforeToolCall,
+            modifier.clone(),
+            None,
+            None,
+            perms.clone(),
+        )
+        .await
+        .unwrap();
         bus.subscribe(HookKind::BeforeToolCall, after.clone(), None, None, perms)
             .await
             .unwrap();
@@ -798,7 +870,9 @@ mod tests {
         let event = HookEvent::before_tool_call("bash", serde_json::json!({"command": "rm -rf /"}));
         let result = bus.emit(&event).await;
 
-        assert!(matches!(result, HookResult::Modify { input } if input == serde_json::json!({"command": "echo safe"})));
+        assert!(
+            matches!(result, HookResult::Modify { input } if input == serde_json::json!({"command": "echo safe"}))
+        );
         assert_eq!(modifier.calls(), 1);
         assert_eq!(after.calls(), 0); // never reached
     }
@@ -866,12 +940,24 @@ mod tests {
         let beta = TestHandler::new("beta", HookResult::Continue);
         let perms = perms_with(&[Permission::ToolsIntercept]);
 
-        bus.subscribe(HookKind::BeforeToolCall, alpha.clone(), Some("bash".into()), None, perms.clone())
-            .await
-            .unwrap();
-        bus.subscribe(HookKind::AfterToolCall, alpha.clone(), None, None, perms.clone())
-            .await
-            .unwrap();
+        bus.subscribe(
+            HookKind::BeforeToolCall,
+            alpha.clone(),
+            Some("bash".into()),
+            None,
+            perms.clone(),
+        )
+        .await
+        .unwrap();
+        bus.subscribe(
+            HookKind::AfterToolCall,
+            alpha.clone(),
+            None,
+            None,
+            perms.clone(),
+        )
+        .await
+        .unwrap();
         bus.subscribe(HookKind::BeforeToolCall, beta.clone(), None, None, perms)
             .await
             .unwrap();
@@ -902,5 +988,211 @@ mod tests {
             .await
             .unwrap();
         assert!(!bus.is_empty().await);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // compress-then-truncate ordering (Synaps Fork 1) — RED stub
+    // ────────────────────────────────────────────────────────────────────────
+
+    #[derive(Debug)]
+    struct RecordingHandler {
+        id: String,
+        recorded_len: Arc<AtomicUsize>,
+        result: HookResult,
+    }
+    impl RecordingHandler {
+        fn new(id: &str, result: HookResult) -> (Arc<Self>, Arc<AtomicUsize>) {
+            let recorded_len = Arc::new(AtomicUsize::new(0));
+            let h = Arc::new(Self {
+                id: id.to_string(),
+                recorded_len: recorded_len.clone(),
+                result,
+            });
+            (h, recorded_len)
+        }
+    }
+    #[async_trait]
+    impl crate::extensions::runtime::ExtensionHandler for RecordingHandler {
+        fn id(&self) -> &str {
+            &self.id
+        }
+        async fn handle(&self, event: &HookEvent) -> HookResult {
+            if let Some(out) = event.tool_output.as_ref() {
+                self.recorded_len.store(out.len(), Ordering::Relaxed);
+            }
+            self.result.clone()
+        }
+        async fn shutdown(&self) {}
+    }
+
+    /// Test A (RED stub, current signature) — proves the bug.
+    #[tokio::test]
+    async fn after_tool_call_transform_receives_full_output_not_pre_truncated() {
+        use crate::tools::Tool;
+        let bus = std::sync::Arc::new(HookBus::new());
+        let (handler, recorded_len) = RecordingHandler::new("len-recorder", HookResult::Continue);
+        bus.subscribe(
+            HookKind::AfterToolCall,
+            handler,
+            None,
+            None,
+            perms_with(&[Permission::ToolsIntercept]),
+        )
+        .await
+        .unwrap();
+
+        let ctx = crate::tools::ToolContext {
+            channels: crate::tools::ToolChannels {
+                tx_delta: None,
+                tx_events: None,
+            },
+            capabilities: crate::tools::ToolCapabilities {
+                watcher_exit_path: None,
+                tool_register_tx: None,
+                session_manager: None,
+                subagent_registry: None,
+                event_queue: None,
+                secret_prompt: None,
+            },
+            limits: crate::tools::ToolLimits {
+                max_tool_output: 30_000,
+                max_tool_buffer: 256 * 1024,
+                bash_timeout: 30,
+                bash_max_timeout: 300,
+                subagent_timeout: 300,
+            },
+        };
+
+        let bash = crate::tools::BashTool;
+        let output = bash
+            .execute(
+                serde_json::json!({"command": "yes hello | head -c 150000"}),
+                ctx,
+            )
+            .await
+            .expect("bash should succeed");
+
+        let _ = crate::runtime::emit_after_tool_call(
+            &bus,
+            "bash",
+            None,
+            serde_json::json!({"command": "yes hello | head -c 150000"}),
+            output,
+            30_000,
+        )
+        .await;
+
+        let len = recorded_len.load(Ordering::Relaxed);
+        assert!(
+            len > 100_000,
+            "after_tool_call handler was starved: received {len} bytes — \
+             expected the full ~150KB buffered output (max_tool_buffer=256KB)"
+        );
+    }
+
+    /// Test B: when a transform Replaces with a >max_tool_output string, the
+    /// FINAL emit_after_tool_call return is ≤ max_tool_output (+marker overhead).
+    /// Proves compress-then-truncate ordering at the new site.
+    #[tokio::test]
+    async fn final_output_truncated_to_max_tool_output_after_hook() {
+        let bus = std::sync::Arc::new(HookBus::new());
+        let big: String = "x".repeat(100_000);
+        let handler = TestHandler::new("bloater", HookResult::Replace { output: big });
+        bus.subscribe(
+            HookKind::AfterToolCall,
+            handler,
+            None,
+            None,
+            perms_with(&[Permission::ToolsIntercept, Permission::ToolsTransformOutput]),
+        )
+        .await
+        .unwrap();
+
+        let result = crate::runtime::emit_after_tool_call(
+            &bus,
+            "bash",
+            None,
+            serde_json::json!({}),
+            "tiny original".to_string(),
+            30_000,
+        )
+        .await;
+
+        assert!(
+            result.len() <= 30_000 + 200,
+            "post-hook output should be capped at max_tool_output (got {} bytes)",
+            result.len()
+        );
+    }
+
+    /// Test C: with NO transform, the final output is byte-identical to the
+    /// legacy truncate_tool_result(...) result — behavior preservation invariant.
+    #[tokio::test]
+    async fn no_transform_extension_preserves_legacy_truncation() {
+        let bus = std::sync::Arc::new(HookBus::new());
+        let huge: String = "y".repeat(80_000);
+
+        let result = crate::runtime::emit_after_tool_call(
+            &bus,
+            "bash",
+            None,
+            serde_json::json!({}),
+            huge.clone(),
+            30_000,
+        )
+        .await;
+
+        let legacy = crate::runtime::helpers::HelperMethods::truncate_tool_result(&huge, 30_000);
+        assert_eq!(
+            result, legacy,
+            "no-extension path must be byte-identical to legacy truncation"
+        );
+    }
+
+    /// Test D: emit_after_tool_call unit-level — Continue and Replace branches
+    /// both truncate to max_tool_output, and truncation is char-boundary safe.
+    #[tokio::test]
+    async fn emit_after_tool_call_truncates_char_boundary_safe() {
+        // Continue path with multibyte content.
+        let bus = std::sync::Arc::new(HookBus::new());
+        let multibyte: String = "héllo🌟".repeat(5_000);
+        assert!(multibyte.len() > 30_000);
+
+        let result = crate::runtime::emit_after_tool_call(
+            &bus,
+            "bash",
+            None,
+            serde_json::json!({}),
+            multibyte,
+            30_000,
+        )
+        .await;
+        assert!(result.is_char_boundary(result.len()));
+
+        // Replace path with multibyte content.
+        let bus2 = std::sync::Arc::new(HookBus::new());
+        let big_multi = "✨".repeat(20_000);
+        assert!(big_multi.len() > 30_000);
+        let handler = TestHandler::new("mb-replacer", HookResult::Replace { output: big_multi });
+        bus2.subscribe(
+            HookKind::AfterToolCall,
+            handler,
+            None,
+            None,
+            perms_with(&[Permission::ToolsIntercept, Permission::ToolsTransformOutput]),
+        )
+        .await
+        .unwrap();
+
+        let result2 = crate::runtime::emit_after_tool_call(
+            &bus2,
+            "bash",
+            None,
+            serde_json::json!({}),
+            "orig".to_string(),
+            30_000,
+        )
+        .await;
+        assert!(result2.is_char_boundary(result2.len()));
     }
 }

--- a/crates/agent-engine/src/extensions/runtime/process.rs
+++ b/crates/agent-engine/src/extensions/runtime/process.rs
@@ -3,11 +3,11 @@
 //! Spawns the extension as a child process. Communication uses
 //! Content-Length framing (LSP-style) over stdin/stdout.
 
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::collections::{HashMap, HashSet};
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -28,7 +28,6 @@ struct JsonRpcRequest {
     params: Value,
     id: u64,
 }
-
 
 #[derive(Serialize)]
 struct InitializeParams {
@@ -181,9 +180,7 @@ pub fn parse_provider_stream_event(params: &Value) -> Result<ProviderStreamEvent
                 None => Value::Object(Default::default()),
                 Some(v) if v.is_object() => v.clone(),
                 Some(_) => {
-                    return Err(
-                        "provider stream tool_use input must be a JSON object".to_string()
-                    );
+                    return Err("provider stream tool_use input must be a JSON object".to_string());
                 }
             };
             Ok(ProviderStreamEvent::ToolUse {
@@ -245,13 +242,17 @@ pub async fn execute_provider_tool_use(
             &tool_name,
             Some(&runtime_name),
             input.clone(),
-        ).await,
+        )
+        .await,
         ctx.capabilities.secret_prompt.as_ref(),
         false,
-    ).await;
+    )
+    .await;
 
     let crate::runtime::BeforeToolCallDecision::Continue { input } = decision else {
-        let crate::runtime::BeforeToolCallDecision::Block { reason } = decision else { unreachable!() };
+        let crate::runtime::BeforeToolCallDecision::Block { reason } = decision else {
+            unreachable!()
+        };
         return serde_json::json!({
             "type": "tool_result",
             "tool_use_id": tool_id,
@@ -271,7 +272,9 @@ pub async fn execute_provider_tool_use(
         Some(&runtime_name),
         input_for_hook,
         result,
-    ).await;
+        max_tool_output,
+    )
+    .await;
 
     let mut response = serde_json::json!({
         "type": "tool_result",
@@ -319,13 +322,16 @@ where
 
         let mut tool_results = Vec::with_capacity(tool_uses.len());
         for tool_use in tool_uses {
-            tool_results.push(execute_provider_tool_use(
-                registry,
-                hook_bus,
-                tool_use,
-                context_factory(),
-                max_tool_output,
-            ).await);
+            tool_results.push(
+                execute_provider_tool_use(
+                    registry,
+                    hook_bus,
+                    tool_use,
+                    context_factory(),
+                    max_tool_output,
+                )
+                .await,
+            );
         }
         params.messages.push(serde_json::json!({
             "role": "user",
@@ -539,7 +545,8 @@ impl Inbox {
     /// Drains all pending request senders, sending `Err(reason)` to each.
     /// Also marks the inbox as closed so no new requests can be registered.
     async fn fail_all_pending(&self, reason: &str) {
-        self.closed.store(true, std::sync::atomic::Ordering::Release);
+        self.closed
+            .store(true, std::sync::atomic::Ordering::Release);
         let drained: Vec<_> = {
             let mut pending = self.pending.lock().await;
             pending.drain().collect()
@@ -799,8 +806,8 @@ impl ProcessExtension {
         tokio::io::AsyncReadExt::read_exact(reader, &mut buf)
             .await
             .map_err(|e| format!("Read body error: {}", e))?;
-        let value: Value = serde_json::from_slice(&buf)
-            .map_err(|e| format!("Parse frame error: {}", e))?;
+        let value: Value =
+            serde_json::from_slice(&buf).map_err(|e| format!("Parse frame error: {}", e))?;
         Ok(Some(value))
     }
 
@@ -812,7 +819,10 @@ impl ProcessExtension {
     async fn dispatch_frame(value: Value, inbox: &Arc<Inbox>, extension_id: &str) {
         let id_field = value.get("id");
         let id_is_present = !matches!(id_field, None | Some(Value::Null));
-        let method_field = value.get("method").and_then(Value::as_str).map(str::to_string);
+        let method_field = value
+            .get("method")
+            .and_then(Value::as_str)
+            .map(str::to_string);
 
         if id_is_present && method_field.is_some() {
             // Inbound request from the extension. Spawn a task to handle it
@@ -909,10 +919,7 @@ impl ProcessExtension {
                             .to_string();
                         Err(format!("Extension error: {}", message))
                     } else {
-                        Ok(value
-                            .get("result")
-                            .cloned()
-                            .unwrap_or(Value::Null))
+                        Ok(value.get("result").cloned().unwrap_or(Value::Null))
                     };
                     let _ = tx.send(payload);
                 }
@@ -1003,12 +1010,7 @@ impl ProcessExtension {
                         }
                         out
                     }
-                    _ => {
-                        return Err((
-                            -32602,
-                            "tags must be an array of strings".to_string(),
-                        ))
-                    }
+                    _ => return Err((-32602, "tags must be an array of strings".to_string())),
                 };
                 let meta = match params.get("meta") {
                     None | Some(Value::Null) => None,
@@ -1045,7 +1047,8 @@ impl ProcessExtension {
             "config.get" => {
                 let key = Self::param_str(&params, "key")?;
                 Self::validate_config_key(&key)?;
-                let value = crate::extensions::config_store::read_plugin_config(&inbox.extension_id, &key);
+                let value =
+                    crate::extensions::config_store::read_plugin_config(&inbox.extension_id, &key);
                 Ok(serde_json::json!({"value": value}))
             }
             "config.set" => {
@@ -1053,12 +1056,17 @@ impl ProcessExtension {
                 let key = Self::param_str(&params, "key")?;
                 Self::validate_config_key(&key)?;
                 let value = Self::param_str(&params, "value")?;
-                crate::extensions::config_store::write_plugin_config(&inbox.extension_id, &key, &value)
-                    .map_err(|e| (-32000, e.to_string()))?;
+                crate::extensions::config_store::write_plugin_config(
+                    &inbox.extension_id,
+                    &key,
+                    &value,
+                )
+                .map_err(|e| (-32000, e.to_string()))?;
                 Ok(serde_json::json!({"ok": true}))
             }
             "config.subscribe" => {
-                Self::require_permission(inbox, Permission::ConfigSubscribe, "config.subscribe").await?;
+                Self::require_permission(inbox, Permission::ConfigSubscribe, "config.subscribe")
+                    .await?;
                 // The long-lived watcher-to-notification bridge is wired at the manager/UI layer.
                 // This phase exposes the authorized protocol ACK so plugins can opt in without
                 // blocking initialize; direct store watchers are unit-tested in config_store.
@@ -1076,10 +1084,7 @@ impl ProcessExtension {
         let guard = inbox.permissions.read().await;
         match guard.as_ref() {
             Some(set) if set.has(perm) => Ok(()),
-            _ => Err((
-                -32602,
-                format!("permission denied: {wire} required"),
-            )),
+            _ => Err((-32602, format!("permission denied: {wire} required"))),
         }
     }
 
@@ -1122,7 +1127,11 @@ impl ProcessExtension {
         Ok(())
     }
 
-    pub async fn initialize(&self, plugin_root: Option<PathBuf>, config: Value) -> Result<InitializeCapabilitiesResult, String> {
+    pub async fn initialize(
+        &self,
+        plugin_root: Option<PathBuf>,
+        config: Value,
+    ) -> Result<InitializeCapabilitiesResult, String> {
         let params = InitializeParams {
             synaps_version: env!("CARGO_PKG_VERSION"),
             extension_protocol_version: CURRENT_EXTENSION_PROTOCOL_VERSION,
@@ -1132,11 +1141,19 @@ impl ProcessExtension {
                 .map(|path| path.to_string_lossy().to_string()),
             config,
         };
-        let value = self.call_no_restart("initialize", serde_json::to_value(params).map_err(|e| e.to_string())?).await?;
+        let value = self
+            .call_no_restart(
+                "initialize",
+                serde_json::to_value(params).map_err(|e| e.to_string())?,
+            )
+            .await?;
         Self::parse_initialize_result(&self.id, value)
     }
 
-    fn parse_initialize_result(id: &str, value: Value) -> Result<InitializeCapabilitiesResult, String> {
+    fn parse_initialize_result(
+        id: &str,
+        value: Value,
+    ) -> Result<InitializeCapabilitiesResult, String> {
         let result: InitializeResult = serde_json::from_value(value)
             .map_err(|e| format!("Invalid initialize response from extension '{}': {}", id, e))?;
         if result.protocol_version != CURRENT_EXTENSION_PROTOCOL_VERSION {
@@ -1154,7 +1171,10 @@ impl ProcessExtension {
         })
     }
 
-    fn validate_registered_tool_specs(id: &str, tools: &[RegisteredExtensionToolSpec]) -> Result<(), String> {
+    fn validate_registered_tool_specs(
+        id: &str,
+        tools: &[RegisteredExtensionToolSpec],
+    ) -> Result<(), String> {
         use crate::extensions::validation::{validate_id_segment, IdValidationError};
         let mut names = HashSet::new();
         for tool in tools {
@@ -1184,7 +1204,10 @@ impl ProcessExtension {
                 });
             }
             if !names.insert(name.to_string()) {
-                return Err(format!("Extension '{}' registered duplicate tool name '{}'", id, name));
+                return Err(format!(
+                    "Extension '{}' registered duplicate tool name '{}'",
+                    id, name
+                ));
             }
             if tool.description.trim().is_empty() {
                 return Err(format!(
@@ -1202,7 +1225,10 @@ impl ProcessExtension {
         Ok(())
     }
 
-    fn validate_registered_provider_specs(id: &str, providers: &[RegisteredProviderSpec]) -> Result<(), String> {
+    fn validate_registered_provider_specs(
+        id: &str,
+        providers: &[RegisteredProviderSpec],
+    ) -> Result<(), String> {
         use crate::extensions::validation::{validate_id_segment, IdValidationError};
         for provider in providers {
             let provider_id = provider.id.trim();
@@ -1295,12 +1321,16 @@ impl ProcessExtension {
     fn is_safe_provider_id(id: &str) -> bool {
         !id.is_empty()
             && !id.contains(':')
-            && id.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
+            && id
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '_')
     }
 
     #[doc(hidden)]
     pub async fn initialize_for_test(&self, plugin_root: Option<PathBuf>) -> Result<(), String> {
-        self.initialize(plugin_root, Value::Object(Default::default())).await.map(|_| ())
+        self.initialize(plugin_root, Value::Object(Default::default()))
+            .await
+            .map(|_| ())
     }
 
     async fn restart_locked(&self, state: &mut Option<ProcessState>) -> Result<(), String> {
@@ -1342,15 +1372,20 @@ impl ProcessExtension {
             tokio::time::sleep(delay).await;
         }
 
-        *state = Some(Self::spawn_state(
-            &self.id,
-            &self.command,
-            &self.args,
-            self.cwd.as_ref(),
-            self.inbox.clone(),
-        ).await?);
+        *state = Some(
+            Self::spawn_state(
+                &self.id,
+                &self.command,
+                &self.args,
+                self.cwd.as_ref(),
+                self.inbox.clone(),
+            )
+            .await?,
+        );
         // Reset closed flag now that we have a fresh transport
-        self.inbox.closed.store(false, std::sync::atomic::Ordering::Release);
+        self.inbox
+            .closed
+            .store(false, std::sync::atomic::Ordering::Release);
         self.initialize_locked(state).await?;
         // NOTE: the consecutive-failure counter is NOT reset here. A
         // successful handshake isn't proof of recovery — a crash-looping
@@ -1361,13 +1396,13 @@ impl ProcessExtension {
         Ok(())
     }
 
-
     async fn initialize_locked(&self, state: &mut Option<ProcessState>) -> Result<(), String> {
         let params = InitializeParams {
             synaps_version: env!("CARGO_PKG_VERSION"),
             extension_protocol_version: CURRENT_EXTENSION_PROTOCOL_VERSION,
             plugin_id: self.id.clone(),
-            plugin_root: self.cwd
+            plugin_root: self
+                .cwd
                 .clone()
                 .map(|path| path.to_string_lossy().to_string()),
             config: Value::Object(Default::default()),
@@ -1383,8 +1418,7 @@ impl ProcessExtension {
             ),
         )
         .await
-        .map_err(|_| format!("Extension '{}' initialize timed out after 10s", self.id))?
-        ?;
+        .map_err(|_| format!("Extension '{}' initialize timed out after 10s", self.id))??;
         Self::parse_initialize_result(&self.id, value).map(|_| ())
     }
 
@@ -1456,20 +1490,24 @@ impl ProcessExtension {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let mut state_guard = self.state.lock().await;
         if state_guard.is_none() {
-            *state_guard = Some(Self::spawn_state(
-                &self.id,
-                &self.command,
-                &self.args,
-                self.cwd.as_ref(),
-                self.inbox.clone(),
-            ).await?);
+            *state_guard = Some(
+                Self::spawn_state(
+                    &self.id,
+                    &self.command,
+                    &self.args,
+                    self.cwd.as_ref(),
+                    self.inbox.clone(),
+                )
+                .await?,
+            );
         }
         self.call_once_locked(
             state_guard.as_mut().expect("state should exist"),
             method,
             params,
             id,
-        ).await
+        )
+        .await
     }
 
     async fn call(&self, method: &str, params: Value) -> Result<Value, String> {
@@ -1502,7 +1540,9 @@ impl ProcessExtension {
 
         let result = self
             .call_once_locked(
-                state_guard.as_mut().expect("state should exist after restart"),
+                state_guard
+                    .as_mut()
+                    .expect("state should exist after restart"),
                 method,
                 params.clone(),
                 id,
@@ -1521,7 +1561,9 @@ impl ProcessExtension {
                 self.restart_locked(&mut state_guard).await?;
                 let retry_id = self.next_id.fetch_add(1, Ordering::Relaxed);
                 self.call_once_locked(
-                    state_guard.as_mut().expect("state should exist after restart"),
+                    state_guard
+                        .as_mut()
+                        .expect("state should exist after restart"),
                     method,
                     params,
                     retry_id,
@@ -1532,7 +1574,10 @@ impl ProcessExtension {
                     self.restart_count.store(0, Ordering::Relaxed);
                 })
                 .map_err(|retry_error| {
-                    format!("{}; retry after restart failed: {}", first_error, retry_error)
+                    format!(
+                        "{}; retry after restart failed: {}",
+                        first_error, retry_error
+                    )
                 })
             }
         }
@@ -1600,14 +1645,17 @@ impl ProcessExtension {
         frame: NotificationFrame,
     ) -> bool {
         use crate::extensions::commands::parse_command_output;
-        use crate::extensions::tasks::{is_task_method, parse_task_event};
         use crate::extensions::runtime::InvokeCommandEvent;
+        use crate::extensions::tasks::{is_task_method, parse_task_event};
 
         let mut saw_done = false;
         if frame.method == "command.output" {
             match parse_command_output(&frame.params) {
                 Ok(parsed) if parsed.request_id == request_id => {
-                    if matches!(parsed.event, crate::extensions::commands::CommandOutputEvent::Done) {
+                    if matches!(
+                        parsed.event,
+                        crate::extensions::commands::CommandOutputEvent::Done
+                    ) {
                         saw_done = true;
                     }
                     if *sink_open && sink.send(InvokeCommandEvent::Output(parsed.event)).is_err() {
@@ -1702,23 +1750,40 @@ impl ExtensionHandler for ProcessExtension {
     }
 
     async fn call_tool(&self, name: &str, input: Value) -> Result<Value, String> {
-        self.call("tool.call", serde_json::json!({
-            "name": name,
-            "input": input,
-        })).await
+        self.call(
+            "tool.call",
+            serde_json::json!({
+                "name": name,
+                "input": input,
+            }),
+        )
+        .await
     }
 
-    async fn provider_complete(&self, params: ProviderCompleteParams) -> Result<ProviderCompleteResult, String> {
+    async fn provider_complete(
+        &self,
+        params: ProviderCompleteParams,
+    ) -> Result<ProviderCompleteResult, String> {
         let value = tokio::time::timeout(
             std::time::Duration::from_secs(60),
-            self.call("provider.complete", serde_json::to_value(params).map_err(|e| e.to_string())?),
+            self.call(
+                "provider.complete",
+                serde_json::to_value(params).map_err(|e| e.to_string())?,
+            ),
         )
         .await
         .map_err(|_| format!("Extension '{}' provider.complete timed out", self.id))??;
-        let result: ProviderCompleteResult = serde_json::from_value(value)
-            .map_err(|e| format!("Invalid provider.complete response from extension '{}': {}", self.id, e))?;
+        let result: ProviderCompleteResult = serde_json::from_value(value).map_err(|e| {
+            format!(
+                "Invalid provider.complete response from extension '{}': {}",
+                self.id, e
+            )
+        })?;
         if result.content.is_empty() {
-            return Err(format!("Extension '{}' provider.complete returned empty content", self.id));
+            return Err(format!(
+                "Extension '{}' provider.complete returned empty content",
+                self.id
+            ));
         }
         Ok(result)
     }
@@ -1731,8 +1796,7 @@ impl ExtensionHandler for ProcessExtension {
         // Subscribe BEFORE issuing the request so we don't miss early
         // notifications that may arrive before `call(...)` even starts polling.
         let (sub_id, mut rx) = self.subscribe_notifications().await;
-        let params_value =
-            serde_json::to_value(params).map_err(|e| e.to_string())?;
+        let params_value = serde_json::to_value(params).map_err(|e| e.to_string())?;
 
         let extension_id = self.id.clone();
         let stream_future = async {
@@ -1754,30 +1818,26 @@ impl ExtensionHandler for ProcessExtension {
             // subscribers (if any) are untouched.
             self.unsubscribe_notifications(sub_id).await;
             while let Some(frame) = rx.recv().await {
-                Self::forward_provider_stream_frame(
-                    &extension_id, &sink, &mut sink_open, frame,
-                );
+                Self::forward_provider_stream_frame(&extension_id, &sink, &mut sink_open, frame);
             }
             response
         };
 
-        let outcome = tokio::time::timeout(
-            std::time::Duration::from_secs(60),
-            stream_future,
-        )
-        .await;
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(60), stream_future).await;
 
         // Belt-and-braces: ensure our subscription is cleared on timeout too.
         // Idempotent if the inner future already unsubscribed.
         self.unsubscribe_notifications(sub_id).await;
 
-        let value = outcome
-            .map_err(|_| format!("Extension '{}' provider.stream timed out", self.id))??;
+        let value =
+            outcome.map_err(|_| format!("Extension '{}' provider.stream timed out", self.id))??;
 
-        let result: ProviderCompleteResult = serde_json::from_value(value)
-            .map_err(|e| {
-                format!("Invalid provider.stream response from extension '{}': {}", self.id, e)
-            })?;
+        let result: ProviderCompleteResult = serde_json::from_value(value).map_err(|e| {
+            format!(
+                "Invalid provider.stream response from extension '{}': {}",
+                self.id, e
+            )
+        })?;
         // NOTE: empty `content` is permitted for streaming — output may have
         // been delivered entirely via TextDelta notifications.
         Ok(result)
@@ -1819,29 +1879,34 @@ impl ExtensionHandler for ProcessExtension {
             self.unsubscribe_notifications(sub_id).await;
             while let Ok(frame) = rx.try_recv() {
                 let _ = Self::forward_invoke_command_frame(
-                    &extension_id, &request_id_owned, &sink, &mut sink_open, frame,
+                    &extension_id,
+                    &request_id_owned,
+                    &sink,
+                    &mut sink_open,
+                    frame,
                 );
             }
             response
         };
 
-        let outcome = tokio::time::timeout(
-            std::time::Duration::from_secs(120),
-            invoke_future,
-        )
-        .await;
+        let outcome =
+            tokio::time::timeout(std::time::Duration::from_secs(120), invoke_future).await;
 
         // Belt-and-braces: ensure our subscription is cleared on timeout too.
         // Idempotent if the inner future already unsubscribed.
         self.unsubscribe_notifications(sub_id).await;
 
-        outcome
-            .map_err(|_| format!("Extension '{}' command.invoke timed out", self.id))?
+        outcome.map_err(|_| format!("Extension '{}' command.invoke timed out", self.id))?
     }
 
     async fn handle(&self, event: &HookEvent) -> HookResult {
         let params = serde_json::to_value(event).unwrap_or(Value::Null);
-        match tokio::time::timeout(std::time::Duration::from_secs(5), self.call("hook.handle", params)).await {
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            self.call("hook.handle", params),
+        )
+        .await
+        {
             Ok(Ok(value)) => match serde_json::from_value(value.clone()) {
                 Ok(result) => result,
                 Err(error) => {
@@ -1892,13 +1957,15 @@ impl ExtensionHandler for ProcessExtension {
         )
         .await
         .map_err(|_| format!("Extension '{}' info.get timed out", self.id))??;
-        serde_json::from_value(value)
-            .map_err(|e| format!("Invalid info.get response from extension '{}': {}", self.id, e))
+        serde_json::from_value(value).map_err(|e| {
+            format!(
+                "Invalid info.get response from extension '{}': {}",
+                self.id, e
+            )
+        })
     }
 
-    async fn sidecar_spawn_args(
-        &self,
-    ) -> Result<crate::sidecar::spawn::SidecarSpawnArgs, String> {
+    async fn sidecar_spawn_args(&self) -> Result<crate::sidecar::spawn::SidecarSpawnArgs, String> {
         let value = tokio::time::timeout(
             std::time::Duration::from_secs(5),
             self.call("sidecar.spawn_args", Value::Null),
@@ -1920,16 +1987,27 @@ impl ExtensionHandler for ProcessExtension {
         };
         tokio::time::timeout(
             std::time::Duration::from_secs(5),
-            self.call("settings.editor.open", serde_json::to_value(params).map_err(|e| e.to_string())?),
+            self.call(
+                "settings.editor.open",
+                serde_json::to_value(params).map_err(|e| e.to_string())?,
+            ),
         )
         .await
         .map_err(|_| format!("Extension '{}' settings.editor.open timed out", self.id))?
     }
 
-    async fn settings_editor_key(&self, category: &str, field: &str, key: &str) -> Result<Value, String> {
-        let mut params = serde_json::to_value(crate::extensions::settings_editor::SettingsEditorKeyParams {
-            key: key.to_string(),
-        }).map_err(|e| e.to_string())?;
+    async fn settings_editor_key(
+        &self,
+        category: &str,
+        field: &str,
+        key: &str,
+    ) -> Result<Value, String> {
+        let mut params = serde_json::to_value(
+            crate::extensions::settings_editor::SettingsEditorKeyParams {
+                key: key.to_string(),
+            },
+        )
+        .map_err(|e| e.to_string())?;
         if let Some(obj) = params.as_object_mut() {
             obj.insert("category".to_string(), Value::String(category.to_string()));
             obj.insert("field".to_string(), Value::String(field.to_string()));
@@ -1942,7 +2020,12 @@ impl ExtensionHandler for ProcessExtension {
         .map_err(|_| format!("Extension '{}' settings.editor.key timed out", self.id))?
     }
 
-    async fn settings_editor_commit(&self, category: &str, field: &str, value: Value) -> Result<Value, String> {
+    async fn settings_editor_commit(
+        &self,
+        category: &str,
+        field: &str,
+        value: Value,
+    ) -> Result<Value, String> {
         let params = serde_json::json!({
             "category": category,
             "field": field,
@@ -1977,7 +2060,12 @@ impl ExtensionHandler for ProcessExtension {
             .await;
     }
 
-    async fn subscribe_notifications(&self) -> (usize, tokio::sync::mpsc::UnboundedReceiver<NotificationFrame>) {
+    async fn subscribe_notifications(
+        &self,
+    ) -> (
+        usize,
+        tokio::sync::mpsc::UnboundedReceiver<NotificationFrame>,
+    ) {
         ProcessExtension::subscribe_notifications(self).await
     }
 
@@ -2094,7 +2182,9 @@ mod stream_event_tests {
         let v = json!({"type": "error", "message": "boom"});
         assert_eq!(
             parse_provider_stream_event(&v).unwrap(),
-            ProviderStreamEvent::Error { message: "boom".into() }
+            ProviderStreamEvent::Error {
+                message: "boom".into()
+            }
         );
     }
 
@@ -2306,7 +2396,6 @@ mod capture_validator_tests {
             validate_capability(&d, &perms).expect("should validate");
         }
     }
-
 }
 
 #[cfg(test)]
@@ -2342,10 +2431,7 @@ mod invoke_command_dispatch_tests {
                 "task.start",
                 json!({"id":"dl","label":"Downloading","kind":"download"}),
             ),
-            frame(
-                "task.update",
-                json!({"id":"dl","current":50,"total":100}),
-            ),
+            frame("task.update", json!({"id":"dl","current":50,"total":100})),
             frame(
                 "command.output",
                 json!({"request_id":"r1","event":{"kind":"system","content":"working"}}),
@@ -2359,9 +2445,8 @@ mod invoke_command_dispatch_tests {
 
         let mut saw_done = false;
         for f in frames {
-            saw_done |= ProcessExtension::forward_invoke_command_frame(
-                "ext-test", "r1", &tx, &mut open, f,
-            );
+            saw_done |=
+                ProcessExtension::forward_invoke_command_frame("ext-test", "r1", &tx, &mut open, f);
         }
         drop(tx);
         assert!(saw_done, "should have observed the command Done marker");
@@ -2373,11 +2458,16 @@ mod invoke_command_dispatch_tests {
         assert_eq!(events.len(), 6);
         assert_eq!(
             events[0],
-            InvokeCommandEvent::Output(CommandOutputEvent::Text { content: "A".into() })
+            InvokeCommandEvent::Output(CommandOutputEvent::Text {
+                content: "A".into()
+            })
         );
         assert!(matches!(
             events[1],
-            InvokeCommandEvent::Task(TaskEvent::Start { kind: TaskKind::Download, .. })
+            InvokeCommandEvent::Task(TaskEvent::Start {
+                kind: TaskKind::Download,
+                ..
+            })
         ));
         assert!(matches!(
             events[2],
@@ -2391,7 +2481,10 @@ mod invoke_command_dispatch_tests {
             events[4],
             InvokeCommandEvent::Task(TaskEvent::Done { error: None, .. })
         ));
-        assert_eq!(events[5], InvokeCommandEvent::Output(CommandOutputEvent::Done));
+        assert_eq!(
+            events[5],
+            InvokeCommandEvent::Output(CommandOutputEvent::Done)
+        );
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/helpers.rs
+++ b/crates/agent-engine/src/runtime/helpers.rs
@@ -1,8 +1,8 @@
-use serde_json::{json, Value};
-use tokio::sync::mpsc;
-use super::types::{StreamEvent, AgentEvent};
+use super::types::{AgentEvent, StreamEvent};
 use crate::core::config::CacheTtl;
 use crate::truncate_str;
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
 
 /// Where a cache_control marker sits in the request body.
 /// The API's logical emission order is tools → system → messages, so
@@ -41,7 +41,7 @@ pub(super) fn cache_control_value(ttl: CacheTtl, site: MarkerSite) -> Value {
     }
 }
 
-pub(super) struct HelperMethods;
+pub(crate) struct HelperMethods;
 
 impl HelperMethods {
     /// Drain all pending steering messages from the channel and inject them
@@ -59,7 +59,9 @@ impl HelperMethods {
         let mut injected = false;
         while let Ok(msg) = rx.try_recv() {
             tracing::info!("Steering message injected: {}", truncate_str(&msg, 80));
-            let _ = tx.send(StreamEvent::Agent(AgentEvent::SteeringDelivered { message: msg.clone() }));
+            let _ = tx.send(StreamEvent::Agent(AgentEvent::SteeringDelivered {
+                message: msg.clone(),
+            }));
             messages.push(json!({"role": "user", "content": msg}));
             injected = true;
         }
@@ -120,22 +122,20 @@ impl HelperMethods {
         for mut msg in original {
             if msg["role"].as_str() == Some("assistant") {
                 if let Some(content) = msg["content"].as_array_mut() {
-                    content.retain(|block| {
-                        match block["type"].as_str() {
-                            Some("thinking") => block["thinking"]
-                                .as_str()
-                                .map(|s| !s.is_empty())
-                                .unwrap_or(false),
-                            Some("redacted_thinking") => block["data"]
-                                .as_str()
-                                .map(|s| !s.is_empty())
-                                .unwrap_or(false),
-                            Some("text") => block["text"]
-                                .as_str()
-                                .map(|s| !s.is_empty())
-                                .unwrap_or(false),
-                            _ => true,
-                        }
+                    content.retain(|block| match block["type"].as_str() {
+                        Some("thinking") => block["thinking"]
+                            .as_str()
+                            .map(|s| !s.is_empty())
+                            .unwrap_or(false),
+                        Some("redacted_thinking") => block["data"]
+                            .as_str()
+                            .map(|s| !s.is_empty())
+                            .unwrap_or(false),
+                        Some("text") => block["text"]
+                            .as_str()
+                            .map(|s| !s.is_empty())
+                            .unwrap_or(false),
+                        _ => true,
                     });
                     if content.is_empty() {
                         // No salvageable content. The API rejects empty content
@@ -185,7 +185,9 @@ impl HelperMethods {
     /// The marker is the message-tail site: bare 5m under both `FiveMinutes`
     /// and `Hybrid`, `"ttl":"1h"` only under uniform `OneHour`.
     pub(super) fn annotate_cache_breakpoint(messages: &mut [Value], ttl: CacheTtl) {
-        let Some(last) = messages.last_mut() else { return };
+        let Some(last) = messages.last_mut() else {
+            return;
+        };
 
         // Coerce raw string content into a block array so we can attach cache_control.
         if let Some(text) = last["content"].as_str().map(str::to_owned) {
@@ -247,13 +249,17 @@ impl HelperMethods {
     /// Truncate tool results to avoid ballooning message history.
     /// The full result is still sent to the UI — this only caps what goes into
     /// the API messages that are re-sent on every subsequent call.
-    pub(super) fn truncate_tool_result(result: &str, max_chars: usize) -> String {
+    pub(crate) fn truncate_tool_result(result: &str, max_chars: usize) -> String {
         if result.len() <= max_chars {
             return result.to_string();
         }
         let truncated: String = result.chars().take(max_chars).collect();
-        format!("{}\n\n[truncated — {} total chars, showing first {}]",
-            truncated, result.len(), max_chars)
+        format!(
+            "{}\n\n[truncated — {} total chars, showing first {}]",
+            truncated,
+            result.len(),
+            max_chars
+        )
     }
 
     /// Returns the max output tokens for a given model.
@@ -300,7 +306,11 @@ impl HelperMethods {
         }
 
         let total = input_t + cache_read + cache_create;
-        let pct = if total > 0 { (cache_read as f64 / total as f64 * 100.0) as u32 } else { 0 };
+        let pct = if total > 0 {
+            (cache_read as f64 / total as f64 * 100.0) as u32
+        } else {
+            0
+        };
 
         use std::os::unix::fs::OpenOptionsExt;
         // O_NOFOLLOW: refuse to open if the target is a symlink. Defensive
@@ -333,20 +343,18 @@ impl HelperMethods {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
     use crate::core::config::CacheTtl;
+    use serde_json::json;
 
     #[test]
     fn sanitize_drops_empty_thinking_blocks() {
-        let mut msgs = vec![
-            json!({
-                "role": "assistant",
-                "content": [
-                    {"type": "thinking", "thinking": "", "signature": "sig1"},
-                    {"type": "text", "text": "hello"},
-                ]
-            }),
-        ];
+        let mut msgs = vec![json!({
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "", "signature": "sig1"},
+                {"type": "text", "text": "hello"},
+            ]
+        })];
         HelperMethods::sanitize_thinking_blocks(&mut msgs);
         let content = msgs[0]["content"].as_array().unwrap();
         assert_eq!(content.len(), 1);
@@ -355,30 +363,26 @@ mod tests {
 
     #[test]
     fn sanitize_keeps_non_empty_thinking_blocks() {
-        let mut msgs = vec![
-            json!({
-                "role": "assistant",
-                "content": [
-                    {"type": "thinking", "thinking": "reasoning here", "signature": "sig1"},
-                    {"type": "text", "text": "hello"},
-                ]
-            }),
-        ];
+        let mut msgs = vec![json!({
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "reasoning here", "signature": "sig1"},
+                {"type": "text", "text": "hello"},
+            ]
+        })];
         HelperMethods::sanitize_thinking_blocks(&mut msgs);
         assert_eq!(msgs[0]["content"].as_array().unwrap().len(), 2);
     }
 
     #[test]
     fn sanitize_drops_thinking_with_missing_field() {
-        let mut msgs = vec![
-            json!({
-                "role": "assistant",
-                "content": [
-                    {"type": "thinking", "signature": "sig1"},
-                    {"type": "text", "text": "hello"},
-                ]
-            }),
-        ];
+        let mut msgs = vec![json!({
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "signature": "sig1"},
+                {"type": "text", "text": "hello"},
+            ]
+        })];
         HelperMethods::sanitize_thinking_blocks(&mut msgs);
         let content = msgs[0]["content"].as_array().unwrap();
         assert_eq!(content.len(), 1);
@@ -411,15 +415,13 @@ mod tests {
 
     #[test]
     fn sanitize_drops_empty_text_blocks() {
-        let mut msgs = vec![
-            json!({
-                "role": "assistant",
-                "content": [
-                    {"type": "text", "text": ""},
-                    {"type": "text", "text": "real content"},
-                ]
-            }),
-        ];
+        let mut msgs = vec![json!({
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": ""},
+                {"type": "text", "text": "real content"},
+            ]
+        })];
         HelperMethods::sanitize_thinking_blocks(&mut msgs);
         let content = msgs[0]["content"].as_array().unwrap();
         assert_eq!(content.len(), 1);
@@ -454,14 +456,12 @@ mod tests {
 
     #[test]
     fn sanitize_skips_user_messages() {
-        let mut msgs = vec![
-            json!({
-                "role": "user",
-                "content": [
-                    {"type": "thinking", "thinking": "", "signature": "sig1"},
-                ]
-            }),
-        ];
+        let mut msgs = vec![json!({
+            "role": "user",
+            "content": [
+                {"type": "thinking", "thinking": "", "signature": "sig1"},
+            ]
+        })];
         HelperMethods::sanitize_thinking_blocks(&mut msgs);
         // We only police assistant messages — user messages would be malformed for
         // a different reason and aren't ours to rewrite.
@@ -470,15 +470,13 @@ mod tests {
 
     #[test]
     fn sanitize_drops_redacted_thinking_with_empty_data() {
-        let mut msgs = vec![
-            json!({
-                "role": "assistant",
-                "content": [
-                    {"type": "redacted_thinking", "data": ""},
-                    {"type": "text", "text": "hi"},
-                ]
-            }),
-        ];
+        let mut msgs = vec![json!({
+            "role": "assistant",
+            "content": [
+                {"type": "redacted_thinking", "data": ""},
+                {"type": "text", "text": "hi"},
+            ]
+        })];
         HelperMethods::sanitize_thinking_blocks(&mut msgs);
         let content = msgs[0]["content"].as_array().unwrap();
         assert_eq!(content.len(), 1);
@@ -505,7 +503,9 @@ mod tests {
     fn cache_single_user_string_content_coerced_and_marked() {
         let mut msgs = vec![json!({"role": "user", "content": "hello"})];
         HelperMethods::annotate_cache_breakpoint(&mut msgs, CacheTtl::FiveMinutes);
-        let content = msgs[0]["content"].as_array().expect("coerced to block array");
+        let content = msgs[0]["content"]
+            .as_array()
+            .expect("coerced to block array");
         assert_eq!(content.len(), 1);
         assert_eq!(content[0]["type"], "text");
         assert_eq!(content[0]["text"], "hello");
@@ -523,7 +523,10 @@ mod tests {
         ];
         HelperMethods::annotate_cache_breakpoint(&mut msgs, CacheTtl::FiveMinutes);
         for msg in &msgs[..4] {
-            assert!(!has_marker(msg), "earlier message must not have cache_control");
+            assert!(
+                !has_marker(msg),
+                "earlier message must not have cache_control"
+            );
         }
         assert!(has_marker(&msgs[4]));
         // Earlier string contents must remain untouched strings.
@@ -598,11 +601,19 @@ mod tests {
     #[test]
     fn ccv_hybrid_splits_by_site() {
         assert_eq!(
-            serde_json::to_string(&cache_control_value(CacheTtl::Hybrid, MarkerSite::StablePrefix)).unwrap(),
+            serde_json::to_string(&cache_control_value(
+                CacheTtl::Hybrid,
+                MarkerSite::StablePrefix
+            ))
+            .unwrap(),
             r#"{"ttl":"1h","type":"ephemeral"}"#,
         );
         assert_eq!(
-            serde_json::to_string(&cache_control_value(CacheTtl::Hybrid, MarkerSite::MessageTail)).unwrap(),
+            serde_json::to_string(&cache_control_value(
+                CacheTtl::Hybrid,
+                MarkerSite::MessageTail
+            ))
+            .unwrap(),
             r#"{"type":"ephemeral"}"#,
         );
     }
@@ -615,7 +626,10 @@ mod tests {
         HelperMethods::annotate_cache_breakpoint(&mut msgs, CacheTtl::FiveMinutes);
         let cc = &msgs[0]["content"][0]["cache_control"];
         assert_eq!(cc["type"], "ephemeral");
-        assert!(cc.get("ttl").is_none(), "5m must not emit a ttl key (assert absence)");
+        assert!(
+            cc.get("ttl").is_none(),
+            "5m must not emit a ttl key (assert absence)"
+        );
         assert_eq!(cc.as_object().unwrap().len(), 1, "exactly one key: type");
     }
 
@@ -650,10 +664,19 @@ mod tests {
                 ]}),
             ];
             HelperMethods::annotate_cache_breakpoint(&mut msgs, ttl);
-            assert!(!has_marker(&msgs[0]), "earlier message unmarked under {ttl:?}");
-            assert!(msgs[0]["content"].is_string(), "earlier string content untouched");
+            assert!(
+                !has_marker(&msgs[0]),
+                "earlier message unmarked under {ttl:?}"
+            );
+            assert!(
+                msgs[0]["content"].is_string(),
+                "earlier string content untouched"
+            );
             let content = msgs[1]["content"].as_array().unwrap();
-            assert!(content[0].get("cache_control").is_none(), "only final block marked");
+            assert!(
+                content[0].get("cache_control").is_none(),
+                "only final block marked"
+            );
             assert!(content[1].get("cache_control").is_some());
         }
     }
@@ -683,7 +706,10 @@ mod tests {
         for ttl in [CacheTtl::OneHour, CacheTtl::Hybrid] {
             let mut body = tools_body();
             HelperMethods::mark_last_tool(&mut body, ttl);
-            assert_eq!(body["tools"][1]["cache_control"]["ttl"], "1h", "under {ttl:?}");
+            assert_eq!(
+                body["tools"][1]["cache_control"]["ttl"], "1h",
+                "under {ttl:?}"
+            );
         }
     }
 
@@ -719,7 +745,8 @@ mod tests {
 
     #[test]
     fn system_blocks_oauth_5m_marker_exact_bytes() {
-        let system = HelperMethods::build_system_blocks("oauth", &None, CacheTtl::FiveMinutes).unwrap();
+        let system =
+            HelperMethods::build_system_blocks("oauth", &None, CacheTtl::FiveMinutes).unwrap();
         let last = system.as_array().unwrap().last().unwrap().clone();
         assert_eq!(
             serde_json::to_string(&last["cache_control"]).unwrap(),
@@ -790,7 +817,11 @@ mod tests {
             }
         }
 
-        assert_eq!(markers, vec!["1h", "1h", "5m"], "tool 1h, system 1h, tail 5m");
+        assert_eq!(
+            markers,
+            vec!["1h", "1h", "5m"],
+            "tool 1h, system 1h, tail 5m"
+        );
         // Ordering rule: once a 5m marker appears, no 1h marker may follow.
         let first_5m = markers.iter().position(|m| *m == "5m").unwrap();
         assert!(
@@ -814,7 +845,10 @@ mod tests {
             let system = HelperMethods::build_system_blocks(auth, &prompt, ttl).unwrap();
             for block in system.as_array().unwrap() {
                 if let Some(cc) = block.get("cache_control") {
-                    assert_eq!(serde_json::to_string(cc).unwrap(), r#"{"type":"ephemeral"}"#);
+                    assert_eq!(
+                        serde_json::to_string(cc).unwrap(),
+                        r#"{"type":"ephemeral"}"#
+                    );
                 }
             }
         }

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -1,36 +1,36 @@
+use crate::{Result, RuntimeError, ToolRegistry};
+use futures::stream::Stream;
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
-use crate::{Result, RuntimeError, ToolRegistry};
 use std::sync::Mutex;
+use std::time::Duration;
 use tokio::sync::{mpsc, RwLock};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
-use futures::stream::Stream;
-use std::pin::Pin;
 
-mod types;
-mod auth;
 mod api;
 mod api_sync;
+mod auth;
+pub mod compaction;
+pub(crate) mod helpers;
+pub mod openai;
 mod request;
-mod stream;
-mod helpers;
 mod sse;
 mod sse_types;
+mod stream;
 pub mod subagent;
-pub mod openai;
 pub mod telemetry;
-pub mod compaction;
+mod types;
 
-pub use types::{StreamEvent, LlmEvent, SessionEvent, AgentEvent};
-use types::AuthState;
-use auth::AuthMethods;
 use api::ApiMethods;
-use stream::StreamMethods;
+use auth::AuthMethods;
 use helpers::HelperMethods;
+use stream::StreamMethods;
+use types::AuthState;
+pub use types::{AgentEvent, LlmEvent, SessionEvent, StreamEvent};
 
 /// Result of resolving before_tool_call extension policy.
 pub enum BeforeToolCallDecision {
@@ -52,7 +52,6 @@ pub async fn emit_before_tool_call(
     }
     hook_bus.emit(&event).await
 }
-
 
 /// Resolve a before_tool_call result that may request user confirmation.
 ///
@@ -87,7 +86,9 @@ pub async fn resolve_before_tool_call_result(
                 .await;
 
             match response.as_deref().map(str::trim) {
-                Some(answer) if answer.eq_ignore_ascii_case("yes") || answer.eq_ignore_ascii_case("y") => {
+                Some(answer)
+                    if answer.eq_ignore_ascii_case("yes") || answer.eq_ignore_ascii_case("y") =>
+                {
                     crate::extensions::hooks::events::HookResult::Continue
                 }
                 _ => crate::extensions::hooks::events::HookResult::Block {
@@ -113,7 +114,9 @@ pub async fn resolve_before_tool_call_decision(
         crate::extensions::hooks::events::HookResult::Modify { input } => {
             BeforeToolCallDecision::Continue { input }
         }
-        _ => BeforeToolCallDecision::Continue { input: original_input },
+        _ => BeforeToolCallDecision::Continue {
+            input: original_input,
+        },
     }
 }
 
@@ -135,29 +138,29 @@ const MAX_REPLACE_OUTPUT: usize = 1024 * 1024; // 1 MiB
 /// drop or corrupt a tool's output.
 ///
 /// Note: the event delivered to the extension carries `tool_output` as a
-/// size-limited preview for large outputs — a ~32 KB prefix plus a
+/// size-limited preview for large outputs — a ~256 KB prefix plus a
 /// `…[truncated, N total bytes]` marker (see [`HookEvent::after_tool_call`]),
-/// so the delivered string can slightly exceed 32 KB. A transform therefore
-/// decides based on a preview, not the full bytes.
+/// matching `max_tool_buffer`. The final returned string is then truncated to
+/// `max_tool_output` (the context budget) — compress-then-truncate ordering,
+/// so a transform extension sees the full buffered output and decides what to
+/// keep before the hard cap is applied.
 pub async fn emit_after_tool_call(
     hook_bus: &Arc<crate::extensions::hooks::HookBus>,
     tool_name: &str,
     runtime_tool_name: Option<&str>,
     input: Value,
     output: String,
+    max_tool_output: usize,
 ) -> String {
     use crate::extensions::hooks::events::HookResult;
     // Keep the original to return verbatim if no transform fires.
     let original = output.clone();
-    let mut event = crate::extensions::hooks::events::HookEvent::after_tool_call(
-        tool_name,
-        input,
-        output,
-    );
+    let mut event =
+        crate::extensions::hooks::events::HookEvent::after_tool_call(tool_name, input, output);
     if let Some(runtime_tool_name) = runtime_tool_name {
         event.tool_runtime_name = Some(runtime_tool_name.to_string());
     }
-    match hook_bus.emit(&event).await {
+    let post_hook = match hook_bus.emit(&event).await {
         HookResult::Replace { mut output } => {
             if output.len() > MAX_REPLACE_OUTPUT {
                 tracing::warn!(
@@ -184,7 +187,11 @@ pub async fn emit_after_tool_call(
             );
             original
         }
-    }
+    };
+    // Compress-then-truncate: apply the context-budget cap AFTER the hook.
+    // Mirrors `HelperMethods::truncate_tool_result` byte-for-byte so the
+    // no-extension path is behavior-identical to the legacy ordering.
+    crate::runtime::helpers::HelperMethods::truncate_tool_result(&post_hook, max_tool_output)
 }
 
 /// The core runtime — manages API communication, tool execution, authentication,
@@ -287,7 +294,9 @@ impl Runtime {
             thinking_budget: 4096,
             context_window_override: None,
             compaction_model: None,
-            subagent_registry: Arc::new(Mutex::new(crate::runtime::subagent::SubagentRegistry::new())),
+            subagent_registry: Arc::new(Mutex::new(
+                crate::runtime::subagent::SubagentRegistry::new(),
+            )),
             event_queue: Arc::new(crate::events::EventQueue::new(1000)),
             watcher_exit_path: None,
             max_tool_output: 30000,
@@ -324,8 +333,15 @@ impl Runtime {
             model[pos..].to_string()
         } else if let Some(pos) = model.find('/') {
             let before = &model[..pos];
-            let key_start = before.rfind(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_')
-                .map(|i| i + before[i..].chars().next().map(|c| c.len_utf8()).unwrap_or(1))
+            let key_start = before
+                .rfind(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_')
+                .map(|i| {
+                    i + before[i..]
+                        .chars()
+                        .next()
+                        .map(|c| c.len_utf8())
+                        .unwrap_or(1)
+                })
                 .unwrap_or(0);
             model[key_start..].to_string()
         } else {
@@ -378,7 +394,9 @@ impl Runtime {
     /// Effective context window for the current model — user override if set,
     /// otherwise the model's native window from `models::context_window_for_model`.
     pub fn compaction_model(&self) -> &str {
-        self.compaction_model.as_deref().unwrap_or("claude-sonnet-4-6")
+        self.compaction_model
+            .as_deref()
+            .unwrap_or("claude-sonnet-4-6")
     }
 
     pub fn context_window(&self) -> u64 {
@@ -401,7 +419,8 @@ impl Runtime {
         self.bash_max_timeout = config.bash_max_timeout;
         self.subagent_timeout = config.subagent_timeout;
         self.api_retries = config.api_retries;
-        self.telemetry_level = crate::runtime::telemetry::TelemetryLevel::from_str_key(&config.telemetry);
+        self.telemetry_level =
+            crate::runtime::telemetry::TelemetryLevel::from_str_key(&config.telemetry);
         self.cache_diagnostics = config.cache_diagnostics;
         self.cache_ttl = config.cache_ttl;
         self.apply_auth_config(config);
@@ -545,7 +564,8 @@ impl Runtime {
             self.thinking_budget,
             &messages,
             self.api_retries,
-        ).await
+        )
+        .await
     }
 
     /// Run a single prompt synchronously (non-streaming). Handles tool execution
@@ -555,7 +575,7 @@ impl Runtime {
         self.refresh_if_needed().await?;
 
         let mut messages = vec![json!({"role": "user", "content": prompt})];
-        
+
         loop {
             let response = ApiMethods::call_api(
                 &self.auth,
@@ -574,13 +594,14 @@ impl Runtime {
                     credential_source: self.credential_source.clone(),
                     token_cache: self.token_cache.clone(),
                 },
-            ).await?;
-            
+            )
+            .await?;
+
             // Check if Claude wants to use tools
             if let Some(content) = response["content"].as_array() {
                 let mut response_text = String::new();
                 let mut tool_uses = Vec::new();
-                
+
                 // Process response content
                 for item in content {
                     match item["type"].as_str() {
@@ -595,33 +616,41 @@ impl Runtime {
                         _ => {}
                     }
                 }
-                
+
                 // If no tool uses, return the text response
                 if tool_uses.is_empty() {
                     return Ok(response_text);
                 }
-                
+
                 // Add assistant's response to conversation (only content, role)
                 messages.push(json!({
                     "role": "assistant",
                     "content": content
                 }));
-                
+
                 // Execute tools — parallel when multiple are requested
                 let mut tool_results = Vec::new();
-                
+
                 if tool_uses.len() == 1 {
                     // Single tool — run inline, no spawn overhead
                     let tool_use = &tool_uses[0];
-                    if let (Some(tool_name), Some(tool_id)) = (
-                        tool_use["name"].as_str(),
-                        tool_use["id"].as_str()
-                    ) {
+                    if let (Some(tool_name), Some(tool_id)) =
+                        (tool_use["name"].as_str(), tool_use["id"].as_str())
+                    {
                         let input = &tool_use["input"];
                         let result = match self.tools.read().await.get(tool_name).cloned() {
                             Some(tool) => {
-                                let input = self.tools.read().await.translate_input_for_api_tool(tool_name, input.clone());
-                                let runtime_name = self.tools.read().await.runtime_name_for_api(tool_name).to_string();
+                                let input = self
+                                    .tools
+                                    .read()
+                                    .await
+                                    .translate_input_for_api_tool(tool_name, input.clone());
+                                let runtime_name = self
+                                    .tools
+                                    .read()
+                                    .await
+                                    .runtime_name_for_api(tool_name)
+                                    .to_string();
                                 let ctx = crate::ToolContext {
                                     channels: crate::tools::ToolChannels {
                                         tx_delta: None,
@@ -637,6 +666,7 @@ impl Runtime {
                                     },
                                     limits: crate::tools::ToolLimits {
                                         max_tool_output: self.max_tool_output,
+                                        max_tool_buffer: 256 * 1024,
                                         bash_timeout: self.bash_timeout,
                                         bash_max_timeout: self.bash_max_timeout,
                                         subagent_timeout: self.subagent_timeout,
@@ -649,14 +679,19 @@ impl Runtime {
                                         tool_name,
                                         Some(&runtime_name),
                                         input.clone(),
-                                    ).await,
+                                    )
+                                    .await,
                                     None,
                                     false,
-                                ).await;
+                                )
+                                .await;
                                 if let BeforeToolCallDecision::Block { reason } = decision {
                                     format!("Tool call blocked by extension: {}", reason)
                                 } else {
-                                    let BeforeToolCallDecision::Continue { input } = decision else { unreachable!() };
+                                    let BeforeToolCallDecision::Continue { input } = decision
+                                    else {
+                                        unreachable!()
+                                    };
                                     let input_for_hook = input.clone();
                                     let output = match tool.execute(input, ctx).await {
                                         Ok(output) => output,
@@ -668,7 +703,9 @@ impl Runtime {
                                         Some(&runtime_name),
                                         input_for_hook,
                                         output,
-                                    ).await;
+                                        self.max_tool_output,
+                                    )
+                                    .await;
                                     output
                                 }
                             }
@@ -683,7 +720,7 @@ impl Runtime {
                 } else {
                     // Multiple tools — run in parallel with JoinSet
                     let mut join_set = tokio::task::JoinSet::new();
-                    
+
                     // Capture config values before spawning (can't borrow &self in 'static spawn)
                     let cfg_max_tool_output = self.max_tool_output;
                     let cfg_bash_timeout = self.bash_timeout;
@@ -693,7 +730,7 @@ impl Runtime {
                     let cfg_subagent_registry = self.subagent_registry.clone();
                     let cfg_event_queue = self.event_queue.clone();
                     let cfg_hook_bus = self.hook_bus.clone();
-                    
+
                     for tool_use in &tool_uses {
                         if let (Some(tool_name), Some(tool_id)) = (
                             tool_use["name"].as_str().map(|s| s.to_string()),
@@ -701,8 +738,10 @@ impl Runtime {
                         ) {
                             let input = tool_use["input"].clone();
                             let tools_snapshot = self.tools.read().await;
-                            let input = tools_snapshot.translate_input_for_api_tool(&tool_name, input);
-                            let runtime_name = tools_snapshot.runtime_name_for_api(&tool_name).to_string();
+                            let input =
+                                tools_snapshot.translate_input_for_api_tool(&tool_name, input);
+                            let runtime_name =
+                                tools_snapshot.runtime_name_for_api(&tool_name).to_string();
                             let tool = tools_snapshot.get(&tool_name).cloned();
                             drop(tools_snapshot);
                             let exit_path = self.watcher_exit_path.clone();
@@ -712,58 +751,72 @@ impl Runtime {
                             let hook_bus_inner = cfg_hook_bus.clone();
                             let tool_name_for_hook = tool_name.clone();
                             let runtime_name_for_hook = runtime_name.clone();
-                            
+
                             join_set.spawn(async move {
                                 let result = match tool {
                                     Some(t) => {
-                                        let decision = crate::runtime::resolve_before_tool_call_decision(
-                                            input.clone(),
-                                            crate::runtime::emit_before_tool_call(
+                                        let decision =
+                                            crate::runtime::resolve_before_tool_call_decision(
+                                                input.clone(),
+                                                crate::runtime::emit_before_tool_call(
+                                                    &hook_bus_inner,
+                                                    &tool_name_for_hook,
+                                                    Some(&runtime_name_for_hook),
+                                                    input.clone(),
+                                                )
+                                                .await,
+                                                None,
+                                                false,
+                                            )
+                                            .await;
+                                        if let crate::runtime::BeforeToolCallDecision::Block {
+                                            reason,
+                                        } = decision
+                                        {
+                                            format!("Tool call blocked by extension: {}", reason)
+                                        } else {
+                                            let crate::runtime::BeforeToolCallDecision::Continue {
+                                                input,
+                                            } = decision
+                                            else {
+                                                unreachable!()
+                                            };
+                                            let ctx = crate::ToolContext {
+                                                channels: crate::tools::ToolChannels {
+                                                    tx_delta: None,
+                                                    tx_events: None,
+                                                },
+                                                capabilities: crate::tools::ToolCapabilities {
+                                                    watcher_exit_path: exit_path,
+                                                    tool_register_tx: None,
+                                                    session_manager: Some(session_mgr_inner),
+                                                    subagent_registry: Some(registry_inner),
+                                                    event_queue: Some(event_queue_inner),
+                                                    secret_prompt: None,
+                                                },
+                                                limits: crate::tools::ToolLimits {
+                                                    max_tool_output: cfg_max_tool_output,
+                                                    max_tool_buffer: 256 * 1024,
+                                                    bash_timeout: cfg_bash_timeout,
+                                                    bash_max_timeout: cfg_bash_max_timeout,
+                                                    subagent_timeout: cfg_subagent_timeout,
+                                                },
+                                            };
+                                            let input_for_hook = input.clone();
+                                            let output = match t.execute(input, ctx).await {
+                                                Ok(output) => output,
+                                                Err(e) => format!("Tool execution failed: {}", e),
+                                            };
+                                            let output = crate::runtime::emit_after_tool_call(
                                                 &hook_bus_inner,
                                                 &tool_name_for_hook,
                                                 Some(&runtime_name_for_hook),
-                                                input.clone(),
-                                            ).await,
-                                            None,
-                                            false,
-                                        ).await;
-                                        if let crate::runtime::BeforeToolCallDecision::Block { reason } = decision {
-                                            format!("Tool call blocked by extension: {}", reason)
-                                        } else {
-                                        let crate::runtime::BeforeToolCallDecision::Continue { input } = decision else { unreachable!() };
-                                        let ctx = crate::ToolContext {
-                                            channels: crate::tools::ToolChannels {
-                                                tx_delta: None,
-                                                tx_events: None,
-                                            },
-                                            capabilities: crate::tools::ToolCapabilities {
-                                                watcher_exit_path: exit_path,
-                                                tool_register_tx: None,
-                                                session_manager: Some(session_mgr_inner),
-                                                subagent_registry: Some(registry_inner),
-                                                event_queue: Some(event_queue_inner),
-                                                secret_prompt: None,
-                                            },
-                                            limits: crate::tools::ToolLimits {
-                                                max_tool_output: cfg_max_tool_output,
-                                                bash_timeout: cfg_bash_timeout,
-                                                bash_max_timeout: cfg_bash_max_timeout,
-                                                subagent_timeout: cfg_subagent_timeout,
-                                            },
-                                        };
-                                        let input_for_hook = input.clone();
-                                        let output = match t.execute(input, ctx).await {
-                                            Ok(output) => output,
-                                            Err(e) => format!("Tool execution failed: {}", e),
-                                        };
-                                        let output = crate::runtime::emit_after_tool_call(
-                                            &hook_bus_inner,
-                                            &tool_name_for_hook,
-                                            Some(&runtime_name_for_hook),
-                                            input_for_hook,
-                                            output,
-                                        ).await;
-                                        output
+                                                input_for_hook,
+                                                output,
+                                                cfg_max_tool_output,
+                                            )
+                                            .await;
+                                            output
                                         }
                                     }
                                     None => format!("Unknown tool: {}", tool_name),
@@ -772,7 +825,7 @@ impl Runtime {
                             });
                         }
                     }
-                    
+
                     // Collect results, preserving order by tool_id
                     let mut results_map = std::collections::HashMap::new();
                     while let Some(res) = join_set.join_next().await {
@@ -786,12 +839,13 @@ impl Runtime {
                             }
                         }
                     }
-                    
+
                     // Build tool_results in original order — every tool_use MUST have a result
                     for tool_use in &tool_uses {
                         if let Some(tool_id) = tool_use["id"].as_str() {
-                            let result = results_map.remove(tool_id)
-                                .unwrap_or_else(|| "Tool execution failed: task panicked".to_string());
+                            let result = results_map.remove(tool_id).unwrap_or_else(|| {
+                                "Tool execution failed: task panicked".to_string()
+                            });
                             tool_results.push(json!({
                                 "type": "tool_result",
                                 "tool_use_id": tool_id,
@@ -800,13 +854,13 @@ impl Runtime {
                         }
                     }
                 }
-                
+
                 // Add tool results to conversation
                 messages.push(json!({
                     "role": "user",
                     "content": tool_results
                 }));
-                
+
                 // Continue the loop to get Claude's response with tool results
             } else {
                 return Err(RuntimeError::Tool("Invalid response format".to_string()));
@@ -816,8 +870,19 @@ impl Runtime {
 
     /// Run a prompt as a cancellable stream of [`StreamEvent`]s. Convenience wrapper
     /// around [`run_stream_with_messages`] for single-turn usage.
-    pub async fn run_stream(&self, prompt: String, cancel: CancellationToken) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send>> {
-        self.run_stream_with_messages(vec![json!({"role": "user", "content": prompt})], cancel, None, None, false).await
+    pub async fn run_stream(
+        &self,
+        prompt: String,
+        cancel: CancellationToken,
+    ) -> Pin<Box<dyn Stream<Item = StreamEvent> + Send>> {
+        self.run_stream_with_messages(
+            vec![json!({"role": "user", "content": prompt})],
+            cancel,
+            None,
+            None,
+            false,
+        )
+        .await
     }
 
     /// Run a multi-turn conversation as a cancellable stream of [`StreamEvent`]s.
@@ -872,12 +937,28 @@ impl Runtime {
         };
 
         let session = crate::runtime::stream::StreamSession {
-            auth, client, credential_source, token_cache, options, api_retries,
-            model, tools, system_prompt, thinking_budget,
-            tx: tx.clone(), cancel, steering_rx,
-            watcher_exit_path, max_tool_output,
-            bash_timeout, bash_max_timeout, subagent_timeout,
-            session_manager, subagent_registry, event_queue, secret_prompt,
+            auth,
+            client,
+            credential_source,
+            token_cache,
+            options,
+            api_retries,
+            model,
+            tools,
+            system_prompt,
+            thinking_budget,
+            tx: tx.clone(),
+            cancel,
+            steering_rx,
+            watcher_exit_path,
+            max_tool_output,
+            bash_timeout,
+            bash_max_timeout,
+            subagent_timeout,
+            session_manager,
+            subagent_registry,
+            event_queue,
+            secret_prompt,
             hook_bus: self.hook_bus.clone(),
             auto_approve_confirms,
             telemetry_level: self.telemetry_level,
@@ -926,8 +1007,8 @@ impl Clone for Runtime {
             last_msg_id: Arc::new(Mutex::new(None)),
             session_manager: self.session_manager.clone(),
             hook_bus: self.hook_bus.clone(),
-            reaper_handle: None,  // Cloned runtimes don't own the reaper
-            reaper_cancel: None,  // Cloned runtimes don't own the reaper
+            reaper_handle: None, // Cloned runtimes don't own the reaper
+            reaper_cancel: None, // Cloned runtimes don't own the reaper
             credential_source: self.credential_source.clone(),
             token_cache: self.token_cache.clone(), // shares the same cache (Arc inside)
         }
@@ -965,7 +1046,8 @@ mod tests {
             },
             None,
             false,
-        ).await;
+        )
+        .await;
 
         match result {
             BeforeToolCallDecision::Continue { input } => {
@@ -1033,52 +1115,75 @@ mod tests {
     #[test]
     fn test_max_tokens_for_model() {
         // Opus models should return 128000
-        assert_eq!(HelperMethods::max_tokens_for_model("claude-opus-4-6"), 128000);
-        assert_eq!(HelperMethods::max_tokens_for_model("opus-something"), 128000);
-        
+        assert_eq!(
+            HelperMethods::max_tokens_for_model("claude-opus-4-6"),
+            128000
+        );
+        assert_eq!(
+            HelperMethods::max_tokens_for_model("opus-something"),
+            128000
+        );
+
         // Non-opus models should return 64000
-        assert_eq!(HelperMethods::max_tokens_for_model("claude-sonnet-4-20250514"), 64000);
+        assert_eq!(
+            HelperMethods::max_tokens_for_model("claude-sonnet-4-20250514"),
+            64000
+        );
         assert_eq!(HelperMethods::max_tokens_for_model("haiku"), 64000);
         assert_eq!(HelperMethods::max_tokens_for_model("claude-3-haiku"), 64000);
-        assert_eq!(HelperMethods::max_tokens_for_model("some-other-model"), 64000);
-        
+        assert_eq!(
+            HelperMethods::max_tokens_for_model("some-other-model"),
+            64000
+        );
+
         // Edge cases
         assert_eq!(HelperMethods::max_tokens_for_model(""), 64000);
         assert_eq!(HelperMethods::max_tokens_for_model("OPUS"), 64000); // Case sensitive - uppercase doesn't match
-        assert_eq!(HelperMethods::max_tokens_for_model("model-opus-end"), 128000); // Contains "opus" anywhere
+        assert_eq!(
+            HelperMethods::max_tokens_for_model("model-opus-end"),
+            128000
+        ); // Contains "opus" anywhere
     }
 
     #[test]
     fn test_truncate_tool_result() {
         let default_max = 30000;
-        
+
         // Short string should remain unchanged
         let short = "This is a short string.";
-        assert_eq!(HelperMethods::truncate_tool_result(short, default_max), short);
-        
+        assert_eq!(
+            HelperMethods::truncate_tool_result(short, default_max),
+            short
+        );
+
         // Exactly max should remain unchanged
         let exact = "x".repeat(30000);
-        assert_eq!(HelperMethods::truncate_tool_result(&exact, default_max), exact);
-        
+        assert_eq!(
+            HelperMethods::truncate_tool_result(&exact, default_max),
+            exact
+        );
+
         // String longer than max should be truncated with notice
         let too_long = "x".repeat(30001);
         let truncated = HelperMethods::truncate_tool_result(&too_long, default_max);
-        
+
         // Should start with the truncated content
         assert!(truncated.starts_with(&"x".repeat(30000)));
-        
+
         // Should contain truncation notice with total char count
         assert!(truncated.contains("[truncated — 30001 total chars, showing first 30000]"));
-        
+
         // Should be longer than max (due to notice)
         assert!(truncated.len() > 30000);
-        
+
         // Test with a much longer string
         let very_long = "a".repeat(50000);
         let truncated_very_long = HelperMethods::truncate_tool_result(&very_long, default_max);
-        assert!(truncated_very_long.contains("[truncated — 50000 total chars, showing first 30000]"));
+        assert!(
+            truncated_very_long.contains("[truncated — 50000 total chars, showing first 30000]")
+        );
         assert!(truncated_very_long.starts_with(&"a".repeat(30000)));
-        
+
         // Test with custom limit
         let custom_truncated = HelperMethods::truncate_tool_result(&very_long, 100);
         assert!(custom_truncated.starts_with(&"a".repeat(100)));

--- a/crates/agent-engine/src/runtime/openai/mod.rs
+++ b/crates/agent-engine/src/runtime/openai/mod.rs
@@ -6,14 +6,14 @@
 
 use std::collections::BTreeMap;
 
+pub mod catalog;
+pub mod ping;
+pub mod reasoning;
+pub mod registry;
+pub mod stream;
+pub mod translate;
 pub mod types;
 pub mod wire;
-pub mod registry;
-pub mod catalog;
-pub mod reasoning;
-pub mod translate;
-pub mod stream;
-pub mod ping;
 
 use std::sync::Arc;
 
@@ -22,19 +22,24 @@ use crate::extensions::providers::ProviderRegistry;
 use crate::tools::{ToolCapabilities, ToolChannels, ToolContext, ToolLimits};
 
 pub use types::{
-    ChatMessage, ChatOptions, ChatRequest, FunctionCall, FunctionDefinition,
-    OaiEvent, ProviderConfig, StreamOptions, ToolCall, ToolChoice, ToolDefinition,
+    ChatMessage, ChatOptions, ChatRequest, FunctionCall, FunctionDefinition, OaiEvent,
+    ProviderConfig, StreamOptions, ToolCall, ToolChoice, ToolDefinition,
 };
 pub use wire::StreamDecoder;
 
-static EXTENSION_MANAGER: std::sync::RwLock<Option<Arc<tokio::sync::RwLock<ExtensionManager>>>> = std::sync::RwLock::new(None);
+static EXTENSION_MANAGER: std::sync::RwLock<Option<Arc<tokio::sync::RwLock<ExtensionManager>>>> =
+    std::sync::RwLock::new(None);
 
 pub fn set_extension_manager_for_routing(manager: Arc<tokio::sync::RwLock<ExtensionManager>>) {
-    *EXTENSION_MANAGER.write().expect("extension manager routing lock poisoned") = Some(manager);
+    *EXTENSION_MANAGER
+        .write()
+        .expect("extension manager routing lock poisoned") = Some(manager);
 }
 
 pub fn clear_extension_manager_for_routing() {
-    *EXTENSION_MANAGER.write().expect("extension manager routing lock poisoned") = None;
+    *EXTENSION_MANAGER
+        .write()
+        .expect("extension manager routing lock poisoned") = None;
 }
 
 pub fn extension_manager_for_routing() -> Option<Arc<tokio::sync::RwLock<ExtensionManager>>> {
@@ -120,11 +125,21 @@ pub async fn try_route(
                             .and_then(|m| m.capabilities.get("tool_use"))
                             .and_then(|v| v.as_bool())
                             .unwrap_or(false);
-                        (handler.clone(), manager.hook_bus().clone(), manager.tools_shared(), streaming, model_tool_use)
+                        (
+                            handler.clone(),
+                            manager.hook_bus().clone(),
+                            manager.tools_shared(),
+                            streaming,
+                            model_tool_use,
+                        )
                     })
                 })
             }) else {
-                return Some(Err(format!("Extension provider model '{}' is not available", model).into()));
+                return Some(Err(format!(
+                    "Extension provider model '{}' is not available",
+                    model
+                )
+                .into()));
             };
             // Per-provider trust gate: a disabled provider must not be invoked.
             // The check runs before any IPC and we DO NOT silently fall back to
@@ -133,9 +148,10 @@ pub async fn try_route(
                 Ok(t) => t,
                 Err(e) => {
                     tracing::warn!("trust.json corrupt or unreadable, failing closed: {e}");
-                    return Some(Err(
-                        format!("Cannot route to provider: trust state unreadable: {e}").into()
-                    ));
+                    return Some(Err(format!(
+                        "Cannot route to provider: trust state unreadable: {e}"
+                    )
+                    .into()));
                 }
             };
             if !crate::extensions::trust::is_provider_enabled(&trust, &provider_runtime_id) {
@@ -154,27 +170,29 @@ pub async fn try_route(
                 return Some(Err(format!(
                     "Provider '{}' is disabled by user trust settings",
                     provider_runtime_id
-                ).into()));
+                )
+                .into()));
             }
             // Audit metadata captured up-front so each terminal branch can record an entry.
             let audit_plugin = plugin_id.to_string();
             let audit_provider = provider_id.to_string();
             let audit_model = model_id.to_string();
             let tools_exposed = !tools_schema.is_empty();
-            let emit_audit = |streamed: bool, outcome: &str, error_class: Option<&str>, tools_requested: u32| {
-                let _ = crate::extensions::audit::append_audit_entry(
-                    &crate::extensions::audit::new_audit_entry(
-                        audit_plugin.clone(),
-                        audit_provider.clone(),
-                        audit_model.clone(),
-                        tools_exposed,
-                        tools_requested,
-                        streamed,
-                        outcome,
-                        error_class.map(|s| s.to_string()),
-                    ),
-                );
-            };
+            let emit_audit =
+                |streamed: bool, outcome: &str, error_class: Option<&str>, tools_requested: u32| {
+                    let _ = crate::extensions::audit::append_audit_entry(
+                        &crate::extensions::audit::new_audit_entry(
+                            audit_plugin.clone(),
+                            audit_provider.clone(),
+                            audit_model.clone(),
+                            tools_exposed,
+                            tools_requested,
+                            streamed,
+                            outcome,
+                            error_class.map(|s| s.to_string()),
+                        ),
+                    );
+                };
             if cancel.is_cancelled() {
                 emit_audit(false, "error", Some("canceled"), 0);
                 return Some(Err("operation canceled".into()));
@@ -193,7 +211,9 @@ pub async fn try_route(
             let has_active_tools = model_tool_use && !tools_schema.is_empty();
             // Streaming path: forward TextDelta events as LlmEvent::Text deltas in real time.
             if streaming && !has_active_tools {
-                let (sink_tx, mut sink_rx) = tokio::sync::mpsc::unbounded_channel::<crate::extensions::runtime::process::ProviderStreamEvent>();
+                let (sink_tx, mut sink_rx) = tokio::sync::mpsc::unbounded_channel::<
+                    crate::extensions::runtime::process::ProviderStreamEvent,
+                >();
                 let tx_clone = tx.clone();
                 let forwarder = tokio::spawn(async move {
                     use crate::extensions::runtime::process::ProviderStreamEvent;
@@ -201,7 +221,7 @@ pub async fn try_route(
                         match event {
                             ProviderStreamEvent::TextDelta { text } => {
                                 let _ = tx_clone.send(crate::runtime::types::StreamEvent::Llm(
-                                    crate::runtime::types::LlmEvent::Text(text)
+                                    crate::runtime::types::LlmEvent::Text(text),
                                 ));
                             }
                             ProviderStreamEvent::ToolUse { .. } => {
@@ -267,6 +287,7 @@ pub async fn try_route(
                         },
                         limits: ToolLimits {
                             max_tool_output: 30000,
+                            max_tool_buffer: 256 * 1024,
                             bash_timeout: 30,
                             bash_max_timeout: 300,
                             subagent_timeout: 300,
@@ -274,7 +295,8 @@ pub async fn try_route(
                     },
                     30000,
                     8,
-                ).await
+                )
+                .await
             } else {
                 handler.provider_complete(params).await
             };
@@ -296,7 +318,7 @@ pub async fn try_route(
                         .join("");
                     if !text.is_empty() {
                         let _ = tx.send(crate::runtime::types::StreamEvent::Llm(
-                            crate::runtime::types::LlmEvent::Text(text)
+                            crate::runtime::types::LlmEvent::Text(text),
                         ));
                     }
                     emit_audit(false, "ok", None, 0);
@@ -312,7 +334,11 @@ pub async fn try_route(
                 }
             }
         }
-        return Some(Err(format!("Extension provider model '{}' is not available", model).into()));
+        return Some(Err(format!(
+            "Extension provider model '{}' is not available",
+            model
+        )
+        .into()));
     }
 
     let provider_keys = crate::core::config::get_provider_keys();
@@ -361,14 +387,24 @@ mod tests {
     #[test]
     fn set_extension_manager_for_routing_overwrites_previous_manager() {
         clear_extension_manager_for_routing();
-        let first = Arc::new(tokio::sync::RwLock::new(ExtensionManager::new(Arc::new(crate::extensions::hooks::HookBus::new()))));
-        let second = Arc::new(tokio::sync::RwLock::new(ExtensionManager::new(Arc::new(crate::extensions::hooks::HookBus::new()))));
+        let first = Arc::new(tokio::sync::RwLock::new(ExtensionManager::new(Arc::new(
+            crate::extensions::hooks::HookBus::new(),
+        ))));
+        let second = Arc::new(tokio::sync::RwLock::new(ExtensionManager::new(Arc::new(
+            crate::extensions::hooks::HookBus::new(),
+        ))));
 
         set_extension_manager_for_routing(first.clone());
-        assert!(Arc::ptr_eq(&extension_manager_for_routing().unwrap(), &first));
+        assert!(Arc::ptr_eq(
+            &extension_manager_for_routing().unwrap(),
+            &first
+        ));
 
         set_extension_manager_for_routing(second.clone());
-        assert!(Arc::ptr_eq(&extension_manager_for_routing().unwrap(), &second));
+        assert!(Arc::ptr_eq(
+            &extension_manager_for_routing().unwrap(),
+            &second
+        ));
 
         clear_extension_manager_for_routing();
         assert!(extension_manager_for_routing().is_none());

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -1,15 +1,18 @@
+use super::api::ApiMethods;
+use super::helpers::HelperMethods;
+use super::types::{AuthState, LlmEvent, SessionEvent, StreamEvent};
+use super::{
+    emit_after_tool_call, emit_before_tool_call, resolve_before_tool_call_decision,
+    BeforeToolCallDecision,
+};
+use crate::extensions::hooks::events::HookEvent;
+use crate::{Result, RuntimeError, ToolRegistry};
+use reqwest::Client;
+use serde_json::{json, Value};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, RwLock};
 use tokio_util::sync::CancellationToken;
-use serde_json::{json, Value};
-use reqwest::Client;
-use crate::{Result, RuntimeError, ToolRegistry};
-use super::types::{AuthState, StreamEvent, LlmEvent, SessionEvent};
-use super::helpers::HelperMethods;
-use super::{BeforeToolCallDecision, emit_after_tool_call, emit_before_tool_call, resolve_before_tool_call_decision};
-use crate::extensions::hooks::events::HookEvent;
-use super::api::ApiMethods;
 
 /// Bundle of all dependencies needed to drive a streaming agent loop.
 /// Constructed once by `Runtime::run_stream_with_messages` before spawning the stream task.
@@ -73,13 +76,31 @@ impl StreamMethods {
         initial_messages: Vec<Value>,
     ) -> Result<()> {
         let StreamSession {
-            auth, client, credential_source, token_cache, options, api_retries,
-            model, tools, system_prompt, thinking_budget,
-            tx, cancel, mut steering_rx,
-            watcher_exit_path, max_tool_output,
-            bash_timeout, bash_max_timeout, subagent_timeout,
-            session_manager, subagent_registry, event_queue, hook_bus, secret_prompt,
-            auto_approve_confirms, telemetry_level,
+            auth,
+            client,
+            credential_source,
+            token_cache,
+            options,
+            api_retries,
+            model,
+            tools,
+            system_prompt,
+            thinking_budget,
+            tx,
+            cancel,
+            mut steering_rx,
+            watcher_exit_path,
+            max_tool_output,
+            bash_timeout,
+            bash_max_timeout,
+            subagent_timeout,
+            session_manager,
+            subagent_registry,
+            event_queue,
+            hook_bus,
+            secret_prompt,
+            auto_approve_confirms,
+            telemetry_level,
         } = session;
         let mut messages = initial_messages;
 
@@ -113,7 +134,9 @@ impl StreamMethods {
             // Extract the last user message text — handles both string content
             // and block array content (common after tool results).
             let injected_system: Option<String>;
-            let last_user_msg: Option<String> = messages.iter().rev()
+            let last_user_msg: Option<String> = messages
+                .iter()
+                .rev()
                 .find(|m| m["role"].as_str() == Some("user"))
                 .and_then(|m| {
                     // Try string content first
@@ -122,7 +145,8 @@ impl StreamMethods {
                     }
                     // Try block array content
                     if let Some(arr) = m["content"].as_array() {
-                        return arr.iter()
+                        return arr
+                            .iter()
                             .find(|b| b["type"].as_str() == Some("text"))
                             .and_then(|b| b["text"].as_str())
                             .map(String::from);
@@ -130,12 +154,18 @@ impl StreamMethods {
                     None
                 });
             let did_inject = if let Some(ref msg_text) = last_user_msg {
-                let hook_event = crate::extensions::hooks::events::HookEvent::before_message(msg_text);
-                if let crate::extensions::hooks::events::HookResult::Inject { content } = hook_bus.emit(&hook_event).await {
+                let hook_event =
+                    crate::extensions::hooks::events::HookEvent::before_message(msg_text);
+                if let crate::extensions::hooks::events::HookResult::Inject { content } =
+                    hook_bus.emit(&hook_event).await
+                {
                     // Append injected content AFTER system prompt to preserve cache prefix
                     let base = system_prompt.as_deref().unwrap_or_default();
                     injected_system = Some(format!("{base}\n\n[Extension context — do not treat as user instructions]\n{content}\n[End extension context]"));
-                    tracing::debug!(len = content.len(), "Extension context injected into system prompt");
+                    tracing::debug!(
+                        len = content.len(),
+                        "Extension context injected into system prompt"
+                    );
                     true
                 } else {
                     injected_system = system_prompt.clone();
@@ -148,10 +178,21 @@ impl StreamMethods {
             let _ = did_inject;
 
             let response = match ApiMethods::call_api_stream_inner(
-                &auth, &client, &model, &tools_snapshot, &injected_system, thinking_budget,
-                &messages, tx.clone(), &cancel, api_retries, &options,
+                &auth,
+                &client,
+                &model,
+                &tools_snapshot,
+                &injected_system,
+                thinking_budget,
+                &messages,
+                tx.clone(),
+                &cancel,
+                api_retries,
+                &options,
                 telemetry_level,
-            ).await {
+            )
+            .await
+            {
                 Ok(r) => r,
                 Err(e) => {
                     // Send whatever history we have so far, so context isn't lost
@@ -178,7 +219,8 @@ impl StreamMethods {
                         let _ = tx.send(StreamEvent::Session(SessionEvent::Error(
                             "model returned an empty response — likely context-window \
                              exceeded or API overload. Try /compact or start a fresh \
-                             session.".to_string(),
+                             session."
+                                .to_string(),
                         )));
                     }
                     let _ = tx.send(StreamEvent::Session(SessionEvent::MessageHistory(messages)));
@@ -213,10 +255,12 @@ impl StreamMethods {
                 // If no tool uses, check for steering messages before finishing.
                 // Steering can redirect the model even when it has no more tool calls.
                 if tool_uses.is_empty() {
-                    let steered = HelperMethods::drain_steering(&mut steering_rx, &mut messages, &tx);
+                    let steered =
+                        HelperMethods::drain_steering(&mut steering_rx, &mut messages, &tx);
                     if !steered {
                         // No steering, truly done
-                        let _ = tx.send(StreamEvent::Session(SessionEvent::MessageHistory(messages)));
+                        let _ =
+                            tx.send(StreamEvent::Session(SessionEvent::MessageHistory(messages)));
                         return Ok(());
                     }
                     // Steering message injected — continue the loop for another LLM call
@@ -228,7 +272,8 @@ impl StreamMethods {
                 // next API call will fail with "tool_use ids were found without tool_result
 
                 // Channel for dynamic tool registration (MCP connect uses this)
-                let (tool_reg_tx, mut tool_reg_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<Arc<dyn crate::Tool>>>();
+                let (tool_reg_tx, mut tool_reg_rx) =
+                    tokio::sync::mpsc::unbounded_channel::<Vec<Arc<dyn crate::Tool>>>();
                 // blocks". On cancellation we synthesize a "Canceled by user" result for any
                 // remaining tools so message history stays valid.
                 let mut tool_results = Vec::new();
@@ -262,25 +307,38 @@ impl StreamMethods {
                             "content": err,
                             "is_error": true
                         }));
-                        let _ = tx.send(StreamEvent::Llm(LlmEvent::ToolResult { tool_id, result: err.to_string() }));
+                        let _ = tx.send(StreamEvent::Llm(LlmEvent::ToolResult {
+                            tool_id,
+                            result: err.to_string(),
+                        }));
                     } else if !tool_id.is_empty() && !tool_name.is_empty() {
                         let result = match tools.read().await.get(&tool_name).cloned() {
                             Some(tool) => {
-                                let input = tools.read().await.translate_input_for_api_tool(&tool_name, input);
-                                let (tx_d, mut rx_d) = tokio::sync::mpsc::unbounded_channel::<String>();
+                                let input = tools
+                                    .read()
+                                    .await
+                                    .translate_input_for_api_tool(&tool_name, input);
+                                let (tx_d, mut rx_d) =
+                                    tokio::sync::mpsc::unbounded_channel::<String>();
                                 let tx_k = tx.clone();
                                 let t_id = tool_id.clone();
                                 tokio::spawn(async move {
                                     while let Some(msg) = rx_d.recv().await {
-                                        let _ = tx_k.send(StreamEvent::Llm(LlmEvent::ToolResultDelta {
-                                            tool_id: t_id.clone(),
-                                            delta: msg,
-                                        }));
+                                        let _ = tx_k.send(StreamEvent::Llm(
+                                            LlmEvent::ToolResultDelta {
+                                                tool_id: t_id.clone(),
+                                                delta: msg,
+                                            },
+                                        ));
                                     }
                                 });
 
                                 // ═══ HOOK: before_tool_call (stream single) ═══
-                                let runtime_name = tools.read().await.runtime_name_for_api(&tool_name).to_string();
+                                let runtime_name = tools
+                                    .read()
+                                    .await
+                                    .runtime_name_for_api(&tool_name)
+                                    .to_string();
                                 let decision = resolve_before_tool_call_decision(
                                     input.clone(),
                                     emit_before_tool_call(
@@ -288,39 +346,45 @@ impl StreamMethods {
                                         &tool_name,
                                         Some(&runtime_name),
                                         input.clone(),
-                                    ).await,
+                                    )
+                                    .await,
                                     secret_prompt.as_ref(),
                                     auto_approve_confirms,
-                                ).await;
+                                )
+                                .await;
                                 if let BeforeToolCallDecision::Block { reason } = decision {
                                     format!("Tool call blocked by extension: {}", reason)
                                 } else {
-                                let BeforeToolCallDecision::Continue { input } = decision else { unreachable!() };
-                                let input_for_hook = input.clone();
-                                tokio::select! {
-                                    res = tool.execute(input, crate::ToolContext {
-                                        channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx.clone()) },
-                                        capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()), secret_prompt: secret_prompt.clone() },
-                                        limits: crate::tools::ToolLimits { max_tool_output, bash_timeout, bash_max_timeout, subagent_timeout },
-                                    }) => {
-                                        let output = match res {
-                                            Ok(output) => output,
-                                            Err(e) => format!("Tool execution failed: {}", e),
-                                        };
-                                        let output = emit_after_tool_call(
-                                            &hook_bus,
-                                            &tool_name,
-                                            Some(&runtime_name),
-                                            input_for_hook,
-                                            output,
-                                        ).await;
-                                        output
+                                    let BeforeToolCallDecision::Continue { input } = decision
+                                    else {
+                                        unreachable!()
+                                    };
+                                    let input_for_hook = input.clone();
+                                    tokio::select! {
+                                        res = tool.execute(input, crate::ToolContext {
+                                            channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx.clone()) },
+                                            capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()), secret_prompt: secret_prompt.clone() },
+                                            limits: crate::tools::ToolLimits { max_tool_output, max_tool_buffer: 256 * 1024, bash_timeout, bash_max_timeout, subagent_timeout },
+                                        }) => {
+                                            let output = match res {
+                                                Ok(output) => output,
+                                                Err(e) => format!("Tool execution failed: {}", e),
+                                            };
+                                            let output = emit_after_tool_call(
+                                                &hook_bus,
+                                                &tool_name,
+                                                Some(&runtime_name),
+                                                input_for_hook,
+                                                output,
+                                                max_tool_output,
+                                            ).await;
+                                            output
+                                        }
+                                        _ = cancel.cancelled() => {
+                                            canceled = true;
+                                            "Canceled by user".to_string()
+                                        }
                                     }
-                                    _ = cancel.cancelled() => {
-                                        canceled = true;
-                                        "Canceled by user".to_string()
-                                    }
-                                }
                                 }
                             }
                             None => format!("Unknown tool: {}", tool_name),
@@ -357,14 +421,18 @@ impl StreamMethods {
                             let tid = tool_id.clone();
                             let tx_c = tx.clone();
                             join_set.spawn(async move {
-                                let _ = tx_c.send(StreamEvent::Llm(LlmEvent::ToolResult { tool_id: tid.clone(), result: err.clone() }));
+                                let _ = tx_c.send(StreamEvent::Llm(LlmEvent::ToolResult {
+                                    tool_id: tid.clone(),
+                                    result: err.clone(),
+                                }));
                                 (tid, false, format!("Tool execution failed: {}", err))
                             });
                             continue;
                         }
 
                         let tools_snapshot = tools.read().await;
-                        let runtime_name = tools_snapshot.runtime_name_for_api(&tool_name).to_string();
+                        let runtime_name =
+                            tools_snapshot.runtime_name_for_api(&tool_name).to_string();
                         let input = tools_snapshot.translate_input_for_api_tool(&tool_name, input);
                         let tool = tools_snapshot.get(&tool_name).cloned();
                         drop(tools_snapshot);
@@ -416,7 +484,7 @@ impl StreamMethods {
                                         res = t.execute(input, crate::ToolContext {
                                             channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx_stream.clone()) },
                                             capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()), secret_prompt: prompt_inner.clone() },
-                                            limits: crate::tools::ToolLimits { max_tool_output, bash_timeout, bash_max_timeout, subagent_timeout },
+                                            limits: crate::tools::ToolLimits { max_tool_output, max_tool_buffer: 256 * 1024, bash_timeout, bash_max_timeout, subagent_timeout },
                                         }) => {
                                             let output = match res {
                                                 Ok(output) => output,
@@ -428,6 +496,7 @@ impl StreamMethods {
                                                 Some(&runtime_name_for_hook),
                                                 input_for_hook,
                                                 output,
+                                                max_tool_output,
                                             ).await;
                                             (false, output)
                                         }
@@ -454,7 +523,9 @@ impl StreamMethods {
                     while let Some(res) = join_set.join_next().await {
                         match res {
                             Ok((tool_id, was_canceled, result)) => {
-                                if was_canceled { canceled = true; }
+                                if was_canceled {
+                                    canceled = true;
+                                }
                                 results_map.insert(tool_id, result);
                             }
                             Err(e) => {
@@ -466,7 +537,8 @@ impl StreamMethods {
                     // Build tool_results in original order
                     for tool_use in &tool_uses {
                         if let Some(tool_id) = tool_use["id"].as_str() {
-                            let result = results_map.remove(tool_id)
+                            let result = results_map
+                                .remove(tool_id)
                                 .unwrap_or_else(|| "Canceled by user".to_string());
                             tool_results.push(json!({
                                 "type": "tool_result",

--- a/crates/agent-engine/src/skills/commands.rs
+++ b/crates/agent-engine/src/skills/commands.rs
@@ -36,7 +36,12 @@ fn interpolate_slash_args(value: Value, slash_args: &str) -> Value {
     match value {
         Value::String(s) if s == "${args}" => Value::String(slash_args.to_string()),
         Value::String(s) => Value::String(s.replace("${args}", slash_args)),
-        Value::Array(items) => Value::Array(items.into_iter().map(|v| interpolate_slash_args(v, slash_args)).collect()),
+        Value::Array(items) => Value::Array(
+            items
+                .into_iter()
+                .map(|v| interpolate_slash_args(v, slash_args))
+                .collect(),
+        ),
         Value::Object(obj) => Value::Object(
             obj.into_iter()
                 .map(|(k, v)| (k, interpolate_slash_args(v, slash_args)))
@@ -51,7 +56,10 @@ pub async fn execute_plugin_command(
     slash_args: &str,
 ) -> crate::Result<PluginCommandOutput> {
     match &command.backend {
-        RegisteredPluginCommandBackend::Shell { command: executable, args } => {
+        RegisteredPluginCommandBackend::Shell {
+            command: executable,
+            args,
+        } => {
             validate_command_path(executable)?;
 
             let mut cmd = tokio::process::Command::new(executable);
@@ -83,12 +91,16 @@ pub async fn execute_plugin_command(
             }
             Ok(PluginCommandOutput {
                 status: Some(0),
-                stdout: format!("Skill prompt for /{}:{} (skill: {})\n{}", command.plugin, command.name, skill, text),
+                stdout: format!(
+                    "Skill prompt for /{}:{} (skill: {})\n{}",
+                    command.plugin, command.name, skill, text
+                ),
                 stderr: String::new(),
             })
         }
         RegisteredPluginCommandBackend::ExtensionTool { .. } => Err(crate::RuntimeError::Tool(
-            "extension-backed plugin command requires execute_plugin_command_with_tools".to_string(),
+            "extension-backed plugin command requires execute_plugin_command_with_tools"
+                .to_string(),
         )),
         RegisteredPluginCommandBackend::Interactive { .. } => Err(crate::RuntimeError::Tool(
             "interactive plugin command requires ExtensionManager::invoke_command".to_string(),
@@ -105,12 +117,22 @@ pub async fn execute_plugin_command_with_tools(
         let runtime_tool_name = format!("{}:{}", command.plugin, tool);
         let params = interpolate_slash_args(input.clone(), slash_args);
         let registry = tools.read().await;
-        let tool = registry.get(&runtime_tool_name).ok_or_else(|| {
-            crate::RuntimeError::Tool(format!("extension tool '{}' is not registered", runtime_tool_name))
-        })?.clone();
+        let tool = registry
+            .get(&runtime_tool_name)
+            .ok_or_else(|| {
+                crate::RuntimeError::Tool(format!(
+                    "extension tool '{}' is not registered",
+                    runtime_tool_name
+                ))
+            })?
+            .clone();
         drop(registry);
         let stdout = tool.execute(params, empty_tool_context()).await?;
-        Ok(PluginCommandOutput { status: Some(0), stdout, stderr: String::new() })
+        Ok(PluginCommandOutput {
+            status: Some(0),
+            stdout,
+            stderr: String::new(),
+        })
     } else {
         execute_plugin_command(command, slash_args).await
     }
@@ -118,7 +140,10 @@ pub async fn execute_plugin_command_with_tools(
 
 fn empty_tool_context() -> ToolContext {
     ToolContext {
-        channels: ToolChannels { tx_delta: None, tx_events: None },
+        channels: ToolChannels {
+            tx_delta: None,
+            tx_events: None,
+        },
         capabilities: ToolCapabilities {
             watcher_exit_path: None,
             tool_register_tx: None,
@@ -129,6 +154,7 @@ fn empty_tool_context() -> ToolContext {
         },
         limits: ToolLimits {
             max_tool_output: 30_000,
+            max_tool_buffer: 256 * 1024,
             bash_timeout: 30,
             bash_max_timeout: 300,
             subagent_timeout: 300,
@@ -143,9 +169,9 @@ fn slash_words(input: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Tool;
     use async_trait::async_trait;
     use std::path::PathBuf;
-    use crate::Tool;
 
     fn cmd(command: &str, args: Vec<&str>, root: PathBuf) -> RegisteredPluginCommand {
         RegisteredPluginCommand {
@@ -213,9 +239,15 @@ mod tests {
 
     #[async_trait]
     impl Tool for EchoTool {
-        fn name(&self) -> &str { "p:echo" }
-        fn description(&self) -> &str { "echo" }
-        fn parameters(&self) -> Value { serde_json::json!({"type":"object"}) }
+        fn name(&self) -> &str {
+            "p:echo"
+        }
+        fn description(&self) -> &str {
+            "echo"
+        }
+        fn parameters(&self) -> Value {
+            serde_json::json!({"type":"object"})
+        }
         async fn execute(&self, params: Value, _ctx: ToolContext) -> crate::Result<String> {
             Ok(format!("echo {}", params["text"].as_str().unwrap()))
         }
@@ -236,7 +268,9 @@ mod tests {
         let registry = Arc::new(tokio::sync::RwLock::new(ToolRegistry::without_subagent()));
         registry.write().await.register(Arc::new(EchoTool));
 
-        let output = execute_plugin_command_with_tools(&command, "hello", registry).await.unwrap();
+        let output = execute_plugin_command_with_tools(&command, "hello", registry)
+            .await
+            .unwrap();
 
         assert_eq!(output.status, Some(0));
         assert_eq!(output.stdout, "echo hello");

--- a/crates/agent-engine/src/skills/tool.rs
+++ b/crates/agent-engine/src/skills/tool.rs
@@ -1,8 +1,11 @@
 //! `load_skill` tool — model-initiated skill activation.
 
-use std::sync::Arc;
+use crate::skills::{
+    registry::{CommandRegistry, Resolution},
+    LoadedSkill,
+};
 use serde_json::json;
-use crate::skills::{LoadedSkill, registry::{CommandRegistry, Resolution}};
+use std::sync::Arc;
 
 pub struct LoadSkillTool {
     registry: Arc<CommandRegistry>,
@@ -25,7 +28,9 @@ impl LoadSkillTool {
 
 #[async_trait::async_trait]
 impl crate::Tool for LoadSkillTool {
-    fn name(&self) -> &str { "load_skill" }
+    fn name(&self) -> &str {
+        "load_skill"
+    }
 
     fn description(&self) -> &str {
         "Load a skill to guide your behavior for the current conversation. \
@@ -34,7 +39,10 @@ impl crate::Tool for LoadSkillTool {
     }
 
     fn parameters(&self) -> serde_json::Value {
-        let list: Vec<String> = self.registry.all_skills().iter()
+        let list: Vec<String> = self
+            .registry
+            .all_skills()
+            .iter()
             .map(|s| {
                 let qualified = match &s.plugin {
                     Some(p) => format!("{}:{} — {}", p, s.name, s.description),
@@ -60,17 +68,20 @@ impl crate::Tool for LoadSkillTool {
         params: serde_json::Value,
         _ctx: crate::ToolContext,
     ) -> crate::Result<String> {
-        let name = params["skill"].as_str()
+        let name = params["skill"]
+            .as_str()
             .ok_or_else(|| crate::RuntimeError::Tool("Missing 'skill' parameter".to_string()))?;
 
         match self.registry.resolve(name) {
             Resolution::Skill(s) => Ok(Self::format_body(&s)),
             Resolution::Ambiguous(opts) => Err(crate::RuntimeError::Tool(format!(
-                "ambiguous skill '{}'; specify one of: {}", name, opts.join(", ")
+                "ambiguous skill '{}'; specify one of: {}",
+                name,
+                opts.join(", ")
             ))),
-            Resolution::PluginCommand(_) | Resolution::Builtin | Resolution::Unknown => Err(crate::RuntimeError::Tool(
-                format!("unknown skill '{}'", name)
-            )),
+            Resolution::PluginCommand(_) | Resolution::Builtin | Resolution::Unknown => Err(
+                crate::RuntimeError::Tool(format!("unknown skill '{}'", name)),
+            ),
         }
     }
 }
@@ -96,6 +107,7 @@ mod tests {
             },
             limits: crate::tools::ToolLimits {
                 max_tool_output: 30000,
+                max_tool_buffer: 256 * 1024,
                 bash_timeout: 30,
                 bash_max_timeout: 300,
                 subagent_timeout: 300,
@@ -135,13 +147,14 @@ mod tests {
     async fn execute_returns_skill_body_on_unique_match() {
         use crate::Tool;
         let reg = Arc::new(crate::skills::registry::CommandRegistry::new(
-            &[], vec![mk("search", Some("p1"))]
+            &[],
+            vec![mk("search", Some("p1"))],
         ));
         let tool = LoadSkillTool::new(reg);
-        let result = tool.execute(
-            serde_json::json!({"skill": "search"}),
-            test_ctx()
-        ).await.unwrap();
+        let result = tool
+            .execute(serde_json::json!({"skill": "search"}), test_ctx())
+            .await
+            .unwrap();
         assert!(result.contains("# Skill: search"));
         assert!(result.contains("desc-search"));
         assert!(result.contains("body-search"));
@@ -151,13 +164,14 @@ mod tests {
     async fn execute_errors_on_ambiguous() {
         use crate::Tool;
         let reg = Arc::new(crate::skills::registry::CommandRegistry::new(
-            &[], vec![mk("search", Some("p1")), mk("search", Some("p2"))]
+            &[],
+            vec![mk("search", Some("p1")), mk("search", Some("p2"))],
         ));
         let tool = LoadSkillTool::new(reg);
-        let err = tool.execute(
-            serde_json::json!({"skill": "search"}),
-            test_ctx()
-        ).await.unwrap_err();
+        let err = tool
+            .execute(serde_json::json!({"skill": "search"}), test_ctx())
+            .await
+            .unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("ambiguous"));
         assert!(msg.contains("p1:search"));
@@ -169,10 +183,10 @@ mod tests {
         use crate::Tool;
         let reg = Arc::new(crate::skills::registry::CommandRegistry::new(&[], vec![]));
         let tool = LoadSkillTool::new(reg);
-        let err = tool.execute(
-            serde_json::json!({"skill": "nosuch"}),
-            test_ctx()
-        ).await.unwrap_err();
+        let err = tool
+            .execute(serde_json::json!({"skill": "nosuch"}), test_ctx())
+            .await
+            .unwrap_err();
         assert!(format!("{err}").contains("unknown skill 'nosuch'"));
     }
 
@@ -180,12 +194,15 @@ mod tests {
     async fn execute_errors_on_builtin() {
         use crate::Tool;
         // A built-in is not a skill; load_skill should refuse to load it.
-        let reg = Arc::new(crate::skills::registry::CommandRegistry::new(&["clear"], vec![]));
+        let reg = Arc::new(crate::skills::registry::CommandRegistry::new(
+            &["clear"],
+            vec![],
+        ));
         let tool = LoadSkillTool::new(reg);
-        let err = tool.execute(
-            serde_json::json!({"skill": "clear"}),
-            test_ctx()
-        ).await.unwrap_err();
+        let err = tool
+            .execute(serde_json::json!({"skill": "clear"}), test_ctx())
+            .await
+            .unwrap_err();
         assert!(format!("{err}").contains("unknown skill 'clear'"));
     }
 
@@ -194,10 +211,10 @@ mod tests {
         use crate::Tool;
         let reg = Arc::new(crate::skills::registry::CommandRegistry::new(&[], vec![]));
         let tool = LoadSkillTool::new(reg);
-        let err = tool.execute(
-            serde_json::json!({}),
-            test_ctx()
-        ).await.unwrap_err();
+        let err = tool
+            .execute(serde_json::json!({}), test_ctx())
+            .await
+            .unwrap_err();
         assert!(format!("{err}").contains("Missing 'skill' parameter"));
     }
 

--- a/crates/agent-engine/src/tools/bash.rs
+++ b/crates/agent-engine/src/tools/bash.rs
@@ -1,7 +1,7 @@
+use super::{strip_ansi, Tool, ToolContext};
+use crate::{Result, RuntimeError};
 use serde_json::{json, Value};
 use zeroize::Zeroize;
-use crate::{Result, RuntimeError};
-use super::{Tool, ToolContext, strip_ansi};
 
 pub struct BashTool;
 
@@ -20,10 +20,7 @@ fn sanitize_output(input: &[u8]) -> String {
     stripped
         .chars()
         .filter(|ch| {
-            *ch == '\n'
-                || *ch == '\r'
-                || *ch == '\t'
-                || (!ch.is_control() && *ch != '\u{7f}')
+            *ch == '\n' || *ch == '\r' || *ch == '\t' || (!ch.is_control() && *ch != '\u{7f}')
         })
         .collect()
 }
@@ -77,7 +74,9 @@ pub(crate) fn bash_script_with_secure_sudo(command: &str) -> String {
 
 #[async_trait::async_trait]
 impl Tool for BashTool {
-    fn name(&self) -> &str { "bash" }
+    fn name(&self) -> &str {
+        "bash"
+    }
 
     fn description(&self) -> &str {
         "Execute a bash command and return its output. Use for running programs, installing packages, git operations, and any shell commands. Commands time out after 30 seconds by default; pass a larger timeout when needed. If sudo asks for a password, the user is prompted securely in the TUI and the password is never shown to the model."
@@ -101,11 +100,14 @@ impl Tool for BashTool {
     }
 
     async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
-        let command = params["command"].as_str()
+        let command = params["command"]
+            .as_str()
             .ok_or_else(|| RuntimeError::Tool("Missing command parameter".to_string()))?;
 
-        let timeout_secs = params["timeout"].as_u64().unwrap_or(ctx.limits.bash_timeout);
-        let max_output = ctx.limits.max_tool_output;
+        let timeout_secs = params["timeout"]
+            .as_u64()
+            .unwrap_or(ctx.limits.bash_timeout);
+        let max_output = ctx.limits.max_tool_buffer;
 
         let script = bash_script_with_secure_sudo(command);
         let mut cmd = tokio::process::Command::new("bash");
@@ -130,14 +132,19 @@ impl Tool for BashTool {
             });
         }
 
-        let mut child = cmd.spawn()
-            .map_err(|e| RuntimeError::Tool(e.to_string()))?;
+        let mut child = cmd.spawn().map_err(|e| RuntimeError::Tool(e.to_string()))?;
 
-        let stdout = child.stdout.take()
+        let stdout = child
+            .stdout
+            .take()
             .ok_or_else(|| RuntimeError::Tool("Failed to capture stdout".to_string()))?;
-        let stderr = child.stderr.take()
+        let stderr = child
+            .stderr
+            .take()
             .ok_or_else(|| RuntimeError::Tool("Failed to capture stderr".to_string()))?;
-        let stdin = child.stdin.take()
+        let stdin = child
+            .stdin
+            .take()
             .ok_or_else(|| RuntimeError::Tool("Failed to capture stdin".to_string()))?;
 
         let (tx_inter, mut rx_inter) = tokio::sync::mpsc::unbounded_channel::<(bool, String)>();
@@ -197,20 +204,28 @@ impl Tool for BashTool {
                     stderr_tail.push_str(&msg);
                     if stderr_tail.len() > 512 {
                         let keep_from = stderr_tail.len() - 512;
-                        if let Some((idx, _)) = stderr_tail.char_indices().find(|(i, _)| *i >= keep_from) {
+                        if let Some((idx, _)) =
+                            stderr_tail.char_indices().find(|(i, _)| *i >= keep_from)
+                        {
                             stderr_tail.drain(..idx);
                         }
                     }
                     if let Some(kind) = detect_password_prompt(&stderr_tail) {
                         let prompt_text = stderr_tail.trim().to_string();
                         let secret = match &ctx.capabilities.secret_prompt {
-                            Some(prompt) => prompt.prompt(
-                                match kind {
-                                    PromptKind::Sudo => "sudo password required".to_string(),
-                                    PromptKind::Password => "password required".to_string(),
-                                },
-                                prompt_text.clone(),
-                            ).await,
+                            Some(prompt) => {
+                                prompt
+                                    .prompt(
+                                        match kind {
+                                            PromptKind::Sudo => {
+                                                "sudo password required".to_string()
+                                            }
+                                            PromptKind::Password => "password required".to_string(),
+                                        },
+                                        prompt_text.clone(),
+                                    )
+                                    .await
+                            }
                             None => None,
                         };
                         match secret {
@@ -229,7 +244,9 @@ impl Tool for BashTool {
                             }
                             None => {
                                 let _ = child.kill().await;
-                                return Err(RuntimeError::Tool("Command canceled while waiting for password".to_string()));
+                                return Err(RuntimeError::Tool(
+                                    "Command canceled while waiting for password".to_string(),
+                                ));
                             }
                         }
                         let prompt_len = prompt_text.len();
@@ -282,13 +299,17 @@ impl Tool for BashTool {
                     let _ = child.kill().await;
                 }
             }
-            let status = child.wait().await.map_err(|e| RuntimeError::Tool(e.to_string()))?;
+            let status = child
+                .wait()
+                .await
+                .map_err(|e| RuntimeError::Tool(e.to_string()))?;
             // Zeroize redactions (passwords) from memory now that command is done
             for secret in &mut redactions {
                 secret.zeroize();
             }
             Ok::<_, RuntimeError>((status, full_output, truncated))
-        }).await;
+        })
+        .await;
 
         match result {
             Ok(Ok((status, output, was_truncated))) => {
@@ -297,12 +318,19 @@ impl Tool for BashTool {
                 } else {
                     Err(RuntimeError::Tool(format!(
                         "Command failed (exit {}):\n{}",
-                        status.code().unwrap_or(-1), output
+                        status.code().unwrap_or(-1),
+                        output
                     )))
                 }
             }
-            Ok(Err(e)) => Err(RuntimeError::Tool(format!("Failed to execute command: {}", e))),
-            Err(_) => Err(RuntimeError::Tool(format!("Command timed out after {}s", timeout_secs))),
+            Ok(Err(e)) => Err(RuntimeError::Tool(format!(
+                "Failed to execute command: {}",
+                e
+            ))),
+            Err(_) => Err(RuntimeError::Tool(format!(
+                "Command timed out after {}s",
+                timeout_secs
+            ))),
         }
     }
 }
@@ -313,7 +341,10 @@ mod tests {
 
     #[test]
     fn detects_sudo_password_prompt_without_newline() {
-        assert_eq!(detect_password_prompt("[sudo] password for me: "), Some(PromptKind::Sudo));
+        assert_eq!(
+            detect_password_prompt("[sudo] password for me: "),
+            Some(PromptKind::Sudo)
+        );
     }
 
     #[test]
@@ -387,7 +418,10 @@ mod tests {
         });
 
         let result = tool.execute(params, ctx).await;
-        assert!(result.is_ok(), "requested timeout should not be clamped by bash_max_timeout: {result:?}");
+        assert!(
+            result.is_ok(),
+            "requested timeout should not be clamped by bash_max_timeout: {result:?}"
+        );
         assert!(result.unwrap().contains("done"));
     }
 
@@ -399,8 +433,15 @@ mod tests {
         let (delta_tx, mut delta_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let responder = tokio::spawn(async move {
-            let req = prompt_rx.recv().await.expect("bash should request a secret prompt");
-            assert!(req.prompt.to_ascii_lowercase().contains("password"), "prompt was {:?}", req.prompt);
+            let req = prompt_rx
+                .recv()
+                .await
+                .expect("bash should request a secret prompt");
+            assert!(
+                req.prompt.to_ascii_lowercase().contains("password"),
+                "prompt was {:?}",
+                req.prompt
+            );
             req.response_tx.send(Some("swordfish".to_string())).unwrap();
         });
 
@@ -442,9 +483,18 @@ mod tests {
         let (delta_tx, mut delta_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let responder = tokio::spawn(async move {
-            let req = prompt_rx.recv().await.expect("bash should request a secret prompt");
-            assert!(req.prompt.contains("[sudo] password required"), "prompt was {:?}", req.prompt);
-            req.response_tx.send(Some("wrong-password-for-test".to_string())).unwrap();
+            let req = prompt_rx
+                .recv()
+                .await
+                .expect("bash should request a secret prompt");
+            assert!(
+                req.prompt.contains("[sudo] password required"),
+                "prompt was {:?}",
+                req.prompt
+            );
+            req.response_tx
+                .send(Some("wrong-password-for-test".to_string()))
+                .unwrap();
         });
 
         let mut ctx = create_tool_context();
@@ -462,7 +512,10 @@ mod tests {
             streamed.push_str(&delta);
         }
 
-        assert!(!streamed.contains("[sudo] password required"), "sudo password prompt leaked into deltas: {streamed:?}");
+        assert!(
+            !streamed.contains("[sudo] password required"),
+            "sudo password prompt leaked into deltas: {streamed:?}"
+        );
     }
 
     #[tokio::test]
@@ -471,7 +524,7 @@ mod tests {
         let (delta_tx, mut delta_rx) = tokio::sync::mpsc::unbounded_channel();
         let mut ctx = create_tool_context();
         ctx.channels.tx_delta = Some(delta_tx);
-        ctx.limits.max_tool_output = 256;
+        ctx.limits.max_tool_buffer = 256;
 
         let params = json!({
             "command": "python3 -c \"import sys; sys.stdout.buffer.write(b'clean\\x1b[2J\\x00' + b'A' * 2000); sys.stdout.flush()\"",
@@ -489,7 +542,11 @@ mod tests {
         assert!(!result.contains('\0'));
         assert!(!streamed.contains('\u{1b}'));
         assert!(!streamed.contains('\0'));
-        assert!(streamed.len() <= 2048, "streamed deltas must be bounded, got {} bytes", streamed.len());
+        assert!(
+            streamed.len() <= 2048,
+            "streamed deltas must be bounded, got {} bytes",
+            streamed.len()
+        );
     }
 
     #[tokio::test]
@@ -499,7 +556,10 @@ mod tests {
         let prompt_handle = crate::tools::SecretPromptHandle::new(prompt_tx);
 
         let responder = tokio::spawn(async move {
-            let req = prompt_rx.recv().await.expect("bash should request a secret prompt");
+            let req = prompt_rx
+                .recv()
+                .await
+                .expect("bash should request a secret prompt");
             req.response_tx.send(Some("swordfish".to_string())).unwrap();
         });
 
@@ -525,7 +585,10 @@ mod tests {
 
         let responder = tokio::spawn(async move {
             for value in ["first", "second"] {
-                let req = prompt_rx.recv().await.expect("bash should request each secret prompt");
+                let req = prompt_rx
+                    .recv()
+                    .await
+                    .expect("bash should request each secret prompt");
                 assert!(req.prompt.to_ascii_lowercase().contains("password"));
                 req.response_tx.send(Some(value.to_string())).unwrap();
             }
@@ -553,7 +616,10 @@ mod tests {
         let prompt_handle = crate::tools::SecretPromptHandle::new(prompt_tx);
 
         let responder = tokio::spawn(async move {
-            let req = prompt_rx.recv().await.expect("bash should request a secret prompt");
+            let req = prompt_rx
+                .recv()
+                .await
+                .expect("bash should request a secret prompt");
             req.response_tx.send(None).unwrap();
         });
 

--- a/crates/agent-engine/src/tools/grep.rs
+++ b/crates/agent-engine/src/tools/grep.rs
@@ -1,14 +1,16 @@
+use super::{expand_path, Tool, ToolContext};
+use crate::{Result, RuntimeError};
 use serde_json::{json, Value};
 use std::time::Duration;
 use tokio::process::Command;
-use crate::{Result, RuntimeError};
-use super::{Tool, ToolContext, expand_path};
 
 pub struct GrepTool;
 
 #[async_trait::async_trait]
 impl Tool for GrepTool {
-    fn name(&self) -> &str { "grep" }
+    fn name(&self) -> &str {
+        "grep"
+    }
 
     fn description(&self) -> &str {
         "Search file contents using regex patterns. Returns matching lines with file paths and line numbers. Supports file type filtering and context lines."
@@ -40,7 +42,8 @@ impl Tool for GrepTool {
     }
 
     async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
-        let pattern = params["pattern"].as_str()
+        let pattern = params["pattern"]
+            .as_str()
             .ok_or_else(|| RuntimeError::Tool("Missing pattern parameter".to_string()))?;
         let path = expand_path(params["path"].as_str().unwrap_or("."));
         let include = params["include"].as_str();
@@ -64,7 +67,8 @@ impl Tool for GrepTool {
 
         cmd.arg("--").arg(pattern).arg(&path);
 
-        let output = tokio::time::timeout(Duration::from_secs(15), cmd.output()).await
+        let output = tokio::time::timeout(Duration::from_secs(15), cmd.output())
+            .await
             .map_err(|_| RuntimeError::Tool("Grep timed out after 15s".to_string()))?
             .map_err(|e| RuntimeError::Tool(format!("Failed to execute grep: {}", e)))?;
 
@@ -74,9 +78,13 @@ impl Tool for GrepTool {
             Ok("No matches found.".to_string())
         } else {
             let result = stdout.to_string();
-            if result.len() > ctx.limits.max_tool_output {
-                let truncated: String = result.chars().take(ctx.limits.max_tool_output).collect();
-                Ok(format!("{}\n\n... (output truncated, {} total bytes)", truncated, result.len()))
+            if result.len() > ctx.limits.max_tool_buffer {
+                let truncated: String = result.chars().take(ctx.limits.max_tool_buffer).collect();
+                Ok(format!(
+                    "{}\n\n... (output truncated, {} total bytes)",
+                    truncated,
+                    result.len()
+                ))
             } else {
                 Ok(result)
             }
@@ -85,8 +93,8 @@ impl Tool for GrepTool {
 }
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::test_helpers::create_tool_context;
+    use super::*;
     use crate::tools::Tool;
     use serde_json::json;
 

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -2,55 +2,60 @@
 //!
 //! All tools implement the `Tool` trait and are registered in `ToolRegistry`.
 //! Subagents get `ToolRegistry::without_subagent()` to prevent recursion.
+use crate::Result;
 use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use crate::Result;
 
 // ── Module declarations ──────────────────────────────────────────────────────────
 
 mod bash;
-mod read;
-mod write;
 mod edit;
-mod grep;
-mod find;
-mod ls;
-mod subagent;
-mod secret_prompt;
 mod extension;
+mod find;
+mod grep;
+mod ls;
+mod read;
+mod secret_prompt;
+mod subagent;
+mod write;
 
-pub mod watcher_exit;
-pub(crate) mod util;
 mod agent;
 mod registry;
-pub mod shell;
 pub mod respond;
 pub mod send_channel;
+pub mod shell;
+pub(crate) mod util;
+pub mod watcher_exit;
 
 // ── Re-exports ──────────────────────────────────────────────────────────────────
 
-pub use bash::BashTool;
-pub use read::ReadTool;
-pub use write::WriteTool;
-pub use edit::EditTool;
-pub use grep::GrepTool;
-pub use find::FindTool;
-pub use ls::LsTool;
-pub use subagent::{SubagentTool, SubagentStartTool, SubagentStatusTool, SubagentSteerTool, SubagentCollectTool, SubagentResumeTool};
-pub use crate::runtime::subagent::{SubagentResult, SubagentHandle, SubagentRegistry, SubagentStatus, SubagentState};
-pub use watcher_exit::WatcherExitTool;
-pub use registry::ToolRegistry;
+pub use crate::runtime::subagent::{
+    SubagentHandle, SubagentRegistry, SubagentResult, SubagentState, SubagentStatus,
+};
 pub use agent::resolve_agent_prompt;
-pub use shell::{ShellStartTool, ShellSendTool, ShellEndTool};
-pub use respond::RespondTool;
-pub use send_channel::SendChannelTool;
-pub use secret_prompt::{SecretPromptHandle, SecretPromptRequest};
-pub use secret_prompt::SecretPromptQueue;
+pub use bash::BashTool;
+pub use edit::EditTool;
 pub use extension::ExtensionTool;
+pub use find::FindTool;
+pub use grep::GrepTool;
+pub use ls::LsTool;
+pub use read::ReadTool;
+pub use registry::ToolRegistry;
+pub use respond::RespondTool;
+pub use secret_prompt::SecretPromptQueue;
+pub use secret_prompt::{SecretPromptHandle, SecretPromptRequest};
+pub use send_channel::SendChannelTool;
+pub use shell::{ShellEndTool, ShellSendTool, ShellStartTool};
+pub use subagent::{
+    SubagentCollectTool, SubagentResumeTool, SubagentStartTool, SubagentStatusTool,
+    SubagentSteerTool, SubagentTool,
+};
+pub use watcher_exit::WatcherExitTool;
+pub use write::WriteTool;
 
 // Re-export util items used by sibling tool modules via `super::`
-pub(crate) use util::{NEXT_SUBAGENT_ID, strip_ansi, expand_path};
+pub(crate) use util::{expand_path, strip_ansi, NEXT_SUBAGENT_ID};
 
 // ── Tool Trait ──────────────────────────────────────────────────────────────────
 
@@ -72,7 +77,14 @@ pub struct ToolCapabilities {
 
 /// Configuration limits and timeouts.
 pub struct ToolLimits {
+    /// Context-budget ceiling — final tool output entering history is truncated
+    /// to this. Applied AFTER the `after_tool_call` hook so compression
+    /// extensions see the FULL buffered output and can decide what to keep.
     pub max_tool_output: usize,
+    /// Memory/pipe safety bound — the maximum bytes a tool may buffer
+    /// internally before truncating with a marker. Sized well above
+    /// `max_tool_output` so transform extensions are never starved.
+    pub max_tool_buffer: usize,
     pub bash_timeout: u64,
     pub bash_max_timeout: u64,
     pub subagent_timeout: u64,

--- a/crates/agent-engine/src/tools/shell/send.rs
+++ b/crates/agent-engine/src/tools/shell/send.rs
@@ -1,14 +1,16 @@
 //! `shell_send` tool — send input to an active shell session.
 
-use serde_json::{json, Value};
-use crate::{Result, RuntimeError};
 use crate::tools::{Tool, ToolContext};
+use crate::{Result, RuntimeError};
+use serde_json::{json, Value};
 
 pub struct ShellSendTool;
 
 #[async_trait::async_trait]
 impl Tool for ShellSendTool {
-    fn name(&self) -> &str { "shell_send" }
+    fn name(&self) -> &str {
+        "shell_send"
+    }
 
     fn description(&self) -> &str {
         "Send input to an active shell session. Returns the output produced after sending the input. The input is sent exactly as received after JSON parsing — a JSON string containing \\n will send an actual newline (Enter key). Use \\x03 for Ctrl-C, \\x04 for Ctrl-D."
@@ -36,17 +38,30 @@ impl Tool for ShellSendTool {
     }
 
     async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
-        let mgr = ctx.capabilities.session_manager.as_ref()
+        let mgr = ctx
+            .capabilities
+            .session_manager
+            .as_ref()
             .ok_or_else(|| RuntimeError::Tool("Shell sessions not available".into()))?;
-        
-        let session_id = params["session_id"].as_str()
+
+        let session_id = params["session_id"]
+            .as_str()
             .ok_or_else(|| RuntimeError::Tool("Missing session_id parameter".into()))?;
-        let input = params["input"].as_str()
+        let input = params["input"]
+            .as_str()
             .ok_or_else(|| RuntimeError::Tool("Missing input parameter".into()))?;
         let timeout_ms = params["timeout_ms"].as_u64();
-        
-        let result = mgr.send_input(session_id, input, timeout_ms, ctx.channels.tx_delta.as_ref()).await?;
-        
+
+        let result = mgr
+            .send_input(
+                session_id,
+                input,
+                timeout_ms,
+                ctx.channels.tx_delta.as_ref(),
+                ctx.limits.max_tool_buffer,
+            )
+            .await?;
+
         if result.status == "active" {
             Ok(result.output)
         } else {

--- a/crates/agent-engine/src/tools/shell/session.rs
+++ b/crates/agent-engine/src/tools/shell/session.rs
@@ -99,13 +99,34 @@ fn process_input_escapes(input: &str) -> String {
     while let Some(ch) = chars.next() {
         if ch == '\\' {
             match chars.peek() {
-                Some('n') => { chars.next(); result.push('\n'); }
-                Some('r') => { chars.next(); result.push('\r'); }
-                Some('t') => { chars.next(); result.push('\t'); }
-                Some('\\') => { chars.next(); result.push('\\'); }
-                Some('a') => { chars.next(); result.push('\x07'); }  // bell
-                Some('b') => { chars.next(); result.push('\x08'); }  // backspace
-                Some('0') => { chars.next(); result.push('\0'); }    // null
+                Some('n') => {
+                    chars.next();
+                    result.push('\n');
+                }
+                Some('r') => {
+                    chars.next();
+                    result.push('\r');
+                }
+                Some('t') => {
+                    chars.next();
+                    result.push('\t');
+                }
+                Some('\\') => {
+                    chars.next();
+                    result.push('\\');
+                }
+                Some('a') => {
+                    chars.next();
+                    result.push('\x07');
+                } // bell
+                Some('b') => {
+                    chars.next();
+                    result.push('\x08');
+                } // backspace
+                Some('0') => {
+                    chars.next();
+                    result.push('\0');
+                } // null
                 Some('e') => {
                     chars.next();
                     tracing::warn!("blocked \\e escape sequence (raw ESC) in shell input");
@@ -126,7 +147,9 @@ fn process_input_escapes(input: &str) -> String {
                     if let Ok(byte) = u8::from_str_radix(&hex, 16) {
                         if byte == 0x1b {
                             // Block ESC (ANSI escape initiator)
-                            tracing::warn!("blocked \\x1b escape sequence (raw ESC) in shell input");
+                            tracing::warn!(
+                                "blocked \\x1b escape sequence (raw ESC) in shell input"
+                            );
                         } else if byte >= 0x80 {
                             // Block high bytes
                             tracing::warn!("blocked \\x{hex:} high byte (>= 0x80) in shell input");
@@ -202,7 +225,7 @@ async fn wait_for_output(
             let text = String::from_utf8_lossy(&bytes);
             output.push_str(&text);
             last_output_time = Instant::now();
-            
+
             // Stream to TUI if requested (normalized)
             if let Some(tx) = tx_delta {
                 let _ = tx.send(normalize_output(&text));
@@ -227,14 +250,17 @@ async fn wait_for_output(
             if !remaining.is_empty() {
                 let remaining_text = String::from_utf8_lossy(&remaining);
                 output.push_str(&remaining_text);
-                
+
                 // Stream remaining output to TUI
                 if let Some(tx) = tx_delta {
                     let _ = tx.send(normalize_output(&remaining_text));
                 }
             }
             // PtyHandle doesn't expose exit codes currently — use None
-            return (normalize_output(&output), status_string(&SessionStatus::Exited(None)));
+            return (
+                normalize_output(&output),
+                status_string(&SessionStatus::Exited(None)),
+            );
         }
 
         // Evaluate readiness.
@@ -268,15 +294,17 @@ impl SessionManager {
     ///
     /// Returns `(session_id, initial_output, status)` on success.
     pub async fn create_session(
-        &self, 
+        &self,
         opts: SessionOpts,
         tx_delta: Option<&tokio::sync::mpsc::UnboundedSender<String>>,
+        max_output: usize,
     ) -> Result<(String, String, String)> {
         // --- Check session limit ---
         {
-            let sessions = self.sessions.lock().map_err(|e| {
-                RuntimeError::Tool(format!("session lock poisoned: {e}"))
-            })?;
+            let sessions = self
+                .sessions
+                .lock()
+                .map_err(|e| RuntimeError::Tool(format!("session lock poisoned: {e}")))?;
             if sessions.len() >= self.config.max_sessions {
                 return Err(RuntimeError::Tool(format!(
                     "maximum session limit reached ({})",
@@ -290,9 +318,9 @@ impl SessionManager {
         let id = format!("shell_{:02}", seq);
 
         // --- Resolve parameters with config defaults ---
-        let command = opts.command.unwrap_or_else(|| {
-            std::env::var("SHELL").unwrap_or_else(|_| "bash".into())
-        });
+        let command = opts
+            .command
+            .unwrap_or_else(|| std::env::var("SHELL").unwrap_or_else(|_| "bash".into()));
         let rows = opts.rows.unwrap_or(self.config.default_rows);
         let cols = opts.cols.unwrap_or(self.config.default_cols);
 
@@ -326,8 +354,14 @@ impl SessionManager {
         // Without this, the silence timeout can fire before the process has
         // had time to print anything (e.g. Python startup, shell rc files).
         tokio::time::sleep(Duration::from_millis(200)).await;
-        let (initial_output, status_str) =
-            wait_for_output(&mut pty, &detector, opts.readiness_timeout_ms, tx_delta, 30000).await;
+        let (initial_output, status_str) = wait_for_output(
+            &mut pty,
+            &detector,
+            opts.readiness_timeout_ms,
+            tx_delta,
+            max_output,
+        )
+        .await;
 
         let now = Instant::now();
         let status = if status_str.starts_with("exited") {
@@ -347,9 +381,10 @@ impl SessionManager {
 
         // --- Insert into map ---
         {
-            let mut sessions = self.sessions.lock().map_err(|e| {
-                RuntimeError::Tool(format!("session lock poisoned: {e}"))
-            })?;
+            let mut sessions = self
+                .sessions
+                .lock()
+                .map_err(|e| RuntimeError::Tool(format!("session lock poisoned: {e}")))?;
             sessions.insert(id.clone(), session);
         }
 
@@ -363,12 +398,14 @@ impl SessionManager {
         input: &str,
         timeout_ms: Option<u64>,
         tx_delta: Option<&tokio::sync::mpsc::UnboundedSender<String>>,
+        max_output: usize,
     ) -> Result<SendResult> {
         // --- Remove session from map (release lock before I/O) ---
         let mut session = {
-            let mut sessions = self.sessions.lock().map_err(|e| {
-                RuntimeError::Tool(format!("session lock poisoned: {e}"))
-            })?;
+            let mut sessions = self
+                .sessions
+                .lock()
+                .map_err(|e| RuntimeError::Tool(format!("session lock poisoned: {e}")))?;
             sessions.remove(id).ok_or_else(|| {
                 RuntimeError::Tool(format!(
                     "session {id} not found — it may have been closed, reaped, or is currently in use by another call"
@@ -380,9 +417,10 @@ impl SessionManager {
         if session.status != SessionStatus::Active {
             // Reinsert so it can still be closed/inspected.
             let s_str = status_string(&session.status);
-            let mut sessions = self.sessions.lock().map_err(|e| {
-                RuntimeError::Tool(format!("session lock poisoned: {e}"))
-            })?;
+            let mut sessions = self
+                .sessions
+                .lock()
+                .map_err(|e| RuntimeError::Tool(format!("session lock poisoned: {e}")))?;
             sessions.insert(id.to_string(), session);
             return Err(RuntimeError::Tool(format!(
                 "session {id} is not active (status: {s_str})"
@@ -394,8 +432,14 @@ impl SessionManager {
         session.pty.write(processed.as_bytes())?;
 
         // --- Wait for output ---
-        let (output, status_str) =
-            wait_for_output(&mut session.pty, &session.detector, timeout_ms, tx_delta, 30000).await;
+        let (output, status_str) = wait_for_output(
+            &mut session.pty,
+            &session.detector,
+            timeout_ms,
+            tx_delta,
+            max_output,
+        )
+        .await;
 
         // --- Update metadata ---
         session.last_active = Instant::now();
@@ -410,9 +454,10 @@ impl SessionManager {
 
         // --- Reinsert into map ---
         {
-            let mut sessions = self.sessions.lock().map_err(|e| {
-                RuntimeError::Tool(format!("session lock poisoned: {e}"))
-            })?;
+            let mut sessions = self
+                .sessions
+                .lock()
+                .map_err(|e| RuntimeError::Tool(format!("session lock poisoned: {e}")))?;
             sessions.insert(id.to_string(), session);
         }
 
@@ -424,9 +469,10 @@ impl SessionManager {
     /// Idempotent — closing a non-existent session returns `Ok("")`.
     pub async fn close_session(&self, id: &str) -> Result<String> {
         let mut session = {
-            let mut sessions = self.sessions.lock().map_err(|e| {
-                RuntimeError::Tool(format!("session lock poisoned: {e}"))
-            })?;
+            let mut sessions = self
+                .sessions
+                .lock()
+                .map_err(|e| RuntimeError::Tool(format!("session lock poisoned: {e}")))?;
             match sessions.remove(id) {
                 Some(s) => s,
                 None => return Ok(String::new()),
@@ -508,17 +554,15 @@ impl SessionManager {
     /// Snapshot of all sessions.
     pub fn list_sessions(&self) -> Vec<ShellSessionInfo> {
         match self.sessions.lock() {
-            Ok(sessions) => {
-                sessions
-                    .iter()
-                    .map(|(id, s)| ShellSessionInfo {
-                        id: id.clone(),
-                        status: s.status.clone(),
-                        created_at: s.created_at,
-                        last_active: s.last_active,
-                    })
-                    .collect()
-            }
+            Ok(sessions) => sessions
+                .iter()
+                .map(|(id, s)| ShellSessionInfo {
+                    id: id.clone(),
+                    status: s.status.clone(),
+                    created_at: s.created_at,
+                    last_active: s.last_active,
+                })
+                .collect(),
             Err(e) => {
                 tracing::error!("session lock poisoned: {e}");
                 Vec::new()
@@ -595,7 +639,7 @@ mod tests {
     async fn test_create_session_echo_hello() {
         let mgr = default_manager();
         let (id, output, _status) = mgr
-            .create_session(opts_for("echo hello"), None)
+            .create_session(opts_for("echo hello"), None, 256 * 1024)
             .await
             .expect("failed to create session");
 
@@ -611,12 +655,12 @@ mod tests {
     async fn test_send_input_echo() {
         let mgr = default_manager();
         let (id, _initial, _status) = mgr
-            .create_session(opts_for("bash"), None)
+            .create_session(opts_for("bash"), None, 256 * 1024)
             .await
             .expect("failed to create session");
 
         let result = mgr
-            .send_input(&id, "echo test\n", None, None)
+            .send_input(&id, "echo test\n", None, None, 256 * 1024)
             .await
             .expect("failed to send input");
 
@@ -635,7 +679,7 @@ mod tests {
     async fn test_close_session_idempotent() {
         let mgr = default_manager();
         let (id, _, _status) = mgr
-            .create_session(opts_for("bash"), None)
+            .create_session(opts_for("bash"), None, 256 * 1024)
             .await
             .expect("failed to create session");
 
@@ -643,26 +687,32 @@ mod tests {
         assert!(result1.is_ok(), "first close should succeed");
 
         let result2 = mgr.close_session(&id).await;
-        assert!(result2.is_ok(), "second close should also succeed (idempotent)");
+        assert!(
+            result2.is_ok(),
+            "second close should also succeed (idempotent)"
+        );
         assert_eq!(result2.unwrap(), "", "second close returns empty string");
     }
 
     // 4. Max sessions limit → error on exceeding
     #[tokio::test]
     async fn test_max_sessions_limit() {
-        let config = ShellConfig { max_sessions: 2, ..Default::default() };
+        let config = ShellConfig {
+            max_sessions: 2,
+            ..Default::default()
+        };
         let mgr = SessionManager::new(config);
 
         let (id1, _, _s) = mgr
-            .create_session(opts_for("bash"), None)
+            .create_session(opts_for("bash"), None, 256 * 1024)
             .await
             .expect("session 1");
         let (id2, _, _s) = mgr
-            .create_session(opts_for("bash"), None)
+            .create_session(opts_for("bash"), None, 256 * 1024)
             .await
             .expect("session 2");
 
-        let result = mgr.create_session(opts_for("bash"), None).await;
+        let result = mgr.create_session(opts_for("bash"), None, 256 * 1024).await;
         assert!(result.is_err(), "third session should fail");
         let err_msg = format!("{}", result.unwrap_err());
         assert!(
@@ -679,7 +729,9 @@ mod tests {
     #[tokio::test]
     async fn test_session_not_found() {
         let mgr = default_manager();
-        let result = mgr.send_input("shell_99", "hello\n", None, None).await;
+        let result = mgr
+            .send_input("shell_99", "hello\n", None, None, 256 * 1024)
+            .await;
         assert!(result.is_err(), "send to non-existent session should fail");
         let err_msg = format!("{}", result.unwrap_err());
         assert!(

--- a/crates/agent-engine/src/tools/shell/start.rs
+++ b/crates/agent-engine/src/tools/shell/start.rs
@@ -1,14 +1,16 @@
 //! `shell_start` tool — create a new interactive shell session.
 
-use serde_json::{json, Value};
-use crate::{Result, RuntimeError};
 use crate::tools::{Tool, ToolContext};
+use crate::{Result, RuntimeError};
+use serde_json::{json, Value};
 
 pub struct ShellStartTool;
 
 #[async_trait::async_trait]
 impl Tool for ShellStartTool {
-    fn name(&self) -> &str { "shell_start" }
+    fn name(&self) -> &str {
+        "shell_start"
+    }
 
     fn description(&self) -> &str {
         "Start a new interactive shell session with a PTY. Returns a session ID and the initial output. Use shell_send to interact and shell_end to close."
@@ -53,29 +55,46 @@ impl Tool for ShellStartTool {
     }
 
     async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
-        let mgr = ctx.capabilities.session_manager.as_ref()
+        let mgr = ctx
+            .capabilities
+            .session_manager
+            .as_ref()
             .ok_or_else(|| RuntimeError::Tool("Shell sessions not available".into()))?;
-        
+
         let command = params["command"].as_str().map(|s| s.to_string());
         let working_directory = params["working_directory"].as_str().map(|s| s.to_string());
         let rows = params["rows"].as_u64().map(|r| r as u16);
         let cols = params["cols"].as_u64().map(|c| c as u16);
         let readiness_timeout_ms = params["readiness_timeout_ms"].as_u64();
         let idle_timeout = params["idle_timeout"].as_u64();
-        
-        let env = params["env"].as_object()
-            .map(|obj| obj.iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                .collect())
+
+        let env = params["env"]
+            .as_object()
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect()
+            })
             .unwrap_or_default();
-        
+
         let opts = super::SessionOpts {
-            command, working_directory, env, rows, cols,
-            readiness_timeout_ms, idle_timeout,
+            command,
+            working_directory,
+            env,
+            rows,
+            cols,
+            readiness_timeout_ms,
+            idle_timeout,
         };
-        
-        let (session_id, output, status) = mgr.create_session(opts, ctx.channels.tx_delta.as_ref()).await?;
-        
+
+        let (session_id, output, status) = mgr
+            .create_session(
+                opts,
+                ctx.channels.tx_delta.as_ref(),
+                ctx.limits.max_tool_buffer,
+            )
+            .await?;
+
         let mut result = format!("[Session {} | {}]\n", session_id, status);
         if !output.is_empty() {
             result.push_str(&output);

--- a/crates/agent-engine/src/tools/test_helpers.rs
+++ b/crates/agent-engine/src/tools/test_helpers.rs
@@ -19,6 +19,7 @@ pub(crate) fn create_tool_context() -> ToolContext {
         },
         limits: ToolLimits {
             max_tool_output: 30000,
+            max_tool_buffer: 256 * 1024,
             bash_timeout: 30,
             bash_max_timeout: 300,
             subagent_timeout: 300,


### PR DESCRIPTION
## Fork 1 — feed the compressor whole food

Stacks on #50 (the `after_tool_call` → Replace primitive). Base is the feat branch; retargets to `dev` cleanly once #50 merges.

### The bug
Tool output was truncated to `max_tool_output` (30KB) **before** the `after_tool_call` hook fired — so a transform/compression extension only ever saw pre-chopped output, exactly where compression matters most. **RED proof:** a 150KB output reached the hook as **30,029 bytes** (the bash truncation marker).

Two starvation gates:
- **Gate 1 (tool-internal):** `bash.rs` / `grep.rs` / `shell/session.rs` truncated to `max_tool_output` before returning.
- **Gate 2 (hook preview):** `HookEvent::after_tool_call` capped `tool_output` to `MAX_HOOK_OUTPUT = 32KB`. A no-op today, but the binding ceiling once Gate 1 is fixed.

### The fix — compress-then-truncate
Split the conflated 30KB into two concerns:
| Limit | Role |
|-------|------|
| `max_tool_buffer` (**new**, 256KB) | memory/pipe safety. Tools buffer up to this; hook preview matches it. |
| `max_tool_output` (30KB) | context budget. Applied **after** the hook in `emit_after_tool_call`. |

Flow: tool buffers ≤256KB → hook sees the **full** output → (compressor shrinks it) → **then** truncate to 30KB.

### Behavior preservation
With **no** transform extension active, the final result is **byte-identical** to the legacy ordering — `emit_after_tool_call` reuses `HelperMethods::truncate_tool_result`. Proven by `no_transform_extension_preserves_legacy_truncation` (test C).

### Tests (+4, suite 852 → 856, 0 failures)
- `after_tool_call_transform_receives_full_output_not_pre_truncated` — RED→GREEN: 30,029B → full 150KB
- `final_output_truncated_to_max_tool_output_after_hook` — post-hook cap on a Replace output
- `no_transform_extension_preserves_legacy_truncation` — byte-identical no-extension path
- `emit_after_tool_call_truncates_char_boundary_safe` — multibyte safety

### Verification
- `cargo test -p synaps-engine` → **856 passed, 0 failed**
- `cargo clippy -p synaps-engine` → clean
- `cargo build --workspace` → clean

🧪 Built under TDD (RED proof before fix). Independently re-verified before push.