### PR TITLE
test(auth): regression coverage for login --provider credential wipe (#159)

### DIFF
--- a/crates/agent-core/src/core/auth/storage.rs
+++ b/crates/agent-core/src/core/auth/storage.rs
@@ -240,4 +240,192 @@ mod tests {
         assert!(parsed.is_object());
         assert!(parsed.get("openai-codex").is_some());
     }
+
+    // ── Bug #159 regression suite ────────────────────────────────────────────
+    //
+    // Repro: `synaps login --provider openai-codex` (saves "openai-codex"),
+    // then `synaps login` (Anthropic OAuth, saves "anthropic") → the first
+    // provider's credential was wiped because save_auth() rebuilt AuthFile
+    // with only the new entry and did a whole-file overwrite.
+    //
+    // Root cause (pre-fix): src/core/auth/storage.rs @ 90f8f71 — save_auth()
+    // constructed `AuthFile { anthropic: creds }` (no read of existing file)
+    // then called `fs::write(path, json)`, discarding every other provider.
+    //
+    // All three multi-provider tests below would FAIL against that code.
+
+    /// Primary repro (bug #159): save openai-codex, then save anthropic via
+    /// the same write path `synaps login` (Anthropic OAuth) takes.
+    /// openai-codex MUST survive the second login.
+    #[test]
+    fn bug159_anthropic_login_preserves_existing_openai_codex() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("auth.json");
+
+        // Step 1: user runs `synaps login --provider openai-codex`
+        let codex_creds = OAuthCredentials {
+            auth_type: "oauth".to_string(),
+            refresh: "codex-refresh".to_string(),
+            access: "codex-access".to_string(),
+            expires: 9_999_999_999_000,
+            account_id: Some("acct_codex_123".to_string()),
+        };
+        save_provider_auth_at(&path, "openai-codex", &codex_creds)
+            .expect("save openai-codex");
+
+        // Step 2: user then runs `synaps login` (Anthropic Claude OAuth)
+        let anthropic_creds = OAuthCredentials {
+            auth_type: "oauth".to_string(),
+            refresh: "anth-refresh".to_string(),
+            access: "anth-access".to_string(),
+            expires: 9_999_999_999_000,
+            account_id: None,
+        };
+        save_provider_auth_at(&path, "anthropic", &anthropic_creds)
+            .expect("save anthropic");
+
+        // Both providers must be present — bug #159 would wipe openai-codex here
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        assert!(
+            parsed.get("anthropic").is_some(),
+            "anthropic credential must be present after login"
+        );
+        assert!(
+            parsed.get("openai-codex").is_some(),
+            "bug #159: openai-codex credential must NOT be wiped when logging in as anthropic"
+        );
+        assert_eq!(
+            parsed["openai-codex"]["refresh"].as_str(),
+            Some("codex-refresh"),
+            "openai-codex refresh token must be unchanged"
+        );
+        assert_eq!(
+            parsed["anthropic"]["refresh"].as_str(),
+            Some("anth-refresh"),
+            "anthropic refresh token must be correctly saved"
+        );
+    }
+
+    /// Reverse of primary repro: anthropic first, then openai-codex login.
+    /// anthropic MUST survive.
+    #[test]
+    fn bug159_openai_codex_login_preserves_existing_anthropic() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("auth.json");
+
+        // Step 1: anthropic already logged in
+        let anthropic_creds = OAuthCredentials {
+            auth_type: "oauth".to_string(),
+            refresh: "anth-refresh-first".to_string(),
+            access: "anth-access-first".to_string(),
+            expires: 9_999_999_999_000,
+            account_id: None,
+        };
+        save_provider_auth_at(&path, "anthropic", &anthropic_creds)
+            .expect("save anthropic");
+
+        // Step 2: user runs `synaps login --provider openai-codex`
+        let codex_creds = OAuthCredentials {
+            auth_type: "oauth".to_string(),
+            refresh: "codex-refresh-second".to_string(),
+            access: "codex-access-second".to_string(),
+            expires: 9_999_999_999_000,
+            account_id: Some("acct_456".to_string()),
+        };
+        save_provider_auth_at(&path, "openai-codex", &codex_creds)
+            .expect("save openai-codex");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        assert!(
+            parsed.get("anthropic").is_some(),
+            "anthropic credential must survive openai-codex login"
+        );
+        assert!(
+            parsed.get("openai-codex").is_some(),
+            "openai-codex credential must be present"
+        );
+        assert_eq!(
+            parsed["anthropic"]["refresh"].as_str(),
+            Some("anth-refresh-first"),
+            "anthropic refresh token must be unchanged"
+        );
+    }
+
+    /// Three-provider scenario: saving a third provider preserves the first two.
+    /// Guards against regressions if/when more OAuth providers are added.
+    #[test]
+    fn bug159_third_provider_login_preserves_both_existing_providers() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("auth.json");
+
+        save_provider_auth_at(&path, "anthropic", &OAuthCredentials {
+            auth_type: "oauth".to_string(),
+            refresh: "anth-r".to_string(),
+            access: "anth-a".to_string(),
+            expires: 1,
+            account_id: None,
+        }).expect("save anthropic");
+
+        save_provider_auth_at(&path, "openai-codex", &OAuthCredentials {
+            auth_type: "oauth".to_string(),
+            refresh: "codex-r".to_string(),
+            access: "codex-a".to_string(),
+            expires: 1,
+            account_id: Some("acct_codex".to_string()),
+        }).expect("save openai-codex");
+
+        save_provider_auth_at(&path, "future-provider", &OAuthCredentials {
+            auth_type: "oauth".to_string(),
+            refresh: "future-r".to_string(),
+            access: "future-a".to_string(),
+            expires: 1,
+            account_id: None,
+        }).expect("save future-provider");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+        assert!(parsed.get("anthropic").is_some(), "anthropic must survive");
+        assert!(parsed.get("openai-codex").is_some(), "openai-codex must survive");
+        assert!(parsed.get("future-provider").is_some(), "future-provider must be present");
+    }
+
+    /// Upsert: saving the same provider twice updates the credential in place
+    /// without duplicating or corrupting the entry.
+    #[test]
+    fn bug159_same_provider_login_upserts_in_place() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("auth.json");
+
+        save_provider_auth_at(&path, "anthropic", &OAuthCredentials {
+            auth_type: "oauth".to_string(),
+            refresh: "old-refresh".to_string(),
+            access: "old-access".to_string(),
+            expires: 1,
+            account_id: None,
+        }).expect("initial save");
+
+        save_provider_auth_at(&path, "anthropic", &OAuthCredentials {
+            auth_type: "oauth".to_string(),
+            refresh: "new-refresh".to_string(),
+            access: "new-access".to_string(),
+            expires: 2,
+            account_id: None,
+        }).expect("upsert save");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let obj = parsed.as_object().unwrap();
+
+        assert_eq!(obj.len(), 1, "only one anthropic entry — no duplicates");
+        assert_eq!(
+            parsed["anthropic"]["refresh"].as_str(),
+            Some("new-refresh"),
+            "credential must be updated to latest value"
+        );
+    }
 }


### PR DESCRIPTION
Bug #159 (login --provider wipes other providers) was fixed incidentally by the agent-core extraction refactor — but the exact repro ordering was never covered. Adds 4 regression tests (codex→anthropic, anthropic→codex, third-provider preservation, same-key upsert). RED verified against the pre-refactor buggy save_auth (whole-file overwrite @ 90f8f71).

Follow-up filed separately: ensure_fresh_token still writes a hardcoded 2-field AuthFile — a third provider would be dropped on token refresh.