### PR TITLE
refactor(tui): migrate Layout .split() → .areas() across all 12 sites

### DIFF
--- a/crates/agent-tui/src/tui/draw.rs
+++ b/crates/agent-tui/src/tui/draw.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     backend::CrosstermBackend,
-    layout::{Alignment, Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Layout},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph, Wrap},
@@ -813,17 +813,15 @@ pub(crate) fn render_frame(
         let input_height = input_lines.min(max_input_lines) + 2;
         let download_height: u16 = if !model.active_tasks.is_empty() { 1 } else { 0 };
 
-        let outer = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(1),
-                Constraint::Min(1),
-                Constraint::Length(subagent_height),
-                Constraint::Length(download_height),
-                Constraint::Length(input_height),
-                Constraint::Length(1),
-            ])
-            .split(frame.area());
+        let [header_area, body, subagent_area, download_area, input_area, footer_area] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(subagent_height),
+            Constraint::Length(download_height),
+            Constraint::Length(input_height),
+            Constraint::Length(1),
+        ])
+        .areas(frame.area());
 
         // ── Header ────────────────────────────────────────────────────────────
         let spinner_idx = (model.spinner_frame / 3) % SPINNER_FRAMES.len();
@@ -933,7 +931,7 @@ pub(crate) fn render_frame(
                 ));
             }
             let used: usize = spans.iter().map(|s| s.content.len()).sum();
-            let total_w = outer[0].width as usize;
+            let total_w = header_area.width as usize;
             if total_w > used + version_span.content.len() {
                 let pad = total_w - used - version_span.content.len();
                 spans.push(Span::raw(" ".repeat(pad)));
@@ -942,10 +940,10 @@ pub(crate) fn render_frame(
             spans
         }))
         .style(Style::default().bg(THEME.load().bg));
-        frame.render_widget(header, outer[0]);
+        frame.render_widget(header, header_area);
 
         // ── Messages ──────────────────────────────────────────────────────────
-        let msg_area = outer[1];
+        let msg_area = body;
         // model.lines IS the visible window (sliced on the main side) — render the whole arc.
         let visible: Vec<ratatui::text::Line> = model.lines.to_vec();
         let visible_is_empty = visible.is_empty();
@@ -1287,7 +1285,7 @@ pub(crate) fn render_frame(
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(THEME.load().subagent_border))
                 .style(Style::default().bg(THEME.load().bg));
-            frame.render_widget(Paragraph::new(agent_lines).block(agent_block), outer[2]);
+            frame.render_widget(Paragraph::new(agent_lines).block(agent_block), subagent_area);
         }
 
         // ── Input ─────────────────────────────────────────────────────────────
@@ -1387,13 +1385,13 @@ pub(crate) fn render_frame(
         let input_widget = Paragraph::new(input_lines_vec)
             .scroll((input_scroll, 0))
             .block(input_block);
-        frame.render_widget(input_widget, outer[4]);
+        frame.render_widget(input_widget, input_area);
 
         // Software cursor
-        let cursor_x = outer[4].x + 1 + cursor_col;
-        let cursor_y = outer[4].y + 1 + cursor_row - input_scroll;
-        if cursor_x < outer[4].x.saturating_add(outer[4].width)
-            && cursor_y < outer[4].y.saturating_add(outer[4].height)
+        let cursor_x = input_area.x + 1 + cursor_col;
+        let cursor_y = input_area.y + 1 + cursor_row - input_scroll;
+        if cursor_x < input_area.x.saturating_add(input_area.width)
+            && cursor_y < input_area.y.saturating_add(input_area.height)
         {
             if let Some(cell) = frame.buffer_mut().cell_mut((cursor_x, cursor_y)) {
                 let symbol = cell.symbol().to_string();
@@ -1410,18 +1408,16 @@ pub(crate) fn render_frame(
 
         // ── Active task bar ───────────────────────────────────────────────────
         if !model.active_tasks.is_empty() {
-            let bar = render_active_tasks_line(&model.active_tasks, outer[3].width);
-            frame.render_widget(bar, outer[3]);
+            let bar = render_active_tasks_line(&model.active_tasks, download_area.width);
+            frame.render_widget(bar, download_area);
         }
 
         // ── Footer ────────────────────────────────────────────────────────────
-        let footer_chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Min(1),
-                Constraint::Length(model.runtime_model.len() as u16 + 75),
-            ])
-            .split(outer[5]);
+        let [keybinds_area, info_area] = Layout::horizontal([
+            Constraint::Min(1),
+            Constraint::Length(model.runtime_model.len() as u16 + 75),
+        ])
+        .areas(footer_area);
 
         let key_style = Style::default().fg(THEME.load().muted);
         let label_style = Style::default().fg(THEME.load().help_fg);
@@ -1450,7 +1446,7 @@ pub(crate) fn render_frame(
             Span::styled("send", label_style),
         ]))
         .style(Style::default().bg(THEME.load().bg));
