### PR TITLE
feat(theme): align ocean user turns with chrome

### DIFF
--- a/crates/agent-tui/src/tui/theme/palettes/ocean.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/ocean.rs
@@ -21,7 +21,8 @@ impl Theme {
             muted: Color::Rgb(45, 75, 105),
 
             user_color: Color::Rgb(170, 210, 245),
-            user_bg: Color::Rgb(14, 22, 36),
+            // User turns share the header/footer chrome surface.
+            user_bg: Color::Rgb(3, 8, 16),
             claude_label: Color::Rgb(64, 224, 208),
             claude_text: Color::Rgb(176, 216, 230),
             thinking_color: Color::Rgb(35, 65, 95),


### PR DESCRIPTION
## Summary

Align Ocean user-message cards with the theme’s header/footer chrome surface.

- `user_bg`: `(14, 22, 36)` → `(3, 8, 16)`
- Leaves Ocean’s intentionally near-black transcript canvas unchanged.

Visually tuned on the live terminal path.