### PR TITLE
feat(kimi): exact per-model /effort reasoning modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ All notable changes to this project will be documented in this file.
   `MOONSHOT_API_KEY` / `KIMI_API_KEY`. Catalog covers Kimi K2.7 Code
   (default), K2.7 Code Highspeed, K3 (1M context), and K2.6 — all
   OpenAI-compatible with tool calling and reasoning support. Use models as
-  `kimi/<model-id>`.
+  `kimi/<model-id>`. `/effort` exposes exact documented reasoning modes per
+  model: K3 supports `low` / `high` / `max` (default `max`) via the
+  top-level `reasoning_effort` field; K2.6/K2.5 support only a thinking
+  on/off toggle (`thinking.type`); the K2.7 Code family always thinks with
+  no effort control. Unsupported levels are rejected at mutation time —
+  never silently swallowed by the API.
 
 - **Typed, brokered provider authentication and routing.** `synaps login` now
   discovers typed OAuth, cloud, and static-key targets from provider

--- a/crates/agent-engine/src/runtime/openai/catalog/kimi.rs
+++ b/crates/agent-engine/src/runtime/openai/catalog/kimi.rs
@@ -1,0 +1,209 @@
+//! Exact-id reasoning capability for the Kimi (Moonshot AI) static provider.
+//!
+//! Evidence: official Moonshot platform docs
+//! (platform.kimi.ai/docs/guide/use-thinking-effort,
+//! platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model), verified live
+//! against `api.moonshot.ai`:
+//!
+//! * `kimi-k3` — always reasons; graduated control via the **top-level**
+//!   `reasoning_effort` request field with exactly `"low"` / `"high"` /
+//!   `"max"` (provider default `"max"`). Reasoning cannot be disabled.
+//! * `kimi-k2.7-code` / `kimi-k2.7-code-highspeed` — thinking is always on;
+//!   the K2.x `thinking` field accepts only `{"type":"enabled"}` and the
+//!   live API errors on `"disabled"`. No effort control exists.
+//! * `kimi-k2.6` / `kimi-k2.5` — thinking on by default, disableable via
+//!   `{"thinking":{"type":"disabled"}}`. No graduated effort control.
+//!
+//! The Moonshot API silently ignores unknown top-level fields and unknown
+//! `reasoning_effort` values (verified live), so local validation is the only
+//! honest gate: an unsupported level must be rejected here, never sent and
+//! silently swallowed upstream.
+
+use agent_core::reasoning::ReasoningLevel;
+use serde_json::{json, Map, Value};
+
+/// Documented reasoning capability for an exact Kimi model id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KimiReasoningCapability {
+    /// Documented named-effort control (top-level `reasoning_effort`).
+    Effort {
+        supported: &'static [ReasoningLevel],
+        default_level: Option<ReasoningLevel>,
+        /// Whether reasoning can be disabled. `false` → `Off` must be
+        /// rejected, never silently omitted/downgraded.
+        can_disable: bool,
+    },
+    /// Thinking is always on; no effort control and no disable switch
+    /// (the live API rejects `thinking.type = "disabled"`).
+    AlwaysThinking,
+    /// Thinking on by default; only a documented on/off toggle
+    /// (`thinking.type = "enabled" | "disabled"`), no graduated effort.
+    ToggleableThinking,
+}
+
+/// Exact-id capability lookup — never substring-based. Unknown ids return
+/// `None` and fail closed at validation time.
+pub fn kimi_static_capability(model_id: &str) -> Option<KimiReasoningCapability> {
+    use ReasoningLevel::*;
+    match model_id {
+        "kimi-k3" => Some(KimiReasoningCapability::Effort {
+            supported: &[Low, High, Max],
+            default_level: Some(Max),
+            can_disable: false,
+        }),
+        "kimi-k2.7-code" | "kimi-k2.7-code-highspeed" => {
+            Some(KimiReasoningCapability::AlwaysThinking)
+        }
+        "kimi-k2.6" | "kimi-k2.5" => Some(KimiReasoningCapability::ToggleableThinking),
+        _ => None,
+    }
+}
+
+/// Exact wire label for a validated Kimi effort level.
+///
+/// Only levels present in a capability row's `supported` slice ever reach
+/// this; anything else returns `None` and the field is omitted (provider
+/// default), never guessed.
+fn kimi_effort_label(level: ReasoningLevel) -> Option<&'static str> {
+    match level {
+        ReasoningLevel::Low => Some("low"),
+        ReasoningLevel::High => Some("high"),
+        ReasoningLevel::Max => Some("max"),
+        _ => None,
+    }
+}
+
+/// Apply the documented Kimi reasoning fields to a Chat Completions body.
+///
+/// Levels are validated upstream by `validation::validate_reasoning_mutation`
+/// against the same capability table; this function is deliberately
+/// omission-biased for anything unexpected (omitted field = provider
+/// default), so it can never send an undocumented value.
+pub fn apply_kimi_reasoning_params(
+    body: &mut Map<String, Value>,
+    model_id: &str,
+    level: ReasoningLevel,
+) {
+    match kimi_static_capability(model_id) {
+        Some(KimiReasoningCapability::Effort { supported, .. }) => {
+            // Adaptive = provider default via field omission.
+            if supported.contains(&level) {
+                if let Some(label) = kimi_effort_label(level) {
+                    body.insert("reasoning_effort".to_string(), json!(label));
+                }
+            }
+        }
+        Some(KimiReasoningCapability::ToggleableThinking) => {
+            if level == ReasoningLevel::Off {
+                body.insert("thinking".to_string(), json!({ "type": "disabled" }));
+            }
+            // Everything else: omit → provider default (thinking enabled).
+        }
+        // Always-thinking models and unknown ids: nothing is expressible on
+        // the wire; send no reasoning fields at all.
+        Some(KimiReasoningCapability::AlwaysThinking) | None => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ReasoningLevel::*;
+
+    #[test]
+    fn k3_capability_is_exact_low_high_max_default_max_no_disable() {
+        let Some(KimiReasoningCapability::Effort {
+            supported,
+            default_level,
+            can_disable,
+        }) = kimi_static_capability("kimi-k3")
+        else {
+            panic!("kimi-k3 must have documented effort capability");
+        };
+        assert_eq!(supported, &[Low, High, Max]);
+        assert_eq!(default_level, Some(Max));
+        assert!(!can_disable);
+    }
+
+    #[test]
+    fn k27_code_family_is_always_thinking() {
+        for id in ["kimi-k2.7-code", "kimi-k2.7-code-highspeed"] {
+            assert_eq!(
+                kimi_static_capability(id),
+                Some(KimiReasoningCapability::AlwaysThinking),
+                "{id}"
+            );
+        }
+    }
+
+    #[test]
+    fn k26_and_k25_are_toggleable() {
+        for id in ["kimi-k2.6", "kimi-k2.5"] {
+            assert_eq!(
+                kimi_static_capability(id),
+                Some(KimiReasoningCapability::ToggleableThinking),
+                "{id}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_ids_fail_closed() {
+        assert_eq!(kimi_static_capability("kimi-k9"), None);
+        assert_eq!(kimi_static_capability(""), None);
+        // Never substring-based.
+        assert_eq!(kimi_static_capability("kimi-k3-preview"), None);
+    }
+
+    #[test]
+    fn k3_body_carries_exact_reasoning_effort() {
+        for (level, label) in [(Low, "low"), (High, "high"), (Max, "max")] {
+            let mut body = Map::new();
+            apply_kimi_reasoning_params(&mut body, "kimi-k3", level);
+            assert_eq!(body.get("reasoning_effort"), Some(&json!(label)));
+            assert!(!body.contains_key("thinking"));
+        }
+    }
+
+    #[test]
+    fn k3_adaptive_omits_the_field() {
+        let mut body = Map::new();
+        apply_kimi_reasoning_params(&mut body, "kimi-k3", Adaptive);
+        assert!(body.is_empty());
+    }
+
+    #[test]
+    fn k3_unsupported_levels_are_omitted_never_guessed() {
+        // Validation rejects these upstream; the wire layer must still never
+        // invent a value for them.
+        for level in [Off, Medium, XHigh, Ultra, UltraCode] {
+            let mut body = Map::new();
+            apply_kimi_reasoning_params(&mut body, "kimi-k3", level);
+            assert!(body.is_empty(), "{level:?} must not serialize");
+        }
+    }
+
+    #[test]
+    fn k26_off_disables_thinking_and_other_levels_omit() {
+        let mut body = Map::new();
+        apply_kimi_reasoning_params(&mut body, "kimi-k2.6", Off);
+        assert_eq!(body.get("thinking"), Some(&json!({"type": "disabled"})));
+        assert!(!body.contains_key("reasoning_effort"));
+        for level in [Adaptive, Low, Medium, High, Max] {
+            let mut body = Map::new();
+            apply_kimi_reasoning_params(&mut body, "kimi-k2.6", level);
+            assert!(body.is_empty(), "{level:?} must omit all fields");
+        }
+    }
+
+    #[test]
+    fn always_thinking_and_unknown_send_nothing() {
+        for id in ["kimi-k2.7-code", "kimi-k2.7-code-highspeed", "kimi-k9"] {
+            for level in [Off, Adaptive, Low, High, Max] {
+                let mut body = Map::new();
+                apply_kimi_reasoning_params(&mut body, id, level);
+                assert!(body.is_empty(), "{id} {level:?} must send nothing");
+            }
+        }
+    }
+}

--- a/crates/agent-engine/src/runtime/openai/catalog/mod.rs
+++ b/crates/agent-engine/src/runtime/openai/catalog/mod.rs
@@ -36,6 +36,7 @@ mod generic;
 mod github_copilot;
 mod google_gemini;
 mod groq;
+pub mod kimi;
 mod nvidia;
 mod openrouter;
 pub mod validation;
@@ -71,6 +72,7 @@ pub use google_gemini::{
     PROVIDER_NAME as GOOGLE_GEMINI_PROVIDER_NAME,
 };
 pub use groq::{infer_groq_reasoning, parse_groq_catalog_models};
+pub use kimi::{apply_kimi_reasoning_params, kimi_static_capability, KimiReasoningCapability};
 pub use nvidia::{infer_nvidia_reasoning, parse_nvidia_catalog_models};
 pub use openrouter::parse_openrouter_catalog_models;
 pub use xai::{

--- a/crates/agent-engine/src/runtime/openai/catalog/validation.rs
+++ b/crates/agent-engine/src/runtime/openai/catalog/validation.rs
@@ -11,9 +11,9 @@
 use agent_core::reasoning::ReasoningLevel;
 
 use super::{
-    anthropic_static_capability, capability_cache, codex_static_capability, plan_codex_execution,
-    xai_static_capability, CatalogProviderKind, CodexMultiAgentVersion, CodexRequestRole,
-    ReasoningSupport, XaiReasoningCapability,
+    anthropic_static_capability, capability_cache, codex_static_capability, kimi_static_capability,
+    plan_codex_execution, xai_static_capability, CatalogProviderKind, CodexMultiAgentVersion,
+    CodexRequestRole, KimiReasoningCapability, ReasoningSupport, XaiReasoningCapability,
 };
 
 /// Conservative option set for providers without authoritative exact-model
@@ -138,6 +138,43 @@ pub fn validate_reasoning_mutation(model: &str, level: ReasoningLevel) -> Result
             )),
         };
     }
