### PR TITLE
feat(tui): handpick the conversation canvas for every theme

### DIFF
--- a/crates/agent-tui/src/tui/theme/mod.rs
+++ b/crates/agent-tui/src/tui/theme/mod.rs
@@ -131,9 +131,9 @@ impl Default for Theme {
             table_header_color: Color::Rgb(80, 210, 230),
             table_cell_color: Color::Rgb(175, 185, 200),
 
-            bg: Color::Rgb(10, 12, 18),
+            bg: Color::Rgb(20, 24, 34),
             // Recessed transcript surface; deliberately distinct from user and tool cards.
-            message_bg: Color::Rgb(6, 8, 13),
+            message_bg: Color::Rgb(10, 12, 18),
             border: Color::Rgb(28, 36, 50),
             border_active: Color::Rgb(50, 180, 210),
             muted: Color::Rgb(50, 58, 72),
@@ -781,5 +781,159 @@ mod theme_tests {
             Some(Color::Rgb(0xff, 0x00, 0xff)),
             "user TOML `ext.hello-ext.accent` must override the manifest"
         );
+    }
+}
+
+#[cfg(test)]
+mod message_canvas_tests {
+    use super::*;
+
+    const BUILTINS: &[&str] = &[
+        "default",
+        "night-city",
+        "neon-rain",
+        "amber",
+        "phosphor",
+        "solarized-dark",
+        "blood",
+        "ocean",
+        "rose-pine",
+        "nord",
+        "dracula",
+        "monokai",
+        "gruvbox",
+        "catppuccin",
+        "tokyo-night",
+        "sunset",
+        "ice",
+        "forest",
+        "lavender",
+    ];
+
+    fn rgb(c: Color) -> (u8, u8, u8) {
+        match c {
+            Color::Rgb(r, g, b) => (r, g, b),
+            other => panic!("expected an explicit Rgb value, got {other:?}"),
+        }
+    }
+
+    /// WCAG relative luminance.
+    fn luminance((r, g, b): (u8, u8, u8)) -> f64 {
+        fn lin(v: u8) -> f64 {
+            let v = f64::from(v) / 255.0;
+            if v <= 0.04045 {
+                v / 12.92
+            } else {
+                ((v + 0.055) / 1.055).powf(2.4)
+            }
+        }
+        0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b)
+    }
+
+    fn contrast(a: (u8, u8, u8), b: (u8, u8, u8)) -> f64 {
+        let (la, lb) = (luminance(a), luminance(b));
+        let (hi, lo) = if la > lb { (la, lb) } else { (lb, la) };
+        (hi + 0.05) / (lo + 0.05)
+    }
+
+    /// Themes whose base is too near black to hold a distinct canvas.
+    ///
+    /// Measured, not guessed: on these palettes `bg` sits within a few RGB
+    /// units of black, so even a *pure black* canvas fails to reach 1.05
+    /// contrast, and raising it instead collides with `code_bg` (which renders
+    /// on top of the canvas). There is no third elevation level available
+    /// between two colours that are already touching.
+    ///
+    /// These deliberately render flush with the header and input chrome. The
+    /// message area still draws its own border, which carries the separation.
+    const FLUSH: &[&str] = &[
+        "amber",
+        "blood",
+        "dracula",
+        "forest",
+        "ice",
+        "lavender",
+        "neon-rain",
+        "night-city",
+        "ocean",
+        "phosphor",
+        "rose-pine",
+        "sunset",
+    ];
+
+    /// Flush themes must match chrome EXACTLY. A near-miss reads as a
+    /// rendering bug rather than a deliberate choice.
+    #[test]
+    fn flush_themes_match_chrome_exactly() {
+        for name in FLUSH {
+            let t = Theme::builtin(name).unwrap_or_else(|| panic!("{name} is a builtin"));
+            assert_eq!(
+                rgb(t.message_background()),
+                rgb(t.bg),
+                "{name} is a flush theme: canvas must equal chrome exactly"
+            );
+        }
+    }
+
+    /// Every non-flush theme must clear the perceptibility floor.
+    #[test]
+    fn elevated_themes_separate_canvas_from_chrome() {
+        for name in BUILTINS.iter().filter(|n| !FLUSH.contains(n)) {
+            let t = Theme::builtin(name).unwrap_or_else(|| panic!("{name} is a builtin"));
+            let c = contrast(rgb(t.bg), rgb(t.message_background()));
+            assert!(
+                (1.05..=1.30).contains(&c),
+                "{name}: canvas/chrome contrast {c:.3} outside 1.05-1.30"
+            );
+        }
+    }
+
+    /// Recessing preserves hue and saturation; lightening did not. An earlier
+    /// attempt raised CIELAB L* with a/b held fixed and `blood` kept 23% of its
+    /// saturation, rendering a grey canvas under a deep-red theme.
+    #[test]
+    fn elevated_themes_keep_their_colour() {
+        fn saturation((r, g, b): (u8, u8, u8)) -> f64 {
+            let (hi, lo) = (r.max(g).max(b), r.min(g).min(b));
+            if hi == 0 {
+                0.0
+            } else {
+                f64::from(hi - lo) / f64::from(hi)
+            }
+        }
+        for name in BUILTINS.iter().filter(|n| !FLUSH.contains(n)) {
+            let t = Theme::builtin(name).unwrap_or_else(|| panic!("{name} is a builtin"));
+            let (bg, canvas) = (rgb(t.bg), rgb(t.message_background()));
+            let base = saturation(bg);
+            if base < 0.05 {
+                continue; // achromatic (gruvbox)
+            }
+            let kept = saturation(canvas) / base;
+            assert!(
+                kept >= 0.85,
+                "{name}: canvas kept only {:.0}% of theme saturation (bg={bg:?} canvas={canvas:?})",
+                kept * 100.0
+            );
+        }
+    }
+
+    /// `code_bg` and `user_bg` render ON TOP of the canvas, so the canvas must
+    /// never be brighter than `code_bg` or code blocks invert.
+    ///
+    /// `solarized-dark` is exempt: its `code_bg` (0,36,43) is already darker
+    /// than its `bg` (0,43,54), so code blocks recess by that palette's own
+    /// design. Its canvas is raised toward its separator instead.
+    #[test]
+    fn canvas_never_outranks_code_blocks() {
+        for name in BUILTINS.iter().filter(|n| !FLUSH.contains(n)) {
+            if *name == "solarized-dark" {
+                continue;
+            }
+            let t = Theme::builtin(name).unwrap_or_else(|| panic!("{name} is a builtin"));
+            assert!(
+                luminance(rgb(t.message_background())) < luminance(rgb(t.code_bg)),
+                "{name}: canvas must sit below code_bg in elevation"
+            );
+        }
     }
 }

