### PR TITLE
refactor(tui): extract 6-pane app layout into AppAreas, kill duplicated height math

### DIFF
--- a/crates/agent-tui/src/tui/draw.rs
+++ b/crates/agent-tui/src/tui/draw.rs
@@ -9,6 +9,41 @@ use ratatui::{
 use std::io;
 use tachyonfx::{fx, Effect, Interpolation};
 
+/// The six named panes that make up the outer app layout.
+///
+/// Single source of truth for the header/body/subagent/download/input/footer
+/// split — use [`AppAreas::from_heights`] instead of inlining the constraints.
+pub(crate) struct AppAreas {
+    pub header: ratatui::layout::Rect,
+    pub body: ratatui::layout::Rect,
+    pub subagent: ratatui::layout::Rect,
+    pub download: ratatui::layout::Rect,
+    pub input: ratatui::layout::Rect,
+    pub footer: ratatui::layout::Rect,
+}
+
+impl AppAreas {
+    /// Split `area` into the 6 app panes given the runtime-computed heights.
+    /// Single source of truth for the outer layout (header/body/subagent/download/input/footer).
+    pub(crate) fn from_heights(
+        area: ratatui::layout::Rect,
+        subagent_height: u16,
+        download_height: u16,
+        input_height: u16,
+    ) -> Self {
+        let [header, body, subagent, download, input, footer] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(subagent_height),
+            Constraint::Length(download_height),
+            Constraint::Length(input_height),
+            Constraint::Length(1),
+        ])
+        .areas(area);
+        Self { header, body, subagent, download, input, footer }
+    }
+}
+
 /// Build a single sidecar pill segment for one `SidecarUiState`.
 #[allow(dead_code)] // used in tests
 fn sidecar_pill_segment(
@@ -468,22 +503,11 @@ pub(crate) fn build_render_model(
         .saturating_add(input_height)
         .saturating_add(1); // footer
 
-    // Replicate the outer layout to find msg_area deterministically.
-    // header(1) + messages(min 1) + subagents + download + input + footer(1).
-    let msg_area_height = term_size
-        .height
-        .saturating_sub(1) // header
-        .saturating_sub(subagent_height)
-        .saturating_sub(download_height)
-        .saturating_sub(input_height)
-        .saturating_sub(1) // footer
-        .max(1);
-    let msg_area = ratatui::layout::Rect {
-        x: 0,
-        y: 1,
-        width: term_size.width,
-        height: msg_area_height,
-    };
+    // Use AppAreas to derive msg_area — single source of truth for the outer layout.
+    // body sits at y=1 (after the 1-line header) with Min(1) height matching the
+    // old saturating_sub chain + .max(1), so the resulting Rect is identical.
+    let area = ratatui::layout::Rect { x: 0, y: 0, width: term_size.width, height: term_size.height };
+    let msg_area = AppAreas::from_heights(area, subagent_height, download_height, input_height).body;
     let content_height = msg_area.height.saturating_sub(2) as usize;
     let content_width = msg_area.width.saturating_sub(2) as usize;
 
@@ -813,15 +837,14 @@ pub(crate) fn render_frame(
         let input_height = input_lines.min(max_input_lines) + 2;
         let download_height: u16 = if !model.active_tasks.is_empty() { 1 } else { 0 };
 
-        let [header_area, body, subagent_area, download_area, input_area, footer_area] = Layout::vertical([
-            Constraint::Length(1),
-            Constraint::Min(1),
-            Constraint::Length(subagent_height),
-            Constraint::Length(download_height),
-            Constraint::Length(input_height),
-            Constraint::Length(1),
-        ])
-        .areas(frame.area());
+        let AppAreas {
+            header: header_area,
+            body,
+            subagent: subagent_area,
+            download: download_area,
+            input: input_area,
+            footer: footer_area,
+        } = AppAreas::from_heights(frame.area(), subagent_height, download_height, input_height);
 
         // ── Header ────────────────────────────────────────────────────────────
         let spinner_idx = (model.spinner_frame / 3) % SPINNER_FRAMES.len();


### PR DESCRIPTION
## What

Applies ratatui maintainer **@joshka's** suggested pattern for layouts whose pane sizes are computed at runtime — the exact case `ratatui-derive`'s `FromRect` *can't* express (its generated `From<Rect>` takes only the rect, with no slot for runtime values).

Introduces `AppAreas` + `AppAreas::from_heights(area, subagent_h, download_h, input_h)`: a single named-field layout function that splits the main TUI area into `header / body / subagent / download / input / footer`. It's the hand-written equivalent of a `FromRect` impl, but flexible enough to take the runtime heights.

```rust
pub(crate) struct AppAreas {
    pub header: Rect, pub body: Rect, pub subagent: Rect,
    pub download: Rect, pub input: Rect, pub footer: Rect,
}
impl AppAreas {
    pub(crate) fn from_heights(area: Rect, subagent_height: u16, download_height: u16, input_height: u16) -> Self { ... }
}
```

## Why — two wins

1. **Named panes for the most complex layout (6 panes).** No more positional coupling between the constraint array and downstream usage — the win we got everywhere else in the `.areas()` migration, now extended to the one layout that couldn't use a derive macro.

2. **Kills duplicated layout math.** The body/message-area height was computed in **two** places that had to stay in sync:
   - `build_render_model()` hand-replicated the outer layout to derive `msg_area` — the code literally carried a `// Replicate the outer layout` comment.
   - the render closure recomputed the same constraints for the real split.

   Both now call `AppAreas::from_heights()` and the body rect is derived from the **exact same `Layout`** → they can no longer drift.

## Equivalence (the careful bit)

`Layout::vertical` with `Constraint::Min(1)` on a `Rect{0,0,W,H}` places `body` at `{0, 1, W, max(H-1-sub-dl-input-1, 1)}` — identical to the previous `saturating_sub` chain + `.max(1)`. **No height-computation logic changed** — only the split mechanism and how `msg_area` is obtained.

## Verification

- ✅ `cargo build` clean · `cargo test -p synaps-tui` **250/250** · clippy clean
- ✅ **Live-proven**: typed a wrapping line → `input_height` grew 1→4 lines → whole layout reflowed correctly (body shrank, footer stayed pinned) → shrank back on clear.

## Context

Born from a Discord exchange with @joshka about `ratatui-derive`. `FromRect` is great for static layouts (verified separately), but synaps's main layout has runtime-computed heights it can't represent. Joshka's recommendation was exactly this: *"do something like `fn layout(&self) -> AppAreas` and push the height calculations into a method that does that one thing."*

Refs #108