+    if let Some(model_id) = model.strip_prefix("kimi/") {
+        // Adaptive = provider default (omit the field) — always expressible.
+        if level == ReasoningLevel::Adaptive {
+            return Ok(());
+        }
+        return match kimi_static_capability(model_id) {
+            Some(KimiReasoningCapability::Effort {
+                supported,
+                can_disable,
+                ..
+            }) => match level {
+                ReasoningLevel::Off if can_disable => Ok(()),
+                ReasoningLevel::Off => Err(format!(
+                    "reasoning cannot be disabled on {model}; use adaptive or a supported effort"
+                )),
+                l if supported.contains(&l) => Ok(()),
+                l => Err(unsupported_msg(l, model, supported)),
+            },
+            Some(KimiReasoningCapability::AlwaysThinking) => match level {
+                ReasoningLevel::Off => Err(format!(
+                    "{model} always thinks and the API rejects disabling; use adaptive"
+                )),
+                l => Err(format!(
+                    "{model} has no documented effort control; level '{l}' cannot be sent — use adaptive"
+                )),
+            },
+            Some(KimiReasoningCapability::ToggleableThinking) => match level {
+                ReasoningLevel::Off => Ok(()),
+                l => Err(format!(
+                    "{model} supports only a thinking on/off toggle; level '{l}' cannot be sent — use off or adaptive"
+                )),
+            },
+            None => Err(format!(
+                "no capability metadata for {model}; cannot authorize level '{level}'"
+            )),
+        };
+    }
     if let Some(model_id) = anthropic_model_id(model) {
         if matches!(level, ReasoningLevel::Max | ReasoningLevel::UltraCode) {
             // Max/UltraCode require an exact qualified Anthropic capability row;
@@ -211,6 +248,16 @@ pub fn default_level_for_model(model: &str) -> Option<ReasoningLevel> {
             _ => ReasoningLevel::Adaptive,
         });
     }
