### PR TITLE
test(tui): #[ignore] estimator syntect-counter test (hermeticity flake)

### DIFF
--- a/crates/agent-tui/src/tui/transcript/estimate.rs
+++ b/crates/agent-tui/src/tui/transcript/estimate.rs
@@ -393,6 +393,7 @@ mod tests {
     // an isolated process.
     // ─────────────────────────────────────────────────────────────────────────
     #[test]
+    #[ignore = "reads process-global HIGHLIGHT_CALLS counter; run isolated with --ignored --test-threads=1 (see task #285)"]
     fn estimator_over_1000_fenced_messages_zero_highlight_calls() {
         use super::super::super::highlight;
 


### PR DESCRIPTION
## What

One-line: adds \`#[ignore = \"reads process-global HIGHLIGHT_CALLS counter…\"]\` to \`estimator_over_1000_fenced_messages_zero_highlight_calls\`, matching the three sibling tests in \`slice3_lazy_ratchets\` that already carry the same attribute.

## Why

Post-#74 dev CI failed on this test:

\`\`\`
assertion \`left == right\` failed: estimator over 1000 fenced messages must
never call the highlight module (got 1 calls -- syntect must NOT be touched
by the estimator)
  left: 1
 right: 0
\`\`\`

Root cause: the test resets the process-global \`HIGHLIGHT_CALLS\` \`AtomicUsize\` (declared in \`crates/agent-tui/src/tui/highlight.rs:74\`), runs the estimator, then asserts the counter is still zero. Under \`cargo test\`'s default parallel execution, any other test that calls syntect between the reset and the read spuriously bumps it. Not caused by #74's changes — #74 didn't touch estimate/highlight code paths at all.

The three sibling tests in \`transcript/slice3_lazy_ratchets.rs\` are already marked:
- \`baseline_slice0_cold_missing_renders_all_messages ... ignored, slow: halo reaches fenced tail msgs → loads syntect; run with --ignored\`
- \`baseline_slice0_warm_cache_second_frame_zero_renders ... ignored, slow: loads syntect defaults; run explicitly with --ignored\`
- \`slice3_t3_offscreen_code_fence_zero_highlight_calls ... ignored, reads process-global highlight counters; run isolated with --ignored --test-threads=1\`

This test just got missed. This PR corrects that.

## Verification

Isolated run passes clean:
\`\`\`
cargo test -p synaps-tui --lib \\
    estimator_over_1000_fenced_messages_zero_highlight_calls \\
    -- --ignored --test-threads=1
\`\`\`
→ \`test result: ok. 1 passed; 0 failed; 0 ignored\`

## Follow-up

**Task #285** filed for the proper fix — tag every syntect-touching test with \`#[serial_test::serial(highlight)]\` (dep already in workspace, used elsewhere in \`commands.rs\` + \`draw.rs\`), then drop all four \`#[ignore]\` attributes. Same debt class as **T160**.