### PR TITLE
feat(skills): self-improving skills — writable + Axel-indexed (Component #1)

### DIFF
--- a/crates/agent-engine/src/runtime/api.rs
+++ b/crates/agent-engine/src/runtime/api.rs
@@ -1391,8 +1391,7 @@ mod tests {
         let events = drain(&mut rx);
         let last_usage = events
             .iter()
-            .filter(|e| matches!(e, StreamEvent::Session(SessionEvent::Usage { .. })))
-            .next_back()
+            .rfind(|e| matches!(e, StreamEvent::Session(SessionEvent::Usage { .. })))
             .expect("delta must emit a Usage event");
         assert!(matches!(
             last_usage,

--- a/crates/agent-engine/src/skills/loader.rs
+++ b/crates/agent-engine/src/skills/loader.rs
@@ -5,7 +5,7 @@ use crate::skills::LoadedSkill;
 
 /// Parse YAML frontmatter from a markdown file.
 /// Returns (frontmatter_fields, body).
-pub(super) fn parse_frontmatter(text: &str) -> (Vec<(String, String)>, String) {
+pub(crate) fn parse_frontmatter(text: &str) -> (Vec<(String, String)>, String) {
     if !text.starts_with("---") {
         return (vec![], text.to_string());
     }

--- a/crates/agent-engine/src/skills/manage_tool.rs
+++ b/crates/agent-engine/src/skills/manage_tool.rs
@@ -1,0 +1,470 @@
+//! `skill_manage` tool — model-initiated skill authorship.
+//!
+//! Companion to `tool.rs::LoadSkillTool` (read path). This is the write
+//! path: create / update / delete a loose skill under
+//! `~/.synaps-cli/skills/<name>/`, atomically. Indexing is **passive**:
+//! Axel's consolidation walks `~/.synaps-cli/skills/` as a registered
+//! source root (RATIFIED DECISION #1), so this tool makes zero Axel RPCs.
+//!
+//! Zero-regression contract with `loader.rs::load_skill_file` (lines 41–73):
+//! we only ever write `SKILL.md` files whose frontmatter contains exactly
+//! `name` and `description`, so the loader's required-field checks pass
+//! byte-identically.
+
+use std::sync::Arc;
+
+use serde_json::json;
+
+use crate::{
+    skills::{
+        registry::CommandRegistry,
+        sidecar::{Provenance, SkillMeta},
+        writer,
+    },
+    RuntimeError, SynapsConfig, Tool, ToolContext,
+};
+
+pub struct SkillManageTool {
+    registry: Arc<CommandRegistry>,
+    config: Arc<SynapsConfig>,
+}
+
+impl SkillManageTool {
+    pub fn new(registry: Arc<CommandRegistry>, config: Arc<SynapsConfig>) -> Self {
+        Self { registry, config }
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for SkillManageTool {
+    fn name(&self) -> &str {
+        "skill_manage"
+    }
+
+    fn description(&self) -> &str {
+        "Author or improve a skill. action ∈ {create, update, delete}. \
+         Creates a new SKILL.md under ~/.synaps-cli/skills/<name>/ (create), \
+         atomically rewrites it (update), or archives it (delete). \
+         The skill becomes searchable in Axel on the next consolidation cycle."
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["create", "update", "delete"]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Skill name; [a-z0-9][a-z0-9-]{0,63}"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "≤200 chars; required on create, optional on update"
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Markdown body (post-frontmatter); required on create/update"
+                },
+                "provenance": {
+                    "type": "string",
+                    "enum": ["user", "learn", "background_review"],
+                    "default": "background_review"
+                }
+            },
+            "required": ["action", "name"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _ctx: ToolContext,
+    ) -> crate::Result<String> {
+        let action = params["action"]
+            .as_str()
+            .ok_or_else(|| RuntimeError::Tool("Missing 'action'".into()))?;
+
+        let name = params["name"]
+            .as_str()
+            .ok_or_else(|| RuntimeError::Tool("Missing 'name'".into()))?;
+
+        writer::validate_name(name)
+            .map_err(|e| RuntimeError::Tool(format!("invalid name: {e}")))?;
+
+        // M4: acquire the per-skill lock BEFORE ensure_writable / skill_exists
+        // — closes the TOCTOU between the existence check and the write.
+        let _guard = writer::lock_skill(name)
+            .map_err(|e| RuntimeError::Tool(format!("lock: {e}")))?;
+
+        // Reject plugin-owned skills (RATIFIED DECISION #4)
+        writer::ensure_writable(&self.registry, name)
+            .map_err(|e| RuntimeError::Tool(e.to_string()))?;
+
+        let outcome = match action {
+            "create" => {
+                let desc = params["description"].as_str().ok_or_else(|| {
+                    RuntimeError::Tool("create: missing description".into())
+                })?;
+                writer::validate_description(desc)
+                    .map_err(|e| RuntimeError::Tool(format!("invalid description: {e}")))?;
+                let body = params["body"]
+                    .as_str()
+                    .ok_or_else(|| RuntimeError::Tool("create: missing body".into()))?;
+
+                if writer::skill_exists(name) {
+                    return Err(RuntimeError::Tool(format!(
+                        "skill '{name}' already exists; use action=update"
+                    )));
+                }
+
+                let provenance = Provenance::parse(params["provenance"].as_str());
+                writer::write_skill_md_atomic(name, desc, body)?;
+                SkillMeta::create(name, provenance)?;
+                "created"
+            }
+
+            "update" => {
+                if !writer::skill_exists(name) {
+                    return Err(RuntimeError::Tool(format!(
+                        "skill '{name}' not found; use action=create to create it"
+                    )));
+                }
+
+                let body = params["body"]
+                    .as_str()
+                    .ok_or_else(|| RuntimeError::Tool("update: missing body".into()))?;
+
+                // M3: distinguish ABSENT (preserve existing) from EMPTY (reject).
+                // `as_str()` returns Some("") for "description":"" — treat
+                // empty as a validation error, missing key as "keep old".
+                let desc = match params.get("description") {
+                    None | Some(serde_json::Value::Null) => writer::read_description(name)?,
+                    Some(serde_json::Value::String(s)) => {
+                        writer::validate_description(s).map_err(|e| {
+                            RuntimeError::Tool(format!("invalid description: {e}"))
+                        })?;
+                        s.clone()
+                    }
+                    Some(_) => {
+                        return Err(RuntimeError::Tool(
+                            "update: 'description' must be a string".into(),
+                        ));
+                    }
+                };
+
+                writer::write_skill_md_atomic(name, &desc, body)?;
+                SkillMeta::touch(name)?;
+                "updated"
+            }
+
+            "delete" => {
+                writer::archive_skill(name)?;
+                "deleted"
+            }
+
+            other => {
+                return Err(RuntimeError::Tool(format!("unknown action '{other}'")));
+            }
+        };
+
+        // Refresh registry so new/updated/deleted skill is immediately resolvable
+        crate::skills::reload_registry(&self.registry, &self.config);
+
+        Ok(format!("skill_manage: {action} {name} → {outcome}"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::sync::Arc;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    fn test_ctx() -> ToolContext {
+        ToolContext {
+            channels: crate::tools::ToolChannels {
+                tx_delta: None,
+                tx_events: None,
+            },
+            capabilities: crate::tools::ToolCapabilities {
+                watcher_exit_path: None,
+                tool_register_tx: None,
+                session_manager: None,
+                subagent_registry: None,
+                event_queue: None,
+                secret_prompt: None,
+            },
+            limits: crate::tools::ToolLimits {
+                max_tool_output: 30000,
+                max_tool_buffer: 256 * 1024,
+                bash_timeout: 30,
+                bash_max_timeout: 300,
+                subagent_timeout: 300,
+            },
+        }
+    }
+
+    fn set_home(dir: &Path) -> String {
+        let old = std::env::var("HOME").unwrap_or_default();
+        unsafe { std::env::set_var("HOME", dir) };
+        old
+    }
+
+    fn restore_home(old: &str) {
+        if old.is_empty() {
+            unsafe { std::env::remove_var("HOME") };
+        } else {
+            unsafe { std::env::set_var("HOME", old) };
+        }
+    }
+
+    #[test]
+    fn parameters_schema_is_well_formed() {
+        let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+        let config = Arc::new(SynapsConfig::default());
+        let tool = SkillManageTool::new(registry, config);
+        let schema = tool.parameters();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["action"].is_object());
+        assert!(schema["properties"]["name"].is_object());
+        assert_eq!(schema["required"], json!(["action", "name"]));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn create_then_create_same_name_errors() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+        let config = Arc::new(SynapsConfig::default());
+        let tool = SkillManageTool::new(registry, config);
+
+        tool.execute(
+            json!({"action": "create", "name": "dup", "description": "d", "body": "# B"}),
+            test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        let err = tool
+            .execute(
+                json!({"action": "create", "name": "dup", "description": "d", "body": "# B"}),
+                test_ctx(),
+            )
+            .await
+            .unwrap_err();
+
+        restore_home(&old);
+        assert!(
+            format!("{err}").contains("already exists"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn update_on_missing_skill_errors() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+        let config = Arc::new(SynapsConfig::default());
+        let tool = SkillManageTool::new(registry, config);
+
+        let err = tool
+            .execute(
+                json!({"action": "update", "name": "no-such", "body": "# B"}),
+                test_ctx(),
+            )
+            .await
+            .unwrap_err();
+
+        restore_home(&old);
+        assert!(
+            format!("{err}").contains("not found"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn delete_on_missing_skill_errors() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+        let config = Arc::new(SynapsConfig::default());
+        let tool = SkillManageTool::new(registry, config);
+
+        let err = tool
+            .execute(
+                json!({"action": "delete", "name": "ghost"}),
+                test_ctx(),
+            )
+            .await
+            .unwrap_err();
+
+        restore_home(&old);
+        assert!(
+            format!("{err}").contains("not found"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn provenance_defaults_to_background_review() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+        let config = Arc::new(SynapsConfig::default());
+        let tool = SkillManageTool::new(registry, config);
+
+        tool.execute(
+            json!({"action": "create", "name": "prov-test", "description": "d", "body": "# B"}),
+            test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        let meta = SkillMeta::read("prov-test").unwrap();
+        restore_home(&old);
+
+        assert_eq!(meta.provenance, Provenance::BackgroundReview);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn plugin_owned_skill_rejected() {
+        use crate::skills::LoadedSkill;
+        use std::path::PathBuf;
+
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        // Seed a plugin-owned skill in the registry
+        let plugin_skill = LoadedSkill {
+            name: "plugin-skill".to_string(),
+            description: "d".to_string(),
+            body: "b".to_string(),
+            plugin: Some("my-plugin".to_string()),
+            base_dir: PathBuf::from("/"),
+            source_path: PathBuf::from("/plugins/my-plugin/skills/plugin-skill/SKILL.md"),
+        };
+        let registry = Arc::new(CommandRegistry::new(&[], vec![plugin_skill]));
+        let config = Arc::new(SynapsConfig::default());
+        let tool = SkillManageTool::new(registry, config);
+
+        let err = tool
+            .execute(
+                json!({"action": "create", "name": "plugin-skill", "description": "d", "body": "b"}),
+                test_ctx(),
+            )
+            .await
+            .unwrap_err();
+
+        restore_home(&old);
+        assert!(
+            format!("{err}").contains("plugin-owned"),
+            "got: {err}"
+        );
+    }
+
+    // --- B1: frontmatter injection refused at tool boundary -------------------
+
+    #[tokio::test]
+    #[serial]
+    async fn create_rejects_injected_description() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+        let config = Arc::new(SynapsConfig::default());
+        let tool = SkillManageTool::new(registry, config);
+
+        let err = tool
+            .execute(
+                json!({
+                    "action": "create",
+                    "name": "inj",
+                    "description": "evil\n---\nbody-pwn",
+                    "body": "b"
+                }),
+                test_ctx(),
+            )
+            .await
+            .unwrap_err();
+
+        let on_disk = tmp.path().join(".synaps-cli/skills/inj/SKILL.md");
+        let exists = on_disk.exists();
+        restore_home(&old);
+
+        assert!(format!("{err}").to_lowercase().contains("description"), "got: {err}");
+        assert!(!exists, "no SKILL.md should be written on rejection");
+    }
+
+    // --- M3: update description handling --------------------------------------
+
+    #[tokio::test]
+    #[serial]
+    async fn update_with_no_description_preserves_existing() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+        let config = Arc::new(SynapsConfig::default());
+        let tool = SkillManageTool::new(registry, config);
+
+        tool.execute(
+            json!({"action": "create", "name": "preserve", "description": "Original", "body": "# b"}),
+            test_ctx(),
+        ).await.unwrap();
+
+        tool.execute(
+            json!({"action": "update", "name": "preserve", "body": "# b2"}),
+            test_ctx(),
+        ).await.unwrap();
+
+        let desc = writer::read_description("preserve").unwrap();
+        restore_home(&old);
+        assert_eq!(desc, "Original");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn update_with_empty_description_errors() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+        let config = Arc::new(SynapsConfig::default());
+        let tool = SkillManageTool::new(registry, config);
+
+        tool.execute(
+            json!({"action": "create", "name": "empty-desc", "description": "Original", "body": "# b"}),
+            test_ctx(),
+        ).await.unwrap();
+
+        let err = tool.execute(
+            json!({"action": "update", "name": "empty-desc", "description": "", "body": "# b"}),
+            test_ctx(),
+        ).await.unwrap_err();
+
+        // Description must still be Original (write was refused).
+        let desc = writer::read_description("empty-desc").unwrap();
+        restore_home(&old);
+        assert!(format!("{err}").to_lowercase().contains("description"), "got: {err}");
+        assert_eq!(desc, "Original", "failed update must not corrupt existing description");
+    }
+}

--- a/crates/agent-engine/src/skills/mod.rs
+++ b/crates/agent-engine/src/skills/mod.rs
@@ -22,6 +22,9 @@ pub mod keybinds;
 pub mod commands;
 pub mod trust;
 pub mod post_install;
+pub mod writer;
+pub mod sidecar;
+pub mod manage_tool;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -126,6 +129,8 @@ pub async fn register(
     let registry = Arc::new(CommandRegistry::new_with_plugins(BUILTIN_COMMANDS, skills, plugins));
     let tool = LoadSkillTool::new(registry.clone());
     tools.write().await.register(Arc::new(tool));
+    let manage = manage_tool::SkillManageTool::new(registry.clone(), Arc::new(config.clone()));
+    tools.write().await.register(Arc::new(manage));
     (registry, Arc::new(std::sync::RwLock::new(kb_registry)))
 }
 

--- a/crates/agent-engine/src/skills/sidecar.rs
+++ b/crates/agent-engine/src/skills/sidecar.rs
@@ -1,0 +1,309 @@
+//! Sidecar metadata for loose skills: `.skill-meta.json`.
+//!
+//! Carries authorship provenance and timestamps. Forward-compatible:
+//! unknown fields are silently ignored on read.
+//!
+//! Missing sidecar is legal — hand-authored skills don't have one.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File};
+use std::io::Write;
+
+use crate::RuntimeError;
+use crate::skills::writer::skill_dir;
+
+// ---------------------------------------------------------------------------
+// Schema types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Provenance {
+    #[default]
+    User,
+    Learn,
+    BackgroundReview,
+}
+
+impl Provenance {
+    /// Parse from optional string; defaults to `BackgroundReview` (used by the
+    /// tool boundary where the caller may explicitly intend background-review).
+    pub fn parse(s: Option<&str>) -> Self {
+        match s {
+            Some("user") => Self::User,
+            Some("learn") => Self::Learn,
+            _ => Self::BackgroundReview,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SkillMeta {
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    #[serde(default)]
+    pub provenance: Provenance,
+    #[serde(default)]
+    pub created: String,     // RFC3339
+    #[serde(default)]
+    pub last_updated: String, // RFC3339
+}
+
+fn default_schema_version() -> u32 { 1 }
+
+impl SkillMeta {
+    /// Create a new sidecar for a freshly-created skill.
+    pub fn new(provenance: Provenance) -> Self {
+        let now = Utc::now().to_rfc3339();
+        Self {
+            schema_version: 1,
+            provenance,
+            created: now.clone(),
+            last_updated: now,
+        }
+    }
+
+    /// Path to the sidecar file for a given skill name.
+    pub fn path(name: &str) -> std::path::PathBuf {
+        skill_dir(name).join(".skill-meta.json")
+    }
+
+    /// Write the sidecar atomically: tmp → fsync → rename.
+    pub fn write_atomic(&self, name: &str) -> Result<(), RuntimeError> {
+        let dir = skill_dir(name);
+        fs::create_dir_all(&dir).map_err(|e| {
+            RuntimeError::Tool(format!("cannot create skill dir for sidecar: {e}"))
+        })?;
+
+        let content = serde_json::to_string_pretty(self).map_err(|e| {
+            RuntimeError::Tool(format!("sidecar serialization failed: {e}"))
+        })?;
+
+        let tmp_path = dir.join(".skill-meta.json.tmp");
+        let final_path = Self::path(name);
+
+        let mut f = File::create(&tmp_path).map_err(|e| {
+            RuntimeError::Tool(format!("cannot create sidecar tmp: {e}"))
+        })?;
+        if let Err(e) = f.write_all(content.as_bytes()) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(RuntimeError::Tool(format!("cannot write sidecar tmp: {e}")));
+        }
+        if let Err(e) = f.sync_all() {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(RuntimeError::Tool(format!("sidecar fsync failed: {e}")));
+        }
+        drop(f);
+
+        if let Err(e) = fs::rename(&tmp_path, &final_path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(RuntimeError::Tool(format!("sidecar rename failed: {e}")));
+        }
+
+        Ok(())
+    }
+
+    /// Read an existing sidecar. Returns None if missing (back-compat).
+    pub fn read(name: &str) -> Option<Self> {
+        let path = Self::path(name);
+        let content = fs::read_to_string(path).ok()?;
+        // Use a permissive Value then re-deserialize so unknown fields are silently dropped
+        let val: serde_json::Value = serde_json::from_str(&content).ok()?;
+        serde_json::from_value(val).ok()
+    }
+
+    /// Create a new sidecar and write it (used by skill_manage create).
+    pub fn create(name: &str, provenance: Provenance) -> Result<Self, RuntimeError> {
+        let meta = Self::new(provenance);
+        meta.write_atomic(name)?;
+        Ok(meta)
+    }
+
+    /// Bump `last_updated` and write. Lazily creates the sidecar if missing
+    /// (back-compat for hand-authored skills). Lazy-create defaults to
+    /// `Provenance::User` — these are hand-authored skills, not learn/review
+    /// artifacts.
+    pub fn touch(name: &str) -> Result<(), RuntimeError> {
+        let now = Utc::now().to_rfc3339();
+        let mut meta = Self::read(name).unwrap_or_else(|| Self {
+            schema_version: 1,
+            provenance: Provenance::User,
+            created: now.clone(),
+            last_updated: now.clone(),
+        });
+        meta.last_updated = now;
+        meta.write_atomic(name)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    fn set_home(dir: &Path) -> String {
+        let old = std::env::var("HOME").unwrap_or_default();
+        unsafe { std::env::set_var("HOME", dir) };
+        old
+    }
+
+    fn restore_home(old: &str) {
+        if old.is_empty() {
+            unsafe { std::env::remove_var("HOME") };
+        } else {
+            unsafe { std::env::set_var("HOME", old) };
+        }
+    }
+
+    #[test]
+    fn roundtrip_serialize_deserialize() {
+        let meta = SkillMeta::new(Provenance::User);
+        let json = serde_json::to_string_pretty(&meta).unwrap();
+        let back: SkillMeta = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.schema_version, 1);
+        assert_eq!(back.provenance, Provenance::User);
+        assert_eq!(back.created, meta.created);
+        assert_eq!(back.last_updated, meta.last_updated);
+    }
+
+    #[test]
+    fn unknown_fields_tolerated() {
+        let json = r#"{
+            "schema_version": 1,
+            "provenance": "user",
+            "created": "2024-01-01T00:00:00Z",
+            "last_updated": "2024-01-01T00:00:00Z",
+            "unknown_future_field": 42,
+            "another_field": "hello"
+        }"#;
+        let meta: SkillMeta = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.schema_version, 1);
+        assert_eq!(meta.provenance, Provenance::User);
+    }
+
+    #[test]
+    #[serial]
+    fn touch_lazily_creates_sidecar() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        // Create the skill directory and SKILL.md (no sidecar)
+        let skill_name = "lazy-create-test";
+        let skill_dir = tmp.path().join(".synaps-cli/skills").join(skill_name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: lazy-create-test\ndescription: d\n---\nBody",
+        )
+        .unwrap();
+
+        // No sidecar yet
+        assert!(!SkillMeta::path(skill_name).exists());
+
+        SkillMeta::touch(skill_name).unwrap();
+
+        // Sidecar should now exist — read while HOME is still set
+        let meta = SkillMeta::read(skill_name).unwrap();
+        restore_home(&old);
+
+        assert_eq!(meta.schema_version, 1);
+        // On lazy create, created == last_updated
+        assert_eq!(meta.created, meta.last_updated);
+    }
+
+    #[test]
+    #[serial]
+    fn touch_bumps_last_updated() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        let skill_name = "touch-bump";
+        let skill_dir = tmp.path().join(".synaps-cli/skills").join(skill_name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+
+        // Create with a fixed early time
+        let early = SkillMeta {
+            schema_version: 1,
+            provenance: Provenance::Learn,
+            created: "2020-01-01T00:00:00+00:00".to_string(),
+            last_updated: "2020-01-01T00:00:00+00:00".to_string(),
+        };
+        early.write_atomic(skill_name).unwrap();
+
+        // Touch should bump last_updated
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        SkillMeta::touch(skill_name).unwrap();
+
+        let meta = SkillMeta::read(skill_name).unwrap();
+        restore_home(&old);
+
+        assert_eq!(meta.created, "2020-01-01T00:00:00+00:00", "created unchanged");
+        assert_ne!(meta.last_updated, "2020-01-01T00:00:00+00:00", "last_updated should change");
+    }
+
+    #[test]
+    #[serial]
+    fn read_missing_sidecar_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+        let result = SkillMeta::read("no-such-skill");
+        restore_home(&old);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn provenance_parse_defaults_to_background_review() {
+        assert_eq!(Provenance::parse(None), Provenance::BackgroundReview);
+        assert_eq!(Provenance::parse(Some("unknown")), Provenance::BackgroundReview);
+        assert_eq!(Provenance::parse(Some("user")), Provenance::User);
+        assert_eq!(Provenance::parse(Some("learn")), Provenance::Learn);
+    }
+
+    // --- M1: missing fields tolerated ----------------------------------------
+
+    #[test]
+    fn deserialize_missing_schema_version_uses_default() {
+        let json = r#"{
+            "provenance": "user",
+            "created": "2024-01-01T00:00:00Z",
+            "last_updated": "2024-01-01T00:00:00Z"
+        }"#;
+        let meta: SkillMeta = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.schema_version, 1);
+        assert_eq!(meta.provenance, Provenance::User);
+    }
+
+    #[test]
+    fn deserialize_empty_object_uses_defaults() {
+        let meta: SkillMeta = serde_json::from_str("{}").unwrap();
+        assert_eq!(meta.schema_version, 1);
+        assert_eq!(meta.provenance, Provenance::default());
+    }
+
+    // --- M2: touch lazy-create defaults to User ------------------------------
+
+    #[test]
+    #[serial]
+    fn touch_lazy_create_defaults_to_user() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        let name = "lazy-user";
+        let skill_dir = tmp.path().join(".synaps-cli/skills").join(name);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "---\nname: lazy-user\ndescription: d\n---\nB").unwrap();
+
+        SkillMeta::touch(name).unwrap();
+        let meta = SkillMeta::read(name).unwrap();
+        restore_home(&old);
+
+        assert_eq!(meta.provenance, Provenance::User, "lazy-create must default to User");
+    }
+}

--- a/crates/agent-engine/src/skills/writer.rs
+++ b/crates/agent-engine/src/skills/writer.rs
@@ -1,0 +1,804 @@
+//! Atomic write primitives for loose skill files.
+//!
+//! All writes go through `write_skill_md_atomic`: tmp file → fsync → rename.
+//! Never truncates SKILL.md directly — crash leaves no partial state.
+//!
+//! Companion to `loader.rs` (read path, UNTOUCHED).
+
+use std::{
+    fs::{self, File, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use fs4::fs_std::FileExt;
+
+use crate::RuntimeError;
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/// `~/.synaps-cli/skills/` — canonical write root for loose skills.
+pub fn skills_root() -> PathBuf {
+    crate::config::base_dir().join("skills")
+}
+
+/// Directory for a specific skill: `~/.synaps-cli/skills/<name>/`.
+pub fn skill_dir(name: &str) -> PathBuf {
+    skills_root().join(name)
+}
+
+/// Archive root: `~/.synaps-cli/skills/.archive/`.
+pub fn archive_root() -> PathBuf {
+    skills_root().join(".archive")
+}
+
+// ---------------------------------------------------------------------------
+// Name validation
+// ---------------------------------------------------------------------------
+
+/// Reserved names (Windows compat + defensive Linux).
+const RESERVED: &[&str] = &[
+    "con", "prn", "aux", "nul",
+    "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
+    "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+];
+
+/// Validate a skill name: `^[a-z0-9][a-z0-9-]{0,63}$`.
+/// Also rejects path separators, `.`, `..`, and Windows reserved names.
+pub fn validate_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("name must not be empty".into());
+    }
+    if name.len() > 64 {
+        return Err(format!("name too long ({} chars, max 64)", name.len()));
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err("name must not contain path separators".into());
+    }
+    if name == "." || name == ".." {
+        return Err("name must not be '.' or '..'".into());
+    }
+    // Defensive: belt-and-braces against frontmatter injection. The
+    // [a-z0-9-] charset rejects these anyway, but be explicit at the
+    // boundary so refactors of the charset can't reintroduce the hole.
+    if name.contains('\n') || name.contains('\r') || name.contains("---") {
+        return Err("name must not contain newlines or '---'".into());
+    }
+    // Must start with [a-z0-9]
+    let mut chars = name.chars();
+    let first = chars.next().unwrap(); // non-empty checked above
+    if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+        return Err(format!("name must start with [a-z0-9], got '{first}'"));
+    }
+    // Remaining chars: [a-z0-9-]
+    for ch in chars {
+        if !ch.is_ascii_lowercase() && !ch.is_ascii_digit() && ch != '-' {
+            return Err(format!("name contains invalid char '{ch}' (only [a-z0-9-] allowed)"));
+        }
+    }
+    // Reserved names
+    if RESERVED.contains(&name) {
+        return Err(format!("'{name}' is a reserved name"));
+    }
+    Ok(())
+}
+
+/// Validate a skill description for inclusion in YAML frontmatter.
+///
+/// Rejects: empty, > 200 chars, embedded newlines/carriage returns,
+/// leading/trailing whitespace, and any occurrence of `---` (which would
+/// terminate the frontmatter block and let body content masquerade as
+/// metadata — frontmatter injection).
+pub fn validate_description(desc: &str) -> Result<(), String> {
+    if desc.is_empty() {
+        return Err("description must not be empty".into());
+    }
+    let char_len = desc.chars().count();
+    if char_len > 200 {
+        return Err(format!("description too long ({char_len} chars, max 200)"));
+    }
+    if desc.contains('\n') || desc.contains('\r') {
+        return Err("description must not contain newlines".into());
+    }
+    if desc.trim() != desc {
+        return Err("description must not have leading/trailing whitespace".into());
+    }
+    if desc.contains("---") {
+        return Err("description must not contain '---' (frontmatter delimiter)".into());
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Plugin-ownership guard
+// ---------------------------------------------------------------------------
+
+/// Canonicalize a path, tolerating non-existent leaves by canonicalizing
+/// the nearest existing ancestor and re-appending the tail.
+fn canonicalize_lenient(p: &Path) -> PathBuf {
+    if let Ok(c) = p.canonicalize() {
+        return c;
+    }
+    let mut cur = p.to_path_buf();
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    while let Some(parent) = cur.parent().map(Path::to_path_buf) {
+        if let Some(name) = cur.file_name() {
+            tail.push(name.to_os_string());
+        }
+        cur = parent;
+        if let Ok(c) = cur.canonicalize() {
+            let mut out = c;
+            for seg in tail.iter().rev() {
+                out.push(seg);
+            }
+            return out;
+        }
+        if cur.as_os_str().is_empty() {
+            break;
+        }
+    }
+    p.to_path_buf()
+}
+
+/// Reject writes to plugin-owned skills.
+///
+/// Robust check (no substring matching on path strings):
+/// 1. Any skill discovered with `plugin: Some(_)` is plugin-owned.
+/// 2. For loose skills with the same name already in the registry,
+///    canonicalize their `source_path` and the loose skills root; refuse
+///    if the source lives outside the loose root (i.e. came from a
+///    plugin discovery root).
+pub fn ensure_writable(
+    registry: &crate::skills::registry::CommandRegistry,
+    name: &str,
+) -> Result<(), RuntimeError> {
+    let loose_root = canonicalize_lenient(&skills_root());
+
+    for skill in registry.all_skills() {
+        if skill.name != name {
+            continue;
+        }
+        if skill.plugin.is_some() {
+            return Err(RuntimeError::Tool(
+                "plugin-owned skill; not writable".into(),
+            ));
+        }
+        let src = canonicalize_lenient(&skill.source_path);
+        if !src.starts_with(&loose_root) {
+            return Err(RuntimeError::Tool(
+                "plugin-owned skill; not writable".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Advisory file lock
+// ---------------------------------------------------------------------------
+
+/// An RAII guard that holds an exclusive lock on a skill-specific lock file.
+/// Dropped when it goes out of scope; the OS releases the lock fd.
+pub struct SkillLockGuard {
+    _file: File,
+}
+
+/// Lock directory: `~/.synaps-cli/skills/.locks/`.
+fn locks_dir() -> PathBuf {
+    skills_root().join(".locks")
+}
+
+/// Acquire a fail-fast exclusive lock for the named skill.
+/// Uses `~/.synaps-cli/skills/.locks/<name>.lock` — separate from the
+/// skill directory so the lock does NOT create the skill dir as a side effect.
+pub fn lock_skill(name: &str) -> Result<SkillLockGuard, RuntimeError> {
+    let dir = locks_dir();
+    fs::create_dir_all(&dir).map_err(|e| {
+        RuntimeError::Tool(format!("cannot create locks dir: {e}"))
+    })?;
+
+    let lock_path = dir.join(format!("{name}.lock"));
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)
+        .map_err(|e| RuntimeError::Tool(format!("cannot open lock file: {e}")))?;
+
+    let acquired = file.try_lock_exclusive().map_err(|e| {
+        RuntimeError::Tool(format!(
+            "lock held by another skill_manage in flight ({}): {e}",
+            lock_path.display()
+        ))
+    })?;
+
+    if !acquired {
+        return Err(RuntimeError::Tool(format!(
+            "lock held by another skill_manage in flight ({})",
+            lock_path.display()
+        )));
+    }
+
+    Ok(SkillLockGuard { _file: file })
+}
+
+// ---------------------------------------------------------------------------
+// Symlink refusal
+// ---------------------------------------------------------------------------
+
+/// Refuse to operate on a skill whose directory (or parent) is a symlink.
+/// Prevents write-through to attacker-controlled targets.
+fn refuse_symlink(path: &Path) -> Result<(), RuntimeError> {
+    match fs::symlink_metadata(path) {
+        Ok(md) if md.file_type().is_symlink() => Err(RuntimeError::Tool(format!(
+            "refusing to write through symlink: {}",
+            path.display()
+        ))),
+        _ => Ok(()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Atomic SKILL.md write
+// ---------------------------------------------------------------------------
+
+/// Build SKILL.md content from name, description, and body.
+/// Callers must have validated `name` (via `validate_name`) and
+/// `description` (via `validate_description`) — otherwise the
+/// generated frontmatter could be malformed or injected.
+pub fn skill_md_content(name: &str, description: &str, body: &str) -> String {
+    format!("---\nname: {name}\ndescription: {description}\n---\n{body}")
+}
+
+/// Write `SKILL.md` atomically: tmp file → fsync → rename.
+/// Creates the skill directory if it doesn't exist.
+pub fn write_skill_md_atomic(
+    name: &str,
+    description: &str,
+    body: &str,
+) -> Result<(), RuntimeError> {
+    // Belt-and-braces — refuse to write garbage even if caller skipped validation.
+    validate_name(name).map_err(|e| RuntimeError::Tool(format!("invalid name: {e}")))?;
+    validate_description(description)
+        .map_err(|e| RuntimeError::Tool(format!("invalid description: {e}")))?;
+
+    let dir = skill_dir(name);
+
+    // Symlink refusal: parent (skills root) and skill dir itself.
+    if let Some(parent) = dir.parent() {
+        if parent.exists() {
+            refuse_symlink(parent)?;
+        }
+    }
+    if dir.exists() {
+        refuse_symlink(&dir)?;
+    }
+
+    fs::create_dir_all(&dir).map_err(|e| {
+        RuntimeError::Tool(format!("cannot create skill dir: {e}"))
+    })?;
+
+    let content = skill_md_content(name, description, body);
+    let skill_md = dir.join("SKILL.md");
+    let tmp_path = dir.join("SKILL.md.tmp");
+
+    // Write to tmp
+    let mut f = File::create(&tmp_path).map_err(|e| {
+        RuntimeError::Tool(format!("cannot create tmp file: {e}"))
+    })?;
+    if let Err(e) = f.write_all(content.as_bytes()) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(RuntimeError::Tool(format!("cannot write tmp file: {e}")));
+    }
+    if let Err(e) = f.sync_all() {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(RuntimeError::Tool(format!("fsync failed: {e}")));
+    }
+    drop(f);
+
+    // Atomic rename — on failure, clean up the tmp file.
+    if let Err(e) = fs::rename(&tmp_path, &skill_md) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(RuntimeError::Tool(format!("atomic rename failed: {e}")));
+    }
+
+    // Best-effort fsync on parent directory (Linux POSIX). Log on failure
+    // — durability isn't guaranteed without it, but it's not fatal.
+    if let Err(e) = fsync_dir(&dir) {
+        tracing::warn!(target: "skills.writer", "fsync(parent) failed for {}: {e}", dir.display());
+    }
+
+    Ok(())
+}
+
+/// Read the description from an existing SKILL.md (to preserve it on update).
+/// Reuses the loader's frontmatter parser for parity with the read path.
+pub fn read_description(name: &str) -> Result<String, RuntimeError> {
+    let path = skill_dir(name).join("SKILL.md");
+    let content = fs::read_to_string(&path).map_err(|e| {
+        RuntimeError::Tool(format!("skill '{}' not found: {e}", name))
+    })?;
+    let (fields, _) = crate::skills::loader::parse_frontmatter(&content);
+    for (k, v) in &fields {
+        if k == "description" {
+            return Ok(v.clone());
+        }
+    }
+    Err(RuntimeError::Tool(format!(
+        "skill '{name}': no 'description' field in frontmatter"
+    )))
+}
+
+/// Check that a skill exists (SKILL.md present).
+pub fn skill_exists(name: &str) -> bool {
+    skill_dir(name).join("SKILL.md").exists()
+}
+
+// ---------------------------------------------------------------------------
+// Archive (delete = move, never hard-delete)
+// ---------------------------------------------------------------------------
+
+/// Move `~/.synaps-cli/skills/<name>/` to `.archive/<name>-<timestamp>/`
+/// and rename the inner `SKILL.md` → `SKILL.md.archived` so Axel's .md
+/// filter skips it. Sub-second timestamp + collision-suffix guard handles
+/// fast create→delete→create→delete cycles.
+pub fn archive_skill(name: &str) -> Result<(), RuntimeError> {
+    let src = skill_dir(name);
+    if !src.exists() {
+        return Err(RuntimeError::Tool(format!("skill '{name}' not found")));
+    }
+
+    fs::create_dir_all(archive_root()).map_err(|e| {
+        RuntimeError::Tool(format!("cannot create archive dir: {e}"))
+    })?;
+
+    // Sub-second precision avoids same-second collisions.
+    let ts = chrono::Utc::now().format("%Y%m%dT%H%M%S%.6fZ").to_string();
+    let base = format!("{name}-{ts}");
+    let mut archive_dir = archive_root().join(&base);
+    let mut suffix = 1u32;
+    while archive_dir.exists() {
+        archive_dir = archive_root().join(format!("{base}-{suffix}"));
+        suffix += 1;
+        if suffix > 1_000 {
+            return Err(RuntimeError::Tool(
+                "archive target collision: exhausted suffixes".into(),
+            ));
+        }
+    }
+
+    fs::rename(&src, &archive_dir).map_err(|e| {
+        RuntimeError::Tool(format!("cannot move skill to archive: {e}"))
+    })?;
+
+    // Rename SKILL.md → SKILL.md.archived so Axel's ext filter skips it
+    let md = archive_dir.join("SKILL.md");
+    let md_archived = archive_dir.join("SKILL.md.archived");
+    if md.exists() {
+        fs::rename(&md, &md_archived).map_err(|e| {
+            RuntimeError::Tool(format!("cannot rename archived skill file: {e}"))
+        })?;
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+fn fsync_dir(dir: &Path) -> std::io::Result<()> {
+    let f = File::open(dir)?;
+    f.sync_all()?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    fn set_home(dir: &Path) -> String {
+        let old = std::env::var("HOME").unwrap_or_default();
+        // SAFETY: tests are single-threaded where env mutation matters
+        unsafe { std::env::set_var("HOME", dir) };
+        old
+    }
+
+    fn restore_home(old: &str) {
+        if old.is_empty() {
+            unsafe { std::env::remove_var("HOME") };
+        } else {
+            unsafe { std::env::set_var("HOME", old) };
+        }
+    }
+
+    #[test]
+    fn validate_name_accepts_valid() {
+        for name in &["a", "abc", "a-b-c", "a1", "z9", "foo-bar-baz"] {
+            validate_name(name).unwrap_or_else(|e| panic!("rejected '{name}': {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_name_rejects_empty() {
+        assert!(validate_name("").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_uppercase() {
+        assert!(validate_name("Abc").is_err());
+        assert!(validate_name("ABC").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_leading_hyphen() {
+        assert!(validate_name("-foo").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_path_sep() {
+        assert!(validate_name("foo/bar").is_err());
+        assert!(validate_name("foo\\bar").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_dots() {
+        assert!(validate_name(".").is_err());
+        assert!(validate_name("..").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_reserved() {
+        assert!(validate_name("con").is_err());
+        assert!(validate_name("com1").is_err());
+        assert!(validate_name("lpt9").is_err());
+        assert!(validate_name("nul").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_too_long() {
+        let long = "a".repeat(65);
+        assert!(validate_name(&long).is_err());
+    }
+
+    #[test]
+    fn validate_name_accepts_64_chars() {
+        let name = format!("a{}", "b".repeat(63));
+        assert_eq!(name.len(), 64);
+        validate_name(&name).unwrap();
+    }
+
+    #[test]
+    fn validate_name_rejects_newlines() {
+        assert!(validate_name("a\nb").is_err());
+        assert!(validate_name("a\rb").is_err());
+    }
+
+    // --- validate_description ------------------------------------------------
+
+    #[test]
+    fn validate_description_accepts_normal() {
+        validate_description("A nice short description.").unwrap();
+    }
+
+    #[test]
+    fn validate_description_rejects_empty() {
+        assert!(validate_description("").is_err());
+    }
+
+    #[test]
+    fn validate_description_rejects_over_200_chars() {
+        let long: String = "x".repeat(201);
+        assert!(validate_description(&long).is_err());
+    }
+
+    #[test]
+    fn validate_description_counts_chars_not_bytes() {
+        // 200 multibyte chars — bytes > 200, chars == 200. Must be ACCEPTED.
+        let s: String = "★".repeat(200);
+        assert!(s.len() > 200, "byte len should exceed 200");
+        validate_description(&s).unwrap();
+    }
+
+    #[test]
+    fn validate_description_rejects_newlines() {
+        assert!(validate_description("hello\nworld").is_err());
+        assert!(validate_description("hello\rworld").is_err());
+    }
+
+    #[test]
+    fn validate_description_rejects_whitespace_edges() {
+        assert!(validate_description(" leading").is_err());
+        assert!(validate_description("trailing ").is_err());
+    }
+
+    #[test]
+    fn validate_description_rejects_frontmatter_delimiter() {
+        assert!(validate_description("evil---thing").is_err());
+        assert!(validate_description("---").is_err());
+    }
+
+    // --- frontmatter injection (B1) ------------------------------------------
+
+    #[test]
+    #[serial]
+    fn write_rejects_injected_description() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+        let result = write_skill_md_atomic(
+            "fm-inject",
+            "evil\n---\nbody-pwn",
+            "# body",
+        );
+        let no_dir = !tmp.path().join(".synaps-cli/skills/fm-inject").exists();
+        restore_home(&old);
+        assert!(result.is_err(), "injection must be refused");
+        assert!(no_dir, "no skill dir should have been created");
+    }
+
+    #[test]
+    #[serial]
+    fn write_roundtrips_valid_description() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+        write_skill_md_atomic("rt", "A clean description.", "# body").unwrap();
+        let desc = read_description("rt").unwrap();
+        restore_home(&old);
+        assert_eq!(desc, "A clean description.");
+    }
+
+    // --- archive collision (B2) ---------------------------------------------
+
+    #[test]
+    #[serial]
+    fn archive_skill_creates_distinct_dirs_in_tight_loop() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        for _ in 0..2 {
+            write_skill_md_atomic("collide", "desc", "body").unwrap();
+            archive_skill("collide").unwrap();
+        }
+
+        let archive_base = tmp.path().join(".synaps-cli/skills/.archive");
+        let entries: Vec<_> = fs::read_dir(&archive_base).unwrap().flatten().collect();
+        restore_home(&old);
+
+        assert_eq!(entries.len(), 2, "expected two distinct archive dirs");
+        let names: Vec<String> = entries
+            .iter()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_ne!(names[0], names[1], "archive dirs must be distinct");
+    }
+
+    // --- plugin guard (H1) ---------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn ensure_writable_allows_home_with_plugins_substring() {
+        // HOME contains the substring "plugins" but the skill lives under
+        // ~/.synaps-cli/skills/ — must NOT be refused by a substring check.
+        let parent = TempDir::new().unwrap();
+        let home = parent.path().join("home-with-plugins-in-name");
+        std::fs::create_dir_all(&home).unwrap();
+        let old = set_home(&home);
+
+        // Pre-create the loose skill so it can be canonicalized.
+        write_skill_md_atomic("looseone", "d", "body").unwrap();
+
+        // Build a registry entry pointing at this loose skill.
+        use crate::skills::LoadedSkill;
+        let src = home
+            .join(".synaps-cli/skills/looseone/SKILL.md")
+            .canonicalize()
+            .unwrap();
+        let base = src.parent().unwrap().to_path_buf();
+        let registry = crate::skills::registry::CommandRegistry::new(
+            &[],
+            vec![LoadedSkill {
+                name: "looseone".into(),
+                description: "d".into(),
+                body: "b".into(),
+                plugin: None,
+                base_dir: base,
+                source_path: src,
+            }],
+        );
+
+        let res = ensure_writable(&registry, "looseone");
+        restore_home(&old);
+        res.unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn ensure_writable_refuses_path_under_real_plugin_root() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        // Create a plugin-style path under HOME that is OUTSIDE skills_root.
+        let plug_src_dir = tmp.path().join(".synaps-cli/plugins/p1/skills/foo");
+        std::fs::create_dir_all(&plug_src_dir).unwrap();
+        std::fs::write(plug_src_dir.join("SKILL.md"), "---\nname: foo\ndescription: d\n---\nb").unwrap();
+        let plug_src = plug_src_dir.join("SKILL.md").canonicalize().unwrap();
+
+        use crate::skills::LoadedSkill;
+        let registry = crate::skills::registry::CommandRegistry::new(
+            &[],
+            vec![LoadedSkill {
+                name: "foo".into(),
+                description: "d".into(),
+                body: "b".into(),
+                plugin: None, // even without plugin marker, path-based guard catches it
+                base_dir: plug_src.parent().unwrap().to_path_buf(),
+                source_path: plug_src,
+            }],
+        );
+
+        let res = ensure_writable(&registry, "foo");
+        restore_home(&old);
+        assert!(res.is_err(), "skill outside loose root must be refused");
+    }
+
+    // --- tmp cleanup (H2) ----------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn rename_failure_cleans_tmp_file() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        // Pre-create a DIRECTORY at the SKILL.md target path so fs::rename
+        // (renaming a regular file onto an existing non-empty dir) fails.
+        let dir = skill_dir("rmtmp");
+        std::fs::create_dir_all(dir.join("SKILL.md")).unwrap();
+        // Put a sentinel file inside the target dir so rename can't succeed.
+        std::fs::write(dir.join("SKILL.md").join("sentinel"), b"x").unwrap();
+
+        let result = write_skill_md_atomic("rmtmp", "d", "body");
+        let tmp_path = dir.join("SKILL.md.tmp");
+        let has_tmp = tmp_path.exists();
+        restore_home(&old);
+
+        assert!(result.is_err(), "rename onto a non-empty dir must fail");
+        assert!(!has_tmp, ".tmp file must be cleaned up on rename failure");
+    }
+
+    // --- symlink refusal (H3) ------------------------------------------------
+
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn refuse_symlink_skill_dir() {
+        use std::os::unix::fs::symlink;
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        let skills = tmp.path().join(".synaps-cli/skills");
+        std::fs::create_dir_all(&skills).unwrap();
+        let target = tmp.path().join("evil-target");
+        std::fs::create_dir_all(&target).unwrap();
+        symlink(&target, skills.join("sneaky")).unwrap();
+
+        let result = write_skill_md_atomic("sneaky", "d", "body");
+        let wrote_through =
+            target.join("SKILL.md").exists() || target.join("SKILL.md.tmp").exists();
+        restore_home(&old);
+
+        assert!(result.is_err(), "must refuse symlinked skill dir");
+        assert!(!wrote_through, "must NOT write through symlink");
+    }
+
+    // --- pre-existing tests --------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn write_skill_md_atomic_creates_file() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+        let result = write_skill_md_atomic("test-skill", "A test skill", "# Body\nContent here");
+        restore_home(&old);
+        result.unwrap();
+
+        let expected = tmp
+            .path()
+            .join(".synaps-cli/skills/test-skill/SKILL.md");
+        assert!(expected.exists(), "SKILL.md not created");
+        let content = fs::read_to_string(&expected).unwrap();
+        assert!(content.contains("name: test-skill"));
+        assert!(content.contains("description: A test skill"));
+        assert!(content.contains("# Body"));
+    }
+
+    #[test]
+    #[serial]
+    fn write_skill_md_atomic_no_tmp_left_behind() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+        write_skill_md_atomic("no-tmp", "desc", "body").unwrap();
+        restore_home(&old);
+
+        let tmp_path = tmp
+            .path()
+            .join(".synaps-cli/skills/no-tmp/SKILL.md.tmp");
+        assert!(!tmp_path.exists(), ".tmp should not remain after successful write");
+    }
+
+    #[test]
+    #[serial]
+    fn archive_skill_moves_dir_and_renames_md() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        write_skill_md_atomic("to-archive", "desc", "body").unwrap();
+        let original = tmp.path().join(".synaps-cli/skills/to-archive");
+        assert!(original.exists());
+
+        archive_skill("to-archive").unwrap();
+        restore_home(&old);
+
+        assert!(!original.exists(), "skill dir should be gone after archive");
+
+        let archive_base = tmp.path().join(".synaps-cli/skills/.archive");
+        let entries: Vec<_> = fs::read_dir(&archive_base)
+            .unwrap()
+            .flatten()
+            .collect();
+        assert_eq!(entries.len(), 1, "expected exactly one archive entry");
+        let archived_dir = &entries[0].path();
+
+        assert!(archived_dir.join("SKILL.md.archived").exists());
+        assert!(!archived_dir.join("SKILL.md").exists());
+
+        let md_files: Vec<_> = walkdir_md(&archive_base);
+        assert!(md_files.is_empty(), "no .md files under .archive: {md_files:?}");
+    }
+
+    #[test]
+    #[serial]
+    fn archive_skill_missing_returns_error() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+        let result = archive_skill("nonexistent");
+        restore_home(&old);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn lock_skill_fail_fast_on_double_lock() {
+        let tmp = TempDir::new().unwrap();
+        let old = set_home(tmp.path());
+
+        let _guard = lock_skill("double-lock").unwrap();
+        let result = lock_skill("double-lock");
+        restore_home(&old);
+
+        assert!(result.is_err(), "second lock on same skill should fail fast");
+    }
+
+    fn walkdir_md(dir: &Path) -> Vec<PathBuf> {
+        let mut out = vec![];
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    out.extend(walkdir_md(&p));
+                } else if p.extension().and_then(|e| e.to_str()) == Some("md") {
+                    out.push(p);
+                }
+            }
+        }
+        out
+    }
+}

--- a/crates/agent-engine/tests/skill_manage_integration.rs
+++ b/crates/agent-engine/tests/skill_manage_integration.rs
@@ -1,0 +1,342 @@
+//! Integration test: skill_manage end-to-end (A1–A4).
+//!
+//! Binds HOME to a TempDir. No Axel involved — indexing is passive.
+
+use std::sync::Arc;
+use serial_test::serial;
+use tempfile::TempDir;
+
+use agent_engine::{
+    skills::{
+        loader::load_skill_file,
+        registry::CommandRegistry,
+        sidecar::SkillMeta,
+    },
+    SynapsConfig, Tool, ToolContext,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn test_ctx() -> ToolContext {
+    ToolContext {
+        channels: agent_engine::tools::ToolChannels {
+            tx_delta: None,
+            tx_events: None,
+        },
+        capabilities: agent_engine::tools::ToolCapabilities {
+            watcher_exit_path: None,
+            tool_register_tx: None,
+            session_manager: None,
+            subagent_registry: None,
+            event_queue: None,
+            secret_prompt: None,
+        },
+        limits: agent_engine::tools::ToolLimits {
+            max_tool_output: 30000,
+            max_tool_buffer: 256 * 1024,
+            bash_timeout: 30,
+            bash_max_timeout: 300,
+            subagent_timeout: 300,
+        },
+    }
+}
+
+fn make_tool(
+    registry: Arc<CommandRegistry>,
+    config: Arc<SynapsConfig>,
+) -> agent_engine::skills::manage_tool::SkillManageTool {
+    agent_engine::skills::manage_tool::SkillManageTool::new(registry, config)
+}
+
+// ---------------------------------------------------------------------------
+// A1 — create → load_skill reads it back byte-identical
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn a1_create_and_load_back() {
+    let tmp = TempDir::new().unwrap();
+    unsafe { std::env::set_var("HOME", tmp.path()) };
+
+    let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+    let config = Arc::new(SynapsConfig::default());
+    let tool = make_tool(registry, config);
+
+    let body = "# My Skill\n\nDo things properly.";
+    let out = tool
+        .execute(
+            serde_json::json!({
+                "action": "create",
+                "name": "my-skill",
+                "description": "Does things",
+                "body": body
+            }),
+            test_ctx(),
+        )
+        .await
+        .unwrap();
+
+    assert!(out.contains("created"), "output: {out}");
+
+    // Verify SKILL.md is on disk
+    let skill_md = tmp
+        .path()
+        .join(".synaps-cli/skills/my-skill/SKILL.md");
+    assert!(skill_md.exists(), "SKILL.md not created");
+
+    // Use load_skill_file directly — A1 round-trip
+    let loaded = load_skill_file(&skill_md, None, None).unwrap();
+    assert_eq!(loaded.name, "my-skill");
+    assert_eq!(loaded.description, "Does things");
+    assert_eq!(loaded.body, body, "body mismatch");
+
+    // On-disk bytes match expected content
+    let on_disk = std::fs::read_to_string(&skill_md).unwrap();
+    assert!(on_disk.starts_with("---\nname: my-skill\n"), "frontmatter: {on_disk}");
+    assert!(on_disk.contains("description: Does things"));
+    assert!(on_disk.contains(body));
+
+    // Sidecar exists
+    assert!(SkillMeta::path("my-skill").exists(), "sidecar missing");
+    let meta = SkillMeta::read("my-skill").unwrap();
+    assert_eq!(meta.schema_version, 1);
+}
+
+// ---------------------------------------------------------------------------
+// A2 — update → body diff persists; sidecar last_updated changes; load works
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn a2_update_persists_diff_and_bumps_sidecar() {
+    let tmp = TempDir::new().unwrap();
+    unsafe { std::env::set_var("HOME", tmp.path()) };
+
+    let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+    let config = Arc::new(SynapsConfig::default());
+    let tool = make_tool(registry, config);
+
+    // Create
+    tool.execute(
+        serde_json::json!({
+            "action": "create",
+            "name": "upd-skill",
+            "description": "Original desc",
+            "body": "# Original\nOriginal body."
+        }),
+        test_ctx(),
+    )
+    .await
+    .unwrap();
+
+    let meta_before = SkillMeta::read("upd-skill").unwrap();
+
+    // Small delay so timestamps differ
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    // Update
+    let new_body = "# Updated\nNew body content.";
+    let out = tool
+        .execute(
+            serde_json::json!({
+                "action": "update",
+                "name": "upd-skill",
+                "body": new_body
+            }),
+            test_ctx(),
+        )
+        .await
+        .unwrap();
+
+    assert!(out.contains("updated"), "output: {out}");
+
+    // Body changed on disk
+    let skill_md = tmp
+        .path()
+        .join(".synaps-cli/skills/upd-skill/SKILL.md");
+    let loaded = load_skill_file(&skill_md, None, None).unwrap();
+    assert_eq!(loaded.body, new_body, "body should be updated");
+
+    // Frontmatter preserved (description unchanged since we didn't pass one)
+    assert_eq!(loaded.description, "Original desc", "description should be preserved");
+
+    // Sidecar last_updated > created
+    let meta_after = SkillMeta::read("upd-skill").unwrap();
+    assert_eq!(meta_after.created, meta_before.created, "created should be unchanged");
+    assert_ne!(
+        meta_after.last_updated, meta_before.last_updated,
+        "last_updated should have changed"
+    );
+    assert!(
+        meta_after.last_updated > meta_before.last_updated,
+        "last_updated should be later"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A3 — static contract: file shape satisfies Axel source-root requirements
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn a3_static_indexing_contract() {
+    let tmp = TempDir::new().unwrap();
+    unsafe { std::env::set_var("HOME", tmp.path()) };
+
+    let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+    let config = Arc::new(SynapsConfig::default());
+    let tool = make_tool(registry, config);
+
+    // Create
+    tool.execute(
+        serde_json::json!({
+            "action": "create",
+            "name": "idx-skill",
+            "description": "Indexable skill",
+            "body": "# Idx\nContent for indexing."
+        }),
+        test_ctx(),
+    )
+    .await
+    .unwrap();
+
+    let skills_root = tmp.path().join(".synaps-cli/skills");
+    let skill_md = skills_root.join("idx-skill/SKILL.md");
+
+    // File has .md extension (Axel reindex ext filter: "md" | "txt")
+    assert_eq!(skill_md.extension().and_then(|e| e.to_str()), Some("md"));
+
+    // File is non-empty
+    let content = std::fs::read_to_string(&skill_md).unwrap();
+    assert!(!content.is_empty());
+
+    // File lives directly under the registered source root
+    assert_eq!(
+        skill_md.parent().unwrap().parent().unwrap(),
+        skills_root,
+        "SKILL.md should be under <skills_root>/<name>/"
+    );
+
+    // Delete → no .md file remains under live skills root for this skill
+    tool.execute(
+        serde_json::json!({"action": "delete", "name": "idx-skill"}),
+        test_ctx(),
+    )
+    .await
+    .unwrap();
+
+    // Live path gone
+    assert!(!skill_md.exists(), "SKILL.md should be gone after delete");
+
+    // Archive renamed to .archived (Axel won't pick it up)
+    let archive_base = skills_root.join(".archive");
+    let mut has_archived_md = false;
+    if let Ok(entries) = std::fs::read_dir(&archive_base) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                let archived = p.join("SKILL.md.archived");
+                if archived.exists() {
+                    has_archived_md = true;
+                }
+                // Assert NO .md file exists under the archive entry
+                let md_in_archive = p.join("SKILL.md");
+                assert!(!md_in_archive.exists(), "SKILL.md should not remain in archive");
+            }
+        }
+    }
+    assert!(has_archived_md, "SKILL.md.archived should exist in archive dir");
+}
+
+// ---------------------------------------------------------------------------
+// A4 — no regression: existing skill round-trip still works
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a4_load_skill_file_unchanged() {
+    // Directly test loader (no HOME needed) — exercises the read path
+    // that must remain byte-identical.
+    let tmp = TempDir::new().unwrap();
+    let skill_dir = tmp.path().join("code-review");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: code-review\ndescription: Review code carefully\n---\n# Code Review\n\nCheck everything.",
+    )
+    .unwrap();
+
+    let path = skill_dir.join("SKILL.md");
+    let skill = load_skill_file(&path, None, None).unwrap();
+
+    assert_eq!(skill.name, "code-review");
+    assert_eq!(skill.description, "Review code carefully");
+    assert_eq!(skill.body, "# Code Review\n\nCheck everything.");
+    assert!(skill.plugin.is_none());
+    assert!(skill.base_dir.is_absolute());
+    assert!(skill.source_path.is_absolute());
+}
+
+// ---------------------------------------------------------------------------
+// Security: frontmatter injection refused end-to-end (B1 from sec review)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn security_frontmatter_injection_refused() {
+    let tmp = TempDir::new().unwrap();
+    unsafe { std::env::set_var("HOME", tmp.path()) };
+
+    let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+    let config = Arc::new(SynapsConfig::default());
+    let tool = make_tool(registry, config);
+
+    let err = tool
+        .execute(
+            serde_json::json!({
+                "action": "create",
+                "name": "inject",
+                "description": "evil\n---\nbody-pwn",
+                "body": "# body"
+            }),
+            test_ctx(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(format!("{err}").to_lowercase().contains("description"), "got: {err}");
+
+    let path = tmp.path().join(".synaps-cli/skills/inject/SKILL.md");
+    assert!(!path.exists(), "no SKILL.md should be on disk after refusal");
+}
+
+// ---------------------------------------------------------------------------
+// Security: archive timestamp collisions (B2 from sec review)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[serial]
+async fn security_archive_no_collision_on_rapid_recreate() {
+    let tmp = TempDir::new().unwrap();
+    unsafe { std::env::set_var("HOME", tmp.path()) };
+
+    let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+    let config = Arc::new(SynapsConfig::default());
+    let tool = make_tool(registry, config);
+
+    for _ in 0..2 {
+        tool.execute(
+            serde_json::json!({"action":"create","name":"rapid","description":"d","body":"# b"}),
+            test_ctx(),
+        ).await.unwrap();
+        tool.execute(
+            serde_json::json!({"action":"delete","name":"rapid"}),
+            test_ctx(),
+        ).await.unwrap();
+    }
+
+    let archive = tmp.path().join(".synaps-cli/skills/.archive");
+    let count = std::fs::read_dir(&archive).unwrap().count();
+    assert_eq!(count, 2, "rapid create/delete must produce two distinct archive dirs");
+}

--- a/docs/specs/PLAN-self-improving-skills.md
+++ b/docs/specs/PLAN-self-improving-skills.md
@@ -1,0 +1,283 @@
+# PLAN — Self-Improving Skills (Component #1)
+
+> **Zero / Architect — Spec-Driven Development Phase 2.**
+> Companion to `SPEC-self-improving-skills.md` (the *what*).
+> This document is the *how*: ordering, dependencies, risks, checkpoints.
+>
+> *"A plan is a blueprint stripped of its romance. What remains is the
+> order in which to lay the stones — and the places where the foundation
+> will crack if you lay them out of sequence."*
+
+---
+
+## 0. Anchor — what is already built (do NOT rewrite)
+
+Cite-and-reuse, in order of relevance:
+
+| Piece | Location | Reuse role |
+|---|---|---|
+| Skill discovery walk | `crates/agent-engine/src/skills/loader.rs:75-…` (`default_roots`, `load_all`) | After our writes, `reload_registry` (below) re-invokes this verbatim. We add zero discovery code. |
+| Frontmatter parser | `crates/agent-engine/src/skills/loader.rs:6-33` | Read path. We never call it from the write path; we just produce bytes it accepts. Untouched. |
+| `load_skill` tool pattern | `crates/agent-engine/src/skills/tool.rs:1-87` | Template for `manage_tool.rs`: same `async_trait::async_trait`, same `serde_json::json!` schema, same `crate::RuntimeError::Tool` for failures. |
+| Command registry + hot-reload | `crates/agent-engine/src/skills/registry.rs:131-165` + `mod.rs:132-142` (`reload_registry`) | Post-write, we call `reload_registry` and the new/updated/deleted skill becomes resolvable. No registry surgery needed. |
+| Tool registration site | `crates/agent-engine/src/skills/mod.rs:125-128` (`tools.write().await.register(...)`) | Drop the second tool registration immediately after `LoadSkillTool`. One-liner. |
+| `Tool` trait + `RuntimeError` | `agent-engine` crate root (used at `tool.rs:29-87`) | Reused as-is. |
+| Axel reindex / prune / strengthen | `axel/crates/axel/src/consolidate/{mod.rs,reindex.rs,strengthen.rs}` | All of indexing, idempotency, usage-tracking. We add **zero** Axel code. |
+| Axel source-root config | `~/.config/axel/sources.toml` (parser: `axel/crates/axel/src/consolidate/mod.rs:86-124`) | One TOML stanza appended. Config-only Axel change. |
+
+Net-new vs reuse, by line count estimate:
+
+| Bucket | Lines (est.) | Notes |
+|---|---|---|
+| **Reused, unmodified** | ~600 (loader + registry + tool template + axel consolidate) | The vast majority of the surface. |
+| **New Rust code** | ~400 (writer.rs ~150, sidecar.rs ~80, manage_tool.rs ~120, tests ~150) | Tight modules; no clever abstractions. |
+| **New config** | 5 lines (1 TOML stanza in `sources.toml`) | The entire "Axel-side change". |
+| **Modified Rust code** | ~6 lines (3 `pub mod` lines + one registration block in `mod.rs::register`) | See risk R3 — anything beyond this trips A4. |
+
+The honest read: this is a **small write-layer bolted onto an existing
+read-layer**. The "self-improving" magic comes from the reflection loop
+(Component #2), not from this component. Component #1 is a hand. The
+brain (Component #2) and the editor (Component #3) follow.
+
+Gap doc cross-ref: `/home/haseeb/Jawz/workspace/repo-analysis/HERMES-LEARNING-LOOP-vs-AXEL.md`
+— §"skill_manage op surface" (~line 354), §"call patterns" (~422–428),
+§"provenance plumbing" (~432). Our op surface matches Hermes's three-
+action contract (`create` / `update` / `delete`) but routes indexing
+through Axel's source-root mechanism rather than Hermes's push-API.
+
+---
+
+## 1. Components & dependencies
+
+Eight discrete build units. Each row lists what it depends on (its
+prerequisites in this plan).
+
+| # | Unit | Type | Depends on |
+|---|---|---|---|
+| C1 | **`writer.rs` — paths + name validation** (`skill_dir(name)`, `skills_root()`, `archive_root()`, `validate_name()`) | new Rust | nothing (pure functions over `HOME`) |
+| C2 | **`writer.rs` — atomic write + lock** (`write_skill_md_atomic`, `lock_skill`, `read_description`) | new Rust | C1; `fs2` crate (already in tree? verify — else `Cargo.toml` add) |
+| C3 | **`writer.rs` — archive-move** (`archive_skill`: move dir to `.archive/<name>-<ts>/`, then rename inner `SKILL.md` → `SKILL.md.archived`) | new Rust | C1, C2 |
+| C4 | **`writer.rs` — plugin-ownership guard** (`ensure_writable(registry, name)`: rejects if `registry.all_skills()` has a hit whose `plugin.is_some()` or whose `source_path` is under any `plugins/` segment) | new Rust | C1; `registry::all_skills()` at `registry.rs:478` |
+| C5 | **`sidecar.rs`** (`SkillMeta`, `Provenance`, `create`, `touch`, `write_atomic`, lenient deserialize) | new Rust | C1 (uses `skill_dir`); `chrono` for RFC3339 (verify in deps) |
+| C6 | **`manage_tool.rs` — `SkillManageTool`** (the `Tool` impl, dispatch, post-write `reload_registry` call) | new Rust | C2, C3, C4, C5; `Tool` trait; `Arc<CommandRegistry>` |
+| C7 | **`mod.rs` wiring** (3 `pub mod` lines + register block) | mod | C6; touch points `mod.rs:11-24` and `mod.rs:127-128` only |
+| C8 | **Axel source-root config** (append `[[source]] name="skills" path="~/.synaps-cli/skills/" priority="high"` to `~/.config/axel/sources.toml`) | config | nothing — independent of C1–C7 |
+| T1 | **Unit tests** (co-located in C2/C3/C4/C5/C6) | new tests | the unit they test |
+| T2 | **Integration test** `tests/skill_manage_integration.rs` | new tests | C7 (full register path); a `TempDir`-bound `HOME` |
+| T3 | **Live-Axel round-trip test** (feature `axel-live`, default off) | new tests | C8 + a throwaway Axel brain in `tempdir`; shells out to `axel consolidate` and `axel search` |
+
+> **Crate deps check before C2/C5.** Run `grep -n '^fs2\|^chrono\|^tempfile' crates/agent-engine/Cargo.toml`. If `fs2` or `chrono` is missing, add them in the same PR step that introduces the module that needs them (don't pre-add). `tempfile` is needed for T2.
+
+---
+
+## 2. Implementation order
+
+The plan is **foundation-first, leaf-last**. Each phase has a single
+proof-of-life command at the end (§4).
+
+### Phase 2.1 — Foundations (sequential)
+1. **C1** — paths + name validation. Standalone, zero deps. Tests inline.
+2. **C5** — sidecar module. Depends only on C1's paths. Can run in
+   **parallel** with C2–C4 from this point on.
+3. **C2** — atomic write + advisory lock. Depends on C1. The lock impl
+   choice (`fs2::FileExt::try_lock_exclusive` on `<skill_dir>/.lock`)
+   should be settled here; the spec mandates **fail-fast**.
+
+> Rationale: validation and atomicity are the load-bearing primitives.
+> Every later component assumes "if `writer::write_skill_md_atomic` returned
+> Ok, the file is on disk with the right bytes; if it errored, the file
+> on disk is unchanged." Get this wrong and the entire system is a liar.
+
+### Phase 2.2 — Policy layer (parallelizable after 2.1)
+4. **C3** — archive-move. Depends on C1+C2. The non-obvious step: after
+   `fs::rename(dir, archive_target)`, rename the inner `SKILL.md` to
+   `SKILL.md.archived` so Axel's `.md|.txt` extension filter
+   (`reindex.rs:67`) skips it. This is the entire delete-side
+   "de-indexing" mechanism — see risk R4.
+5. **C4** — plugin-ownership guard. Depends on C1 and on having an
+   `Arc<CommandRegistry>` handle. Can develop in parallel with C3.
+
+### Phase 2.3 — Wiring (sequential, after 2.2)
+6. **C6** — `SkillManageTool`. Depends on C2/C3/C4/C5. This is mostly a
+   dispatcher; if Phase 2.1/2.2 are clean, C6 is ~120 lines of glue.
+7. **C7** — `mod.rs` edit: add the three `pub mod` lines (C7a) and the
+   one-line registration after `LoadSkillTool` at `mod.rs:127-128` (C7b).
+   These are two separate diffs; do C7a with C1 to keep the tree
+   compiling, do C7b with C6.
+
+### Phase 2.4 — Axel + tests (parallelizable, after 2.3)
+8. **C8** — append `sources.toml` stanza. Completely independent of the
+   Rust work. **Can be done first** (Phase 2.0) as a smoke test that the
+   path is well-formed, even before C1 lands. Recommended: do C8 as
+   step 1, so live-Axel test infrastructure exists from the start.
+9. **T1** — co-located unit tests (already incrementally written through
+   Phases 2.1–2.3).
+10. **T2** — integration test, full round-trip. Tempdir HOME, no Axel.
+11. **T3** — live-Axel test, feature-gated, manual-only by default.
+
+### What is genuinely sequential vs parallel
+
+- **Strictly sequential**: C1 → C2 → C3 (paths → atomic-write → archive).
+- **Strictly sequential**: {C2, C4, C5} → C6 → C7b → T2.
+- **Parallelizable from the start**: C8 (config), C5 (sidecar — only
+  needs C1), C4 (only needs C1 + registry API).
+- **Order-of-PR-commits suggestion**: C8 → C1 → (C2 ∥ C5) → C4 → C3 → C6
+  → C7 → T2 → T3. This is the order that maximizes "tree always
+  compiles, tests always pass" between commits.
+
+---
+
+## 3. Risks & mitigations
+
+### R1 — Atomic-write crash safety
+**Risk**: power-loss between writing `SKILL.md.tmp` and the `rename` leaves
+a half-written `.tmp` lingering forever. Worse: writing to `SKILL.md`
+directly (without tmp+rename) corrupts a previously-good skill.
+**Mitigation**: `write_skill_md_atomic` MUST: (a) write to
+`<dir>/SKILL.md.tmp`, (b) `f.sync_all()`, (c) `fs::rename(.tmp, SKILL.md)`,
+(d) best-effort `fsync` on the parent dir (Linux POSIX). On startup,
+`loader::load_all` ignores `*.tmp` files because its frontmatter required-
+field check fails on empty/partial files — verified by leaving the loader
+unchanged (zero-regression). Add a unit test that drops a half-written
+`.tmp` into a tempdir and asserts the loader silently skips it.
+
+### R2 — Lock contention / lock leaks
+**Risk**: a panicking write leaves `<dir>/.lock` held forever; or two
+in-process callers deadlock.
+**Mitigation**: `fs2::FileExt::try_lock_exclusive` (non-blocking) — fail-
+fast with a clear error message when contended (`RuntimeError::Tool("lock
+held; another skill_manage in flight")`). The lock file is held by an
+OS-level fd; when the process exits (panic or otherwise) the kernel
+releases it. The lock file itself is a small artifact left on disk; that
+is fine. Unit test: open a lock, attempt second open, assert err.
+
+### R3 — Breaking `load_skill` (A4 tripwire)
+**Risk**: any drift in `loader.rs` or `tool.rs` regressing the read path
+silently degrades existing skills. The SPEC's A4 catches this only if we
+keep those files literally untouched.
+**Mitigation**: enforce mechanically — PR diff MUST NOT touch
+`loader.rs`, `tool.rs`, or `registry.rs`. The only edits in
+`crates/agent-engine/src/skills/` are: 3 added `pub mod` lines in
+`mod.rs:11-24` and one `register(...)` call after `mod.rs:127-128`. CI
+runs `cargo test -p agent-engine skills::` *unchanged* and we expect
+zero diff to those test files. Recommend a PR-time `git diff --stat`
+sanity check listed in the merge checklist.
+
+### R4 — `.archive/` getting reindexed by Axel
+**Risk**: the archive lives at `~/.synaps-cli/skills/.archive/<name>-<ts>/SKILL.md`
+— inside the indexed source root. Axel's `reindex_source` uses `walkdir`
+with no hidden-dir filter (`reindex.rs:63-66`), so a `.md` under
+`.archive/` will be picked up as a *new* document distinct from the
+original (different absolute path), and the deletion will not propagate
+because the prune pass only fires when `file_path` no longer exists —
+but the archive moves it, doesn't delete it.
+**Mitigation** (the *only* clean solution that requires no Axel code
+change): the `archive_skill` step **renames the inner file** from
+`SKILL.md` → `SKILL.md.archived` after the directory move. Axel's
+extension filter at `reindex.rs:67` (`ext == "md" || ext == "txt"`)
+skips it. The original absolute path no longer exists on disk → prune
+pass deletes the documents row on the next consolidation. Unit test in
+C3 must assert: (a) `<archive>/<name>-<ts>/SKILL.md.archived` exists,
+(b) no file with extension `.md` exists under `.archive/`.
+*Alternative considered and rejected*: moving the archive outside the
+skills root (e.g. `~/.synaps-cli/.skills-archive/`). Rejected because the
+human ratified the path `~/.synaps-cli/skills/.archive/` in decision #3.
+
+### R5 — Axel reindex latency violates A3 expectations
+**Risk**: "within one consolidation cycle" is only meaningful if a cycle
+runs in a reasonable window. The user's installed `axel-consolidate.timer`
+cadence is unknown to us; if it is daily, a freshly-created skill is not
+searchable for up to a day. Component #2's reflection loop will assume
+near-realtime hit-ability.
+**Mitigation**: do NOT promise realtime in the SPEC (already corrected
+— A3 says "within one cycle"). Document for Component #2's designers
+that they should either (a) call `axel consolidate --phase reindex
+--sources <…>` themselves after `skill_manage`, or (b) tolerate latency.
+This is **not** Component #1's problem to solve — the SPEC's hard rule
+is "no Axel RPCs from skill_manage", and a synchronous consolidation
+trigger would violate that.
+
+### R6 — Concurrent `skill_manage` + a long-running `axel consolidate`
+**Risk**: Axel reads `SKILL.md` mid-write. With our `rename`-based
+atomic write, Axel will see either the old version or the new — never a
+torn read. No mitigation needed beyond R1. Listed here so it is not
+mistaken for an open risk.
+
+### Top 3 (for human eyeball)
+**R1** (atomic-write correctness) · **R3** (A4 regression, mechanically
+enforced by diff scope) · **R4** (`.archive/` reindex — the file-rename
+trick is the entire delete pipeline).
+
+---
+
+## 4. Verification checkpoints
+
+One command per checkpoint. Each must be green before moving to the next.
+
+| After phase | Command | Proves |
+|---|---|---|
+| 2.0 (C8 only) | `tomlq '.source[] \| select(.name=="skills")' ~/.config/axel/sources.toml` (or `grep -A2 'name = "skills"' ~/.config/axel/sources.toml`) returns a stanza with `path = "~/.synaps-cli/skills/"` | Config edit applied; Axel will pick up the source on next consolidation. |
+| 2.0 (smoke) | `axel consolidate --phase reindex --dry-run --verbose` lists `~/.synaps-cli/skills/` among walked sources | Axel parsed the stanza; path resolution works. |
+| 2.1 (C1+C2+C5) | `cargo test -p agent-engine skills::writer skills::sidecar` | Foundations correct; atomic-write + lock + sidecar JSON round-trip. |
+| 2.2 (C3+C4) | `cargo test -p agent-engine skills::writer::tests::archive skills::writer::tests::plugin_guard` | Archive rename trick verified (no `.md` under `.archive/`); plugin-owned guard rejects. |
+| 2.3 (C6+C7) | `cargo build -p agent-engine` then `cargo test -p agent-engine skills::manage_tool` | Tool registered, dispatch wired, schema well-formed. |
+| 2.4 (T2) | `cargo test -p agent-engine --test skill_manage_integration` | End-to-end: create → load_skill round-trip; update → diff persists; delete → archive present + live `.md` gone. |
+| Regression gate | `cargo test -p agent-engine skills::` | A4 — pre-existing skills tests untouched and green. |
+| Lint gate | `cargo clippy -p agent-engine --all-targets -- -D warnings` | Same bar as the rest of the repo. |
+| Live A3 (manual / nightly) | `cargo test -p agent-engine --features axel-live --test skill_manage_integration -- --ignored axel_round_trip` | After `axel consolidate --phase reindex`, `axel search "<name>"` returns a hit with `doc_id` matching `skills::<name>::SKILL`. |
+
+CI gate (merge bar) = the four mandatory rows: foundations + tool + integration + lint. Live-Axel is human-run.
+
+---
+
+## 5. The Axel index-root change — exact diff
+
+**File**: `~/.config/axel/sources.toml`
+**Parser**: `axel/crates/axel/src/consolidate/mod.rs:86-124`
+**Change type**: **CONFIG ONLY** — no Axel code change.
+
+Append this stanza to the end of the existing file (current contents
+end at the `memories` entry):
+
+```toml
+[[source]]
+name = "skills"
+path = "~/.synaps-cli/skills/"
+priority = "high"
+```
+
+Notes for the human eyeball:
+
+- The `~` expansion is handled at `consolidate/mod.rs:103`
+  (`path_str.replace("~", &home)`) — it works.
+- `priority = "high"` means this source is reindexed before the lower-
+  priority ones (`consolidate/mod.rs:148-153`). Skills are small, hot,
+  and few — high priority is correct and cheap.
+- The source name `skills` is what shows up in `doc_id`s:
+  `skills::<skill-name>::SKILL` (per `reindex.rs:99-107`). Component #2
+  can use a `doc_id LIKE 'skills::%'` predicate to scope reflection
+  queries to skills.
+- **There is no `default_sources()` change** at
+  `consolidate/mod.rs:69-79`. We deliberately do NOT add `skills` to the
+  hard-coded fallback list, because that fallback only fires when
+  `sources.toml` is missing or unparseable — a pathological state we
+  shouldn't paper over by silently re-adding skills.
+- The `.archive/` exclusion is **not** handled in this config — it is
+  handled by C3 renaming the file extension. Re-confirmed in risk R4.
+
+If the user wants to be defensive, an optional Axel-side improvement
+(out of scope for this plan, noted for completeness): teach
+`reindex.rs:63-66` to skip directories whose name starts with `.`. That
+would obviate the file-rename trick. **We do not depend on this.**
+
+---
+
+## 6. Merge checklist (the human runs this before pulling)
+
+- [ ] `git diff --stat crates/agent-engine/src/skills/` shows changes ONLY in: `mod.rs` (≤6 lines), `writer.rs` (new), `sidecar.rs` (new), `manage_tool.rs` (new).
+- [ ] `git diff crates/agent-engine/src/skills/loader.rs crates/agent-engine/src/skills/tool.rs crates/agent-engine/src/skills/registry.rs` is **empty**.
+- [ ] All four CI commands from §4 green.
+- [ ] `~/.config/axel/sources.toml` contains the `skills` stanza, verified with the §4 smoke command.
+- [ ] Manual: create a test skill via `skill_manage`, run `axel consolidate --phase reindex`, run `axel search <name>` — hit.
+
+— *Zero*

--- a/docs/specs/SPEC-self-improving-skills.md
+++ b/docs/specs/SPEC-self-improving-skills.md
@@ -1,0 +1,474 @@
+# SPEC — Self-Improving Skills (Component #1)
+
+> **Zero / Architect — Spec-Driven Development gate.**
+> Status: **DRAFT — awaiting human ratification before implementation.**
+> Scope: Component #1 of the self-improving-agent stack. The reflection
+> loop (component #2) and the curator (component #3) consume this surface
+> but are **out of scope here**.
+>
+> *"A loop without a write-surface is a thought without a hand. We give the
+> agent its hand — and we make sure it cannot cut itself with it."*
+
+---
+
+## RATIFIED DECISIONS — final, locked
+
+The six forks from the prior draft are resolved. These are not negotiable
+within the scope of Component #1; subsequent components may extend, never
+contradict.
+
+1. **Axel indexing = index-as-document, NOT axel_remember.** Skills are
+   documents on disk, not memory rows. We do **not** add a `skill`
+   MemoryCategory and we do **not** call `axel_remember`. Instead, the
+   skills directory `~/.synaps-cli/skills/` is registered as an additional
+   Axel **source root** (alongside `mikoshi`, `notes`, `context`, …).
+   Axel's existing consolidation Phase 1 (`crates/axel/src/consolidate/reindex.rs`)
+   walks the root, hashes/mtimes via the documents/file_provenance tables,
+   re-embeds deltas, and prunes deleted files. Usage-frequency and
+   excitability accrue automatically through Axel's `document_access` /
+   strengthen-on-access machinery — no new Axel write API is needed, and
+   `skill_manage` does **zero** Axel RPCs. The only Axel-side change is a
+   **config-only** append to `~/.config/axel/sources.toml`. See PLAN §
+   "Axel index-root change" for the exact diff.
+2. **`create` on an existing skill name = ERROR.** No auto-update. Caller
+   must explicitly use `action="update"`. Surfaces as
+   `RuntimeError::Tool("skill '<name>' already exists; use action=update")`.
+3. **`delete` = archive-move, never hard-delete.** Target path:
+   `~/.synaps-cli/skills/.archive/<name>-<UTC-RFC3339-compact>/`. The
+   archive directory MUST live where Axel's reindex walker will not pick
+   it back up as a live document — see PLAN risk R4 for the mechanical
+   guard.
+4. **Plugin-owned skills are read-only to `skill_manage`.** Any `name`
+   that resolves to a discovered skill whose `LoadedSkill.plugin` is
+   `Some(_)`, or whose `source_path` is under any `plugins/<p>/skills/`,
+   is rejected with `RuntimeError::Tool("plugin-owned skill; not writable")`.
+   Only loose skills under `~/.synaps-cli/skills/<name>/` are writable.
+5. **Sidecar schema.** `.skill-meta.json` carries `schema_version: 1` and
+   exactly these fields: `schema_version`, `provenance` (`user` |
+   `learn` | `background_review`), `created` (ISO-8601 / RFC3339),
+   `last_updated` (ISO-8601 / RFC3339). Forward-compat: unknown JSON
+   fields are tolerated by the deserializer (`#[serde(default)]` +
+   ignore-unknown). **No `usage_count` field** — usage lives in Axel
+   (decision #1). **No `axel_doc_id` field** — Axel addresses by
+   absolute file_path (`reindex.rs:107`), and identity is reconstructed
+   from the source name + relative path, so no opaque id needs to be
+   round-tripped through the sidecar.
+6. **SKILL.md frontmatter stays exactly `{name, description}`.** All
+   loop metadata lives in the sidecar. The loader struct
+   (`loader.rs:6-33`) is untouched — zero-regression rule, enforced by
+   A4.
+
+---
+
+## 1. Objective
+
+### What we are building
+A **write/improve/index** capability for the EXISTING skills subsystem at
+`crates/agent-engine/src/skills/`. Three new behaviors, no parallel system:
+
+| Capability | Surface | Backing store |
+|---|---|---|
+| Create a skill | `skill_manage(action="create")` | `~/.synaps-cli/skills/<name>/SKILL.md` + `.skill-meta.json` |
+| Update a skill | `skill_manage(action="update")` | overwrites `SKILL.md` atomically; bumps sidecar `last_updated` |
+| Delete a skill | `skill_manage(action="delete")` | archive-move (file un-named to drop `.md` so reindex prunes the live entry) |
+| Index on write | **passive** — Axel reindexes the skills source root on its consolidation cycle | Axel `documents` table, `doc_id = "skills::<name>::SKILL"`, addressed by absolute `file_path` |
+
+### Users
+- **Primary (Now)**: the running agent, called programmatically via the
+  tool dispatcher — exactly the surface that component #2's reflection
+  loop will call.
+- **Secondary (Now)**: tests + future curator (component #3).
+- **Not a user**: humans editing SKILL.md by hand — that already works
+  through the lenient loader and must keep working (back-compat).
+
+### Success — measurable
+The four acceptance criteria (A1–A4) below pass in CI. Concretely:
+- A skill written by the agent is read back byte-identical by `load_skill`.
+- An updated skill's body diff persists and the sidecar reflects it.
+- A newly created skill becomes hit-able by `axel_search` **within one
+  consolidation cycle** (i.e. after the next `axel consolidate --phase reindex`
+  pass; not instant — see RATIFIED DECISION #1).
+- The existing skills test suite is unchanged and green.
+
+### Non-goals (explicit)
+- **No** reflection / decision-to-write logic (component #2).
+- **No** curator / consolidation across the library (component #3).
+- **No** new frontmatter fields, no schema migration on existing skills.
+- **No** filesystem watcher; indexing is push-on-write only.
+- **No** UI / slash command surface — programmatic tool only.
+
+---
+
+## 2. Commands
+
+All from repo root (`/home/haseeb/Projects/agent-runtime`):
+
+```bash
+# Build (must compile clean)
+cargo build -p agent-engine
+
+# Unit + integration tests for this component
+cargo test -p agent-engine skills::
+cargo test -p agent-engine --test skill_manage_integration   # new test file
+
+# Lint gate — same bar as the rest of the repo
+cargo clippy -p agent-engine --all-targets -- -D warnings
+
+# Manual smoke (after wiring into the runtime tool registry)
+#   the tool is dispatched by name; programmatic only, no slash command.
+#   Example payload:
+#     {"action":"create","name":"foo","description":"foo skill","body":"# Foo\n..."}
+#     {"action":"update","name":"foo","body":"# Foo v2\n..."}
+#     {"action":"delete","name":"foo"}
+```
+
+CI gate: **all four** of the above must pass before merge.
+
+---
+
+## 3. Project Structure
+
+### Files touched
+
+| Path | Change | Why |
+|---|---|---|
+| `crates/agent-engine/src/skills/mod.rs:11-24` | **MOD**: add `pub mod writer;`, `pub mod sidecar;`, `pub mod manage_tool;` | Wire new submodules. No change to existing `pub mod` lines, no change to `LoadedSkill`. **No `axel_index` module** — indexing is passive via Axel's source-root reindex (RATIFIED DECISION #1). |
+| `crates/agent-engine/src/skills/mod.rs:68-130` (`register`) | **MOD**: after `LoadSkillTool` registration, register `SkillManageTool::new(registry.clone(), config.clone())` | Expose the new tool to the runtime, alongside `load_skill`. |
+| `crates/agent-engine/src/skills/loader.rs:6-33` (`parse_frontmatter`) | **UNCHANGED** | Hard zero-regression rule. The lenient parser already ignores unknown fields, so even if a future change re-adds frontmatter fields, the loader is safe. We rely on this in tests (A4). |
+| `crates/agent-engine/src/skills/loader.rs:41-73` (`load_skill_file`) | **UNCHANGED** | Same reason. |
+
+### Files added (all under `crates/agent-engine/src/skills/`)
+
+| Path | Responsibility |
+|---|---|
+| `writer.rs` | Atomic write primitives: `write_skill_md_atomic(dir, name, description, body)`; name validation; archive-move for delete (renames `SKILL.md` → `SKILL.md.archived` inside the moved dir so Axel's `.md|.txt` reindex filter skips it — see §6 / risk R4); advisory file lock per skill dir. Pure I/O, no tool wiring. |
+| `sidecar.rs` | Sidecar `.skill-meta.json` (de)serialization, lazy creation, "back-compat — missing sidecar is fine" rules. Defines `SkillMeta` struct. |
+| `manage_tool.rs` | `SkillManageTool` implementing `crate::Tool`. Parses params, dispatches to `writer` + `sidecar`, then calls `reload_registry` (see `mod.rs:134-142`) so the new skill is immediately resolvable. **No Axel calls.** |
+| `tests/skill_manage_integration.rs` (in `crates/agent-engine/tests/`) | End-to-end: tempdir HOME, create → load_skill round-trip; update → diff persists; delete → archive present + live path gone. |
+
+### Where the tool registers
+Same spot as `LoadSkillTool` — `skills::mod.rs::register` (~line 127–128).
+This guarantees the runtime sees `skill_manage` at the same lifecycle
+moment it sees `load_skill`, with the same `Arc<CommandRegistry>` reference,
+so post-write `reload_registry` (`mod.rs:134`) works without plumbing.
+
+### Where tests go
+- **Unit tests**: co-located `#[cfg(test)] mod tests` at the bottom of
+  `writer.rs`, `sidecar.rs`, `manage_tool.rs` — same style
+  as `tool.rs:89-230`.
+- **Integration tests**: `crates/agent-engine/tests/skill_manage_integration.rs`
+  with `HOME` overridden via env to a `tempfile::TempDir`, exercising the
+  full `register → skill_manage → reload_registry → load_skill` cycle.
+
+---
+
+## 4. Code Style — single illustrative snippet
+
+Matches the existing module conventions (`tool.rs`, `loader.rs`,
+`mod.rs`): `async_trait::async_trait` Tool impl, `serde_json::json!`
+schemas, `crate::RuntimeError::Tool` for failures, `Arc<CommandRegistry>`
+dependency, doc comment with file-line cross-refs.
+
+```rust
+//! `skill_manage` tool — model-initiated skill authorship.
+//!
+//! Companion to `tool.rs::LoadSkillTool` (read path). This is the write
+//! path: create / update / delete a loose skill under
+//! `~/.synaps-cli/skills/<name>/`, atomically. Indexing is **passive**:
+//! Axel's consolidation walks `~/.synaps-cli/skills/` as a registered
+//! source root (RATIFIED DECISION #1), so this tool makes zero Axel RPCs.
+//!
+//! Zero-regression contract with `loader.rs::load_skill_file` (lines 41–73):
+//! we only ever write `SKILL.md` files whose frontmatter contains exactly
+//! `name` and `description`, so the loader's required-field checks pass
+//! byte-identically.
+
+use crate::skills::{
+    registry::CommandRegistry,
+    sidecar::{SkillMeta, Provenance},
+    writer,
+};
+use serde_json::json;
+use std::sync::Arc;
+
+pub struct SkillManageTool {
+    registry: Arc<CommandRegistry>,
+    config:   Arc<crate::SynapsConfig>,
+}
+
+#[async_trait::async_trait]
+impl crate::Tool for SkillManageTool {
+    fn name(&self) -> &str { "skill_manage" }
+
+    fn description(&self) -> &str {
+        "Author or improve a skill. action ∈ {create, update, delete}. \
+         Creates a new SKILL.md under ~/.synaps-cli/skills/<name>/ (create), \
+         atomically rewrites it (update), or archives it (delete). \
+         The skill becomes searchable in Axel on the next consolidation cycle."
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action":      { "type": "string", "enum": ["create","update","delete"] },
+                "name":        { "type": "string", "description": "Skill name; [a-z0-9][a-z0-9-]{0,63}" },
+                "description": { "type": "string", "description": "≤200 chars; required on create, optional on update" },
+                "body":        { "type": "string", "description": "Markdown body (post-frontmatter); required on create/update" },
+                "provenance":  { "type": "string", "enum": ["user","learn","background_review"], "default": "background_review" }
+            },
+            "required": ["action","name"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _ctx: crate::ToolContext,
+    ) -> crate::Result<String> {
+        let action = params["action"].as_str()
+            .ok_or_else(|| crate::RuntimeError::Tool("Missing 'action'".into()))?;
+        let name = params["name"].as_str()
+            .ok_or_else(|| crate::RuntimeError::Tool("Missing 'name'".into()))?;
+        writer::validate_name(name)
+            .map_err(|e| crate::RuntimeError::Tool(format!("invalid name: {e}")))?;
+
+        // Refuse plugin-owned skills (RATIFIED DECISION #4).
+        writer::ensure_writable(&self.registry, name)
+            .map_err(|e| crate::RuntimeError::Tool(e.to_string()))?;
+
+        // Per-skill advisory lock — guards concurrent writes to same dir.
+        let _guard = writer::lock_skill(name)
+            .map_err(|e| crate::RuntimeError::Tool(format!("lock: {e}")))?;
+
+        let outcome = match action {
+            "create" => {
+                let desc = params["description"].as_str()
+                    .ok_or_else(|| crate::RuntimeError::Tool("create: missing description".into()))?;
+                let body = params["body"].as_str()
+                    .ok_or_else(|| crate::RuntimeError::Tool("create: missing body".into()))?;
+                if writer::skill_dir(name).exists() {
+                    return Err(crate::RuntimeError::Tool(
+                        format!("skill '{name}' already exists; use action=update")));
+                }
+                let provenance = Provenance::parse(params["provenance"].as_str());
+                writer::write_skill_md_atomic(name, desc, body)?;
+                SkillMeta::create(name, provenance)?.write_atomic()?;
+                "created"
+            }
+            "update" => {
+                let body = params["body"].as_str()
+                    .ok_or_else(|| crate::RuntimeError::Tool("update: missing body".into()))?;
+                let desc = match params["description"].as_str() {
+                    Some(d) => d.to_string(),
+                    None    => writer::read_description(name)?, // preserve existing
+                };
+                writer::write_skill_md_atomic(name, &desc, body)?;
+                SkillMeta::touch(name)?;  // lazy-create if missing (back-compat)
+                "updated"
+            }
+            "delete" => {
+                writer::archive_skill(name)?; // move to .archive/<name>-<ts>/ + un-name SKILL.md
+                "deleted"
+            }
+            other => return Err(crate::RuntimeError::Tool(
+                format!("unknown action '{other}'"))),
+        };
+
+        // Refresh registry so the new/updated/deleted skill is immediately
+        // resolvable via `load_skill`. See `mod.rs::reload_registry` (line 134).
+        crate::skills::reload_registry(&self.registry, &self.config);
+
+        Ok(format!("skill_manage: {action} {name} → {outcome}"))
+    }
+}
+```
+
+And the sidecar shape (`sidecar.rs`):
+
+```rust
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+pub struct SkillMeta {
+    pub schema_version: u32,          // 1
+    pub provenance:     Provenance,   // user | learn | background_review
+    pub created:        String,       // RFC3339
+    pub last_updated:   String,       // RFC3339
+    // NOTE: no usage_count, no axel_doc_id. Usage tracking lives in
+    // Axel's `document_access` table (RATIFIED DECISION #1); doc identity
+    // is reconstructed from absolute file_path by Axel's reindex pass.
+}
+```
+
+> **Usage-frequency tracking lives in Axel, not the sidecar.** Each call
+> to `load_skill` is followed (by Axel's own search-time strengthen
+> mechanism, when the agent issues `axel_search` to *find* the skill) by
+> a `document_access` write. The sidecar stays cold — only mutated on
+> author actions.
+
+---
+
+## 5. Testing Strategy
+
+### Unit tests (co-located)
+- `writer.rs::tests`
+  - `validate_name` accepts `a`, `abc`, `a-b-c`, `a1`; rejects `""`,
+    `"A"`, `"-foo"`, `"foo/bar"`, `".."`, `"con"` (reserved on Windows
+    path-compat — we reject defensively even on Linux), `"x".repeat(65)`.
+  - `write_skill_md_atomic` writes to a `.tmp` sibling then `rename`s;
+    on simulated mid-write panic (drop a half-written tmp file in setup),
+    `SKILL.md` is untouched.
+  - `archive_skill` moves `<name>/` to `.archive/<name>-<ts>/` and the
+    original path no longer exists.
+  - `lock_skill` returns an error (or blocks, per impl choice — spec says
+    **fail-fast with `try_lock`**, error message includes pid) when called
+    twice for the same name from the same process.
+- `sidecar.rs::tests`
+  - Round-trip serialize/deserialize.
+  - `SkillMeta::touch` on a skill with **no sidecar** lazily creates one,
+    `created == last_updated` (back-compat).
+  - Unknown fields in on-disk JSON are tolerated (deserializer ignores).
+- `manage_tool.rs::tests`
+  - Schema well-formed (mirrors `tool.rs:222-230`).
+  - `create` then `create` same name → `RuntimeError::Tool("...already exists...")`.
+  - `update` on missing skill → error (no implicit create).
+  - `delete` on missing skill → error.
+  - `create` on a plugin-owned name (seeded via a fake plugin skill in
+    `tempdir`) → `RuntimeError::Tool("plugin-owned skill; not writable")`.
+  - `provenance` defaults to `background_review` when omitted.
+
+### Integration test (`tests/skill_manage_integration.rs`)
+Bind `HOME` to a `TempDir`. Build a real `CommandRegistry` via
+`skills::register(...)`. Axel is **not** invoked from this test —
+indexing is asserted via a separate, optional, feature-gated round-trip
+(see A3 below).
+
+- **A1** — `skill_manage create {name:"t1",description:"d",body:"# B"}` →
+  read `~/.synaps-cli/skills/t1/SKILL.md`, then call
+  `loader::load_skill_file` directly, assert `LoadedSkill.name == "t1"`,
+  `description == "d"`, `body.starts_with("# B")`, and that on-disk bytes
+  match what was written.
+- **A2** — `create` then `update {body:"# B v2"}` → assert on-disk body
+  changed, sidecar `last_updated > created`, frontmatter unchanged,
+  `load_skill_file` still returns a valid `LoadedSkill`.
+- **A3 (indexing)** — split into two layers:
+  - **Static contract test (always-on)**: assert that after `create`, the
+    file `~/.synaps-cli/skills/t1/SKILL.md` exists with extension `.md`,
+    is non-empty, lives directly under the registered Axel source root,
+    and that after `delete`, no `.md` file remains under that root for
+    `t1` (the archived copy has been renamed to `SKILL.md.archived`).
+    This proves the file is in the shape Axel's `reindex.rs:67` walker
+    accepts (or rejects, post-archive).
+  - **Live-Axel round-trip (gated on `cfg(feature = "axel-live")`,
+    off in CI by default)**: spawn `axel consolidate --phase reindex
+    --sources <tmp-sources.toml>` against a throwaway brain, then issue
+    `axel search "t1"` and assert a hit with `doc_id` starting
+    `skills::t1`. This is the empirical proof of "within one
+    consolidation cycle".
+- **A4** — run the pre-existing tests (`cargo test -p agent-engine skills::`)
+  and assert nothing in `loader.rs`, `tool.rs::tests`, or `registry.rs`
+  needed modification. This is enforced socially in PR review (no diff
+  lines outside the allowed file list in §3) and mechanically by leaving
+  those modules untouched.
+
+### Indexing contract (testable)
+Axel discovers skills as **documents**, not memories. There is no
+write-path RPC from `skill_manage` to Axel.
+
+- **Where**: `~/.synaps-cli/skills/` is registered as a source in
+  `~/.config/axel/sources.toml` (see PLAN — exact diff). Axel's
+  `consolidate::reindex_source` (`crates/axel/src/consolidate/reindex.rs:30`)
+  walks it, filtered to `.md` / `.txt`.
+- **doc_id shape**: `format!("{source_name}::{rel_path_no_ext}")` per
+  `reindex.rs:99-107` → for source name `skills` and skill `t1`, the id
+  is `skills::t1::SKILL`. Stable across re-indexes because Axel keys on
+  absolute `file_path`.
+- **What text is indexed**: the full SKILL.md file contents — frontmatter
+  + body. Axel's `index_document` (called at `reindex.rs:107`) receives
+  the raw file string. The frontmatter is small (~2 lines) and does not
+  meaningfully dilute embeddings.
+- **Idempotency**: provided for free by `reindex.rs:80-86` — re-walks
+  compare mtime to `indexed_at`, only re-embed on delta.
+- **Delete**: handled by `reindex.rs:117-128` prune pass — when the live
+  `SKILL.md` is gone (archived under a different filename), the row is
+  removed from the documents table on the next consolidation. There is
+  no synchronous de-index; A3 documents the latency bound.
+- **Failure of Axel = invisible to `skill_manage`**: the tool has no Axel
+  dependency. If Axel is broken, skills are still written, still loadable
+  via `load_skill`, and will index on the next successful consolidation.
+
+---
+
+## 6. Boundaries
+
+### ALWAYS
+- **ALWAYS** write SKILL.md atomically: write to `SKILL.md.tmp` in the
+  same directory, `fsync`, then `rename`. Same for sidecar.
+- **ALWAYS** hold a per-skill advisory file lock (`fs2::FileExt::try_lock_exclusive`
+  on `<skill_dir>/.lock`) for the entire create/update/delete operation.
+- **ALWAYS** keep the SKILL.md frontmatter to exactly `name:` and
+  `description:` — nothing else — so `loader.rs::parse_frontmatter` sees
+  no surprises.
+- **ALWAYS** call `reload_registry` (`mod.rs:134`) after a successful
+  write so `load_skill` resolution reflects reality immediately.
+- **ALWAYS** treat a missing sidecar as legal (back-compat for hand-authored
+  skills under `~/.synaps-cli/skills/`).
+- **ALWAYS** validate skill names against `^[a-z0-9][a-z0-9-]{0,63}$`,
+  reject path separators, `.`, `..`, and the Windows reserved names
+  (`con`, `prn`, `aux`, `nul`, `com[1-9]`, `lpt[1-9]`).
+
+### ASK FIRST (escalate to human before doing)
+- **ASK** before adding any field to the loader's frontmatter struct or
+  changing `parse_frontmatter` — that touches the read path.
+- **ASK** before changing the on-disk skill layout (e.g. moving to
+  `skills/<name>/v1/SKILL.md`).
+- **ASK** before bumping `SkillMeta::schema_version` past 1.
+- **ASK** before changing the Axel source-root contract (the
+  `sources.toml` entry name, the skills-dir path, or the archive-rename
+  trick that keeps `.archive/` out of the index) — component #2 and #3
+  will depend on it.
+- **ASK** before allowing `skill_manage` to operate on plugin-owned skills
+  (currently forbidden — RATIFIED DECISION #4).
+
+### NEVER
+- **NEVER** regress `load_skill`, `loader::load_skill_file`, or
+  `registry::CommandRegistry` behavior. A1/A4 are the tripwires.
+- **NEVER** edit a skill in-place (no `OpenOptions::write().truncate()`
+  on `SKILL.md` directly). Atomic rename only.
+- **NEVER** delete a skill irreversibly. `delete` = archive-move.
+- **NEVER** call `axel_remember` for skills, and **NEVER** add a `skill`
+  MemoryCategory. Skills are documents (RATIFIED DECISION #1).
+- **NEVER** mutate the sidecar from the read path (`load_skill`). The
+  sidecar is author-write-only; access-frequency lives in Axel.
+- **NEVER** make `skill_manage` block on Axel availability — it has no
+  Axel dependency at all. Indexing is the consolidator's job.
+- **NEVER** spawn a filesystem watcher. Push-on-write to disk; Axel
+  pulls on its own schedule.
+- **NEVER** leave a `.md` file under `~/.synaps-cli/skills/.archive/`
+  — the archive step MUST rename the file so the reindex walker skips it
+  (see §3 / `writer.rs`).
+- **NEVER** allow `skill_manage` to traverse outside
+  `~/.synaps-cli/skills/`. Reject any `name` that, when joined, escapes
+  the canonical skills root.
+
+---
+
+## Appendix A — Cross-references
+
+- Existing read path: `crates/agent-engine/src/skills/loader.rs:6-73`
+- Existing tool pattern to mirror: `crates/agent-engine/src/skills/tool.rs:1-87`
+- Registry hot-reload (used post-write): `crates/agent-engine/src/skills/mod.rs:132-142`
+- Tool registration site: `crates/agent-engine/src/skills/mod.rs:127-128`
+- On-disk skills: `~/.synaps-cli/skills/<name>/SKILL.md` (e.g.
+  `~/.synaps-cli/skills/code-review/SKILL.md`)
+- Axel source-root contract: `~/.config/axel/sources.toml`, parsed by
+  `axel/crates/axel/src/consolidate/mod.rs:86-124`. Reindex walker:
+  `axel/crates/axel/src/consolidate/reindex.rs:30-128` (extension filter
+  `.md|.txt` at line 67, doc_id construction at lines 99-107, prune pass
+  at lines 117-128).
+- Hermes parity reference (do not copy code, copy contract):
+  `/home/haseeb/Jawz/workspace/repo-analysis/HERMES-LEARNING-LOOP-vs-AXEL.md`
+  — esp. lines 143 (provenance guard), 158 (filesystem layout), 354
+  (`skill_manage` op surface), 422–428 (call patterns), 432 (provenance
+  plumbing), 486 (op breakdown), 508 (validation budget).
+
+— *Zero*


### PR DESCRIPTION
## What & why
Component #1 of a self-improving agent (closed learning loop, à la Nous Research's Hermes, on the Axel brain). This makes Synaps's **existing** skills system *writable* — an agent can now create and improve its own skills (procedural memory). The reflection loop (#2) and curator (#3) build on this.

Spec-driven: `docs/specs/SPEC-self-improving-skills.md` + `PLAN-self-improving-skills.md` (included).

## The `skill_manage` tool (create / update / delete)
- **Atomic writes** — tmp → fsync(file) → rename → fsync(parent); tmp cleaned on any failure. No half-written SKILL.md is ever visible.
- **Per-skill `fs4` lock** — fail-fast, lock-before-check.
- **Sidecar `.skill-meta.json`** — `{schema_version, provenance, created, last_updated}`; forward-compatible (`#[serde(default)]` + ignore-unknown). Usage tracking is Axel's job (document excitability), not the sidecar.
- **Delete = archive-move** to `.archive/<name>-<ts.µs>/` with `SKILL.md` → `SKILL.md.archived` so Axel's `.md` filter skips it. Never hard-deletes.

## Security (hardened after review)
6-axis review flagged **2 blockers + 3 high + 5 med — all fixed with regression tests before merge:**
- 🛡️ **Frontmatter injection** — `description` rejects newlines / `---` / >200 chars. The agent can't corrupt its own SKILL.md.
- 🛡️ **Archive timestamp collision** — µs precision + `-N` suffix; rapid create→delete→create→delete can't lose a skill.
- Plugin-ownership guard via **canonical path check** (no substring grep); **symlink dirs refused**; directory-traversal-proof names.

## Axel indexing — B1, zero new Axel API
Skills are **documents, not memories**. The skills dir is registered as an Axel source root (machine config: `~/.config/axel/sources.toml`). Existing reindex picks up writes; skills become searchable docs under doc_id prefix `skills::`. **Proven live end-to-end:** write skill → `axel consolidate` → `axel_search` finds it as `skills::<name>::SKILL`.

## Zero regression (hard guarantee)
- `loader.rs` change is **signature-only** (`parse_frontmatter` `pub(super)`→`pub(crate)` for reuse). `tool.rs` / `registry.rs` untouched. `load_skill` behavior unchanged.

## Tests
- **903** lib tests pass · **6** integration tests (A1–A4 acceptance + 2 security) · `clippy --all-targets -D warnings` clean.

## Note
- Incidental: one test-only clippy fix in `runtime/api.rs` (`.filter().next_back()` → `.rfind()`) to keep `--all-targets` green under newer clippy. Unrelated to skills; pre-existing latent lint.
- `sources.toml` is machine config (not in this repo) — the deploy step adds the skills source stanza.