### PR TITLE
feat(tui): ocean user_bg lift + drop turn-separator divider

### DIFF
--- a/crates/agent-tui/src/tui/render.rs
+++ b/crates/agent-tui/src/tui/render.rs
@@ -249,7 +249,8 @@ impl TranscriptStore {
         match &tmsg.msg {
             ChatMessage::User(text) => {
                 let bg = Style::default().bg(THEME.load().user_bg);
-                // Top margin
+                // Top margin — extra <br> for breathing room before the pill
+                lines.push(Line::from(""));
                 lines.push(Line::from(""));
                 // Top padding
                 lines.push(Line::from(Span::styled(
@@ -465,6 +466,8 @@ impl TranscriptStore {
                         lines.push_meta(line, meta);
                     }
                 }
+                // Bottom margin — <br> after the agent message
+                lines.push(Line::from(""));
             }
 
             ChatMessage::ToolUseStart {

--- a/crates/agent-tui/src/tui/render.rs
+++ b/crates/agent-tui/src/tui/render.rs
@@ -414,11 +414,11 @@ impl TranscriptStore {
             }
 
             ChatMessage::Text(text) => {
-                // Separator between user block and agent response: always a
-                // single blank line, whether or not thinking preceded. The
-                // ──── · ──── divider was removed on user request; the blank
-                // line alone carries the beat.
+                // Turn boundary: two blank lines of breathing room between the
+                // previous block and the agent header. Replaces the old
+                // ──── · ──── divider — the extra <br> carries the beat.
                 if i > 0 {
+                    lines.push(Line::from(""));
                     lines.push(Line::from(""));
                 }
                 // Header

--- a/crates/agent-tui/src/tui/render.rs
+++ b/crates/agent-tui/src/tui/render.rs
@@ -414,27 +414,11 @@ impl TranscriptStore {
             }
 
             ChatMessage::Text(text) => {
-                // Separator between user block and agent response
-                // After thinking: just a single blank line (no separator)
-                let prev_was_thinking =
-                    i > 0 && matches!(&self.messages()[i - 1].msg, ChatMessage::Thinking(_));
-                if prev_was_thinking {
-                    lines.push(Line::from(""));
-                } else if i > 0 {
-                    lines.push(Line::from(""));
-                    let sep_total = width.min(40);
-                    let sep_half = sep_total / 2;
-                    let sep_left: String = "\u{2500}".repeat(sep_half.saturating_sub(2));
-                    let sep_right: String = "\u{2500}".repeat(sep_half.saturating_sub(2));
-                    let sep_content_width =
-                        sep_left.chars().count() + 3 + sep_right.chars().count();
-                    let pad_left = width.saturating_sub(sep_content_width) / 2;
-                    lines.push(Line::from(vec![
-                        Span::styled(" ".repeat(pad_left), Style::default()),
-                        Span::styled(sep_left, Style::default().fg(THEME.load().separator)),
-                        Span::styled(" \u{00b7} ", Style::default().fg(Color::Rgb(35, 55, 75))),
-                        Span::styled(sep_right, Style::default().fg(THEME.load().separator)),
-                    ]));
+                // Separator between user block and agent response: always a
+                // single blank line, whether or not thinking preceded. The
+                // ──── · ──── divider was removed on user request; the blank
+                // line alone carries the beat.
+                if i > 0 {
                     lines.push(Line::from(""));
                 }
                 // Header

--- a/crates/agent-tui/src/tui/theme/palettes/ocean.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/ocean.rs
@@ -21,7 +21,7 @@ impl Theme {
             muted: Color::Rgb(45, 75, 105),
 
             user_color: Color::Rgb(170, 210, 245),
-            user_bg: Color::Rgb(3, 8, 16),
+            user_bg: Color::Rgb(14, 22, 36),
             claude_label: Color::Rgb(64, 224, 208),
             claude_text: Color::Rgb(176, 216, 230),
             thinking_color: Color::Rgb(35, 65, 95),


### PR DESCRIPTION
Small QoL batch on top of the v0.7.1 canvas work.

## 1. `feat(theme): ocean — lift user_bg above chrome for a visible pill`

Ocean's `user_bg` was `(3, 8, 16)` — byte-identical to chrome `bg` — so user messages had no visible surface distinct from the canvas. Bumped to `(14, 22, 36)`, Δ `(+11, +14, +20)`.

- Preserves ocean's blue-forward hue (largest lift on the blue channel).
- Sits below `code_bg (5, 10, 20)` in luminance so code blocks still recess correctly.
- No test constraint changes needed.

## 2. `feat(tui): drop the ──── · ──── divider between turns`

The centered horizontal-rule-with-middle-dot separator was rendered between every user block and its following agent \`Text\` response, except when a thinking block had already carried the beat. It added visual noise without structural information — the agent header (\`◈ + name + timestamp\`) is already a strong turn-boundary marker on its own.

Uses the blank-line-only path unconditionally now. \`THEME.separator\` is no longer referenced from \`render.rs\`; leaving the token in the theme struct since user themes may still declare it and other surfaces could consume it later.

## Test status

492 passed / 1 failed / 3 ignored.

The single failure is \`tui::models::input::tests::e_opens_expanded_provider_browser\` — pre-existing flaky test (tracked as task #160, "make TUI test e_opens_expanded_provider_browser hermetic"), unrelated to this diff.

## Follow-up

This is the first slice of the "handpick canvas per theme" pass; only ocean got a pill tweak this round because Haseeb eyeball-approved solarized-dark's canon values. More themes can land in subsequent PRs as they get eyeballed.