### PR TITLE
fix(tui): scope the background toggle to the conversation canvas

### DIFF
--- a/crates/agent-tui/src/tui/draw.rs
+++ b/crates/agent-tui/src/tui/draw.rs
@@ -993,12 +993,18 @@ pub(crate) fn render_frame_into(
         .padding(Padding::horizontal(1));
     let msg_inner = msg_block.inner(msg_area);
     let messages_widget = Paragraph::new(visible).block(msg_block.clone());
-    // The conversation gets its own surface, distinct from the header, input,
-    // and footer chrome. Paint it in both modes so the separation is reliable.
-    frame.render_widget(
-        Block::default().style(Style::default().bg(THEME.load().message_background())),
-        msg_area,
-    );
+    // The conversation canvas is the ONLY surface the background toggle owns.
+    // Opaque paints the themed canvas; invisible falls back to 0.7.0's exact
+    // behaviour (`Clear`) so the terminal background shows through while the
+    // header, input, and footer chrome stay painted, unchanged from 0.7.0.
+    if background_is_opaque() {
+        frame.render_widget(
+            Block::default().style(Style::default().bg(THEME.load().message_background())),
+            msg_area,
+        );
+    } else {
+        frame.render_widget(Clear, msg_area);
+    }
     if model.secret_prompt.is_some() {
         let blank = Paragraph::new(Vec::<ratatui::text::Line>::new()).block(msg_block);
         frame.render_widget(blank, msg_area);
@@ -1732,5 +1738,83 @@ fn render_toasts_from_snap(frame: &mut ratatui::Frame<'_>, toasts: &[super::toas
                 .style(Style::default().fg(THEME.load().help_fg))
         };
         frame.render_widget(paragraph, rect);
+    }
+}
+
+#[cfg(test)]
+mod background_toggle_tests {
+    use super::super::testing::TestHarness;
+    use super::super::theme::{background_is_opaque, set_background_opaque};
+    use ratatui::style::Color;
+    use serial_test::serial;
+
+    /// Background colour of every cell in one row.
+    fn row_bgs(h: &mut TestHarness, y: u16) -> Vec<Option<Color>> {
+        let buf = h.render();
+        let area = *buf.area();
+        (area.x..area.x + area.width)
+            .map(|x| buf[(x, y)].style().bg)
+            .collect()
+    }
+
+    /// Regression (S278): `invisible` must change ONLY the conversation
+    /// canvas. An earlier fix routed header/input/footer through the toggle
+    /// too, which made the whole frame lose its chrome. 0.7.0 painted all
+    /// chrome unconditionally and used `Clear` for the message area — that
+    /// is exactly what `invisible` must still look like.
+    #[test]
+    #[serial]
+    fn invisible_leaves_header_and_footer_chrome_identical_to_opaque() {
+        let prior = background_is_opaque();
+        let mut h = TestHarness::boot();
+        let bottom = 23; // 80x24 default geometry
+
+        set_background_opaque(true);
+        let header_opaque = row_bgs(&mut h, 0);
+        let footer_opaque = row_bgs(&mut h, bottom);
+
+        set_background_opaque(false);
+        let header_invisible = row_bgs(&mut h, 0);
+        let footer_invisible = row_bgs(&mut h, bottom);
+
+        assert_eq!(
+            header_opaque, header_invisible,
+            "header chrome must be identical in both modes — invisible owns \
+             only the conversation canvas"
+        );
+        assert_eq!(
+            footer_opaque, footer_invisible,
+            "footer/input chrome must be identical in both modes"
+        );
+
+        set_background_opaque(prior);
+    }
+
+    /// The other half of the contract: the canvas itself really does stop
+    /// painting, otherwise the toggle is a no-op (the original bug).
+    #[test]
+    #[serial]
+    fn invisible_stops_painting_the_conversation_canvas() {
+        let prior = background_is_opaque();
+        let mut h = TestHarness::boot();
+
+        set_background_opaque(true);
+        let opaque: Vec<Vec<Option<Color>>> = (0..24).map(|y| row_bgs(&mut h, y)).collect();
+
+        set_background_opaque(false);
+        let invisible: Vec<Vec<Option<Color>>> = (0..24).map(|y| row_bgs(&mut h, y)).collect();
+
+        let changed: Vec<usize> = (0..24).filter(|&y| opaque[y] != invisible[y]).collect();
+
+        assert!(
+            !changed.is_empty(),
+            "toggling to invisible changed nothing — the canvas is still painted"
+        );
+        assert!(
+            !changed.contains(&0),
+            "row 0 (header) must not change between modes, but did"
+        );
+
+        set_background_opaque(prior);
     }
 }


### PR DESCRIPTION
## Problem

The `Background: opaque / invisible` setting appeared to do nothing.

`background_is_opaque()` was consulted in exactly **one** place in the draw path (the root canvas block). Every other paint site ran unconditionally — including the message area, which covers most of the screen:

```rust
// The conversation gets its own surface, distinct from the header, input,
// and footer chrome. Paint it in both modes so the separation is reliable.
frame.render_widget(
    Block::default().style(Style::default().bg(THEME.load().message_background())),
    msg_area,
);
```

That replaced 0.7.0's `frame.render_widget(Clear, msg_area)` — and `Clear` is precisely what lets a transparent terminal show through. So `invisible` skipped one full-screen block and then repainted the canvas anyway.

Worse: with `message_bg = Color::Reset`, `message_background()` derives `bg + (4,6,6)` — a colour nearly identical to the theme background. Maximally looks-broken.

## Fix

`invisible` now reproduces **0.7.0 exactly**. The toggle owns the conversation canvas and nothing else:

- All chrome — header, input, footer, subagent panel — keeps painting `THEME.bg` unconditionally, byte-identical to 0.7.0.
- The canvas paints the themed surface when opaque, and falls back to `Clear` when invisible.
- Floating overlays (modals, toasts) stay opaque by design; transparent overlays render over the transcript and are unreadable.

The entire delta versus 0.7.0 in `draw.rs` is the new opaque-only root block plus one `if/else` around the canvas. Exactly one line was ever removed, and it returns verbatim in the `else` branch.

## Tests

Two `#[serial]` render regression tests through the headless `TestHarness`:

- `invisible_leaves_header_and_footer_chrome_identical_to_opaque` — asserts header and footer background cells are identical across both modes. This is the regression guard: an earlier attempt routed chrome through the toggle too and stripped the whole frame.
- `invisible_stops_painting_the_conversation_canvas` — asserts the canvas genuinely changes, so the toggle can't silently regress into a no-op.

`#[serial]` is deliberate: `BACKGROUND_OPAQUE` is a global `AtomicBool`, and both tests save and restore the prior value.

## Verification

Run on a 24-core builder, rebased onto `dev` @ 68a5a8da (post Kimi OAuth merge):

```
cargo test --workspace --locked    3602 passed  0 failed  exit 0
cargo clippy --all-targets -D warnings                    exit 0
cargo build --release              20M binary             exit 0
```

Not verified: visual confirmation in a real transparent terminal. The logic is proven by cell-level assertions, but no human has looked at it yet.