--- a/crates/agent-tui/src/tui/theme/palettes/amber.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/amber.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(200, 180, 140),
 
             bg: Color::Rgb(10, 8, 5),
-            message_bg: Color::Rgb(6, 5, 3),
+            message_bg: Color::Rgb(10, 8, 5),
             border: Color::Rgb(40, 30, 15),
             border_active: Color::Rgb(255, 176, 0),
             muted: Color::Rgb(80, 65, 35),

--- a/crates/agent-tui/src/tui/theme/palettes/blood.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/blood.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(200, 160, 160),
 
             bg: Color::Rgb(8, 3, 3),
-            message_bg: Color::Rgb(5, 2, 2),
+            message_bg: Color::Rgb(8, 3, 3),
             border: Color::Rgb(40, 15, 15),
             border_active: Color::Rgb(255, 50, 50),
             muted: Color::Rgb(80, 40, 40),

--- a/crates/agent-tui/src/tui/theme/palettes/catppuccin.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/catppuccin.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(166, 173, 200),
 
             bg: Color::Rgb(30, 30, 46),
-            message_bg: Color::Rgb(24, 24, 38),
+            message_bg: Color::Rgb(21, 21, 33),
             border: Color::Rgb(88, 91, 112),
             border_active: Color::Rgb(180, 190, 254),
             muted: Color::Rgb(108, 112, 134),

--- a/crates/agent-tui/src/tui/theme/palettes/dracula.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/dracula.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(248, 248, 242),
 
             bg: Color::Rgb(12, 10, 18),
-            message_bg: Color::Rgb(8, 7, 13),
+            message_bg: Color::Rgb(12, 10, 18),
             border: Color::Rgb(30, 25, 40),
             border_active: Color::Rgb(189, 147, 249),
             muted: Color::Rgb(68, 71, 90),

--- a/crates/agent-tui/src/tui/theme/palettes/forest.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/forest.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(110, 160, 90),
 
             bg: Color::Rgb(8, 12, 6),