-        frame.render_widget(keybinds, footer_chunks[0]);
+        frame.render_widget(keybinds, keybinds_area);
 
         let cost_str = if model.session_cost > 0.0 {
             format!("${:.4} ", model.session_cost)
@@ -1530,7 +1526,7 @@ pub(crate) fn render_frame(
         ]))
         .alignment(Alignment::Right)
         .style(Style::default().bg(THEME.load().bg));
-        frame.render_widget(info, footer_chunks[1]);
+        frame.render_widget(info, info_area);
 
         // ── Effects ───────────────────────────────────────────────────────────
         if let Some(ref mut fx) = boot_fx {

--- a/crates/agent-tui/src/tui/help_find.rs
+++ b/crates/agent-tui/src/tui/help_find.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, BorderType, Clear, Paragraph},
@@ -76,22 +76,20 @@ pub(crate) fn render(frame: &mut Frame, area: Rect, state: &mut synaps_cli::help
         return;
     }
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(2),
-            Constraint::Min(1),
-            Constraint::Length(1),
-        ])
-        .split(inner);
+    let [search_bar, results, status_bar] = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .areas(inner);
 
     let search = Paragraph::new(Line::from(vec![
         Span::styled("Search: ", Style::default().fg(THEME.load().muted)),
         Span::styled(state.filter().to_string(), Style::default().fg(THEME.load().input_fg)),
     ]));
-    frame.render_widget(search, chunks[0]);
+    frame.render_widget(search, search_bar);
 
-    let visible_height = chunks[1].height as usize;
+    let visible_height = results.height as usize;
     state.set_visible_height(visible_height);
     let rows = state.filtered_rows();
     let result_count = state.filtered_entries().len();
@@ -102,7 +100,7 @@ pub(crate) fn render(frame: &mut Frame, area: Rect, state: &mut synaps_cli::help
             .map(|line| Line::from(Span::styled(line.to_string(), Style::default().fg(THEME.load().muted))))
             .collect()
     } else {
-        let rendered_rows = render_help_find_rows(&rows, state, chunks[1].width as usize);
+        let rendered_rows = render_help_find_rows(&rows, state, results.width as usize);
         let row_heights = rendered_rows.iter().map(Vec::len).collect::<Vec<_>>();
         let start = synaps_cli::help::visible_help_find_window(
             &row_heights,
@@ -126,12 +124,12 @@ pub(crate) fn render(frame: &mut Frame, area: Rect, state: &mut synaps_cli::help
             .flatten()
             .collect()
     };
-    frame.render_widget(Paragraph::new(lines), chunks[1]);
+    frame.render_widget(Paragraph::new(lines), results);
 
     let footer = format!("{} result{}  ↑↓ move  Enter details  type filter  Esc close", result_count, if result_count == 1 { "" } else { "s" });
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(footer, Style::default().fg(THEME.load().muted)))),
-        chunks[2],
+        status_bar,
     );
 }
 

