### PR TITLE
TUI input editor → tui-textarea-2 hybrid (P1+P2): real multiline editing, undo/redo, CR-safe paste

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3415,6 +3415,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tui-textarea-2",
  "unicode-width",
  "uuid",
  "vt100",
@@ -3987,6 +3988,20 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tui-textarea-2"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4296a13cbcb20abd7b62f96154cad81053eb82ee8d24db3d7fdca16b31f118e9"
+dependencies = [
+ "crossterm",
+ "portable-atomic",
+ "ratatui-core",
+ "ratatui-widgets",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "tungstenite"

--- a/crates/agent-tui/Cargo.toml
+++ b/crates/agent-tui/Cargo.toml
@@ -43,6 +43,10 @@ syntect       = { version = "5", default-features = false, features = ["default-
 arc-swap      = "1"
 unicode-width = "0.2.0"
 arboard       = "3"
+# Input editing state machine (hybrid plan §4): maintained fork of tui-textarea.
+# TextArea is never rendered — it owns editing semantics only; the existing
+# soft-wrap render pipeline consumes flat (text, cursor) via compat accessors.
+tui-textarea-2 = { version = "0.12", default-features = false, features = ["crossterm"] }
 
 # Signal handling (tui/signals.rs)
 signal-hook  = { version = "0.3", features = ["iterator"] }

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -29,6 +29,12 @@ pub(crate) const WIDGET_EVENT_QUEUE_CAPACITY: usize = 256;
 /// come back as a [`super::view_model::RenderPatch`].
 pub(crate) struct App {
     pub(crate) transcript: TranscriptStore,
+    /// Editing state machine (hybrid plan §3.1, tui-textarea-2). Never
+    /// rendered — snapshot time derives flat `(text, cursor)` via the compat
+    /// accessors (`input_text`, `cursor_char_pos`) and feeds the unchanged
+    /// soft-wrap render pipeline. `input`/`cursor_pos` below are one-way
+    /// mirrors (editor → mirror via `sync_input_mirror`) until P3 removes them.
+    pub(crate) editor: tui_textarea::TextArea<'static>,
     pub(crate) input: String,
     /// Cursor position as a **char index** (not byte index).
     /// Use `cursor_byte_pos()` to convert to byte offset for String operations.
@@ -240,6 +246,7 @@ impl App {
             tokio::sync::mpsc::channel(WIDGET_EVENT_QUEUE_CAPACITY);
         Self {
             transcript: TranscriptStore::new(clock.clone()),
+            editor: tui_textarea::TextArea::default(),
             input: String::new(),
             cursor_pos: 0,
             api_messages: Vec::new(),
@@ -367,6 +374,55 @@ impl App {
                 after_paste.trim()
             ),
         }
+    }
+
+    // ── Editor compat accessors (hybrid plan §3.1) ─────────────────────────
+    // The editor owns editing state; everything else keeps reading the flat
+    // `input`/`cursor_pos` mirrors, refreshed by `sync_input_mirror` after
+    // every editor mutation. P3 deletes the mirrors and these become the only
+    // way in/out of the input buffer.
+
+    /// Flat input text — editor lines joined by `\n`.
+    pub(crate) fn input_text(&self) -> String {
+        self.editor.lines().join("\n")
+    }
+
+    /// True when the input buffer contains no text at all.
+    pub(crate) fn input_is_empty(&self) -> bool {
+        let lines = self.editor.lines();
+        lines.len() <= 1 && lines.first().is_none_or(|l| l.is_empty())
+    }
+
+    /// Flat **char** index of the editor cursor within `input_text()`.
+    pub(crate) fn cursor_char_pos(&self) -> usize {
+        flat_cursor_pos(self.editor.lines(), self.editor.cursor())
+    }
+
+    /// Replace the whole buffer, cursor moved to the end of the text.
+    pub(crate) fn set_input_text(&mut self, s: &str) {
+        self.editor = tui_textarea::TextArea::from(s.split('\n'));
+        self.editor.move_cursor(tui_textarea::CursorMove::Bottom);
+        self.editor.move_cursor(tui_textarea::CursorMove::End);
+        self.sync_input_mirror();
+    }
+
+    /// Clear the whole buffer (today's Ctrl-U semantics — plan §3.2 note).
+    pub(crate) fn clear_input(&mut self) {
+        self.editor = tui_textarea::TextArea::default();
+        self.sync_input_mirror();
+    }
+
+    /// Insert text at the cursor (paste, sidecar transcription, tab-complete).
+    pub(crate) fn insert_at_cursor(&mut self, s: &str) {
+        self.editor.insert_str(s);
+        self.sync_input_mirror();
+    }
+
+    /// One-way editor → mirror sync. Must run after every editor mutation so
+    /// snapshot/draw (which still read `input`/`cursor_pos`) stay coherent.
+    pub(crate) fn sync_input_mirror(&mut self) {
+        self.input = self.input_text();
+        self.cursor_pos = self.cursor_char_pos();
     }
 
     /// Restore SynapsCLI's TUI after casino (or failed spawn).
@@ -758,6 +814,19 @@ impl App {
     pub(crate) fn render_lines(&self, width: usize) -> Vec<ratatui::text::Line<'static>> {
         self.transcript.render_lines(width, &self.render_ctx())
     }
+}
+
+/// Map the editor's `(row, col)` char-wise cursor to a flat char index into
+/// `lines.join("\n")` — the only new math in the hybrid design (plan §3.1):
+/// `sum(chars(lines[..row]) + 1) + col`, the `+ 1` counting each `\n`.
+/// `col` is clamped to the row's char count defensively.
+pub(crate) fn flat_cursor_pos(lines: &[String], (row, col): (usize, usize)) -> usize {
+    let mut flat = 0;
+    for line in lines.iter().take(row) {
+        flat += line.chars().count() + 1; // +1 for the joining '\n'
+    }
+    let row_chars = lines.get(row).map_or(0, |l| l.chars().count());
+    flat + col.min(row_chars)
 }
 
 #[cfg(test)]
@@ -1863,5 +1932,89 @@ mod tests {
             expected_flat.len(),
             "cum_heights total must track the reference render after insert + incremental rebuild"
         );
+    }
+
+    // ── flat_cursor_pos (hybrid plan §3.1 helper) ──────────────────────────
+
+    fn lines_of(strs: &[&str]) -> Vec<String> {
+        strs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn flat_cursor_empty_buffer() {
+        assert_eq!(flat_cursor_pos(&lines_of(&[""]), (0, 0)), 0);
+        // Truly empty slice must not panic either.
+        assert_eq!(flat_cursor_pos(&[], (0, 0)), 0);
+    }
+
+    #[test]
+    fn flat_cursor_single_line() {
+        let lines = lines_of(&["hello"]);
+        assert_eq!(flat_cursor_pos(&lines, (0, 0)), 0);
+        assert_eq!(flat_cursor_pos(&lines, (0, 3)), 3);
+        assert_eq!(flat_cursor_pos(&lines, (0, 5)), 5); // at end
+    }
+
+    #[test]
+    fn flat_cursor_multi_line() {
+        // "ab\ncde\nf" — flat chars: a=0 b=1 \n=2 c=3 d=4 e=5 \n=6 f=7
+        let lines = lines_of(&["ab", "cde", "f"]);
+        assert_eq!(flat_cursor_pos(&lines, (0, 2)), 2); // end of line 0
+        assert_eq!(flat_cursor_pos(&lines, (1, 0)), 3); // just after first \n
+        assert_eq!(flat_cursor_pos(&lines, (1, 2)), 5);
+        assert_eq!(flat_cursor_pos(&lines, (2, 0)), 7); // after second \n
+        assert_eq!(flat_cursor_pos(&lines, (2, 1)), 8); // end of buffer
+    }
+
+    #[test]
+    fn flat_cursor_wide_chars() {
+        // Char-wise, not width-wise: CJK and emoji count 1 each.
+        let lines = lines_of(&["日本語", "a👍b"]);
+        assert_eq!(flat_cursor_pos(&lines, (0, 2)), 2);
+        assert_eq!(flat_cursor_pos(&lines, (0, 3)), 3); // end of CJK line
+        assert_eq!(flat_cursor_pos(&lines, (1, 0)), 4);
+        assert_eq!(flat_cursor_pos(&lines, (1, 2)), 6); // after the emoji
+        assert_eq!(flat_cursor_pos(&lines, (1, 3)), 7); // end
+    }
+
+    #[test]
+    fn flat_cursor_clamps_out_of_range_col() {
+        let lines = lines_of(&["ab", "cd"]);
+        assert_eq!(flat_cursor_pos(&lines, (0, 99)), 2);
+        assert_eq!(flat_cursor_pos(&lines, (1, 99)), 5);
+    }
+
+    #[test]
+    fn accessors_round_trip_and_mirror_sync() {
+        let mut app = test_app();
+        assert!(app.input_is_empty());
+        assert_eq!(app.cursor_char_pos(), 0);
+
+        app.set_input_text("hello\nworld");
+        assert_eq!(app.input_text(), "hello\nworld");
+        assert!(!app.input_is_empty());
+        // set_input_text puts the cursor at the very end.
+        assert_eq!(app.cursor_char_pos(), 11);
+        // Mirrors track the editor.
+        assert_eq!(app.input, "hello\nworld");
+        assert_eq!(app.cursor_pos, 11);
+
+        app.insert_at_cursor("!");
+        assert_eq!(app.input_text(), "hello\nworld!");
+        assert_eq!(app.cursor_pos, 12);
+
+        app.clear_input();
+        assert!(app.input_is_empty());
+        assert_eq!(app.input, "");
+        assert_eq!(app.cursor_pos, 0);
+    }
+
+    #[test]
+    fn editor_cursor_matches_flat_pos_after_typing() {
+        let mut app = test_app();
+        app.set_input_text("日本\nab");
+        // cursor at end: row 1 col 2 → flat 3 (line0) + 2
+        assert_eq!(app.editor.cursor(), (1, 2));
+        assert_eq!(app.cursor_char_pos(), 5);
     }
 }

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -435,11 +435,6 @@ impl App {
             .unwrap_or(self.input.len())
     }
 
-    /// Number of chars in self.input (for bounds checking cursor_pos).
-    pub(crate) fn input_char_count(&self) -> usize {
-        self.input.chars().count()
-    }
-
     /// Calculate the number of visual lines the input needs, given an inner width.
     /// Returns (total_lines, cursor_row, cursor_col) for layout and cursor placement.
     ///
@@ -675,7 +670,7 @@ impl App {
         }
         match self.history_index {
             None => {
-                self.input_stash = self.input.clone();
+                self.input_stash = self.input_text();
                 self.history_index = Some(self.input_history.len() - 1);
             }
             Some(i) if i > 0 => {
@@ -684,8 +679,9 @@ impl App {
             _ => return,
         }
         if let Some(idx) = self.history_index {
-            self.input = self.input_history[idx].clone();
-            self.cursor_pos = self.input.chars().count();
+            let text = self.input_history[idx].clone();
+            // set_input_text keeps editor + mirrors coherent, cursor at end.
+            self.set_input_text(&text);
         }
     }
 
@@ -693,13 +689,13 @@ impl App {
         if let Some(i) = self.history_index {
             if i + 1 < self.input_history.len() {
                 self.history_index = Some(i + 1);
-                self.input = self.input_history[i + 1].clone();
+                let text = self.input_history[i + 1].clone();
+                self.set_input_text(&text);
             } else {
                 self.history_index = None;
-                self.input = self.input_stash.clone();
-                self.input_stash.clear();
+                let stash = std::mem::take(&mut self.input_stash);
+                self.set_input_text(&stash);
             }
-            self.cursor_pos = self.input.chars().count();
         }
     }
 

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -29,16 +29,11 @@ pub(crate) const WIDGET_EVENT_QUEUE_CAPACITY: usize = 256;
 /// come back as a [`super::view_model::RenderPatch`].
 pub(crate) struct App {
     pub(crate) transcript: TranscriptStore,
-    /// Editing state machine (hybrid plan §3.1, tui-textarea-2). Never
-    /// rendered — snapshot time derives flat `(text, cursor)` via the compat
+    /// Sole input-buffer state (hybrid plan §3.1, tui-textarea-2). Never
+    /// rendered — snapshot time derives flat `(text, cursor)` via the
     /// accessors (`input_text`, `cursor_char_pos`) and feeds the unchanged
-    /// soft-wrap render pipeline. `input`/`cursor_pos` below are one-way
-    /// mirrors (editor → mirror via `sync_input_mirror`) until P3 removes them.
+    /// soft-wrap render pipeline.
     pub(crate) editor: tui_textarea::TextArea<'static>,
-    pub(crate) input: String,
-    /// Cursor position as a **char index** (not byte index).
-    /// Use `cursor_byte_pos()` to convert to byte offset for String operations.
-    pub(crate) cursor_pos: usize,
     pub(crate) api_messages: Vec<synaps_cli::SharedMessage>,
     pub(crate) streaming: bool,
     /// `api_messages.len()` at active-turn start. Failure repair may only
@@ -247,8 +242,6 @@ impl App {
         Self {
             transcript: TranscriptStore::new(clock.clone()),
             editor: tui_textarea::TextArea::default(),
-            input: String::new(),
-            cursor_pos: 0,
             api_messages: Vec::new(),
             streaming: false,
             turn_baseline: 0,
@@ -376,15 +369,20 @@ impl App {
         }
     }
 
-    // ── Editor compat accessors (hybrid plan §3.1) ─────────────────────────
-    // The editor owns editing state; everything else keeps reading the flat
-    // `input`/`cursor_pos` mirrors, refreshed by `sync_input_mirror` after
-    // every editor mutation. P3 deletes the mirrors and these become the only
-    // way in/out of the input buffer.
+    // ── Editor accessors (hybrid plan §3.1) ────────────────────────────────
+    // The editor is the sole input-buffer state; these accessors are the only
+    // way in/out. The render path materializes one flat `(text, cursor)` pair
+    // per frame in `ViewInputs::from_app`.
 
     /// Flat input text — editor lines joined by `\n`.
     pub(crate) fn input_text(&self) -> String {
         self.editor.lines().join("\n")
+    }
+
+    /// First line of the buffer, borrowed — for cheap hot-path guards that
+    /// only care about the line a slash command lives on (`/`-detection).
+    pub(crate) fn input_first_line(&self) -> &str {
+        self.editor.lines().first().map_or("", |s| s.as_str())
     }
 
     /// True when the input buffer contains no text at all.
@@ -403,36 +401,16 @@ impl App {
         self.editor = tui_textarea::TextArea::from(s.split('\n'));
         self.editor.move_cursor(tui_textarea::CursorMove::Bottom);
         self.editor.move_cursor(tui_textarea::CursorMove::End);
-        self.sync_input_mirror();
     }
 
     /// Clear the whole buffer (today's Ctrl-U semantics — plan §3.2 note).
     pub(crate) fn clear_input(&mut self) {
         self.editor = tui_textarea::TextArea::default();
-        self.sync_input_mirror();
     }
 
     /// Insert text at the cursor (paste, sidecar transcription, tab-complete).
     pub(crate) fn insert_at_cursor(&mut self, s: &str) {
         self.editor.insert_str(s);
-        self.sync_input_mirror();
-    }
-
-    /// One-way editor → mirror sync. Must run after every editor mutation so
-    /// snapshot/draw (which still read `input`/`cursor_pos`) stay coherent.
-    pub(crate) fn sync_input_mirror(&mut self) {
-        self.input = self.input_text();
-        self.cursor_pos = self.cursor_char_pos();
-    }
-
-    /// Restore SynapsCLI's TUI after casino (or failed spawn).
-    /// Convert char-based cursor_pos to byte offset in self.input.
-    pub(crate) fn cursor_byte_pos(&self) -> usize {
-        self.input
-            .char_indices()
-            .nth(self.cursor_pos)
-            .map(|(i, _)| i)
-            .unwrap_or(self.input.len())
     }
 
     /// Calculate the number of visual lines the input needs, given an inner width.
@@ -680,7 +658,7 @@ impl App {
         }
         if let Some(idx) = self.history_index {
             let text = self.input_history[idx].clone();
-            // set_input_text keeps editor + mirrors coherent, cursor at end.
+            // set_input_text rebuilds the editor with the cursor at the end.
             self.set_input_text(&text);
         }
     }
@@ -1981,7 +1959,7 @@ mod tests {
     }
 
     #[test]
-    fn accessors_round_trip_and_mirror_sync() {
+    fn accessors_round_trip() {
         let mut app = test_app();
         assert!(app.input_is_empty());
         assert_eq!(app.cursor_char_pos(), 0);
@@ -1991,18 +1969,17 @@ mod tests {
         assert!(!app.input_is_empty());
         // set_input_text puts the cursor at the very end.
         assert_eq!(app.cursor_char_pos(), 11);
-        // Mirrors track the editor.
-        assert_eq!(app.input, "hello\nworld");
-        assert_eq!(app.cursor_pos, 11);
+        assert_eq!(app.input_first_line(), "hello");
 
         app.insert_at_cursor("!");
         assert_eq!(app.input_text(), "hello\nworld!");
-        assert_eq!(app.cursor_pos, 12);
+        assert_eq!(app.cursor_char_pos(), 12);
 
         app.clear_input();
         assert!(app.input_is_empty());
-        assert_eq!(app.input, "");
-        assert_eq!(app.cursor_pos, 0);
+        assert_eq!(app.input_text(), "");
+        assert_eq!(app.cursor_char_pos(), 0);
+        assert_eq!(app.input_first_line(), "");
     }
 
     #[test]

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -390,7 +390,7 @@ impl App {
     /// True when the input buffer contains no text at all.
     pub(crate) fn input_is_empty(&self) -> bool {
         let lines = self.editor.lines();
-        lines.len() <= 1 && lines.first().is_none_or(|l| l.is_empty())
+        lines.len() <= 1 && lines.first().map_or(true, |l| l.is_empty())
     }
 
     /// Flat **char** index of the editor cursor within `input_text()`.

--- a/crates/agent-tui/src/tui/draw.rs
+++ b/crates/agent-tui/src/tui/draw.rs
@@ -519,7 +519,7 @@ pub(crate) fn build_render_model(
     };
     let input_inner_width = term_size.width.saturating_sub(2);
     let (input_lines, _, _) =
-        super::view_model::input_wrap_info(inputs.input, inputs.cursor_pos, input_inner_width);
+        super::view_model::input_wrap_info(&inputs.input, inputs.cursor_pos, input_inner_width);
     let max_input_lines: u16 = 10;
     let input_height = input_lines.min(max_input_lines) + 2;
     let download_height: u16 = if !inputs.active_tasks.is_empty() {

--- a/crates/agent-tui/src/tui/input.rs
+++ b/crates/agent-tui/src/tui/input.rs
@@ -341,6 +341,13 @@ fn handle_key(
             app.editor.insert_newline();
             app.sync_input_mirror();
         }
+        // Alt-Enter: same as Shift-Enter. Legacy terminals (and tmux) encode
+        // it as ESC+CR, which survives everywhere — Shift-Enter needs the
+        // kitty keyboard protocol and often arrives as plain Enter.
+        (KeyCode::Enter, KeyModifiers::ALT) if !streaming => {
+            app.editor.insert_newline();
+            app.sync_input_mirror();
+        }
         (KeyCode::Enter, _) if !streaming && !app.input_is_empty() => {
             return process_submit(app, registry);
         }

--- a/crates/agent-tui/src/tui/input.rs
+++ b/crates/agent-tui/src/tui/input.rs
@@ -111,7 +111,7 @@ fn handle_event_inner(
     scroll_lines: u16,
 ) -> InputAction {
     match event {
-        Event::Key(key) => handle_key(key.code, key.modifiers, app, streaming, registry, keybinds),
+        Event::Key(key) => handle_key(key, app, streaming, registry, keybinds),
         Event::Mouse(mouse) => handle_mouse(mouse, app, scroll_lines),
         Event::Paste(text) => {
             // Suppress paste events that fire immediately after a right-click copy.
@@ -141,11 +141,9 @@ fn handle_event_inner(
                 text
             };
             if app.input_before_paste.is_none() {
-                app.input_before_paste = Some(app.input.clone());
+                app.input_before_paste = Some(app.input_text());
             }
-            let byte_pos = app.cursor_byte_pos();
-            app.input.insert_str(byte_pos, &text);
-            app.cursor_pos += text.chars().count();
+            app.insert_at_cursor(&text);
             app.pasted_char_count += text.chars().count();
             InputAction::None
         }
@@ -223,11 +221,9 @@ fn handle_mouse(
                 if let Some(text) = paste_from_clipboard() {
                     if !text.is_empty() {
                         if app.input_before_paste.is_none() {
-                            app.input_before_paste = Some(app.input.clone());
+                            app.input_before_paste = Some(app.input_text());
                         }
-                        let byte_pos = app.cursor_byte_pos();
-                        app.input.insert_str(byte_pos, &text);
-                        app.cursor_pos += text.chars().count();
+                        app.insert_at_cursor(&text);
                         app.pasted_char_count += text.chars().count();
                     }
                 }
@@ -275,15 +271,21 @@ fn paste_from_clipboard() -> Option<String> {
     None
 }
 
-/// Handle a key event.
+/// Handle a key event on the base Chat pane.
+///
+/// Interception contract (hybrid plan §3.2): app-level keys — quit, abort,
+/// submit, tab-completion, transcript scroll, Ctrl-O, Ctrl-U (clear whole
+/// buffer), history-at-edges Up/Down (§3.3) — are matched here with today's
+/// exact semantics. Every other editing key is forwarded to the TextArea
+/// editor, then mirrored via `sync_input_mirror`.
 fn handle_key(
-    code: KeyCode,
-    modifiers: KeyModifiers,
+    key: crossterm::event::KeyEvent,
     app: &mut App,
     streaming: bool,
     registry: &Arc<CommandRegistry>,
     keybinds: &synaps_cli::skills::keybinds::KeybindRegistry,
 ) -> InputAction {
+    let (code, modifiers) = (key.code, key.modifiers);
     // Clear text selection on any keypress (typing dismisses selection)
     app.transcript.clear_selection();
     // Any non-Tab key resets the tab-completion cycle state. (Tab handler
@@ -333,16 +335,18 @@ fn handle_key(
             return InputAction::Abort;
         }
         (KeyCode::Enter, KeyModifiers::SHIFT) if !streaming => {
-            let byte_pos = app.cursor_byte_pos();
-            app.input.insert(byte_pos, '\n');
-            app.cursor_pos += 1;
+            app.editor.insert_newline();
+            app.sync_input_mirror();
         }
-        (KeyCode::Enter, _) if !streaming && !app.input.is_empty() => {
+        (KeyCode::Enter, _) if !streaming && !app.input_is_empty() => {
             return process_submit(app, registry);
         }
-        (KeyCode::Enter, _) if streaming && !app.input.is_empty() => {
+        (KeyCode::Enter, _) if streaming && !app.input_is_empty() => {
             return process_streaming_submit(app);
         }
+        // Enter that matched none of the above (empty buffer) stays a no-op.
+        // It must NOT reach the editor, which would insert a newline.
+        (KeyCode::Enter, _) => {}
         (KeyCode::Tab, _) if app.input.starts_with('/') && app.input.len() > 1 => {
             if open_help_find_for_ambiguous_slash(app, registry) {
                 return InputAction::HelpFindOutcome;
@@ -351,31 +355,15 @@ fn handle_key(
             // Skip the tab_cycle reset below — we just set it.
             return InputAction::None;
         }
-        // Cursor movement
-        (KeyCode::Char('a'), KeyModifiers::CONTROL) => {
-            app.cursor_pos = 0;
-        }
-        (KeyCode::Char('e'), KeyModifiers::CONTROL) => {
-            app.cursor_pos = app.input.chars().count();
-        }
-        (KeyCode::Char('w'), KeyModifiers::CONTROL) | (KeyCode::Backspace, KeyModifiers::ALT) => {
-            delete_word_backward(app);
-        }
+        // Tab outside slash-completion was a no-op before; the editor would
+        // insert a literal tab char. Keep the no-op.
+        (KeyCode::Tab, _) => {}
+        // Esc outside streaming: no-op, never forwarded.
+        (KeyCode::Esc, _) => {}
+        // Ctrl-U clears the WHOLE buffer (today's semantics), not the lib's
+        // default binding.
         (KeyCode::Char('u'), KeyModifiers::CONTROL) => {
-            app.input.clear();
-            app.cursor_pos = 0;
-        }
-        (KeyCode::Home, _) => {
-            app.cursor_pos = 0;
-        }
-        (KeyCode::End, _) => {
-            app.cursor_pos = app.input.chars().count();
-        }
-        (KeyCode::Left, KeyModifiers::ALT) => {
-            jump_word_left(app);
-        }
-        (KeyCode::Right, KeyModifiers::ALT) => {
-            jump_word_right(app);
+            app.clear_input();
         }
         (KeyCode::Char('o'), KeyModifiers::CONTROL) => {
             // Store-owned toggle invalidates internally (locked decision #1);
@@ -384,21 +372,15 @@ fn handle_key(
                 .set_show_full_output(!app.transcript.show_full_output());
             app.request_redraw();
         }
-        (KeyCode::Char(c), _) => {
-            let byte_pos = app.cursor_byte_pos();
-            app.input.insert(byte_pos, c);
-            app.cursor_pos += 1;
+        // Alt-←/→ word jumps: the lib maps Alt-b/f and Ctrl-←/→ but leaves
+        // plain Alt-←/→ unmapped — keep today's semantics via explicit moves.
+        (KeyCode::Left, KeyModifiers::ALT) => {
+            app.editor.move_cursor(tui_textarea::CursorMove::WordBack);
+            app.sync_input_mirror();
         }
-        (KeyCode::Backspace, _) if app.cursor_pos > 0 => {
-            app.cursor_pos -= 1;
-            let byte_pos = app.cursor_byte_pos();
-            app.input.remove(byte_pos);
-        }
-        (KeyCode::Left, _) if app.cursor_pos > 0 => {
-            app.cursor_pos -= 1;
-        }
-        (KeyCode::Right, _) if app.cursor_pos < app.input_char_count() => {
-            app.cursor_pos += 1;
+        (KeyCode::Right, KeyModifiers::ALT) => {
+            app.editor.move_cursor(tui_textarea::CursorMove::WordForward);
+            app.sync_input_mirror();
         }
         (KeyCode::Up, KeyModifiers::SHIFT) => {
             app.transcript.scroll_up(1);
@@ -406,13 +388,30 @@ fn handle_key(
         (KeyCode::Down, KeyModifiers::SHIFT) => {
             app.transcript.scroll_down(1);
         }
+        // Up/Down: history only at buffer edges (§3.3 DECIDED); inside a
+        // multi-line buffer they move the cursor.
         (KeyCode::Up, _) => {
-            app.history_up();
+            if app.editor.cursor().0 == 0 {
+                app.history_up();
+            } else {
+                app.editor.input(key);
+                app.sync_input_mirror();
+            }
         }
         (KeyCode::Down, _) => {
-            app.history_down();
+            if app.editor.cursor().0 + 1 >= app.editor.lines().len() {
+                app.history_down();
+            } else {
+                app.editor.input(key);
+                app.sync_input_mirror();
+            }
         }
-        _ => {}
+        // Everything else — chars, Backspace/Delete, ←/→, Home/End,
+        // Ctrl-A/E/W/K, Alt-Backspace, undo/redo — is the editor's job.
+        _ => {
+            app.editor.input(key);
+            app.sync_input_mirror();
+        }
     }
     InputAction::None
 }
@@ -422,12 +421,11 @@ fn process_submit(app: &mut App, registry: &Arc<CommandRegistry>) -> InputAction
     if app.transcript.is_empty() {
         app.logo_dismiss_t = Some(0.001);
     }
-    let input = app.input.clone();
+    let input = app.input_text();
     app.input_history.push(input.clone());
     app.history_index = None;
     app.input_stash.clear();
-    app.input.clear();
-    app.cursor_pos = 0;
+    app.clear_input();
     app.transcript.scroll_to_bottom();
 
     if input.starts_with('/') && input.len() > 1 {
@@ -444,12 +442,11 @@ fn process_submit(app: &mut App, registry: &Arc<CommandRegistry>) -> InputAction
 
 /// User pressed Enter with non-empty input while streaming.
 fn process_streaming_submit(app: &mut App) -> InputAction {
-    let input = app.input.clone();
+    let input = app.input_text();
     app.input_history.push(input.clone());
     app.history_index = None;
     app.input_stash.clear();
-    app.input.clear();
-    app.cursor_pos = 0;
+    app.clear_input();
     app.input_before_paste = None;
     app.pasted_char_count = 0;
 
@@ -869,8 +866,7 @@ fn handle_tab_complete(app: &mut App, registry: &Arc<CommandRegistry>) {
             return;
         }
         let next = (idx + 1) % matching_cmds.len();
-        app.input = format!("/{}", matching_cmds[next]);
-        app.cursor_pos = app.input.chars().count();
+        app.set_input_text(&format!("/{}", matching_cmds[next]));
         app.tab_cycle = Some((prefix.clone(), next, matching_cmds.clone()));
         return;
     }
@@ -884,8 +880,7 @@ fn handle_tab_complete(app: &mut App, registry: &Arc<CommandRegistry>) {
         .collect();
 
     if matches.len() == 1 {
-        app.input = format!("/{}", matches[0]);
-        app.cursor_pos = app.input.chars().count();
+        app.set_input_text(&format!("/{}", matches[0]));
         return;
     }
 
@@ -903,12 +898,10 @@ fn handle_tab_complete(app: &mut App, registry: &Arc<CommandRegistry>) {
 
         if common_len > partial.len() {
             // Extend to common prefix — don't start cycling yet.
-            app.input = format!("/{}", &first[..common_len]);
-            app.cursor_pos = app.input.chars().count();
+            app.set_input_text(&format!("/{}", &first[..common_len]));
         } else {
             // Already at common prefix — start cycle from match[0].
-            app.input = format!("/{}", matches[0]);
-            app.cursor_pos = app.input.chars().count();
+            app.set_input_text(&format!("/{}", matches[0]));
             app.tab_cycle = Some((partial, 0, matches));
         }
         return;
@@ -916,57 +909,8 @@ fn handle_tab_complete(app: &mut App, registry: &Arc<CommandRegistry>) {
 
     // No prefix matches — try fuzzy matching
     if let Some(fuzzy) = super::commands::fuzzy_match(&partial, &commands) {
-        app.input = format!("/{}", fuzzy);
-        app.cursor_pos = app.input.chars().count();
+        app.set_input_text(&format!("/{}", fuzzy));
     }
-}
-
-/// Delete word backward (Ctrl+W / Alt+Backspace).
-fn delete_word_backward(app: &mut App) {
-    let chars: Vec<char> = app.input.chars().collect();
-    let mut pos = app.cursor_pos;
-    while pos > 0 && chars[pos - 1] == ' ' {
-        pos -= 1;
-    }
-    while pos > 0 && chars[pos - 1] != ' ' {
-        pos -= 1;
-    }
-    let byte_start = app
-        .input
-        .char_indices()
-        .nth(pos)
-        .map(|(i, _)| i)
-        .unwrap_or(app.input.len());
-    let byte_end = app.cursor_byte_pos();
-    app.input.drain(byte_start..byte_end);
-    app.cursor_pos = pos;
-}
-
-/// Jump cursor one word left.
-fn jump_word_left(app: &mut App) {
-    let chars: Vec<char> = app.input.chars().collect();
-    let mut pos = app.cursor_pos;
-    while pos > 0 && chars[pos - 1] == ' ' {
-        pos -= 1;
-    }
-    while pos > 0 && chars[pos - 1] != ' ' {
-        pos -= 1;
-    }
-    app.cursor_pos = pos;
-}
-
-/// Jump cursor one word right.
-fn jump_word_right(app: &mut App) {
-    let chars: Vec<char> = app.input.chars().collect();
-    let len = chars.len();
-    let mut pos = app.cursor_pos;
-    while pos < len && chars[pos] != ' ' {
-        pos += 1;
-    }
-    while pos < len && chars[pos] == ' ' {
-        pos += 1;
-    }
-    app.cursor_pos = pos;
 }
 
 #[cfg(test)]
@@ -1085,5 +1029,94 @@ mod tests {
         };
         let step = cfg.scroll_lines.unwrap_or(3);
         assert_eq!(step, 7);
+    }
+
+    // ── P2: editing keys route through the TextArea editor ────────────────
+
+    /// Drive one keypress through the chat-pane key handler (not streaming).
+    fn press(app: &mut App, code: KeyCode, mods: KeyModifiers) -> InputAction {
+        let registry = Arc::new(CommandRegistry::new(&[], vec![]));
+        let keybinds = synaps_cli::skills::keybinds::KeybindRegistry::new();
+        handle_key(
+            crossterm::event::KeyEvent::new(code, mods),
+            app,
+            false,
+            &registry,
+            &keybinds,
+        )
+    }
+
+    /// Shift-Enter inserts a newline into the buffer instead of submitting.
+    #[test]
+    fn shift_enter_inserts_newline() {
+        let mut app = make_app();
+        press(&mut app, KeyCode::Char('a'), KeyModifiers::NONE);
+        press(&mut app, KeyCode::Char('b'), KeyModifiers::NONE);
+        assert!(matches!(
+            press(&mut app, KeyCode::Enter, KeyModifiers::SHIFT),
+            InputAction::None
+        ));
+        press(&mut app, KeyCode::Char('c'), KeyModifiers::NONE);
+        assert_eq!(app.input_text(), "ab\nc");
+        // Mirrors track the editor for the render pipeline.
+        assert_eq!(app.input, "ab\nc");
+        assert_eq!(app.cursor_pos, 4);
+    }
+
+    /// Up inside a multi-line buffer moves the cursor, not history (§3.3).
+    #[test]
+    fn up_on_multiline_buffer_moves_cursor_not_history() {
+        let mut app = make_app();
+        app.input_history.push("older entry".to_string());
+        app.set_input_text("line1\nline2"); // cursor at end: row 1
+        press(&mut app, KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.input_text(), "line1\nline2", "buffer must be untouched");
+        assert_eq!(app.history_index, None, "history must not engage");
+        assert_eq!(app.editor.cursor().0, 0, "cursor should move to row 0");
+        // A second Up — now on the first line — engages history.
+        press(&mut app, KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.input_text(), "older entry");
+        assert_eq!(app.history_index, Some(0));
+    }
+
+    /// Up on a single-line buffer recalls history immediately, and Down at
+    /// the last line restores the stashed draft.
+    #[test]
+    fn up_on_single_line_triggers_history() {
+        let mut app = make_app();
+        app.input_history.push("older entry".to_string());
+        app.set_input_text("draft");
+        press(&mut app, KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.input_text(), "older entry");
+        assert_eq!(app.history_index, Some(0));
+        press(&mut app, KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(app.input_text(), "draft", "Down at edge restores stash");
+        assert_eq!(app.history_index, None);
+    }
+
+    /// Ctrl-U clears the WHOLE buffer (our semantics, not the lib default).
+    #[test]
+    fn ctrl_u_clears_whole_buffer() {
+        let mut app = make_app();
+        app.set_input_text("hello\nworld");
+        press(&mut app, KeyCode::Char('u'), KeyModifiers::CONTROL);
+        assert!(app.input_is_empty());
+        assert_eq!(app.input, "");
+        assert_eq!(app.cursor_pos, 0);
+    }
+
+    /// Backspace / word-delete now route through the editor and keep the
+    /// mirrors in sync.
+    #[test]
+    fn editing_keys_forward_to_editor_and_sync_mirror() {
+        let mut app = make_app();
+        for c in "hi there".chars() {
+            press(&mut app, KeyCode::Char(c), KeyModifiers::NONE);
+        }
+        press(&mut app, KeyCode::Backspace, KeyModifiers::NONE);
+        assert_eq!(app.input, "hi ther");
+        press(&mut app, KeyCode::Char('w'), KeyModifiers::CONTROL);
+        assert_eq!(app.input, "hi ");
+        assert_eq!(app.cursor_pos, 3);
     }
 }

--- a/crates/agent-tui/src/tui/input.rs
+++ b/crates/agent-tui/src/tui/input.rs
@@ -280,7 +280,7 @@ fn paste_from_clipboard() -> Option<String> {
 /// submit, tab-completion, transcript scroll, Ctrl-O, Ctrl-U (clear whole
 /// buffer), history-at-edges Up/Down (§3.3) — are matched here with today's
 /// exact semantics. Every other editing key is forwarded to the TextArea
-/// editor, then mirrored via `sync_input_mirror`.
+/// editor, which is the sole input-buffer state.
 fn handle_key(
     key: crossterm::event::KeyEvent,
     app: &mut App,
@@ -339,14 +339,12 @@ fn handle_key(
         }
         (KeyCode::Enter, KeyModifiers::SHIFT) if !streaming => {
             app.editor.insert_newline();
-            app.sync_input_mirror();
         }
         // Alt-Enter: same as Shift-Enter. Legacy terminals (and tmux) encode
         // it as ESC+CR, which survives everywhere — Shift-Enter needs the
         // kitty keyboard protocol and often arrives as plain Enter.
         (KeyCode::Enter, KeyModifiers::ALT) if !streaming => {
             app.editor.insert_newline();
-            app.sync_input_mirror();
         }
         (KeyCode::Enter, _) if !streaming && !app.input_is_empty() => {
             return process_submit(app, registry);
@@ -357,7 +355,9 @@ fn handle_key(
         // Enter that matched none of the above (empty buffer) stays a no-op.
         // It must NOT reach the editor, which would insert a newline.
         (KeyCode::Enter, _) => {}
-        (KeyCode::Tab, _) if app.input.starts_with('/') && app.input.len() > 1 => {
+        (KeyCode::Tab, _)
+            if app.input_first_line().starts_with('/') && app.input_first_line().len() > 1 =>
+        {
             if open_help_find_for_ambiguous_slash(app, registry) {
                 return InputAction::HelpFindOutcome;
             }
@@ -381,11 +381,9 @@ fn handle_key(
         // editor's redo via the catch-all.
         (KeyCode::Char('z'), KeyModifiers::CONTROL) => {
             app.editor.undo();
-            app.sync_input_mirror();
         }
         (KeyCode::Char('y'), KeyModifiers::CONTROL) => {
             app.editor.redo();
-            app.sync_input_mirror();
         }
         (KeyCode::Char('o'), KeyModifiers::CONTROL) => {
             // Store-owned toggle invalidates internally (locked decision #1);
@@ -398,11 +396,10 @@ fn handle_key(
         // plain Alt-←/→ unmapped — keep today's semantics via explicit moves.
         (KeyCode::Left, KeyModifiers::ALT) => {
             app.editor.move_cursor(tui_textarea::CursorMove::WordBack);
-            app.sync_input_mirror();
         }
         (KeyCode::Right, KeyModifiers::ALT) => {
-            app.editor.move_cursor(tui_textarea::CursorMove::WordForward);
-            app.sync_input_mirror();
+            app.editor
+                .move_cursor(tui_textarea::CursorMove::WordForward);
         }
         (KeyCode::Up, KeyModifiers::SHIFT) => {
             app.transcript.scroll_up(1);
@@ -417,20 +414,17 @@ fn handle_key(
         }
         (KeyCode::Up, _) => {
             app.editor.input(key);
-            app.sync_input_mirror();
         }
         (KeyCode::Down, _) if app.editor.cursor().0 + 1 >= app.editor.lines().len() => {
             app.history_down();
         }
         (KeyCode::Down, _) => {
             app.editor.input(key);
-            app.sync_input_mirror();
         }
         // Everything else — chars, Backspace/Delete, ←/→, Home/End,
         // Ctrl-A/E/W/K, Alt-Backspace, undo/redo — is the editor's job.
         _ => {
             app.editor.input(key);
-            app.sync_input_mirror();
         }
     }
     InputAction::None
@@ -851,7 +845,8 @@ fn route_secret_prompt(event: Event, app: &mut App) -> InputAction {
 }
 
 fn open_help_find_for_ambiguous_slash(app: &mut App, registry: &Arc<CommandRegistry>) -> bool {
-    let Some(query) = synaps_cli::help::prefilter_query_for_slash_command(&app.input) else {
+    let Some(query) = synaps_cli::help::prefilter_query_for_slash_command(app.input_first_line())
+    else {
         return false;
     };
     let help_registry = synaps_cli::help::HelpRegistry::new(
@@ -892,7 +887,7 @@ fn handle_tab_complete(app: &mut App, registry: &Arc<CommandRegistry>) {
     }
 
     // Fresh tab press — find matches for the current partial.
-    let partial = app.input[1..].to_string();
+    let partial = app.input_first_line()[1..].to_string();
     let matches: Vec<String> = commands
         .iter()
         .filter(|c| c.starts_with(partial.as_str()))
@@ -1078,9 +1073,7 @@ mod tests {
         ));
         press(&mut app, KeyCode::Char('c'), KeyModifiers::NONE);
         assert_eq!(app.input_text(), "ab\nc");
-        // Mirrors track the editor for the render pipeline.
-        assert_eq!(app.input, "ab\nc");
-        assert_eq!(app.cursor_pos, 4);
+        assert_eq!(app.cursor_char_pos(), 4);
     }
 
     /// Up inside a multi-line buffer moves the cursor, not history (§3.3).
@@ -1121,22 +1114,20 @@ mod tests {
         app.set_input_text("hello\nworld");
         press(&mut app, KeyCode::Char('u'), KeyModifiers::CONTROL);
         assert!(app.input_is_empty());
-        assert_eq!(app.input, "");
-        assert_eq!(app.cursor_pos, 0);
+        assert_eq!(app.cursor_char_pos(), 0);
     }
 
-    /// Backspace / word-delete now route through the editor and keep the
-    /// mirrors in sync.
+    /// Backspace / word-delete route through the editor.
     #[test]
-    fn editing_keys_forward_to_editor_and_sync_mirror() {
+    fn editing_keys_forward_to_editor() {
         let mut app = make_app();
         for c in "hi there".chars() {
             press(&mut app, KeyCode::Char(c), KeyModifiers::NONE);
         }
         press(&mut app, KeyCode::Backspace, KeyModifiers::NONE);
-        assert_eq!(app.input, "hi ther");
+        assert_eq!(app.input_text(), "hi ther");
         press(&mut app, KeyCode::Char('w'), KeyModifiers::CONTROL);
-        assert_eq!(app.input, "hi ");
-        assert_eq!(app.cursor_pos, 3);
+        assert_eq!(app.input_text(), "hi ");
+        assert_eq!(app.cursor_char_pos(), 3);
     }
 }

--- a/crates/agent-tui/src/tui/input.rs
+++ b/crates/agent-tui/src/tui/input.rs
@@ -143,6 +143,9 @@ fn handle_event_inner(
             if app.input_before_paste.is_none() {
                 app.input_before_paste = Some(app.input_text());
             }
+            // Terminals (and tmux) convert \n to \r inside bracketed paste —
+            // normalize so multi-line pastes actually become multiple lines.
+            let text = text.replace("\r\n", "\n").replace('\r', "\n");
             app.insert_at_cursor(&text);
             app.pasted_char_count += text.chars().count();
             InputAction::None
@@ -360,10 +363,22 @@ fn handle_key(
         (KeyCode::Tab, _) => {}
         // Esc outside streaming: no-op, never forwarded.
         (KeyCode::Esc, _) => {}
-        // Ctrl-U clears the WHOLE buffer (today's semantics), not the lib's
-        // default binding.
+        // Ctrl-U clears the WHOLE buffer (today's semantics). This shadows the
+        // fork's own Ctrl-U binding (undo) — so undo/redo get explicit,
+        // conventional binds below.
         (KeyCode::Char('u'), KeyModifiers::CONTROL) => {
             app.clear_input();
+        }
+        // Undo/redo: the fork's defaults (Ctrl-U undo) are shadowed/unmapped;
+        // bind the conventional keys explicitly. Ctrl-R also reaches the
+        // editor's redo via the catch-all.
+        (KeyCode::Char('z'), KeyModifiers::CONTROL) => {
+            app.editor.undo();
+            app.sync_input_mirror();
+        }
+        (KeyCode::Char('y'), KeyModifiers::CONTROL) => {
+            app.editor.redo();
+            app.sync_input_mirror();
         }
         (KeyCode::Char('o'), KeyModifiers::CONTROL) => {
             // Store-owned toggle invalidates internally (locked decision #1);

--- a/crates/agent-tui/src/tui/input.rs
+++ b/crates/agent-tui/src/tui/input.rs
@@ -390,21 +390,19 @@ fn handle_key(
         }
         // Up/Down: history only at buffer edges (§3.3 DECIDED); inside a
         // multi-line buffer they move the cursor.
+        (KeyCode::Up, _) if app.editor.cursor().0 == 0 => {
+            app.history_up();
+        }
         (KeyCode::Up, _) => {
-            if app.editor.cursor().0 == 0 {
-                app.history_up();
-            } else {
-                app.editor.input(key);
-                app.sync_input_mirror();
-            }
+            app.editor.input(key);
+            app.sync_input_mirror();
+        }
+        (KeyCode::Down, _) if app.editor.cursor().0 + 1 >= app.editor.lines().len() => {
+            app.history_down();
         }
         (KeyCode::Down, _) => {
-            if app.editor.cursor().0 + 1 >= app.editor.lines().len() {
-                app.history_down();
-            } else {
-                app.editor.input(key);
-                app.sync_input_mirror();
-            }
+            app.editor.input(key);
+            app.sync_input_mirror();
         }
         // Everything else — chars, Backspace/Delete, ←/→, Home/End,
         // Ctrl-A/E/W/K, Alt-Backspace, undo/redo — is the editor's job.

--- a/crates/agent-tui/src/tui/sidecar.rs
+++ b/crates/agent-tui/src/tui/sidecar.rs
@@ -260,9 +260,8 @@ pub(crate) fn insert_text_into_input(app: &mut App, text: &str) {
     } else {
         trimmed.to_string()
     };
-    let byte_pos = app.cursor_byte_pos();
-    app.input.insert_str(byte_pos, &to_insert);
-    app.cursor_pos += to_insert.chars().count();
+    // Route through the editor so it stays coherent with the mirrors (P2).
+    app.insert_at_cursor(&to_insert);
     app.invalidate();
 }
 
@@ -371,8 +370,7 @@ mod tests {
     #[test]
     fn insert_text_appends_with_leading_space() {
         let mut app = fresh_app();
-        app.input = "first".to_string();
-        app.cursor_pos = "first".chars().count();
+        app.set_input_text("first");
         insert_text_into_input(&mut app, "second sentence");
         assert_eq!(app.input, "first second sentence");
         assert_eq!(app.cursor_pos, "first second sentence".chars().count());
@@ -381,8 +379,7 @@ mod tests {
     #[test]
     fn insert_text_no_double_space_when_input_ends_with_space() {
         let mut app = fresh_app();
-        app.input = "first ".to_string();
-        app.cursor_pos = "first ".chars().count();
+        app.set_input_text("first ");
         insert_text_into_input(&mut app, "second");
         assert_eq!(app.input, "first second");
     }
@@ -406,9 +403,10 @@ mod tests {
     #[test]
     fn insert_text_inserts_at_cursor_not_end() {
         let mut app = fresh_app();
-        app.input = "hello world".to_string();
+        app.set_input_text("hello world");
         // Place cursor between "hello" and " world" (after "hello")
-        app.cursor_pos = 5;
+        app.editor.move_cursor(tui_textarea::CursorMove::Jump(0, 5));
+        app.sync_input_mirror();
         insert_text_into_input(&mut app, "beautiful");
         assert_eq!(app.input, "hello beautiful world");
     }

--- a/crates/agent-tui/src/tui/sidecar.rs
+++ b/crates/agent-tui/src/tui/sidecar.rs
@@ -246,21 +246,25 @@ pub(crate) fn insert_text_into_input(app: &mut App, text: &str) {
     if trimmed.is_empty() {
         return;
     }
-    let needs_leading_space = !app.input.is_empty()
-        && app.cursor_byte_pos() > 0
-        && !app
-            .input
-            .as_bytes()
-            .get(app.cursor_byte_pos().saturating_sub(1))
-            .copied()
-            .map(|b| (b as char).is_whitespace())
-            .unwrap_or(true);
+    // A leading space is needed only when the char immediately before the
+    // cursor exists and is non-whitespace. col > 0 means there's a char on
+    // this line before the cursor; at col 0 the preceding char (if any) is a
+    // newline — whitespace — so no space is inserted.
+    let needs_leading_space = {
+        let (row, col) = app.editor.cursor();
+        col > 0
+            && app
+                .editor
+                .lines()
+                .get(row)
+                .and_then(|line| line.chars().nth(col - 1))
+                .is_some_and(|c| !c.is_whitespace())
+    };
     let to_insert = if needs_leading_space {
         format!(" {}", trimmed)
     } else {
         trimmed.to_string()
     };
-    // Route through the editor so it stays coherent with the mirrors (P2).
     app.insert_at_cursor(&to_insert);
     app.invalidate();
 }
@@ -279,8 +283,8 @@ mod tests {
     fn insert_text_into_empty_input() {
         let mut app = fresh_app();
         insert_text_into_input(&mut app, "hello world");
-        assert_eq!(app.input, "hello world");
-        assert_eq!(app.cursor_pos, "hello world".chars().count());
+        assert_eq!(app.input_text(), "hello world");
+        assert_eq!(app.cursor_char_pos(), "hello world".chars().count());
     }
 
     // ---- build_spawn_args tests ---------------------------------------
@@ -372,8 +376,11 @@ mod tests {
         let mut app = fresh_app();
         app.set_input_text("first");
         insert_text_into_input(&mut app, "second sentence");
-        assert_eq!(app.input, "first second sentence");
-        assert_eq!(app.cursor_pos, "first second sentence".chars().count());
+        assert_eq!(app.input_text(), "first second sentence");
+        assert_eq!(
+            app.cursor_char_pos(),
+            "first second sentence".chars().count()
+        );
     }
 
     #[test]
@@ -381,14 +388,14 @@ mod tests {
         let mut app = fresh_app();
         app.set_input_text("first ");
         insert_text_into_input(&mut app, "second");
-        assert_eq!(app.input, "first second");
+        assert_eq!(app.input_text(), "first second");
     }
 
     #[test]
     fn insert_text_trims_whitespace_from_payload() {
         let mut app = fresh_app();
         insert_text_into_input(&mut app, "  spaced text  ");
-        assert_eq!(app.input, "spaced text");
+        assert_eq!(app.input_text(), "spaced text");
     }
 
     #[test]
@@ -396,8 +403,8 @@ mod tests {
         let mut app = fresh_app();
         insert_text_into_input(&mut app, "");
         insert_text_into_input(&mut app, "   ");
-        assert_eq!(app.input, "");
-        assert_eq!(app.cursor_pos, 0);
+        assert_eq!(app.input_text(), "");
+        assert_eq!(app.cursor_char_pos(), 0);
     }
 
     #[test]
@@ -406,9 +413,8 @@ mod tests {
         app.set_input_text("hello world");
         // Place cursor between "hello" and " world" (after "hello")
         app.editor.move_cursor(tui_textarea::CursorMove::Jump(0, 5));
-        app.sync_input_mirror();
         insert_text_into_input(&mut app, "beautiful");
-        assert_eq!(app.input, "hello beautiful world");
+        assert_eq!(app.input_text(), "hello beautiful world");
     }
 
     // ---- status_line label tests --------------------------------------

--- a/crates/agent-tui/src/tui/testing.rs
+++ b/crates/agent-tui/src/tui/testing.rs
@@ -332,9 +332,9 @@ impl TestHarness {
 
     // ── State inspection ─────────────────────────────────────────────────────
 
-    /// Current contents of the input box.
-    pub fn input_contents(&self) -> &str {
-        &self.app.input
+    /// Current contents of the input box (flattened from the editor).
+    pub fn input_contents(&self) -> String {
+        self.app.input_text()
     }
 
     /// Whether a `Quit` action was dispatched (the real loop would start the

--- a/crates/agent-tui/src/tui/view_model.rs
+++ b/crates/agent-tui/src/tui/view_model.rs
@@ -37,7 +37,11 @@ pub(crate) struct ViewInputs<'a> {
     pub(crate) transcript: &'a mut super::transcript::TranscriptStore,
 
     // ── input / edit chrome ──
-    pub(crate) input: &'a String,
+    /// Flat input text, materialized ONCE per frame from the editor
+    /// (`App::input_text`) in [`ViewInputs::from_app`]. Owned because the
+    /// editor stores lines, not a flat string — this is the single per-frame
+    /// flattening point.
+    pub(crate) input: String,
     pub(crate) cursor_pos: usize,
 
     // ── status / spinner / identity ──
@@ -86,11 +90,14 @@ impl<'a> ViewInputs<'a> {
     /// builder consumes is named here; everything it may mutate comes back
     /// as a [`RenderPatch`].
     pub(crate) fn from_app(app: &'a mut App) -> Self {
+        // Flatten editor state before the disjoint field borrows below.
+        let input = app.input_text();
+        let cursor_pos = app.cursor_char_pos();
         Self {
             gamba_active: app.gamba_child.is_some(),
             transcript: &mut app.transcript,
-            input: &app.input,
-            cursor_pos: app.cursor_pos,
+            input,
+            cursor_pos,
             streaming: app.streaming,
             spinner_frame: app.spinner_frame,
             agent_name: &app.agent_name,

--- a/docs/tui-textarea-hybrid-input-plan.md
+++ b/docs/tui-textarea-hybrid-input-plan.md
@@ -1,0 +1,179 @@
+# Input Editor → tui-textarea (Hybrid) — Scope & Plan
+
+**Status:** SCOPED — not started
+**Created:** 2026-08-03 (S289)
+**Decision:** Option B — `TextArea` owns editing **state**; existing soft-wrap
+rendering stays. Chosen over full swap because `tui-textarea` has **no soft-wrap**
+(long-standing upstream issue) and the wrapped input box (up to 10 lines) is
+load-bearing UX for a chat CLI.
+
+---
+
+## 1. Core insight (from recon)
+
+agent-tui renders from a **`RenderModel` snapshot** (render-thread architecture),
+not from `App`. `draw.rs` consumes `model.input: String` + `model.cursor_pos`.
+
+Therefore the hybrid is clean: **`TextArea` is never rendered.** It lives in
+`App` purely as the editing state machine. At snapshot time we derive
+`(flat_text, flat_cursor_char_pos)` and feed the *unchanged* render pipeline
+(wrap math, ghost hints, software cursor, height calc all stay).
+
+```text
+key events ─→ App.editor: TextArea<'static> ─→ snapshot (text, cursor)
+                     │                              │
+             editing semantics                render pipeline
+             (lib-owned)                      (ours, UNCHANGED)
+```
+
+## 2. Current inventory (what exists today)
+
+| Piece | Where | Fate |
+|---|---|---|
+| `App.input: String`, `cursor_pos: usize` (char-based) | app.rs:34-35 | **replaced** by `editor: TextArea<'static>` + compat accessors |
+| `cursor_byte_pos()`, `input_char_count()` | app.rs:374-383 | deleted (byte/char conversion is the lib's problem now) |
+| `input_history: Vec<String>`, `history_index`, `history_up/down` | app.rs:41-42, 616-646 | **kept** (ours; textarea's history is undo, not prompt history) |
+| Hand-rolled editing in `handle_key` — char insert, backspace, left/right, Ctrl-A/E/W/U, Home/End, Alt-arrows, Shift-Enter newline | input.rs:279-421 | **deleted**, forwarded to `editor.input(...)` |
+| `delete_word_backward`, `jump_word_left/right` | input.rs:925-977 | deleted (lib provides) |
+| `handle_tab_complete`, `tab_cycle` | input.rs:862+, app.rs:48 | kept; mutation rewritten via editor set-text helper |
+| Paste path (dedupe, size cap, `input_before_paste`) | input.rs:116-140, app.rs:90,326 | kept; insertion becomes `editor.insert_str` |
+| Sidecar transcription insert-at-cursor | sidecar.rs:249-265 | kept; rewritten via `editor.insert_str` |
+| Modal routing (models/settings/plugins/help/secret) | input.rs (~⅔ of file) | untouched |
+| Keybind registry check | input.rs:296-326 | untouched (runs before editor forwarding) |
+| Wrap math `input_wrap_info` | view_model.rs:157 | **untouched** |
+| Input rendering + ghost hint + software cursor + scroll | draw.rs:1360-1460, 852, 868 | **untouched** |
+| Snapshot fields `input`, `cursor_pos` | render_model.rs, draw.rs:708-709 | untouched; fed from accessors |
+| Testing harness `&self.app.input` | testing.rs:337 | accessor swap |
+| Tests writing `app.input =` directly | sidecar.rs tests, input.rs tests | migrate to `app.set_input_text(...)` helper |
+
+## 3. Design
+
+### 3.1 State
+
+```rust
+// app.rs
+pub(crate) editor: tui_textarea::TextArea<'static>,  // replaces input + cursor_pos
+
+// compat accessors (used by snapshot, commands, sidecar, tests):
+fn input_text(&self) -> String            // editor.lines().join("\n")
+fn input_is_empty(&self) -> bool
+fn cursor_char_pos(&self) -> usize        // flat char index from editor.cursor() (row,col)
+fn set_input_text(&mut self, s: &str)     // rebuild editor, cursor→end
+fn clear_input(&mut self)
+fn insert_at_cursor(&mut self, s: &str)   // editor.insert_str
+```
+
+Flat-cursor mapping (for the snapshot): `sum(chars(lines[..row]) + 1) + col`.
+One ~10-line helper + unit tests. This is the only new math.
+
+### 3.2 Key routing in `handle_key` (the contract)
+
+Intercepted BEFORE the editor (unchanged semantics):
+
+| Key | Behavior |
+|---|---|
+| Ctrl-C | Quit |
+| Esc (streaming) | Abort |
+| Enter (non-empty, !streaming) | submit |
+| Enter (non-empty, streaming) | queue/steer submit |
+| Shift-Enter | newline → forward to editor as insert `\n` |
+| Tab on `/…` | completion cycle (unchanged) |
+| Shift-Up/Down | transcript scroll |
+| Ctrl-O | toggle full output |
+| plugin/user keybinds | registry first, as today |
+| Up / Down | **see 3.3** |
+
+Everything else editing-related → `editor.input(Event::Key(...))`:
+chars, backspace/delete, ←/→, Home/End, Ctrl-A/E, Ctrl-W/Alt-Backspace,
+Alt-←/→ (word jumps), Ctrl-U, plus **new for free**: Ctrl-K, proper
+Delete-forward, multi-line ↑/↓ cursor movement, **undo/redo (Ctrl-Z / Ctrl-Y)**.
+
+Note: tui-textarea's default Ctrl-U = delete-to-line-start, today's Ctrl-U =
+clear whole buffer. Keep today's behavior (intercept, `clear_input`). Any other
+semantic drift found in review gets the same treatment: **our semantics win.**
+
+### 3.3 Up/Down policy (DECIDED 2026-08-03: edges)
+
+- **Up** → history iff cursor on first line of buffer; else cursor up.
+- **Down** → history-forward iff on last line; else cursor down.
+- History navigation replaces buffer via `set_input_text` (as today).
+
+Cheap to implement (`editor.cursor().0 == 0` / `== lines.len()-1`). If it feels
+wrong in practice, trivial to revert to history-always.
+
+### 3.4 What we explicitly do NOT adopt
+
+- TextArea's rendering/widget path, block/cursor styles, its horizontal scroll.
+- Its search, its selection (transcript selection already exists separately).
+- Its line-number/placeholder features.
+
+## 4. Dependency
+
+**P0 gate RESOLVED (2026-08-03, S289).** Original `tui-textarea` is dormant
+(0.7.0, Oct 2024; master still pins ratatui ^0.29) → **fails** against our
+ratatui 0.30.2 / crossterm 0.29.
+
+**Use `tui-textarea-2` = "0.12"** (maintained continuation fork,
+github.com/srothgan/tui-textarea, ~90K downloads, updated 2026-07):
+- depends on `ratatui-core ^0.1` — satisfied by ratatui 0.30.2's
+  `ratatui-core 0.1.2` already in our lockfile; **no duplicate ratatui**
+- `crossterm ^0.29` feature matches our pin exactly — our `KeyEvent`s feed
+  `editor.input()` natively, no manual `Input` mapping layer
+- features: `["crossterm"]`, no `search`/`serde`/`arbitrary`
+
+(Runner-up: `ratatui-textarea` 0.9.2 — also ratatui-core-compatible but events
+go through a `ratatui-crossterm` adapter. Fallback if `-2` disappoints.)
+API drift vs. the original crate is possible (0.7 → 0.12); P1 verifies the
+exact method surface used by §3.1 before anything else builds on it.
+
+## 5. Phases
+
+- **P1 — beachhead.** Add dep (compat-gated). `editor` field + accessors +
+  flat-cursor helper + unit tests. `input`/`cursor_pos` fields still present,
+  kept in sync one-way (editor → mirror) so nothing else changes yet. Green.
+- **P2 — key routing.** `handle_key` editing branches → `editor.input()`.
+  Delete `delete_word_backward`/`jump_word_*`. Up/Down policy per 3.3.
+  Ctrl-U interception. Existing input.rs tests updated. Green.
+- **P3 — mutators.** Paste path, tab-complete, history nav, sidecar insert,
+  `/`-detection sites (draw.rs:604, commands) all through accessors. Delete
+  mirror fields; snapshot reads accessors. `cursor_byte_pos` dies. Green.
+- **P4 — polish + proof.** Testing-harness accessor; migrate direct
+  `app.input =` in tests; manual QA checklist (below); update CHANGELOG.
+
+Each phase is a separate commit, workspace-green (`cargo test`), TUI boots and
+chats between phases. P1+P2 prove the concept; P3 is the risky sweep — if it
+sours, revert to the P2 commit and reassess.
+
+## 6. QA checklist (P4, by hand, in a real terminal)
+
+- [ ] type/edit ASCII + emoji + CJK (wide chars) — cursor lands right at wraps
+- [ ] long paragraph wraps to ≤10 lines, scrolls beyond, cursor tracks
+- [ ] Shift-Enter multi-line; ↑/↓ moves within buffer; history at edges (3.3)
+- [ ] paste multi-line, paste >cap (truncation toast), paste during streaming
+- [ ] `/` ghost hint renders; Tab completion cycles; ambiguous `/` opens finder
+- [ ] Ctrl-A/E/W/U, Alt-arrows, Home/End behave as before; Ctrl-Z undo works
+- [ ] sidecar transcription inserts at cursor with spacing rules (tests too)
+- [ ] streaming: Esc aborts, Enter queues, typing stays live
+- [ ] modals (models/settings/plugins/help/secret) unaffected
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| ratatui 0.30 compat of the crate | P0 gate (§4) — checked before any code |
+| Semantic drift in default keybinds | Contract table (3.2) is law; our semantics win via interception |
+| Flat-cursor mapping bugs (wide chars, newlines) | Property-ish unit tests vs `input_wrap_info` expectations |
+| Hidden direct `app.input` writers | `rg '\.input\b'` sweep in P3; compiler does the rest once fields die |
+| Up/Down policy feels wrong | Single function, feature-flag-free, easy revert |
+
+## 8. Payoff
+
+~250–300 lines of hand-rolled editing + cursor conversion deleted; unicode
+correctness delegated to a maintained lib; undo/redo + multiline navigation
+gained; **zero rendering/UX regression** because the render path never changes.
+
+## 9. Estimate
+
+P1: small · P2: medium · P3: medium, mechanical · P4: small.
+One focused session for P1–P2, one for P3–P4. Good spike-dispatch shape:
+one phase per dispatch, review between.


### PR DESCRIPTION
## What

Replaces the hand-rolled input editing code with `tui-textarea-2` as an **editing state machine only** — the existing soft-wrap render pipeline is untouched (TextArea is never rendered; the render-model snapshot consumes flat `(text, cursor)` via compat accessors).

Plan: `docs/tui-textarea-hybrid-input-plan.md` (P0 gate + design decisions recorded there). This PR delivers phases **P1+P2** of 4; P3 (mirror-field removal) and P4 (QA sweep/changelog) follow separately.

## Why hybrid

`tui-textarea` and its forks have no soft-wrap; the wrapped input box (≤10 lines) is load-bearing UX. Splitting state (lib) from rendering (ours) gets library-grade editing with zero render regression.

## Changes

- **P1** — `editor: TextArea<'static>` on `App` behind compat accessors (`input_text`, `cursor_char_pos`, `set_input_text`, `insert_at_cursor`, …) + flat-cursor mapping helper w/ unit tests (CJK/emoji, clamping). Mirror fields (`input`, `cursor_pos`) kept one-way-synced until P3.
- **P2** — `handle_key` routes editing keys through the editor; hand-rolled insert/backspace/word-ops deleted (~130 lines). Interception contract preserved: submit, tab-completion, transcript scroll, Ctrl-O, Ctrl-U (clear whole buffer — shadows the fork's undo bind), plugin keybinds first.
- **History at buffer edges** (decided): Up = history only on first line; Down = history-forward only on last line; otherwise cursor movement.
- **Undo/redo**: Ctrl-Z / Ctrl-Y bound explicitly (fork's default undo bind is shadowed by clear-buffer).
- **CR-safe paste**: terminals/tmux convert `\n`→`\r` in bracketed paste; normalized to `\n` so multiline pastes actually multiline. (Pre-existing bug, surfaced by testing.)
- **Alt-Enter inserts newline** — legacy-safe (ESC+CR survives tmux); Shift-Enter still requires kitty keyboard protocol (future work).

## Dependency

`tui-textarea-2 = "0.12"` (maintained fork; original `tui-textarea` is dormant and pins ratatui 0.29). Uses `ratatui-core 0.1` + `crossterm 0.29` already in our tree — no duplicate deps.

## Testing

- `cargo test --workspace`: 3632 passed / 0 failed; clippy `-D warnings` clean (built + verified on bella)
- New tests: flat-cursor mapping (wide chars, clamping), Shift-Enter newline, history-at-edges, Ctrl-U clear, editor forwarding + mirror sync
- Interactive QA on bella (tmux-driven): multiline paste, Up/Down inside buffer vs at edges, Ctrl-Z/Ctrl-Y, tab-completion single-match + ambiguous (help-finder), Alt-Enter

## Notes for review

- `input.rs` modal routing untouched; `draw.rs`/`view_model.rs`/`render_model.rs` untouched by design (mirrors keep them working until P3)
- Known deviation from plan §3.2: Alt-←/→ intercepted with explicit `WordBack`/`WordForward` — the fork leaves plain Alt-arrows unmapped