-            message_bg: Color::Rgb(5, 8, 4),
+            message_bg: Color::Rgb(8, 12, 6),
             border: Color::Rgb(50, 70, 35),
             border_active: Color::Rgb(120, 180, 100),
             muted: Color::Rgb(70, 90, 50),

--- a/crates/agent-tui/src/tui/theme/palettes/ice.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/ice.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(160, 200, 240),
 
             bg: Color::Rgb(5, 8, 12),
-            message_bg: Color::Rgb(3, 5, 8),
+            message_bg: Color::Rgb(5, 8, 12),
             border: Color::Rgb(40, 60, 90),
             border_active: Color::Rgb(180, 220, 255),
             muted: Color::Rgb(70, 90, 130),

--- a/crates/agent-tui/src/tui/theme/palettes/lavender.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/lavender.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(195, 180, 225),
 
             bg: Color::Rgb(12, 8, 20),
-            message_bg: Color::Rgb(8, 5, 15),
+            message_bg: Color::Rgb(12, 8, 20),
             border: Color::Rgb(50, 30, 80),
             border_active: Color::Rgb(170, 120, 255),
             muted: Color::Rgb(85, 60, 130),

--- a/crates/agent-tui/src/tui/theme/palettes/monokai.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/monokai.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(230, 219, 116),
 
             bg: Color::Rgb(33, 34, 28),
-            message_bg: Color::Rgb(27, 28, 23),
+            message_bg: Color::Rgb(24, 25, 21),
             border: Color::Rgb(73, 72, 62),
             border_active: Color::Rgb(253, 151, 31),
             muted: Color::Rgb(117, 113, 94),

--- a/crates/agent-tui/src/tui/theme/palettes/neon_rain.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/neon_rain.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(216, 210, 224),
 
             bg: Color::Rgb(8, 6, 12),
-            message_bg: Color::Rgb(5, 3, 8),
+            message_bg: Color::Rgb(8, 6, 12),
             border: Color::Rgb(30, 21, 48),
             border_active: Color::Rgb(255, 46, 136),
             muted: Color::Rgb(74, 58, 90),