--- a/crates/agent-tui/src/tui/models/mod.rs
+++ b/crates/agent-tui/src/tui/models/mod.rs
@@ -52,7 +52,7 @@ fn dev_model_providers() -> Vec<DevProviderSelection> {
 
 use ratatui::{
     buffer::Buffer,
-    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    layout::{Alignment, Constraint, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Padding, Paragraph, Widget},
@@ -608,37 +608,35 @@ impl Widget for ModelsModalWidget<'_> {
             ModelsView::Favorites => "✦ All  [★ Favorites]",
         };
 
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(1),
-                Constraint::Length(1),
-                Constraint::Length(1),
-                Constraint::Min(1),
-                Constraint::Length(1),
-            ])
-            .split(inner);
+        let [title, search_bar, view_bar, list_area, footer] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .areas(inner);
 
         Paragraph::new(Line::from(vec![
             Span::styled("◇ Switch model", Style::default().fg(theme.header_fg).add_modifier(Modifier::BOLD)),
             Span::styled(format!(" · {model_count} available · {favorite_count} ★ favorites"), Style::default().fg(theme.muted)),
         ]))
-        .render(chunks[0], buf);
+        .render(title, buf);
 
         Paragraph::new(Line::from(vec![
             Span::styled("Search: ", Style::default().fg(theme.muted)),
             Span::styled(if self.state.search.is_empty() { "▎".to_string() } else { format!("{}▎", self.state.search) }, Style::default().fg(theme.header_fg)),
         ]))
-        .render(chunks[1], buf);
+        .render(search_bar, buf);
 
         Paragraph::new(Line::from(vec![
             Span::styled("View:   ", Style::default().fg(theme.muted)),
             Span::styled(view, Style::default().fg(theme.help_fg)),
             Span::styled(format!("   current: {}", self.current_model), Style::default().fg(theme.muted)),
         ]))
-        .render(chunks[2], buf);
+        .render(view_bar, buf);
 
-        let list_height = chunks[3].height as usize;
+        let list_height = list_area.height as usize;
         let offset = self.state.cursor.saturating_sub(list_height.saturating_sub(1));
         let lines: Vec<Line> = rows
             .iter()
@@ -697,12 +695,12 @@ impl Widget for ModelsModalWidget<'_> {
         } else {
             lines
         };
-        Paragraph::new(list).render(chunks[3], buf);
+        Paragraph::new(list).render(list_area, buf);
 
         Paragraph::new("↑/↓ select • Enter use • f favorite • e expand • Tab view • c collapse • Esc close")
             .style(Style::default().fg(theme.muted))
             .alignment(Alignment::Center)
-            .render(chunks[4], buf);
+            .render(footer, buf);
 
         if let Some(expanded) = self.state.expanded.as_ref() {
             render_expanded_lightbox(area, buf, self.state, expanded);
@@ -737,22 +735,20 @@ fn render_expanded_lightbox(area: Rect, buf: &mut Buffer, state: &ModelsModalSta
     let inner = block.inner(popup);
     block.render(popup, buf);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1),
-            Constraint::Min(1),
-            Constraint::Length(1),
-        ])
-        .split(inner);
+    let [search_bar, list, footer] = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .areas(inner);
 
     Paragraph::new(Line::from(vec![
         Span::styled("Search: ", Style::default().fg(theme.muted)),
         Span::styled(if expanded.search.is_empty() { "▎".to_string() } else { format!("{}▎", expanded.search) }, Style::default().fg(theme.header_fg)),
     ]))
-    .render(chunks[0], buf);
+    .render(search_bar, buf);
 
-    let list_height = chunks[1].height as usize;
+    let list_height = list.height as usize;
     let visible = expanded_visible_models(state);
     let offset = expanded.cursor.saturating_sub(list_height.saturating_sub(1));
     let lines = match &expanded.load_state {
@@ -784,12 +780,12 @@ fn render_expanded_lightbox(area: Rect, buf: &mut Buffer, state: &ModelsModalSta
             })
             .collect(),
     };