+    if let Some(model_id) = model.strip_prefix("kimi/") {
+        return Some(match kimi_static_capability(model_id) {
+            Some(KimiReasoningCapability::Effort {
+                default_level: Some(level),
+                ..
+            }) => level,
+            // Toggle/always-thinking/unknown → provider default via omission.
+            _ => ReasoningLevel::Adaptive,
+        });
+    }
     None
 }
 
@@ -228,6 +275,14 @@ pub fn reasoning_type_for_model(model: &str) -> &'static str {
             Some(XaiReasoningCapability::Effort { .. }) => "effort",
             Some(XaiReasoningCapability::IntrinsicReasoning) => "intrinsic",
             Some(XaiReasoningCapability::NonReasoning) => "none",
+            None => "unknown",
+        };
+    }
+    if let Some(model_id) = model.strip_prefix("kimi/") {
+        return match kimi_static_capability(model_id) {
+            Some(KimiReasoningCapability::Effort { .. }) => "effort",
+            Some(KimiReasoningCapability::AlwaysThinking) => "intrinsic",
+            Some(KimiReasoningCapability::ToggleableThinking) => "toggle (on/off)",
             None => "unknown",
         };
     }
@@ -273,6 +328,27 @@ pub fn thinking_options_for_model(model: &str) -> Vec<String> {
             Some(XaiReasoningCapability::NonReasoning) => owned(&["off", "adaptive"]),
             // Intrinsic reasoning without effort control, or unknown id:
             // only the provider default is expressible.
+            _ => owned(&["adaptive"]),
+        };
+    }
+    if let Some(model_id) = model.strip_prefix("kimi/") {
+        return match kimi_static_capability(model_id) {
+            Some(KimiReasoningCapability::Effort {
+                supported,
+                can_disable,
+                ..
+            }) => {
+                let mut opts = Vec::new();
+                if can_disable {
+                    opts.push("off".to_string());
+                }
+                opts.push("adaptive".to_string());
+                opts.extend(supported.iter().map(|l| l.as_str().to_string()));
+                opts
+            }
+            Some(KimiReasoningCapability::ToggleableThinking) => owned(&["off", "adaptive"]),
+            // Always-thinking without effort control, or unknown id: only
+            // the provider default is expressible.
             _ => owned(&["adaptive"]),
         };
     }
