### PR TITLE
feat(host): request-lifecycle hardening and continuous-memory runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,18 @@ jobs:
           components: clippy
       - run: cargo clippy --all-targets -- -D warnings
 
+  # The suite was previously never run in CI, so a failing test could sit on a
+  # green PR indefinitely — `infinite_tool_loop_stops_at_exact_round_budget`
+  # did exactly that after graceful round-renewal landed. Serial-marked tests
+  # mutate process-global state (HOME, env, audit spool), so this must NOT be
+  # sharded or the `#[serial]` guarantees stop holding.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.95.0
+      - run: cargo test --workspace --locked
+
   feature-gate:
     runs-on: ubuntu-latest
     steps:

--- a/crates/agent-engine/src/extensions/runtime/process.rs
+++ b/crates/agent-engine/src/extensions/runtime/process.rs
@@ -322,17 +322,26 @@ pub async fn complete_provider_with_tools<F>(
     mut context_factory: F,
     max_tool_output: usize,
     max_iterations: usize,
+    // Out-param: total tool calls the provider requested across every
+    // interior round. An out-param (rather than a return tuple) so the
+    // count is still observable on the error paths below — the audit
+    // record must stay honest when the iteration limit is hit.
+    tools_requested: &mut u32,
 ) -> Result<ProviderCompleteResult, String>
 where
     F: FnMut() -> crate::ToolContext,
 {
     let max_iterations = max_iterations.max(1);
+    *tools_requested = 0;
     for iteration in 0..max_iterations {
         let result = handler.provider_complete(params.clone()).await?;
         let tool_uses = extract_provider_tool_uses(&result.content)?;
         if tool_uses.is_empty() {
             return Ok(result);
         }
+        // Counted before the limit check: the provider DID request these,
+        // even when we refuse to run another round.
+        *tools_requested = tools_requested.saturating_add(tool_uses.len() as u32);
         if iteration + 1 == max_iterations {
             return Err(format!(
                 "extension provider '{}' exceeded provider tool-use iteration limit ({})",

--- a/crates/agent-engine/src/runtime/budget.rs
+++ b/crates/agent-engine/src/runtime/budget.rs
@@ -231,6 +231,28 @@ impl TurnBudgetMeter {
         self.round_renewals
     }
 
+    /// Wall-clock consumed by this turn so far. Diagnostics only — the
+    /// enforcement path uses [`Self::wall_clock_exceeded`].
+    pub fn elapsed(&self) -> Duration {
+        self.started.elapsed()
+    }
+
+    /// Provider rounds charged since the last renewal (reset by
+    /// [`Self::try_renew_rounds`]). Diagnostics only.
+    pub fn rounds_used(&self) -> u32 {
+        self.rounds
+    }
+
+    /// Tool calls charged this turn. Diagnostics only.
+    pub fn tool_calls_used(&self) -> u32 {
+        self.tool_calls
+    }
+
+    /// Accumulated tool-result bytes charged this turn. Diagnostics only.
+    pub fn tool_result_bytes_used(&self) -> usize {
+        self.tool_result_bytes
+    }
+
     /// Remaining tool-call allowance (for exact-cap batch splitting).
     pub fn remaining_tool_calls(&self) -> u32 {
         self.budget.max_tool_calls.saturating_sub(self.tool_calls)

--- a/crates/agent-engine/src/runtime/openai/extension_route.rs
+++ b/crates/agent-engine/src/runtime/openai/extension_route.rs
@@ -199,6 +199,14 @@ pub(crate) async fn route_extension_provider(
                 crate::extensions::runtime::process::PROVIDER_EVENT_QUEUE_CAPACITY,
             );
         let tx_clone = tx.clone();
+        // Honest audit metric: `ToolUse` events genuinely arrive here and are
+        // dropped (streaming tool-use is not routed yet). Reporting 0
+        // regardless contradicted `tools_requested`'s documented meaning
+        // ("0 if no tool-use loop ran") and hid the drop from the TUI, which
+        // only renders `tools=N` when N > 0. Count what the provider actually
+        // asked for, even though we discard it.
+        let stream_tool_uses = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let stream_tool_uses_fwd = std::sync::Arc::clone(&stream_tool_uses);
         let forwarder = tokio::spawn(async move {
             use crate::extensions::runtime::process::ProviderStreamEvent;
             while let Some(event) = sink_rx.recv().await {
@@ -211,6 +219,7 @@ pub(crate) async fn route_extension_provider(
                     }
                     ProviderStreamEvent::ToolUse { .. } => {
                         first_event.mark();
+                        stream_tool_uses_fwd.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         tracing::warn!("provider.stream tool_use event ignored (streaming tool-use not yet wired)");
                     }
                     ProviderStreamEvent::ThinkingDelta { .. }
@@ -230,20 +239,24 @@ pub(crate) async fn route_extension_provider(
             _ = cancel.cancelled() => {
                 forwarder.abort();
                 attempt.finish_canceled();
-                emit_audit(true, "error", Some("canceled"), 0);
+                emit_audit(
+                    true,
+                    "error",
+                    Some("canceled"),
+                    stream_tool_uses.load(std::sync::atomic::Ordering::Relaxed),
+                );
                 return Err("operation canceled".into());
             }
             res = stream_fut => res,
         };
         let _ = forwarder.await;
+        // Forwarder joined: the counter is final.
+        let stream_tool_uses = stream_tool_uses.load(std::sync::atomic::Ordering::Relaxed);
         if cancel.is_cancelled() {
             attempt.finish_canceled();
-            emit_audit(true, "error", Some("canceled"), 0);
+            emit_audit(true, "error", Some("canceled"), stream_tool_uses);
             return Err("operation canceled".into());
         }
-        // TODO(audit): tools_requested is reported as 0 for the streaming
-        // path until ProviderStreamEvent::ToolUse is wired through the
-        // forwarder; tool-use over streaming is not yet routed.
         match result {
             Ok(complete) => {
                 attempt.finish_success(
@@ -253,7 +266,7 @@ pub(crate) async fn route_extension_provider(
                         .map(trace_ext::stop_reason_from_extension),
                     trace_ext::usage_from_extension_value(complete.usage.as_ref()),
                 );
-                emit_audit(true, "ok", None, 0);
+                emit_audit(true, "ok", None, stream_tool_uses);
                 Ok(serde_json::json!({
                     "content": complete.content,
                     "stop_reason": complete.stop_reason.unwrap_or_else(|| "end_turn".to_string()),
@@ -262,7 +275,7 @@ pub(crate) async fn route_extension_provider(
             }
             Err(e) => {
                 attempt.finish_failed(trace_ext::EXTENSION_PROVIDER_ERROR_CODE);
-                emit_audit(true, "error", Some("provider_error"), 0);
+                emit_audit(true, "error", Some("provider_error"), stream_tool_uses);
                 Err(format!("extension provider: {e}").into())
             }
         }
@@ -272,6 +285,9 @@ pub(crate) async fn route_extension_provider(
         // tool-loop helper may perform several interior provider.complete
         // calls, which are deliberately not counted as separate attempts
         // (see `trace::extension` module docs).
+        // Populated by the tool-loop helper; stays 0 on the direct-complete
+        // branch, where no loop runs.
+        let mut tools_requested: u32 = 0;
         let mut attempt = trace_ext::ExtensionAttempt::new(
             trace_ext::begin_extension_tracer(
                 trace,
@@ -347,6 +363,7 @@ pub(crate) async fn route_extension_provider(
                 },
                 30000,
                 8,
+                &mut tools_requested,
             )
             .await
         } else {
@@ -354,13 +371,9 @@ pub(crate) async fn route_extension_provider(
         };
         if cancel.is_cancelled() {
             attempt.finish_canceled();
-            emit_audit(false, "error", Some("canceled"), 0);
+            emit_audit(false, "error", Some("canceled"), tools_requested);
             return Err("operation canceled".into());
         }
-        // TODO(audit): tools_requested is reported as 0 here; the
-        // complete_provider_with_tools helper does not yet expose its
-        // observed tool-use iteration count. Wire that through when the
-        // helper grows a return-tuple or counter argument.
         match result {
             Ok(complete) => {
                 let text = complete
@@ -381,7 +394,7 @@ pub(crate) async fn route_extension_provider(
                         .map(trace_ext::stop_reason_from_extension),
                     trace_ext::usage_from_extension_value(complete.usage.as_ref()),
                 );
-                emit_audit(false, "ok", None, 0);
+                emit_audit(false, "ok", None, tools_requested);
                 Ok(serde_json::json!({
                     "content": complete.content,
                     "stop_reason": complete.stop_reason.unwrap_or_else(|| "end_turn".to_string()),
@@ -390,7 +403,7 @@ pub(crate) async fn route_extension_provider(
             }
             Err(e) => {
                 attempt.finish_failed(trace_ext::EXTENSION_PROVIDER_ERROR_CODE);
-                emit_audit(false, "error", Some("provider_error"), 0);
+                emit_audit(false, "error", Some("provider_error"), tools_requested);
                 Err(format!("extension provider: {e}").into())
             }
         }

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -210,9 +210,28 @@ impl StreamMethods {
         // every call site; surface the typed outcome and stop cleanly.
         macro_rules! finish_budget_exceeded {
             ($dimension:expr) => {{
+                let dimension: agent_core::BudgetDimension = $dimension;
+                // Observability (metadata only — no request content, per the
+                // Phase 1 privacy rule). Without this the turn dies silently:
+                // `SessionEvent::Error` is rendered by the frontend and
+                // dropped, so an exhausted turn left NO trace in synaps.log.
+                tracing::warn!(
+                    event = "turn_budget_exhausted",
+                    dimension = dimension.as_str(),
+                    elapsed_secs = budget_meter.elapsed().as_secs(),
+                    max_elapsed_secs = budget_meter.budget().max_elapsed.as_secs(),
+                    rounds_used = budget_meter.rounds_used(),
+                    max_provider_rounds = budget_meter.budget().max_provider_rounds,
+                    round_renewals_used = budget_meter.round_renewals_used(),
+                    max_round_renewals = budget_meter.budget().max_round_renewals,
+                    tool_calls_used = budget_meter.tool_calls_used(),
+                    max_tool_calls = budget_meter.budget().max_tool_calls,
+                    tool_result_bytes = budget_meter.tool_result_bytes_used(),
+                    "turn ended: budget exhausted"
+                );
                 let _ = tx.send(StreamEvent::Session(SessionEvent::MessageHistory(messages)));
                 let _ = tx.send(StreamEvent::Session(SessionEvent::Error(
-                    agent_core::TurnError::budget($dimension),
+                    agent_core::TurnError::budget(dimension),
                 )));
                 return Ok(());
             }};
@@ -242,6 +261,20 @@ impl StreamMethods {
                     match budget_meter.try_renew_rounds() {
                         Some(remaining) => match budget_meter.begin_round() {
                             Ok(()) => {
+                                // Soft checkpoint: the turn self-healed. Logged
+                                // so renewal frequency is measurable rather
+                                // than inferred from user reports.
+                                tracing::info!(
+                                    event = "turn_budget_round_renewed",
+                                    dimension = agent_core::BudgetDimension::ProviderRounds.as_str(),
+                                    renewals_used = budget_meter.round_renewals_used(),
+                                    renewals_remaining = remaining,
+                                    elapsed_secs = budget_meter.elapsed().as_secs(),
+                                    max_elapsed_secs =
+                                        budget_meter.budget().max_elapsed.as_secs(),
+                                    tool_calls_used = budget_meter.tool_calls_used(),
+                                    "provider-round checkpoint: renewed, continuing automatically"
+                                );
                                 let _ = tx.send(StreamEvent::Session(SessionEvent::Notice(
                                     format!(
                                         "Reached a provider-round checkpoint — work preserved, continuing automatically ({remaining} extension(s) left)."
@@ -1145,6 +1178,17 @@ impl StreamMethods {
 
                 // Synthetic valid results for over-budget calls (model
                 // order preserved: executed prefix first, suffix here).
+                if !over_budget_tool_uses.is_empty() {
+                    tracing::warn!(
+                        event = "turn_budget_tool_calls_truncated",
+                        dimension = agent_core::BudgetDimension::ToolCalls.as_str(),
+                        not_executed = over_budget_tool_uses.len(),
+                        tool_calls_used = budget_meter.tool_calls_used(),
+                        max_tool_calls = budget_meter.budget().max_tool_calls,
+                        elapsed_secs = budget_meter.elapsed().as_secs(),
+                        "tool calls dropped: turn tool-call budget exhausted"
+                    );
+                }
                 for tool_use in &over_budget_tool_uses {
                     if let Some(tool_id) = tool_use["id"].as_str() {
                         let content = "Tool call not executed: turn tool-call budget exhausted";

--- a/crates/agent-engine/src/tools/bash.rs
+++ b/crates/agent-engine/src/tools/bash.rs
@@ -593,8 +593,57 @@ mod tests {
         assert!(script.ends_with("sudo id"));
     }
 
+    /// Writes an executable stub `sudo` into `dir` that emulates the flags the
+    /// secure wrapper passes (`-S -p PROMPT`): `-k` exits silently like a real
+    /// timestamp reset, anything else writes PROMPT to stderr, consumes one
+    /// stdin line, and fails. Lets the wrapper be tested without the system
+    /// sudo, whose prompting behaviour is host-dependent.
+    #[cfg(unix)]
+    fn write_fake_sudo(dir: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+        let sudo_path = dir.join("sudo");
+        std::fs::write(
+            &sudo_path,
+            r#"#!/bin/sh
+prompt=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -S) shift ;;
+    -p) prompt="$2"; shift 2 ;;
+    -k) exit 0 ;;
+    *) break ;;
+  esac
+done
+printf '%s' "$prompt" >&2
+read -r _pw
+exit 1
+"#,
+        )
+        .expect("write fake sudo");
+        let mut perms = std::fs::metadata(&sudo_path)
+            .expect("stat fake sudo")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&sudo_path, perms).expect("chmod fake sudo");
+    }
+
+    /// The `sudo()` wrapper's prompt is intercepted by the secret-prompt path
+    /// and never reaches the delta stream.
+    ///
+    /// Hermetic by construction: it drives a STUB sudo on PATH, not the host's.
+    /// `command sudo` bypasses the shell function but still honours PATH, so
+    /// the real wrapper path is exercised. PATH is exported inside the script
+    /// rather than through `std::env::set_var` because these tests are not
+    /// `#[serial]` and mutating process-global env would race them.
+    ///
+    /// This previously drove the system sudo and asserted that it prompts —
+    /// false on any host with passwordless sudo, which includes every GitHub
+    /// runner, so it could never pass in CI.
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_bash_sudo_function_prompt_is_intercepted_before_streaming() {
+        let fake_bin = tempfile::tempdir().expect("tempdir");
+        write_fake_sudo(fake_bin.path());
         let tool = BashTool;
         let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
         let prompt_handle = crate::tools::SecretPromptHandle::new(prompt_tx);
@@ -620,7 +669,10 @@ mod tests {
         ctx.capabilities.secret_prompt = Some(prompt_handle);
         ctx.channels.tx_delta = Some(delta_tx);
         let params = json!({
-            "command": "sudo -k; sudo -v",
+            "command": format!(
+                "export PATH=\"{}:$PATH\"; sudo -k; sudo -v",
+                fake_bin.path().display()
+            ),
             "timeout": 30
         });
 

--- a/crates/agent-tui/src/tui/models/input.rs
+++ b/crates/agent-tui/src/tui/models/input.rs
@@ -320,19 +320,35 @@ mod tests {
         assert_eq!(expanded.load_state, ExpandedLoadState::Loading);
     }
 
+    /// `e` expands whichever provider is under the cursor.
+    ///
+    /// The expectation is DERIVED from `build_sections`, not hardcoded: that
+    /// function reads real host state (`configured_static_provider_keys()` and
+    /// `logged_in_oauth_providers()`), so which provider sorts first differs
+    /// per machine. Asserting "anthropic" passed only on hosts holding
+    /// Anthropic credentials and failed everywhere else — on a clean CI runner
+    /// the first row is `azure-openai`.
+    ///
+    /// Load semantics stay out of scope here because they are provider-class
+    /// dependent (live-catalog providers go to `Loading`, static-OAuth ones to
+    /// a `Ready` row set without fetching). Those are covered exactly by
+    /// `expanding_anthropic_still_requests_live_catalog` and the static-OAuth
+    /// test above; this one pins the routing.
     #[test]
     fn e_opens_expanded_provider_browser() {
         let mut state = ModelsModalState::new();
         state.view = ModelsView::All;
+        let sections = crate::tui::models::build_sections("claude-opus-4-7", &state);
+        let expected = crate::tui::models::selected_provider(&sections, &state)
+            .expect("a provider row is selected at cursor 0")
+            .provider_key
+            .clone();
+
         let outcome = handle_event(&mut state, key(KeyCode::Char('e')), "claude-opus-4-7");
-        assert_eq!(
-            outcome,
-            InputOutcome::ExpandProvider("anthropic".to_string())
-        );
+        assert_eq!(outcome, InputOutcome::ExpandProvider(expected.clone()));
         let expanded = state.expanded.expect("expanded state");
-        assert_eq!(expanded.provider_key, "anthropic");
+        assert_eq!(expanded.provider_key, expected);
         assert_eq!(expanded.search, "");
-        assert_eq!(expanded.load_state, ExpandedLoadState::Loading);
     }
 
     #[test]

--- a/tests/extension_provider_tool_loop.rs
+++ b/tests/extension_provider_tool_loop.rs
@@ -151,6 +151,7 @@ async fn provider_tool_loop_returns_final_text_after_tool_result_turn() {
         thinking_budget: 0,
     };
 
+    let mut tools_requested: u32 = 0;
     let result = complete_provider_with_tools(
         handler,
         params,
@@ -160,6 +161,7 @@ async fn provider_tool_loop_returns_final_text_after_tool_result_turn() {
         test_context,
         1000,
         4,
+        &mut tools_requested,
     )
     .await
     .expect("provider loop succeeds");
@@ -167,6 +169,13 @@ async fn provider_tool_loop_returns_final_text_after_tool_result_turn() {
     assert_eq!(
         result.content,
         vec![json!({"type": "text", "text": "done"})]
+    );
+    // Honest audit metric: this provider requested exactly one tool before
+    // its final text turn, so the count must be 1 — not the hardcoded 0 the
+    // audit record used to report for every tool-loop turn.
+    assert_eq!(
+        tools_requested, 1,
+        "the tool-use the provider actually requested must be counted"
     );
 }
 
@@ -325,6 +334,7 @@ async fn provider_loop_denies_unverified_tool_before_hooks_and_execution() {
         thinking_budget: 0,
     };
 
+    let mut tools_requested: u32 = 0;
     let result = complete_provider_with_tools(
         handler,
         params,
@@ -334,6 +344,7 @@ async fn provider_loop_denies_unverified_tool_before_hooks_and_execution() {
         test_context,
         1000,
         4,
+        &mut tools_requested,
     )
     .await
     .expect("loop terminates with the final text turn");

--- a/tests/turn_budget_stream.rs
+++ b/tests/turn_budget_stream.rs
@@ -186,6 +186,10 @@ async fn infinite_tool_loop_stops_at_exact_round_budget() {
 
     let budget = TurnBudget {
         max_provider_rounds: 3,
+        // Strict fixture: graceful continuation OFF so the round cap is the
+        // exact hard stop this test pins. (Foreground defaults to 8
+        // renewals, which would yield 3 * (1 + 8) = 27 rounds.)
+        max_round_renewals: 0,
         ..TurnBudget::for_role(TurnRole::Foreground)
     };
     let (rt, executions) = runtime_with_fixture(budget, 8).await;

--- a/tests/turn_budget_stream.rs
+++ b/tests/turn_budget_stream.rs
@@ -352,3 +352,128 @@ fn per_role_defaults_and_auto_turn_composition() {
         "at the cap: denied independent of any TurnBudget"
     );
 }
+
+// ── observability: budget terminations must reach the log ──────────────────
+//
+// Regression guard for the silent-exhaustion defect: `finish_budget_exceeded!`
+// used to emit ONLY `SessionEvent::Error`, which every frontend renders and
+// drops. An exhausted turn therefore left no trace in synaps.log, so the
+// failure mode was invisible to log inspection and could only be reported by
+// hand. These tests fail if that silence ever returns.
+
+/// Writer that accumulates formatted log lines into a shared buffer.
+struct CaptureWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// The stream loop runs on multi-thread tokio workers, so a thread-local
+/// `set_default` subscriber would miss events emitted off the test thread.
+/// Install ONE process-global capture subscriber and hand back the cleared
+/// shared buffer; `#[serial]` keeps tests from interleaving into it.
+fn install_log_capture() -> Arc<std::sync::Mutex<Vec<u8>>> {
+    static CAPTURE: std::sync::OnceLock<Arc<std::sync::Mutex<Vec<u8>>>> =
+        std::sync::OnceLock::new();
+    let buf = CAPTURE
+        .get_or_init(|| {
+            let buf = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let sink = Arc::clone(&buf);
+            let subscriber = tracing_subscriber::fmt()
+                .with_max_level(tracing::Level::TRACE)
+                .with_writer(move || CaptureWriter(Arc::clone(&sink)))
+                .with_ansi(false)
+                .finish();
+            let _ = tracing::subscriber::set_global_default(subscriber);
+            buf
+        })
+        .clone();
+    buf.lock().unwrap().clear();
+    buf
+}
+
+fn captured(buf: &Arc<std::sync::Mutex<Vec<u8>>>) -> String {
+    String::from_utf8_lossy(&buf.lock().unwrap()).into_owned()
+}
+
+/// A hard stop on the provider-round cap emits a WARN carrying the exact
+/// dimension and the budget counters — metadata only, no request content.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn budget_exhaustion_is_logged_with_exact_dimension() {
+    let logs = install_log_capture();
+    let _guard = HomeGuard::new();
+    let (url, _hits, _) = spawn_stub(Script::SeqSse(&[SSE_TOOL_LOOP])).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+
+    let budget = TurnBudget {
+        max_provider_rounds: 2,
+        max_round_renewals: 0,
+        ..TurnBudget::for_role(TurnRole::Foreground)
+    };
+    let (rt, _executions) = runtime_with_fixture(budget, 8).await;
+    let _events = drive_runtime_turn(&rt, "loop forever", false).await;
+
+    let log = captured(&logs);
+    assert!(
+        log.contains("turn_budget_exhausted"),
+        "budget exhaustion must be logged, not only sent to the frontend; got:\n{log}"
+    );
+    assert!(
+        log.contains(BudgetDimension::ProviderRounds.as_str()),
+        "log must name the exact exhausted dimension; got:\n{log}"
+    );
+    assert!(
+        log.contains("rounds_used") && log.contains("max_provider_rounds"),
+        "log must carry the budget counters for diagnosis; got:\n{log}"
+    );
+    // Privacy (Phase 1): metadata only — the prompt must never be logged.
+    assert!(
+        !log.contains("loop forever"),
+        "budget log must not contain request content; got:\n{log}"
+    );
+}
+
+/// The graceful provider-round renewal is the one dimension that already
+/// self-heals. It must be logged too, so renewal frequency is measurable
+/// instead of inferred from user reports.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn graceful_round_renewal_is_logged() {
+    let logs = install_log_capture();
+    let _guard = HomeGuard::new();
+    let (url, hits, _) = spawn_stub(Script::SeqSse(&[SSE_TOOL_LOOP])).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+
+    let budget = TurnBudget {
+        max_provider_rounds: 2,
+        max_round_renewals: 2,
+        ..TurnBudget::for_role(TurnRole::Foreground)
+    };
+    let (rt, _executions) = runtime_with_fixture(budget, 8).await;
+    let _events = drive_runtime_turn(&rt, "loop forever", false).await;
+
+    // 2 rounds, then 2 renewals of 2 rounds each = 6 provider calls.
+    assert_eq!(hits.load(Ordering::SeqCst), 6, "renewals extend the turn");
+
+    let log = captured(&logs);
+    assert!(
+        log.contains("turn_budget_round_renewed"),
+        "auto-continuation must be observable in the log; got:\n{log}"
+    );
+    assert!(
+        log.contains("renewals_remaining"),
+        "renewal log must report the remaining allowance; got:\n{log}"
+    );
+    // Renewals are bounded: the turn still ends on a logged hard stop.
+    assert!(
+        log.contains("turn_budget_exhausted"),
+        "exhausted renewals must still log a hard stop; got:\n{log}"
+    );
+}


### PR DESCRIPTION
## Summary

This PR is the **SynapsCLI host/runtime delivery** for the request-lifecycle hardening and Axel continuous-memory program. It contains the host-owned policy, authorization, context, execution, persistence, and frontend work.

The Axel storage/ranking implementation and plugin wire handlers are intentionally documented in their own PRs:

- Axel core: https://github.com/maha-media/axel/pull/2
- Axel plugin/spec: https://github.com/maha-media/synaps-skills/pull/47

This branch is stacked on `feat/jr-provider-orchestration-platform`, where PR #63's exact-model authorization foundation landed.

---

## SynapsCLI request-lifecycle program (36 tasks)

### Phase 1 — Privacy and correctness (T1–T6)

- Metadata-only request tracing by default; no raw request payload in generic traces.
- UTF-8-safe `BoundedText` and typed terminal `TurnOutcome` across frontends.
- Private sensitive-state filesystem handling and honest text-only cloud preflight.
- Provider-controlled error bodies withheld.
- Automated privacy/correctness harness.

### Phase 2 — Provider-neutral observability (T7–T13)

- Versioned `synaps-request-trace/1` envelope and typed transport outcomes.
- Exact local wire provenance; honest `wire: None` for cloud/broker paths.
- Normalized conversation IR and provider translation reports.
- Retry/cancellation/timing/usage metadata; no fabricated metrics.
- Bounded nonblocking trace persistence, `/context`, `/trace`, private export, recursive redaction.
- Timing/conformance harness across providers.

### Phase 3 — Authorization-enforced progressive disclosure (T14–T22)

- Typed `ToolCatalog`, bounded `DiscoveryIndex`, and per-session `SessionToolSet`.
- Load-bearing `ExecutionGate` immediately before tool execution.
- Exact discovery/activation tools and deterministic bulk updates.
- Opt-in minimized core schema set.
- Exact MCP leases and capability-driven extension lifecycle.
- Lazy skill bodies.
- Adversarial activation harness proving no spawn/network before exact activation, no sibling escalation, and no cross-session inheritance.

### Phase 4 — Bounded, side-effect-aware execution (T23–T28)

- Central `TurnBudget`: rounds, calls, elapsed time, bytes, token/cost, delegation depth/fanout, and side effects.
- Typed `ToolEffect` scheduling; unknown tools default non-idempotent.
- Tool-call ledger and cancellation-safe valid history.
- Bounded provider, PTY, bash, extension, command, widget, and caller output channels.
- Correlated execution events and acceptance harness.

### Phase 5 — Context management and project memory substrate (T29–T36)

- Request-aware provider-semantic context budgeting.
- Unified compaction transition with provenance, atomic successor persistence, rollback, and disclosure preview.
- Proven local-only compaction at the transport-construction seam.
- Backend-neutral project-memory tools with stable IDs, sensitivity, retention, provenance, tombstones, and bounded search/fetch.
- Staged local lexical index with integrity manifests and corruption rebuild.
- Unified disclosure/retention across sessions, memory, indexes, traces, and logs.
- Directory-handle-relative export/forget confinement.
- Opt-in journaled session persistence, crash recovery, snapshots, schema gates, and 1/10/100 MiB benchmarks.
- Phase 5 harness and program benchmarks.

Authoritative host artifacts:

- `docs/request-lifecycle-hardening-spec.md`
- `docs/request-lifecycle-hardening-plan.md`
- `docs/reviews/request-lifecycle-final-holdout.md`

---

## SynapsCLI continuous-memory host phases (A–F)

### Phase A — Host lease and context-provider protocol

- Typed `MemoryContextMode`, `MemoryContextLease`, `UserIntentProof`, actions/status/errors.
- `memory.*` settings fail closed with default mode `off`.
- Additive dormant context-provider extension capability.
- Exact `memory_context` control tool.
- Shared `/memory` commands across TUI/chat/RPC/server/watcher/agent.
- Exact provider validation, immediate revocation, session scoping, and no subagent inheritance.
- Typed `ContextSegment::Memory` and T29-protected budget reserve.

### Phase B — Recall integration

- Versioned recall request/contribution protocol and host validator.
- Per-prompt recall before provider translation, 150 ms timeout, fail-open without stale reuse.
- Exact one-shot semantics; logical-request retries reuse one accepted contribution.
- Injection-neutralized lower-authority rendering; memory never becomes system policy or user-authored text.
- `/memory why` with selected IDs, rank reasons, accounting, latency, and withholding metadata.
- Real fixture-process E2E harness.

### Phase C — Structured chat capture

- Typed terminal-only `ChatTurnCapture` builder.
- Bounded capture worker with fixed queue capacity and exact overflow accounting.
- Capture-capable lease + disclosure/persistence gates before dispatch.
- Completed user turn is never invalidated by capture failure.
- First-class compaction-summary capture with source-range provenance.
- Idempotency-key crash/retry/cancellation tests and cross-session recall after kill/reopen.

### Phase D — Existing-history import

- Host-computed disclosure preview and explicit confirmation.
- Declined consent performs zero content reads and zero Axel writes.
- Canonical host API streams legacy JSON and journal sessions; plugin never crawls session storage.
- Bounded batches/queues, cross-project exclusion, redaction/retention gates.
- Atomic resumable checkpoints and source-digest dedupe.
- One-million-turn bounded import benchmark.

### Phase E — Host checkpoint/review integration

Host checkpoint artifacts connect Axel ranking/consolidation evidence back to the request budget, disclosure, and model-visible boundaries:

- `docs/reviews/continuous-memory-cp-a.md` through `continuous-memory-cp-e.md`

The storage/ranking code for supersession, diversity, embeddings, consolidation, quality corpus, and retrieval benchmarks is reviewed in the Axel core PR, not duplicated here.

### Phase F — Host harness, adversarial gates, and holdout

- Headless consent → `/memory on` → recall → capture → restart → cross-session recall → `/memory why` → `/memory off` → import harness.
- Adversarial injection, forged enable, foreign-project probing, durable-default denial, and crash/no-child-leak suite.
- Full workspace gate and independent security/privacy holdout.
- Host review artifacts:
  - `docs/reviews/continuous-memory-cp-f.md`
  - `docs/reviews/continuous-memory-holdout.md`

---

## Human-test fixes included

### Backup plugin discovery

Timestamped plugin backups under `~/.synaps-cli/plugins/*.backup.<timestamp>` were mistakenly discovered as active plugins. This could spawn old Axel binaries, including a legacy `before_message` hook implementation.

Fix: exclude conservative backup/disabled/temp naming conventions during discovery while preserving legitimate plugin names.

### Built-in/extension API-name collision

An extension runtime name sanitizing to `memory_fetch` could claim the built-in API name before the built-in, exposing an incompatible `{id}` schema while built-in `{ids}` was renamed.

Fix: built-ins claim API names first; extension/MCP tools remain deterministically namespaced. Exact execution gates remain unchanged.

### Explicit Codex memory workflow

GPT-5.6-sol treated `memory_search.query` as semantic search, then inferred a historical decision from current JSONL implementation after one overly broad query missed.

Fix:

- Add Codex-only `builtin.codex.project-memory` doctrine.
- Decision/choice/earlier questions search memory before repository inference.
- Use one short literal substring and a bounded synonym retry.
- Wait for search before fetch and copy only exact returned IDs.
- Never invent or reuse unrelated IDs.
- Treat memory as lower-authority historical evidence (“project memory records”), not ground truth.
- Parallelize only independent calls.
- Strengthen tool descriptions without changing schemas.

Manual replay:

```json
memory_search {"query":"database",...}
memory_fetch {"ids":["mem-f0bb762420e1467faede94dad8d0b9ac"]}
```

The model answered: “Project memory records say we chose PostgreSQL, not SQLite.”

`memory_forget` was also manually verified: an append-only tombstone was written and subsequent search returned no record.

---

## Host-facing controls

```text
/memory on
/memory recall
/memory capture
/memory once
/memory status
/memory why
/memory index-history
/memory off
```

Existing host memory tools remain compatible:

- `memory_search`
- `memory_fetch`
- `memory_store`
- `memory_forget`

---

## Host security invariants

- Off by default; only a host-created exact session lease enables automatic behavior.
- Model/plugin/tool output cannot mint the lease.
- No subagent or new-session inheritance.
- Host-owned canonical project identity.
- Foreign-project reads fail closed without existence leakage.
- Secret/local-only/never-transmit bodies never enter model context, snippets, indexes, traces, logs, or errors.
- Memory remains typed lower-authority data with injection neutralization.
- T29 protects output/thinking/tool/safety reserves.
- Every queue, payload, contribution, capture, and import batch is bounded.
- Capture/import are idempotent, resumable, cancellation-safe, and tombstone-aware.

---

## Verification

Final host workspace, including human-test fixes:

```text
118 summaries
3,526 passed
0 failed
19 ignored
```

Other evidence:

- Request-lifecycle final holdout: weighted **0.945**, spec fidelity **0.94**, zero Critical/Important findings.
- Continuous-memory host holdout: weighted **0.8835**, spec fidelity **0.85**, zero Critical/Important findings.
- Real process harnesses for deferred extensions, recall, capture, crash/reopen, and history import.
- Manual GPT-5.6-sol search→exact-fetch and tombstoned forget tests.

## Review order

1. Request lifecycle: `d20e03f6..048cb5c0`
2. Continuous-memory host: `048cb5c0..dd0248cf`
3. Human-test fixes: `dd0248cf..1241e898`
4. Review Axel core PR #2 and plugin PR #47 for backend-specific implementation.