-    Paragraph::new(lines).render(chunks[1], buf);
+    Paragraph::new(lines).render(list, buf);
 
     Paragraph::new("type to fuzzy-search • ↑/↓ select • Enter use • f favorite • Esc back")
         .style(Style::default().fg(theme.muted))
         .alignment(Alignment::Center)
-        .render(chunks[2], buf);
+        .render(footer, buf);
 }
 
 #[cfg(test)]

--- a/crates/agent-tui/src/tui/plugins/draw.rs
+++ b/crates/agent-tui/src/tui/plugins/draw.rs
@@ -1,5 +1,5 @@
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, Gauge, Paragraph, Wrap};
@@ -65,18 +65,14 @@ pub(crate) fn render(frame: &mut Frame, area: Rect, state: &PluginsModalState) {
     let inner = block.inner(modal);
     frame.render_widget(block, modal);
 
-    let outer = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(1)])
-        .split(inner);
-    let panes = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(20), Constraint::Min(1)])
-        .split(outer[0]);
+    let [content, footer_bar] = Layout::vertical([Constraint::Min(1), Constraint::Length(1)])
+        .areas(inner);
+    let [sidebar, main] = Layout::horizontal([Constraint::Length(20), Constraint::Min(1)])
+        .areas(content);
 
-    render_left(frame, panes[0], state);
-    render_right(frame, panes[1], state);
-    render_footer(frame, outer[1], state);
+    render_left(frame, sidebar, state);
+    render_right(frame, main, state);
+    render_footer(frame, footer_bar, state);
 }
 
 fn render_left(frame: &mut Frame, area: Rect, state: &PluginsModalState) {
@@ -524,16 +520,14 @@ fn render_installing(frame: &mut Frame, area: Rect, progress: &InstallProgressHa
     let height = (needed as u16).max(OVERLAY_HEIGHT).min(area.height.max(1));
     let inner = centered_overlay_with_height(frame, area, " Installing ", height);
 
-    let layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // title
-            Constraint::Length(1), // blank
-            Constraint::Length(1), // gauge
-            Constraint::Length(1), // status line
-            Constraint::Min(0),    // error / spacer
-        ])
-        .split(inner);
+    let [title_row, _blank, gauge_row, status_row, error_row] = Layout::vertical([
+        Constraint::Length(1), // title
+        Constraint::Length(1), // blank
+        Constraint::Length(1), // gauge
+        Constraint::Length(1), // status line
+        Constraint::Min(0),    // error / spacer
+    ])
+    .areas(inner);
 
     let spinner_ch = SPINNER_FRAMES[spinner_frame % SPINNER_FRAMES.len()];
     let title_line = Line::from(vec![
@@ -552,7 +546,7 @@ fn render_installing(frame: &mut Frame, area: Rect, progress: &InstallProgressHa
             Style::default().fg(THEME.load().help_fg),
         ),
     ]);
-    frame.render_widget(Paragraph::new(title_line), layout[0]);
+    frame.render_widget(Paragraph::new(title_line), title_row);
 
     // Gauge — show indeterminate spinner-style fill while connecting,
     // real percentage once we have one.
@@ -578,7 +572,7 @@ fn render_installing(frame: &mut Frame, area: Rect, progress: &InstallProgressHa
         )
         .ratio(pct_ratio)
         .label(gauge_label);
-    frame.render_widget(gauge, layout[2]);
+    frame.render_widget(gauge, gauge_row);
 
     // Status line: phase label + throughput
     let mut status_spans = vec![Span::styled(
@@ -591,7 +585,7 @@ fn render_installing(frame: &mut Frame, area: Rect, progress: &InstallProgressHa
             Style::default().fg(THEME.load().help_fg),
         ));
     }