@@ -671,5 +747,111 @@ mod tests {
             assert!(!opts.contains(&"max".to_string()), "{model}");
             assert!(!opts.contains(&"ultra".to_string()), "{model}");
         }
+    }
+
+    #[test]
+    fn kimi_k3_accepts_exact_efforts_and_rejects_off_medium_xhigh_ultra() {
+        let model = "kimi/kimi-k3";
+        for level in [Adaptive, Low, High, Max] {
+            assert!(
+                validate_reasoning_mutation(model, level).is_ok(),
+                "{model} {level}"
+            );
+        }
+        for level in [Off, Medium, XHigh, Ultra, UltraCode] {
+            let err = validate_reasoning_mutation(model, level).unwrap_err();
+            assert!(err.contains("kimi"), "{err}");
+        }
+    }
+
+    #[test]
+    fn kimi_always_thinking_models_accept_only_adaptive() {
+        for model in ["kimi/kimi-k2.7-code", "kimi/kimi-k2.7-code-highspeed"] {
+            assert!(
+                validate_reasoning_mutation(model, Adaptive).is_ok(),
+                "{model}"
+            );
+            for level in [Off, Low, Medium, High, Max] {
+                assert!(
+                    validate_reasoning_mutation(model, level).is_err(),
+                    "{model} {level}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn kimi_toggleable_models_accept_off_and_adaptive_only() {
+        for model in ["kimi/kimi-k2.6", "kimi/kimi-k2.5"] {
+            for level in [Off, Adaptive] {
+                assert!(
+                    validate_reasoning_mutation(model, level).is_ok(),
+                    "{model} {level}"
+                );
+            }
+            for level in [Low, Medium, High, Max] {
+                assert!(
+                    validate_reasoning_mutation(model, level).is_err(),
+                    "{model} {level}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn kimi_unknown_ids_fail_closed_except_adaptive() {
+        let model = "kimi/kimi-k9000";
+        assert!(validate_reasoning_mutation(model, Adaptive).is_ok());
+        for level in [Off, Low, Medium, High, Max, Ultra] {
+            assert!(
+                validate_reasoning_mutation(model, level).is_err(),
+                "{level}"
+            );
+        }
+    }
+
+    #[test]
+    fn kimi_options_are_exact_per_model() {
+        assert_eq!(
+            thinking_options_for_model("kimi/kimi-k3"),
+            vec!["adaptive", "low", "high", "max"]
+        );
+        for model in ["kimi/kimi-k2.7-code", "kimi/kimi-k2.7-code-highspeed"] {
+            assert_eq!(
+                thinking_options_for_model(model),
+                vec!["adaptive"],
+                "{model}"
+            );
+        }
+        for model in ["kimi/kimi-k2.6", "kimi/kimi-k2.5"] {
+            assert_eq!(
+                thinking_options_for_model(model),
+                vec!["off", "adaptive"],
+                "{model}"
+            );
+        }
+        assert_eq!(
+            thinking_options_for_model("kimi/kimi-k9000"),
+            vec!["adaptive"]
+        );
+    }
+
+    #[test]
+    fn kimi_reasoning_types_and_default_level() {
+        assert_eq!(reasoning_type_for_model("kimi/kimi-k3"), "effort");
+        assert_eq!(reasoning_type_for_model("kimi/kimi-k2.7-code"), "intrinsic");
+        assert_eq!(
+            reasoning_type_for_model("kimi/kimi-k2.6"),
+            "toggle (on/off)"
+        );
+        assert_eq!(reasoning_type_for_model("kimi/kimi-k9000"), "unknown");
+        assert_eq!(
+            default_level_for_model("kimi/kimi-k3"),
+            Some(ReasoningLevel::Max)
+        );
+        assert_eq!(
+            default_level_for_model("kimi/kimi-k2.6"),
+            Some(ReasoningLevel::Adaptive)
+        );
     }
 }

--- a/crates/agent-engine/src/runtime/openai/mod.rs
+++ b/crates/agent-engine/src/runtime/openai/mod.rs
@@ -251,6 +251,7 @@ pub async fn try_route(
                 temperature,
                 max_tokens,
                 thinking_budget,
+                reasoning_level,
                 cancel,
                 trace,
                 exact_wire_bytes,

--- a/crates/agent-engine/src/runtime/openai/reasoning.rs
+++ b/crates/agent-engine/src/runtime/openai/reasoning.rs
@@ -7,6 +7,9 @@ pub enum OpenAiReasoningProvider {
     OpenRouter,
     Groq,
     NvidiaNim,
+    /// Kimi (Moonshot AI): level-driven exact capability wiring
+    /// (`catalog::kimi`), not budget-driven inference.
+    Kimi,
     Generic,
 }
 
@@ -29,7 +32,16 @@ pub fn apply_openai_reasoning_params(
     provider: OpenAiReasoningProvider,
     model: &str,
     thinking_budget: u32,
+    reasoning_level: agent_core::reasoning::ReasoningLevel,
 ) {
+    // Kimi is level-driven, not budget-driven: `Off` must still serialize
+    // (`thinking:{"type":"disabled"}` on toggleable models) and `Max` has no
+    // numeric budget, so the budget==0 guard below must not apply here.
+    // Exact per-model wiring lives in `catalog::kimi`.
+    if provider == OpenAiReasoningProvider::Kimi {
+        crate::runtime::openai::catalog::apply_kimi_reasoning_params(body, model, reasoning_level);
+        return;
+    }
     // Don't inject reasoning params when thinking is disabled.
     // Without this guard, non-reasoning models (e.g. llama-3.3) get
     // unsupported fields that cause request failures.
@@ -54,6 +66,7 @@ pub fn apply_openai_reasoning_params(
                 );
             }
         }
+        OpenAiReasoningProvider::Kimi => unreachable!("handled above"),
         OpenAiReasoningProvider::NvidiaNim | OpenAiReasoningProvider::Generic => {}
     }
 }
@@ -63,6 +76,7 @@ pub fn provider_for_key(provider_key: &str) -> OpenAiReasoningProvider {
         "openrouter" => OpenAiReasoningProvider::OpenRouter,
         "groq" => OpenAiReasoningProvider::Groq,
         "nvidia" => OpenAiReasoningProvider::NvidiaNim,
+        "kimi" => OpenAiReasoningProvider::Kimi,
         _ => OpenAiReasoningProvider::Generic,
     }
 }
@@ -79,6 +93,7 @@ mod tests {
             OpenAiReasoningProvider::OpenRouter,
             "deepseek/deepseek-r1",
             4096,
+            agent_core::reasoning::ReasoningLevel::Medium,
         );
         assert_eq!(body["reasoning"]["effort"], "medium");
         assert_eq!(body["include_reasoning"], true);
@@ -92,6 +107,7 @@ mod tests {
             OpenAiReasoningProvider::Groq,
             "openai/gpt-oss-120b",
             16_384,
+            agent_core::reasoning::ReasoningLevel::Medium,
         );
         assert_eq!(body["reasoning_format"], "parsed");
         assert_eq!(body["reasoning_effort"], "high");
@@ -102,6 +118,7 @@ mod tests {
             OpenAiReasoningProvider::Groq,
             "llama-3.3-70b-versatile",
             16_384,
+            agent_core::reasoning::ReasoningLevel::Medium,
         );
         assert!(plain.is_empty());
     }
@@ -114,6 +131,7 @@ mod tests {
             OpenAiReasoningProvider::NvidiaNim,
             "moonshotai/kimi-k2-thinking",
             4096,
+            agent_core::reasoning::ReasoningLevel::Medium,
         );
         assert!(body.is_empty());
         apply_openai_reasoning_params(
@@ -121,6 +139,7 @@ mod tests {
             OpenAiReasoningProvider::Generic,
             "some/model",
             4096,
+            agent_core::reasoning::ReasoningLevel::Medium,
         );
         assert!(body.is_empty());
     }
@@ -133,6 +152,7 @@ mod tests {
             OpenAiReasoningProvider::OpenRouter,
             "deepseek/deepseek-r1",
             0,
+            agent_core::reasoning::ReasoningLevel::Medium,
         );
         assert!(
             body.is_empty(),
@@ -144,10 +164,54 @@ mod tests {
             OpenAiReasoningProvider::Groq,
             "openai/gpt-oss-120b",
             0,
+            agent_core::reasoning::ReasoningLevel::Medium,
         );
         assert!(
             body.is_empty(),
             "Groq should not inject reasoning when budget is 0"
         );
+    }
+
+    #[test]
+    fn kimi_key_maps_to_kimi_provider() {
+        assert_eq!(provider_for_key("kimi"), OpenAiReasoningProvider::Kimi);
+    }
+
+    #[test]
+    fn kimi_is_level_driven_not_budget_driven() {
+        use agent_core::reasoning::ReasoningLevel;
+        // Max has no numeric budget; the level must still reach the wire.
+        let mut body = Map::new();
+        apply_openai_reasoning_params(
+            &mut body,
+            OpenAiReasoningProvider::Kimi,
+            "kimi-k3",
+            0,
+            ReasoningLevel::Max,
+        );
+        assert_eq!(body["reasoning_effort"], "max");
+
+        // Off carries budget 0 but must still serialize the disable toggle
+        // on toggleable models — the zero-budget guard must not swallow it.
+        let mut body = Map::new();
+        apply_openai_reasoning_params(
+            &mut body,
+            OpenAiReasoningProvider::Kimi,
+            "kimi-k2.6",
+            0,
+            ReasoningLevel::Off,
+        );
+        assert_eq!(body["thinking"]["type"], "disabled");
+
+        // Adaptive omits every reasoning field (provider default).
+        let mut body = Map::new();
+        apply_openai_reasoning_params(
+            &mut body,
+            OpenAiReasoningProvider::Kimi,
+            "kimi-k3",
+            0,
+            ReasoningLevel::Adaptive,
+        );
+        assert!(body.is_empty());
     }
 }