--- a/crates/agent-tui/src/tui/theme/palettes/night_city.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/night_city.rs
@@ -30,7 +30,7 @@ impl Theme {
 
             // Base — deep blue-black haze, not pure black
             bg: Color::Rgb(10, 11, 17),
-            message_bg: Color::Rgb(6, 7, 12),
+            message_bg: Color::Rgb(10, 11, 17),
             border: Color::Rgb(30, 35, 52),
             border_active: CYAN,
             muted: Color::Rgb(74, 82, 104),

--- a/crates/agent-tui/src/tui/theme/palettes/nord.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/nord.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(216, 222, 233),
 
             bg: Color::Rgb(16, 18, 22),
-            message_bg: Color::Rgb(12, 14, 17),
+            message_bg: Color::Rgb(7, 8, 10),
             border: Color::Rgb(35, 40, 50),
             border_active: Color::Rgb(129, 161, 193),
             muted: Color::Rgb(75, 85, 105),

--- a/crates/agent-tui/src/tui/theme/palettes/ocean.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/ocean.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(176, 216, 230),
 
             bg: Color::Rgb(3, 8, 16),
-            message_bg: Color::Rgb(5, 12, 22),
+            message_bg: Color::Rgb(3, 8, 16),
             border: Color::Rgb(15, 30, 45),
             border_active: Color::Rgb(0, 206, 209),
             muted: Color::Rgb(45, 75, 105),

--- a/crates/agent-tui/src/tui/theme/palettes/phosphor.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/phosphor.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(60, 200, 90),
 
             bg: Color::Rgb(3, 8, 5),
-            message_bg: Color::Rgb(5, 13, 8),
+            message_bg: Color::Rgb(3, 8, 5),
             border: Color::Rgb(15, 40, 20),
             border_active: Color::Rgb(50, 255, 80),
             muted: Color::Rgb(25, 70, 35),

--- a/crates/agent-tui/src/tui/theme/palettes/rose_pine.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/rose_pine.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(224, 222, 244),
 
             bg: Color::Rgb(13, 10, 16),
-            message_bg: Color::Rgb(8, 6, 11),
+            message_bg: Color::Rgb(13, 10, 16),
             border: Color::Rgb(35, 28, 42),
             border_active: Color::Rgb(235, 111, 146),
             muted: Color::Rgb(85, 75, 95),

--- a/crates/agent-tui/src/tui/theme/palettes/solarized_dark.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/solarized_dark.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(147, 161, 161), // base1
 
             bg: Color::Rgb(0, 43, 54), // base03
-            message_bg: Color::Rgb(0, 35, 44),
+            message_bg: Color::Rgb(4, 49, 61),
             border: Color::Rgb(7, 54, 66), // base02
             border_active: Color::Rgb(38, 139, 210),
             muted: Color::Rgb(88, 110, 117), // base01

--- a/crates/agent-tui/src/tui/theme/palettes/sunset.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/sunset.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(220, 140, 100),
 
             bg: Color::Rgb(15, 8, 10),
-            message_bg: Color::Rgb(10, 5, 7),
+            message_bg: Color::Rgb(15, 8, 10),
             border: Color::Rgb(80, 40, 50),
             border_active: Color::Rgb(255, 140, 90),
             muted: Color::Rgb(100, 50, 60),

--- a/crates/agent-tui/src/tui/theme/palettes/tokyo_night.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/tokyo_night.rs
@@ -15,7 +15,7 @@ impl Theme {
             table_cell_color: Color::Rgb(169, 177, 214),
 
             bg: Color::Rgb(26, 27, 38),
-            message_bg: Color::Rgb(20, 21, 30),
+            message_bg: Color::Rgb(16, 17, 24),
             border: Color::Rgb(41, 46, 66),
             border_active: Color::Rgb(122, 162, 247),
             muted: Color::Rgb(86, 95, 137),


### PR DESCRIPTION
## Why a formula didn't work

`code_bg` and `user_bg` render **on top of** the conversation canvas, so the canvas must stay below `code_bg` in elevation or code blocks invert against the surface they sit on. Three algorithmic passes all violated that on 16/19 themes.

Measuring every palette against the real constraint:

| | themes | treatment |
|---|---|---|
| no headroom | 12 | flush with chrome |
| real headroom | 5 | recessed canvas, 1.07–1.11 |
| inverted palette | 1 | raised (`solarized-dark`) |
| shop window | 1 | chrome lifted (`default`) |

**12 flush** — `amber blood dracula forest ice lavender neon-rain night-city ocean phosphor rose-pine sunset`. These sit within a few RGB units of black. Even a *pure black* canvas fails to reach 1.05 contrast, and raising it collides with `code_bg`. There is no third elevation level available between two colours that already touch. They render flush and let the message border carry the separation.

**5 recessed** — `catppuccin` 1.103, `gruvbox` 1.105, `monokai` 1.102, `nord` 1.069, `tokyo-night` 1.102. Recessing preserves hue and saturation (91–110% kept). Lightening did not: an earlier attempt raised CIELAB L* with a/b fixed, and `blood` kept **23%** of its saturation — a grey canvas under a deep-red theme.

**`solarized-dark` raised.** Its `code_bg` (0,43,54 → 0,36,43) is *darker* than its `bg`, so code blocks already recess by that palette's own design. Recessing the canvas would collide. It goes up toward its own separator instead.

**`default` was flush**, which left the first theme anyone sees without a canvas. Its `bg` is too near black to recess into — pure black only reaches 1.074, and 1.05 needs (2,3,5), discarding the blue character. So the chrome lifts to (20,24,34) and the canvas takes the old bg (10,12,18): **the conversation surface keeps exactly the colour it had**, only header/input/footer move. Lands at 1.102, in line with the rest. `separator` and `border` remain above the new `bg`, so borders still read.

## Tests

Four tests encode the split rather than describe it, via an explicit `FLUSH` list carrying the measured reason — so nobody later "fixes" those 12 by inventing values that cannot exist:

- `flush_themes_match_chrome_exactly` — flush must match **exactly**; a near-miss reads as a rendering bug, not a choice
- `elevated_themes_separate_canvas_from_chrome` — 1.05–1.30 band
- `elevated_themes_keep_their_colour` — ≥85% saturation retained, the guard against the grey-mud version
- `canvas_never_outranks_code_blocks` — the elevation rule that invalidated the algorithmic attempts

The floor was not lowered to make values pass; the population was split and the reason documented.

## Verification

```
cargo test --workspace --locked    3606 passed  0 failed  exit 0
cargo clippy --all-targets -D warnings                    exit 0
cargo build --release                                     exit 0
```

Not verified: nobody has looked at these in a terminal yet. The numbers are sound; the taste call is open.