-    frame.render_widget(Paragraph::new(Line::from(status_spans)), layout[3]);
+    frame.render_widget(Paragraph::new(Line::from(status_spans)), status_row);
 
     if has_error {
         if let Some(msg) = last_raw {
@@ -601,7 +595,7 @@ fn render_installing(frame: &mut Frame, area: Rect, progress: &InstallProgressHa
                     Style::default().fg(THEME.load().error_color),
                 )))
                 .wrap(Wrap { trim: false }),
-                layout[4],
+                error_row,
             );
         }
     }

--- a/crates/agent-tui/src/tui/settings/draw.rs
+++ b/crates/agent-tui/src/tui/settings/draw.rs
@@ -1,5 +1,5 @@
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::Style;
 use ratatui::widgets::{Block, Borders, BorderType, Clear, Paragraph};
 use super::{SettingsState, Focus, RuntimeSnapshot, ActiveEditor};
@@ -28,21 +28,17 @@ pub(crate) fn render(
     let inner = block.inner(modal);
     frame.render_widget(block, modal);
 
-    let outer = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(1)])
-        .split(inner);
-    let panes = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(20), Constraint::Min(1)])
-        .split(outer[0]);
+    let [content, footer_bar] = Layout::vertical([Constraint::Min(1), Constraint::Length(1)])
+        .areas(inner);
+    let [sidebar, main] = Layout::horizontal([Constraint::Length(20), Constraint::Min(1)])
+        .areas(content);
 
-    render_categories(frame, panes[0], state, snap);
-    render_settings(frame, panes[1], state, snap);
-    render_footer(frame, outer[1], state, snap);
+    render_categories(frame, sidebar, state, snap);
+    render_settings(frame, main, state, snap);
+    render_footer(frame, footer_bar, state, snap);
 
     if let Some(ActiveEditor::PluginCustom { render, .. }) = &state.edit_mode {
-        render_plugin_custom_editor(frame, panes[1], render);
+        render_plugin_custom_editor(frame, main, render);
     }
 }
 
@@ -465,11 +461,9 @@ fn render_plugin_custom_editor(
     frame.render_widget(block, rect);
 
     let (list_area, footer_area) = if footer_lines > 0 {
-        let split = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Min(1), Constraint::Length(footer_lines)])
-            .split(inner);
-        (split[0], Some(split[1]))
+        let [body, foot] = Layout::vertical([Constraint::Min(1), Constraint::Length(footer_lines)])
+            .areas(inner);
+        (body, Some(foot))
     } else {
         (inner, None)
     };