--- a/crates/agent-engine/src/runtime/openai/stream.rs
+++ b/crates/agent-engine/src/runtime/openai/stream.rs
@@ -203,6 +203,7 @@ pub(crate) async fn call_oai_stream_inner(
     temperature: Option<f32>,
     max_tokens: Option<u32>,
     thinking_budget: u32,
+    reasoning_level: agent_core::reasoning::ReasoningLevel,
     cancel: &tokio_util::sync::CancellationToken,
     trace: &crate::runtime::trace::TraceContext,
     exact_wire_bytes: bool,
@@ -249,6 +250,7 @@ pub(crate) async fn call_oai_stream_inner(
         super::reasoning::provider_for_key(&cfg.provider),
         &cfg.model,
         thinking_budget,
+        reasoning_level,
     );
     let body = Value::Object(body);
 
@@ -2025,6 +2027,7 @@ mod broker_stream_tests {
             None,
             None,
             0,
+            agent_core::reasoning::ReasoningLevel::Medium,
             &cancel,
             &crate::runtime::trace::TraceContext::disabled(),
             true,
@@ -2075,6 +2078,7 @@ mod broker_stream_tests {
             None,
             None,
             0,
+            agent_core::reasoning::ReasoningLevel::Medium,
             &tokio_util::sync::CancellationToken::new(),
             &crate::runtime::trace::TraceContext::disabled(),
             true,
@@ -2110,6 +2114,7 @@ mod broker_stream_tests {
             None,
             None,
             0,
+            agent_core::reasoning::ReasoningLevel::Medium,
             &cancel,
             &crate::runtime::trace::TraceContext::disabled(),
             true,
@@ -2175,6 +2180,7 @@ mod broker_stream_tests {
             None,
             None,
             0,
+            agent_core::reasoning::ReasoningLevel::Medium,
             &cancel,
             &crate::runtime::trace::TraceContext::disabled(),
             true,

--- a/crates/agent-engine/src/runtime/trace/openai_wiring_tests.rs
+++ b/crates/agent-engine/src/runtime/trace/openai_wiring_tests.rs
@@ -158,6 +158,7 @@ async fn drive_chat(
         None,
         None,
         0,
+        agent_core::reasoning::ReasoningLevel::Medium,
         cancel,
         trace,
         exact,


### PR DESCRIPTION
Follow-up to the Kimi provider work merged into `dev` as `1bb42a5c` (PR #66). That merge landed the static-key provider; this commit came ~3h later and was left stranded on the branch after #66 was closed. Diff here is the single commit `1cc6808e`.

## What

Wires the documented Moonshot reasoning controls into the shared mutation-validation / option-derivation / wire-application pipeline (`catalog::kimi`, mirroring the xAI exact-id capability pattern):

- **kimi-k3** — top-level `reasoning_effort` with exactly `low` / `high` / `max` (default `max`). Always reasons; `Off` is rejected.
- **kimi-k2.7-code (+highspeed)** — always thinking, no wire knob. Only adaptive is expressible (live API rejects `thinking.type=disabled`).
- **kimi-k2.6 / k2.5** — thinking on/off toggle via `thinking.type`; named effort levels rejected.
- **Unknown kimi ids** — fail closed to adaptive-only.

The OpenAI-compat stream path now receives the session `ReasoningLevel` rather than just the legacy numeric budget, so Kimi `Off` and `Max` — which have no budget representation — serialize exactly. Other providers keep budget-driven behavior unchanged.

## Why local validation

Verified live against `api.moonshot.ai`: the API **silently ignores** unknown `reasoning_effort` values. Local validation is therefore the only honest gate — unsupported levels are rejected at mutation time instead of being quietly swallowed.

Evidence: platform.kimi.ai thinking-effort + thinking-mode docs, confirmed against the live API.

## Scope

8 files, +474/-4 — new `runtime/openai/catalog/kimi.rs`, `reasoning.rs`, catalog validation, stream wiring, CHANGELOG. Merges into `dev` conflict-free.