### PR TITLE
fix(runtime): retain extension secret across restart + short RPC socket

### DIFF
--- a/crates/agent-engine/src/events/registry.rs
+++ b/crates/agent-engine/src/events/registry.rs
@@ -13,9 +13,16 @@ pub struct SessionRegistration {
     pub started_at: DateTime<Utc>,
 }
 
-/// Returns `~/.synaps-cli/run/`, creating it (mode 0700) if it doesn't exist.
+/// Returns the session runtime directory, creating it mode 0700 if needed.
+///
+/// `SYNAPS_RUNTIME_DIR` deliberately controls only ephemeral Unix sockets and
+/// registration files. Persistent state and plugin discovery remain rooted at
+/// `SYNAPS_BASE_DIR`; this avoids the 108-byte `sun_path` limit when the base
+/// directory is an EFS session path.
 pub fn registry_dir() -> PathBuf {
-    let dir = base_dir().join("run");
+    let dir = std::env::var_os("SYNAPS_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| base_dir().join("run"));
     if let Err(e) = std::fs::create_dir_all(&dir) {
         tracing::warn!("registry: failed to create run dir {:?}: {}", dir, e);
     }
@@ -44,8 +51,12 @@ pub fn sanitize_session_id(raw: &str) -> String {
 /// Sockets live in the registry dir (~/.synaps-cli/run/) which is user-owned
 /// and mode 0700, avoiding /tmp symlink squatting and TOCTOU races.
 pub fn socket_path_for_session(session_id: &str) -> String {
+    socket_path_in_dir(&registry_dir(), session_id)
+}
+
+fn socket_path_in_dir(dir: &std::path::Path, session_id: &str) -> String {
     let safe_id = sanitize_session_id(session_id);
-    registry_dir().join(format!("{}.sock", safe_id))
+    dir.join(format!("{}.sock", safe_id))
         .to_string_lossy()
         .into_owned()
 }
@@ -328,6 +339,25 @@ mod tests {
         // Sockets now live in the registry dir, not /tmp
         assert!(path.ends_with("/run/20240101-120000-ab12.sock"), "got: {}", path);
         assert!(!path.contains("/tmp/"), "socket should not be in /tmp");
+    }
+
+    // Regression: an EFS-backed SYNAPS_BASE_DIR can exceed Linux's 108-byte
+    // sockaddr_un.sun_path limit. Runtime sockets must be independently rooted.
+    #[test]
+    fn short_runtime_dirs_keep_long_session_socket_bindable_and_isolated() {
+        use std::os::unix::net::UnixListener;
+        let long_session = "s".repeat(80);
+        // These model deterministic per-UID runtime roots created by guest-agent.
+        let path_a = socket_path_in_dir(std::path::Path::new("/tmp/a"), &long_session);
+        let path_b = socket_path_in_dir(std::path::Path::new("/tmp/b"), &long_session);
+        assert!(path_a.len() < 108, "Unix socket path too long: {path_a}");
+        assert_ne!(path_a, path_b, "per-user runtime roots must isolate same session ids");
+
+        let root = tempfile::tempdir().unwrap();
+        let a = root.path().join("a"); let b = root.path().join("b");
+        std::fs::create_dir_all(&a).unwrap(); std::fs::create_dir_all(&b).unwrap();
+        let _a = UnixListener::bind(socket_path_in_dir(&a, &long_session)).unwrap();
+        let _b = UnixListener::bind(socket_path_in_dir(&b, &long_session)).unwrap();
     }
 
     #[cfg(unix)]

--- a/crates/agent-engine/src/events/registry.rs
+++ b/crates/agent-engine/src/events/registry.rs
@@ -48,8 +48,10 @@ pub fn sanitize_session_id(raw: &str) -> String {
 }
 
 /// Returns the Unix domain socket path for a session.
-/// Sockets live in the registry dir (~/.synaps-cli/run/) which is user-owned
-/// and mode 0700, avoiding /tmp symlink squatting and TOCTOU races.
+/// Sockets live in the registry dir — `$SYNAPS_RUNTIME_DIR` when set (e.g.
+/// `/run/user/<uid>/synaps`), otherwise `$SYNAPS_BASE_DIR/run` (default
+/// `~/.synaps-cli/run/`) — which is user-owned and mode 0700, avoiding /tmp
+/// symlink squatting and TOCTOU races.
 pub fn socket_path_for_session(session_id: &str) -> String {
     socket_path_in_dir(&registry_dir(), session_id)
 }
@@ -343,6 +345,7 @@ mod tests {
 
     // Regression: an EFS-backed SYNAPS_BASE_DIR can exceed Linux's 108-byte
     // sockaddr_un.sun_path limit. Runtime sockets must be independently rooted.
+    #[cfg(unix)]
     #[test]
     fn short_runtime_dirs_keep_long_session_socket_bindable_and_isolated() {
         use std::os::unix::net::UnixListener;
@@ -353,11 +356,20 @@ mod tests {
         assert!(path_a.len() < 108, "Unix socket path too long: {path_a}");
         assert_ne!(path_a, path_b, "per-user runtime roots must isolate same session ids");
 
-        let root = tempfile::tempdir().unwrap();
-        let a = root.path().join("a"); let b = root.path().join("b");
-        std::fs::create_dir_all(&a).unwrap(); std::fs::create_dir_all(&b).unwrap();
+        // Bind under SHORT, /tmp-rooted dirs. The whole point is short socket
+        // paths; some platforms' tempdir() (e.g. macOS /var/folders/...) is long
+        // enough to blow the sun_path limit and flake this exact assertion, so we
+        // control the root length explicitly. Two sibling dirs model two per-uid
+        // runtime roots.
+        let pid = std::process::id();
+        let a = std::path::PathBuf::from(format!("/tmp/sa{pid}"));
+        let b = std::path::PathBuf::from(format!("/tmp/sb{pid}"));
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
         let _a = UnixListener::bind(socket_path_in_dir(&a, &long_session)).unwrap();
         let _b = UnixListener::bind(socket_path_in_dir(&b, &long_session)).unwrap();
+        let _ = std::fs::remove_dir_all(&a);
+        let _ = std::fs::remove_dir_all(&b);
     }
 
     #[cfg(unix)]

--- a/crates/agent-engine/src/extensions/runtime/process.rs
+++ b/crates/agent-engine/src/extensions/runtime/process.rs
@@ -574,6 +574,10 @@ pub struct ProcessExtension {
     call_lock: Arc<Mutex<()>>,
     next_id: AtomicU64,
     restart_count: AtomicUsize,
+    /// Last resolved initialize config. Kept in memory only so a restarted
+    /// extension receives the same manifest-resolved values (including secrets).
+    /// Never written to disk or emitted in logs.
+    initialize_config: Mutex<Value>,
     /// Lifetime restart total — never reset. `restart_count` tracks
     /// *consecutive* failures (reset on successful restart, H-8) for the
     /// exhaustion budget; this one feeds health/reporting so a previously
@@ -614,6 +618,7 @@ impl ProcessExtension {
             call_lock: Arc::new(Mutex::new(())),
             next_id: AtomicU64::new(1),
             restart_count: AtomicUsize::new(0),
+            initialize_config: Mutex::new(Value::Object(Default::default())),
             total_restarts: AtomicUsize::new(0),
             restart_policy: RestartPolicy::default(),
             inbox,
@@ -1132,6 +1137,9 @@ impl ProcessExtension {
         plugin_root: Option<PathBuf>,
         config: Value,
     ) -> Result<InitializeCapabilitiesResult, String> {
+        // Retain only in memory: restart handshakes must receive the same
+        // resolved config, while secrets never enter env, logs, or storage.
+        *self.initialize_config.lock().await = config.clone();
         let params = InitializeParams {
             synaps_version: env!("CARGO_PKG_VERSION"),
             extension_protocol_version: CURRENT_EXTENSION_PROTOCOL_VERSION,
@@ -1397,6 +1405,7 @@ impl ProcessExtension {
     }
 
     async fn initialize_locked(&self, state: &mut Option<ProcessState>) -> Result<(), String> {
+        let config = self.initialize_config.lock().await.clone();
         let params = InitializeParams {
             synaps_version: env!("CARGO_PKG_VERSION"),
             extension_protocol_version: CURRENT_EXTENSION_PROTOCOL_VERSION,
@@ -1405,7 +1414,7 @@ impl ProcessExtension {
                 .cwd
                 .clone()
                 .map(|path| path.to_string_lossy().to_string()),
-            config: Value::Object(Default::default()),
+            config,
         };
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let value = tokio::time::timeout(

--- a/tests/extensions_e2e.rs
+++ b/tests/extensions_e2e.rs
@@ -637,6 +637,36 @@ async fn extension_missing_required_config_fails_before_spawn() {
 
 
 #[tokio::test(flavor = "current_thread")]
+async fn declared_secret_env_survives_extension_restart_without_persistence() {
+    let _guard = BASE_DIR_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tempfile::tempdir().unwrap();
+    config::set_base_dir_for_tests(home.path().to_path_buf());
+    std::env::set_var("PRIA_AGENT_TOOL_TOKEN", "regression-secret-token");
+
+    let fixture = std::env::current_dir().unwrap()
+        .join("tests/fixtures/config_seen_extension.py").to_string_lossy().to_string();
+    let plugin_dir = tempfile::tempdir().unwrap();
+    let mut manager = ExtensionManager::new(Arc::new(HookBus::new()));
+    let manifest = synaps_cli::extensions::manifest::ExtensionManifest {
+        theme_tokens: Default::default(), protocol_version: synaps_cli::extensions::manifest::CURRENT_EXTENSION_PROTOCOL_VERSION,
+        runtime: synaps_cli::extensions::manifest::ExtensionRuntime::Process, command: "python3".to_string(), setup: None,
+        prebuilt: ::std::collections::HashMap::new(), args: vec![fixture, "--exit-on-hook-once".to_string()],
+        permissions: vec!["tools.intercept".to_string()],
+        hooks: vec![synaps_cli::extensions::manifest::HookSubscription { hook: "before_tool_call".to_string(), tool: Some("bash".to_string()), matcher: None }],
+        config: vec![ExtensionConfigEntry { key: "pria_agent_tool_token".to_string(), value_type: None, description: None, required: true, default: None, secret_env: Some("PRIA_AGENT_TOOL_TOKEN".to_string()) }],
+    };
+    manager.load_with_cwd("knowledge", &manifest, Some(plugin_dir.path().to_path_buf())).await.unwrap();
+    assert_eq!(manager.hook_bus().emit(&HookEvent::before_tool_call("bash", json!({}))).await, HookResult::Continue);
+    manager.shutdown_all().await;
+    std::env::remove_var("PRIA_AGENT_TOOL_TOKEN");
+
+    let seen = fs::read_to_string(plugin_dir.path().join("config-seen.json")).unwrap();
+    assert_eq!(serde_json::from_str::<Value>(&seen).unwrap()["pria_agent_tool_token"], "regression-secret-token");
+    assert!(!home.path().join("config").exists(), "secret must not be persisted");
+    assert!(!std::fs::read_dir(home.path()).unwrap().filter_map(Result::ok).any(|e| e.path().is_file() && fs::read_to_string(e.path()).unwrap_or_default().contains("regression-secret-token")));
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn extension_provider_complete_routes_to_process() {
     let _guard = BASE_DIR_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let home = tempfile::tempdir().unwrap();

--- a/tests/fixtures/config_seen_extension.py
+++ b/tests/fixtures/config_seen_extension.py
@@ -7,6 +7,9 @@ legacy extension-manager tests that only need to assert resolved manifest config
 import json
 import sys
 
+EXIT_ON_HOOK_ONCE = "--exit-on-hook-once" in sys.argv
+EXIT_MARKER = ".exit-on-hook-once"
+
 
 def read_message():
     content_length = None
@@ -46,6 +49,9 @@ while True:
             json.dump(config, f, sort_keys=True)
         write_message(request, {"protocol_version": 1, "capabilities": {}})
     elif method == "hook.handle":
+        if EXIT_ON_HOOK_ONCE and not __import__("os").path.exists(EXIT_MARKER):
+            open(EXIT_MARKER, "w", encoding="utf-8").close()
+            sys.exit(42)
         write_message(request, {"action": "continue"})
     elif method == "shutdown":
         write_message(request, None)


### PR DESCRIPTION
Two runtime fixes required by the Pria capability-gateway agent path. Both were
final blockers in the S251 live proof (a real browser agent calling
`search_knowledge` through the gateway).

## Commits

- **`e127f96` fix(extensions): retain resolved config across restart**
  Extension processes lost their resolved `secret_env` values (e.g.
  `PRIA_AGENT_TOOL_TOKEN`) when the transport restarted — `initialize_locked()`
  re-sent an empty config `{}`. A restarted plugin then had no gateway token and
  every tool call failed with "token not configured". Now the resolved
  initialize config is retained in memory and replayed on restart. The secret is
  never persisted or logged.

- **`639211b` fix(rpc): use short runtime socket root**
  The RPC socket was derived from `SYNAPS_BASE_DIR`, which on EFS-backed session
  dirs exceeded the Unix `sun_path` 108-byte limit and failed to bind. Sockets
  now live under a short per-uid `SYNAPS_RUNTIME_DIR` (`/run/user/<uid>/synaps`);
  persistent state stays on `SYNAPS_BASE_DIR`.

## Tests

- `events::registry::tests` — 12 pass (incl. long-session-id socket bindable +
  per-uid isolation).
- `extensions_e2e::declared_secret_env_survives_extension_restart_without_persistence`
  — red/green verified (secret survives a forced restart; not persisted).

Build + clippy clean on `synaps-engine`.

Scope: `crates/agent-engine` (registry.rs, extensions/runtime/process.rs) + tests.