--- a/src/bin/hidden/ui/mod.rs
+++ b/src/bin/hidden/ui/mod.rs
@@ -19,34 +19,32 @@ use crate::app::App;
 
 pub fn draw(f: &mut Frame, app: &App) {
     use crate::app::Screen;
-    use ratatui::layout::{Layout, Constraint, Direction};
+    use ratatui::layout::{Layout, Constraint};
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Min(1),     // main area
-            Constraint::Length(3),  // HUD
-        ])
-        .split(f.area());
+    let [main_area, hud_area] = Layout::vertical([
+        Constraint::Min(1),     // main area
+        Constraint::Length(3),  // HUD
+    ])
+    .areas(f.area());
 
     // Main content
     match &app.screen {
-        Screen::Boot => boot::draw_boot(f, app, chunks[0]),
-        Screen::Hub => hub::draw_hub(f, app, chunks[0]),
-        Screen::Blackjack => blackjack_ui::draw_blackjack(f, app, &app.blackjack, chunks[0]),
-        Screen::Slots => slots_ui::draw_slots(f, app, &app.slots, chunks[0]),
-        Screen::Roulette => roulette_ui::draw_roulette(f, app, &app.roulette, chunks[0]),
-        Screen::War => war_ui::draw_war(f, app, &app.war, chunks[0]),
-        Screen::Baccarat => baccarat_ui::draw_baccarat(f, app, &app.baccarat, chunks[0]),
-        Screen::VideoPoker => video_poker_ui::draw_video_poker(f, app, &app.video_poker, chunks[0]),
-        Screen::Keno => keno_ui::draw_keno(f, app, &app.keno, chunks[0]),
-        Screen::SicBo => sicbo_ui::draw_sicbo(f, app, &app.sicbo, chunks[0]),
-        Screen::Craps => craps_ui::draw_craps(f, app, &app.craps, chunks[0]),
-        Screen::GameOver => draw_game_over(f, app, chunks[0]),
+        Screen::Boot => boot::draw_boot(f, app, main_area),
+        Screen::Hub => hub::draw_hub(f, app, main_area),
+        Screen::Blackjack => blackjack_ui::draw_blackjack(f, app, &app.blackjack, main_area),
+        Screen::Slots => slots_ui::draw_slots(f, app, &app.slots, main_area),
+        Screen::Roulette => roulette_ui::draw_roulette(f, app, &app.roulette, main_area),
+        Screen::War => war_ui::draw_war(f, app, &app.war, main_area),
+        Screen::Baccarat => baccarat_ui::draw_baccarat(f, app, &app.baccarat, main_area),
+        Screen::VideoPoker => video_poker_ui::draw_video_poker(f, app, &app.video_poker, main_area),
+        Screen::Keno => keno_ui::draw_keno(f, app, &app.keno, main_area),
+        Screen::SicBo => sicbo_ui::draw_sicbo(f, app, &app.sicbo, main_area),
+        Screen::Craps => craps_ui::draw_craps(f, app, &app.craps, main_area),
+        Screen::GameOver => draw_game_over(f, app, main_area),
     }
 
     // HUD (always visible)
-    hud::draw_hud(f, app, chunks[1]);
+    hud::draw_hud(f, app, hud_area);
 
     // ── CRT OVERLAY (always on) ─────────────────────────────────────
     draw_crt_overlay(f, app);


### PR DESCRIPTION
## What

Migrates every ratatui layout split in the TUI from the legacy `.split()` idiom to the typed-array `.areas()` form.

**Before** — `Rc<[Rect]>` indexed by raw number:
```rust
let outer = Layout::default()
    .direction(Direction::Vertical)
    .constraints([Constraint::Min(1), Constraint::Length(1)])
    .split(inner);
// downstream: outer[0], outer[1]  ← position→meaning lives nowhere
```

**After** — `[Rect; N]` destructured into named bindings:
```rust
let [body, footer] = Layout::vertical([
    Constraint::Min(1),
    Constraint::Length(1),
]).areas(inner);
// downstream: body, footer
```

## Why

- **Kills a runtime-panic class.** `outer[3]` on a 2-pane layout compiles fine and panics at runtime. `.areas()` count-mismatch is a *compile* error — N is checked.
- **Removes the drift footgun.** Reorder a constraint array and every `[n]` site silently points at the wrong rect. Named bindings can't drift.
- **Self-documenting.** Panes are named at the bind site (`header_area`, `body`, `sidebar`, `main`, `footer`…) instead of tribal-knowledge indices.
- **Drops the `Rc` allocation** per split.

## Scope

- **12 layout sites across 6 files**, 40 numeric-index accesses removed (net −24 lines).
- Includes **3 nested splits** (inner split consumes a named pane from the outer).
- Two name conflicts resolved by suffixing the area (`list_area`, `header_area`) to avoid shadowing existing widget/`Vec<Line>` bindings.
- Removed 5 now-unused `Direction` imports.

ratatui is already on 0.30.2 — **no dependency change**; this is the API-migration half of #108 (the version bump was already done).

## Verification

- ✅ `cargo build` clean
- ✅ `cargo test -p agent-tui` → **250/250 pass**
- ✅ `cargo clippy -p agent-tui` clean
- ✅ **All 12 sites rendered correct live** across both binaries — main TUI, `/models`, `/settings`, `/plugins`, `/help find`, and GamblersDen (`hidden`).

Refs #108