### PR TITLE
feat(tui): myx theme — album-reactive colors via MXC, with animated transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Synaps auto-targets `http://localhost:11434/v1`, which is Ollama's default, so a
 - **🧠 Context that lasts.** 90%+ prompt-cache hit rate. `/compact` checkpoints history. Chain sessions across days. Continuous memory persists across projects.
 - **🤖 Autonomous mode.** `synaps watcher` runs a fleet with heartbeats, crash recovery, cost limits, and session handoff.
 - **⚡ Fast and lean.** ~210K lines of Rust, one 20MB binary, ~2ms cold start, zero runtime deps.
-- **🎨 18 themes.** `catppuccin`, `gruvbox`, `nord`, `rose-pine`, `dracula`, `tokyo-night`, plus originals like `neon-rain` and `night-city`. Hot-swap with `/theme`.
+- **🎨 19 themes.** `catppuccin`, `gruvbox`, `nord`, `rose-pine`, `dracula`, `tokyo-night`, plus originals like `neon-rain` and `night-city`. Hot-swap with `/theme`.
 
 ---
 

--- a/crates/agent-core/src/core/auth/token.rs
+++ b/crates/agent-core/src/core/auth/token.rs
@@ -46,7 +46,11 @@ pub async fn exchange_code_for_tokens(
         // Truncate error body — server responses may contain sensitive data
         // (tokens, internal errors). Status code alone is usually sufficient.
         let text = resp.text().await.unwrap_or_default();
-        let truncated = if text.len() > 200 { &text[..200] } else { &text };
+        let truncated = if text.len() > 200 {
+            &text[..200]
+        } else {
+            &text
+        };
         return Err(format!("Token exchange failed ({}): {}", status, truncated));
     }
 
@@ -90,7 +94,11 @@ pub async fn refresh_token(
     if !resp.status().is_success() {
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
-        let truncated = if text.len() > 200 { &text[..200] } else { &text };
+        let truncated = if text.len() > 200 {
+            &text[..200]
+        } else {
+            &text
+        };
         return Err(format!("Token refresh failed ({}): {}", status, truncated));
     }
 

--- a/crates/agent-core/src/core/config.rs
+++ b/crates/agent-core/src/core/config.rs
@@ -219,6 +219,52 @@ impl CacheTtl {
     }
 }
 
+/// Animated theme-transition mode, parsed from `theme_transition`:
+/// - `"on"` (default): cross-fade theme changes over the default 350 ms.
+/// - `"off"`: instant snap — accessibility, and mercy on tmux-over-ssh.
+/// - integer milliseconds: cross-fade over that duration (clamped to
+///   0–2000 ms; `0` behaves like `off`).
+///
+/// Purely a TUI presentation knob: it changes *how* a new palette is
+/// applied, never *which* palette wins.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ThemeTransitionMode {
+    #[default]
+    On,
+    Off,
+    Ms(u64),
+}
+
+impl ThemeTransitionMode {
+    /// Default cross-fade duration for `On` (and the fallback when a live
+    /// palette update carries no advisory duration of its own).
+    pub const DEFAULT_MS: u64 = 350;
+    /// Duration ceiling — both this knob and MXC wire `fade_ms` clamp here.
+    pub const MAX_MS: u64 = 2000;
+
+    /// Parse a config value (case-insensitive). Returns `None` for unknown
+    /// values so the caller can warn and fall back to the default.
+    pub fn parse(val: &str) -> Option<ThemeTransitionMode> {
+        match val.to_ascii_lowercase().as_str() {
+            "on" | "true" | "yes" => Some(ThemeTransitionMode::On),
+            "off" | "false" | "no" => Some(ThemeTransitionMode::Off),
+            other => other
+                .parse::<u64>()
+                .ok()
+                .map(|ms| ThemeTransitionMode::Ms(ms.min(Self::MAX_MS))),
+        }
+    }
+
+    /// Effective default duration in milliseconds; `0` means "snap".
+    pub fn duration_ms(self) -> u64 {
+        match self {
+            ThemeTransitionMode::On => Self::DEFAULT_MS,
+            ThemeTransitionMode::Off => 0,
+            ThemeTransitionMode::Ms(ms) => ms.min(Self::MAX_MS),
+        }
+    }
+}
+
 /// Runtime event routing configuration parsed from `events.*` keys.
 ///
 /// Controls how runtime events (from the `EventQueue`) are delivered in
@@ -490,6 +536,9 @@ pub struct SynapsConfig {
     /// Default: 3. Range 1–20.
     pub scroll_lines: Option<u16>,
     pub theme: Option<String>,
+    /// Animated theme transitions: `"on"` (350 ms cross-fade, default),
+    /// `"off"` (instant snap), or integer milliseconds (0–2000).
+    pub theme_transition: ThemeTransitionMode,
     /// Whether the TUI paints its own opaque background. `false` preserves the terminal background.
     pub tui_background_opaque: bool,
     pub agent_name: Option<String>,
@@ -548,6 +597,7 @@ impl Default for SynapsConfig {
             max_fps: 60,
             scroll_lines: None,
             theme: None,
+            theme_transition: ThemeTransitionMode::default(),
             tui_background_opaque: true,
             agent_name: None,
             identity: None,
@@ -589,6 +639,7 @@ const KNOWN_CONFIG_KEYS: &[&str] = &[
     "max_fps",
     "scroll_lines",
     "theme",
+    "theme_transition",
     "tui_background_opaque",
     "agent_name",
     "identity",
@@ -995,6 +1046,12 @@ fn apply_config_content(config: &mut SynapsConfig, content: &str) {
                     .push(format!("scroll_lines = {val} — not a number; ignoring")),
             },
             "theme" => config.theme = Some(val.to_string()),
+            "theme_transition" => match ThemeTransitionMode::parse(val) {
+                Some(mode) => config.theme_transition = mode,
+                None => config.warnings.push(format!(
+                    "theme_transition = {val} — expected on, off, or milliseconds (0–2000); using on"
+                )),
+            },
             "tui_background_opaque" => match val {
                 "true" | "1" | "on" | "yes" | "opaque" => config.tui_background_opaque = true,
                 "false" | "0" | "off" | "no" | "invisible" => config.tui_background_opaque = false,
@@ -1496,6 +1553,59 @@ mod tests {
     #[test]
     fn test_max_fps_default_is_60() {
         assert_eq!(SynapsConfig::default().max_fps, 60);
+    }
+
+    // ── theme_transition parse table (animated theme transitions) ──
+
+    #[test]
+    fn test_theme_transition_parse_table() {
+        use ThemeTransitionMode as M;
+        assert_eq!(M::parse("on"), Some(M::On));
+        assert_eq!(M::parse("ON"), Some(M::On));
+        assert_eq!(M::parse("off"), Some(M::Off));
+        assert_eq!(M::parse("Off"), Some(M::Off));
+        // integer ms, clamped to 0..=2000
+        assert_eq!(M::parse("500"), Some(M::Ms(500)));
+        assert_eq!(M::parse("0"), Some(M::Ms(0)));
+        assert_eq!(M::parse("2000"), Some(M::Ms(2000)));
+        assert_eq!(M::parse("99999"), Some(M::Ms(2000)), "clamped to MAX_MS");
+        // garbage → None (caller warns + keeps default)
+        assert_eq!(M::parse("fast"), None);
+        assert_eq!(M::parse(""), None);
+        assert_eq!(M::parse("-5"), None);
+        assert_eq!(M::parse("1.5"), None);
+    }
+
+    #[test]
+    fn test_theme_transition_duration_ms() {
+        use ThemeTransitionMode as M;
+        assert_eq!(M::On.duration_ms(), M::DEFAULT_MS);
+        assert_eq!(M::DEFAULT_MS, 350);
+        assert_eq!(M::Off.duration_ms(), 0);
+        assert_eq!(M::Ms(120).duration_ms(), 120);
+        assert_eq!(M::Ms(0).duration_ms(), 0, "0 ms behaves like off");
+        assert_eq!(M::Ms(u64::MAX).duration_ms(), M::MAX_MS);
+    }
+
+    #[test]
+    fn test_theme_transition_config_key_parses_and_defaults() {
+        use ThemeTransitionMode as M;
+        assert_eq!(SynapsConfig::default().theme_transition, M::On);
+        assert_eq!(
+            super::load_config_from_str("theme_transition = off\n").theme_transition,
+            M::Off
+        );
+        assert_eq!(
+            super::load_config_from_str("theme_transition = 750\n").theme_transition,
+            M::Ms(750)
+        );
+        let bad = super::load_config_from_str("theme_transition = warp\n");
+        assert_eq!(bad.theme_transition, M::On, "bad value keeps default");
+        assert!(
+            bad.warnings.iter().any(|w| w.contains("theme_transition")),
+            "{:?}",
+            bad.warnings
+        );
     }
 
     #[test]

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -216,6 +216,11 @@ pub(crate) struct App {
     /// active. Aborted on theme switch-away (`sync_myx_live`) and at
     /// shutdown, so no task leaks and nothing writes after teardown.
     pub(crate) myx_task: Option<tokio::task::JoinHandle<()>>,
+    /// In-flight animated theme cross-fade (theme::transition). `Some` is
+    /// the "animation active" signal the tick GUARD in mod.rs keys on; the
+    /// tick arm advances it and clears it on landing, so idle cost returns
+    /// to zero the moment the fade completes (#131 discipline).
+    pub(crate) theme_transition: Option<super::theme::transition::ThemeTransition>,
     /// Injectable clock (P6.2). Real in production, Test in the harness so
     /// time-dependent state (toast expiry, tool timers) stays deterministic.
     pub(crate) clock: super::clock::TuiClock,
@@ -328,6 +333,7 @@ impl App {
             myx_theme_rx: myx_theme_rx_init,
             myx_theme_tx: myx_theme_tx_init,
             myx_task: None,
+            theme_transition: None,
             keybinds: None,
             clock,
         }
@@ -781,7 +787,10 @@ impl App {
                 match synaps_cli::config::write_config_value("theme", name) {
                     Ok(_) => {
                         let new_theme = super::theme::load_theme_by_name(name).unwrap_or_default();
-                        super::theme::set_theme(new_theme);
+                        // Animated cross-fade (350ms default; theme_transition
+                        // knob can retune or disable it). The tick arm applies
+                        // frames through the same set_theme path as before.
+                        self.apply_theme_animated(new_theme, None);
                         // Reconcile the live-MXC layer: spawn the subscriber
                         // when switching TO myx, abort it when switching away.
                         self.sync_myx_live(name);
@@ -799,6 +808,25 @@ impl App {
                 )));
             }
         }
+    }
+
+    /// Start (or retarget) an animated theme change toward `target`.
+    /// `requested` is a per-change advisory duration (MXC wire `fade_ms`,
+    /// clamped upstream); `None` = the configured default. When transitions
+    /// are off (or the duration resolves to zero) this snaps instantly —
+    /// byte-identical to the old `set_theme` behavior.
+    pub(crate) fn apply_theme_animated(
+        &mut self,
+        target: super::theme::Theme,
+        requested: Option<std::time::Duration>,
+    ) {
+        super::theme::transition::apply_animated(
+            &mut self.theme_transition,
+            target,
+            requested,
+            std::time::Instant::now(),
+        );
+        self.invalidate();
     }
 
     /// Reconcile the background MXC subscriber with the active theme name.

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -203,13 +203,15 @@ pub(crate) struct App {
     /// Live keybind registry — held so /settings can hot-swap plugin toggle keys.
     pub(crate) keybinds:
         Option<std::sync::Arc<std::sync::RwLock<synaps_cli::skills::keybinds::KeybindRegistry>>>,
-    /// Live MXC palettes from the myx subscriber task (theme::mxc). The main
-    /// loop's receiver arm is the ONLY place these are applied (set_theme +
-    /// invalidate — the same path /theme uses); the task never mutates theme
-    /// state. Unbounded is safe: the publisher dedupes and emits a handful of
-    /// events per minute, and each message is small (one Theme value).
-    pub(crate) myx_theme_rx: tokio::sync::mpsc::UnboundedReceiver<super::theme::Theme>,
-    pub(crate) myx_theme_tx: tokio::sync::mpsc::UnboundedSender<super::theme::Theme>,
+    /// Live MXC palettes from the myx subscriber task (theme::mxc), paired
+    /// with the wire's advisory `fade_ms` (None = absent). The main loop's
+    /// receiver arm is the ONLY place these are applied (animated through
+    /// the same set_theme + invalidate path /theme uses); the task never
+    /// mutates theme state. Unbounded is safe: the publisher dedupes and
+    /// emits a handful of events per minute, and each message is small (one
+    /// Theme value).
+    pub(crate) myx_theme_rx: tokio::sync::mpsc::UnboundedReceiver<(super::theme::Theme, Option<u64>)>,
+    pub(crate) myx_theme_tx: tokio::sync::mpsc::UnboundedSender<(super::theme::Theme, Option<u64>)>,
     /// The running MXC subscriber, present only while the "myx" theme is
     /// active. Aborted on theme switch-away (`sync_myx_live`) and at
     /// shutdown, so no task leaks and nothing writes after teardown.

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -203,6 +203,17 @@ pub(crate) struct App {
     /// Live keybind registry — held so /settings can hot-swap plugin toggle keys.
     pub(crate) keybinds:
         Option<std::sync::Arc<std::sync::RwLock<synaps_cli::skills::keybinds::KeybindRegistry>>>,
+    /// Live MXC palettes from the myx subscriber task (theme::mxc). The main
+    /// loop's receiver arm is the ONLY place these are applied (set_theme +
+    /// invalidate — the same path /theme uses); the task never mutates theme
+    /// state. Unbounded is safe: the publisher dedupes and emits a handful of
+    /// events per minute, and each message is small (one Theme value).
+    pub(crate) myx_theme_rx: tokio::sync::mpsc::UnboundedReceiver<super::theme::Theme>,
+    pub(crate) myx_theme_tx: tokio::sync::mpsc::UnboundedSender<super::theme::Theme>,
+    /// The running MXC subscriber, present only while the "myx" theme is
+    /// active. Aborted on theme switch-away (`sync_myx_live`) and at
+    /// shutdown, so no task leaks and nothing writes after teardown.
+    pub(crate) myx_task: Option<tokio::task::JoinHandle<()>>,
     /// Injectable clock (P6.2). Real in production, Test in the harness so
     /// time-dependent state (toast expiry, tool timers) stays deterministic.
     pub(crate) clock: super::clock::TuiClock,
@@ -239,6 +250,7 @@ impl App {
             tokio::sync::mpsc::unbounded_channel();
         let (widget_tx_init, widget_rx_init) =
             tokio::sync::mpsc::channel(WIDGET_EVENT_QUEUE_CAPACITY);
+        let (myx_theme_tx_init, myx_theme_rx_init) = tokio::sync::mpsc::unbounded_channel();
         Self {
             transcript: TranscriptStore::new(clock.clone()),
             editor: tui_textarea::TextArea::default(),
@@ -311,6 +323,9 @@ impl App {
             extension_loader_running: false,
             widget_rx: widget_rx_init,
             widget_tx: widget_tx_init,
+            myx_theme_rx: myx_theme_rx_init,
+            myx_theme_tx: myx_theme_tx_init,
+            myx_task: None,
             keybinds: None,
             clock,
         }
@@ -765,6 +780,9 @@ impl App {
                     Ok(_) => {
                         let new_theme = super::theme::load_theme_by_name(name).unwrap_or_default();
                         super::theme::set_theme(new_theme);
+                        // Reconcile the live-MXC layer: spawn the subscriber
+                        // when switching TO myx, abort it when switching away.
+                        self.sync_myx_live(name);
                         self.push_msg(ChatMessage::System(format!("Theme applied: {}", name)));
                         self.invalidate();
                     }
@@ -777,6 +795,25 @@ impl App {
                     "unknown theme: '{}'. Use /theme to list available themes.",
                     name
                 )));
+            }
+        }
+    }
+
+    /// Reconcile the background MXC subscriber with the active theme name.
+    ///
+    /// `"myx"` active and no live task → spawn `theme::mxc::run_subscriber`
+    /// with a clone of our sender. Any other theme → abort the task if one is
+    /// running. Idempotent, so callers can invoke it on every theme change
+    /// and at boot. Must run on the main loop's runtime (it spawns).
+    pub(crate) fn sync_myx_live(&mut self, theme_name: &str) {
+        let want = theme_name == "myx";
+        let running = self.myx_task.as_ref().is_some_and(|h| !h.is_finished());
+        if want && !running {
+            let tx = self.myx_theme_tx.clone();
+            self.myx_task = Some(tokio::spawn(super::theme::mxc::run_subscriber(tx)));
+        } else if !want {
+            if let Some(h) = self.myx_task.take() {
+                h.abort();
             }
         }
     }

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -216,7 +216,16 @@ pub(crate) struct App {
     /// The running MXC subscriber, present only while the "myx" theme is
     /// active. Aborted on theme switch-away (`sync_myx_live`) and at
     /// shutdown, so no task leaks and nothing writes after teardown.
+    /// `Some` here doubles as the receive-side guard's "the active theme is
+    /// still myx" bit: `sync_myx_live` is the single writer, on this thread,
+    /// on every theme-apply path.
     pub(crate) myx_task: Option<tokio::task::JoinHandle<()>>,
+    /// Last-good LIVE palette from the MXC subscriber. Re-applying "myx"
+    /// statically (`/theme myx` again, settings Esc-revert, picker browse)
+    /// restores this instead of stranding on the static snapshot until the
+    /// next track change. Cleared on switch-away so a stale album palette
+    /// can never resurrect through it.
+    pub(crate) myx_last_live: Option<super::theme::Theme>,
     /// In-flight animated theme cross-fade (theme::transition). `Some` is
     /// the "animation active" signal the tick GUARD in mod.rs keys on; the
     /// tick arm advances it and clears it on landing, so idle cost returns
@@ -334,6 +343,7 @@ impl App {
             myx_theme_rx: myx_theme_rx_init,
             myx_theme_tx: myx_theme_tx_init,
             myx_task: None,
+            myx_last_live: None,
             theme_transition: None,
             keybinds: None,
             clock,
@@ -787,7 +797,10 @@ impl App {
             if is_valid {
                 match synaps_cli::config::write_config_value("theme", name) {
                     Ok(_) => {
-                        let new_theme = super::theme::load_theme_by_name(name).unwrap_or_default();
+                        // Prefer the cached live palette when re-applying
+                        // "myx" over a healthy subscriber — the static
+                        // snapshot would strand until the next track change.
+                        let new_theme = self.resolve_apply_theme(name).unwrap_or_default();
                         // Animated cross-fade (350ms default; theme_transition
                         // knob can retune or disable it). The tick arm applies
                         // frames through the same set_theme path as before.
@@ -846,7 +859,36 @@ impl App {
             if let Some(h) = self.myx_task.take() {
                 h.abort();
             }
+            // A queued stale palette must not resurrect through the
+            // last-good cache after switch-away (the receive-side guard in
+            // `handle_myx_theme_arm` drops the message itself).
+            self.myx_last_live = None;
         }
+    }
+
+    /// Resolve the theme to apply for `name`: prefers the cached last-good
+    /// LIVE palette when (re-)applying "myx" over a running subscriber, so
+    /// `/theme myx`, settings picker browse, and Esc-revert land back on the
+    /// palette that is actually current — not the static snapshot.
+    pub(crate) fn resolve_apply_theme(&self, name: &str) -> Option<super::theme::Theme> {
+        if name == "myx" && self.myx_task.is_some() {
+            if let Some(live) = &self.myx_last_live {
+                return Some(live.clone());
+            }
+        }
+        super::theme::load_theme_by_name(name)
+    }
+
+    /// Settings-modal theme commit: the same persisted + animated apply as
+    /// `/theme <name>`, INCLUDING the live-MXC subscriber reconcile. Every
+    /// theme-apply path that changes the persisted theme must call
+    /// `sync_myx_live`, or switching away from myx leaks the subscriber
+    /// (album colors re-stomp the chosen theme on every track change) and
+    /// switching to myx never goes live.
+    pub(crate) fn apply_theme_from_settings(&mut self, name: &str) {
+        let target = self.resolve_apply_theme(name).unwrap_or_default();
+        self.apply_theme_animated(target, None);
+        self.sync_myx_live(name);
     }
 }
 
@@ -2072,5 +2114,106 @@ mod tests {
         // cursor at end: row 1 col 2 → flat 3 (line0) + 2
         assert_eq!(app.editor.cursor(), (1, 2));
         assert_eq!(app.cursor_char_pos(), 5);
+    }
+
+    // ---- live-MXC lifecycle (receive-side guard, last-good cache) ----
+
+    /// A never-completing stand-in for the subscriber: `myx_task.is_some()`
+    /// is the receive-side guard bit; the task body is irrelevant.
+    fn dummy_subscriber() -> tokio::task::JoinHandle<()> {
+        tokio::spawn(std::future::pending::<()>())
+    }
+
+    fn live_sentinel() -> super::super::theme::Theme {
+        super::super::theme::Theme {
+            bg: ratatui::style::Color::Rgb(1, 2, 3),
+            ..Default::default()
+        }
+    }
+
+    /// Receive-side guard (shady F1): `UnboundedSender::send` is synchronous,
+    /// so a palette queued before `/theme nord` + `abort()` still arrives.
+    /// With `myx_task` gone the arm must drop it — the cache staying empty
+    /// is the deterministic proxy (the animated-apply duration depends on
+    /// the user's `theme_transition` knob, so we don't assert on the slot).
+    #[test]
+    fn stale_myx_palette_after_switch_away_is_dropped() {
+        let mut app = test_app();
+        assert!(app.myx_task.is_none());
+        super::super::loop_arms::handle_myx_theme_arm(&mut app, (live_sentinel(), Some(600)));
+        assert!(
+            app.myx_last_live.is_none(),
+            "guarded arm must drop the stale palette before caching or applying"
+        );
+    }
+
+    /// Preview shield (shady F4): while a settings theme preview is browsing,
+    /// a live palette is CACHED but not applied — the preview owns the screen.
+    #[tokio::test]
+    async fn live_palette_is_cached_but_not_applied_during_settings_preview() {
+        let mut app = test_app();
+        app.myx_task = Some(dummy_subscriber());
+        let mut st = super::super::settings::SettingsState::new();
+        st.original_theme_name = Some("myx".to_string());
+        app.settings = Some(st);
+
+        let live = live_sentinel();
+        super::super::loop_arms::handle_myx_theme_arm(&mut app, (live.clone(), None));
+
+        assert_eq!(app.myx_last_live.as_ref(), Some(&live), "must cache as last-good");
+        assert!(
+            app.theme_transition.is_none(),
+            "preview shield must skip the apply entirely"
+        );
+        app.myx_task.take().unwrap().abort();
+    }
+
+    /// Last-good cache (shady F3): re-applying "myx" over a RUNNING
+    /// subscriber resolves to the cached live palette; without a subscriber
+    /// (or for any other theme) it resolves exactly like the static loader.
+    #[tokio::test]
+    async fn resolve_apply_theme_prefers_live_cache_only_while_subscriber_runs() {
+        let mut app = test_app();
+        let live = live_sentinel();
+        app.myx_last_live = Some(live.clone());
+
+        // No running subscriber → static resolution, cache ignored.
+        assert_eq!(
+            app.resolve_apply_theme("myx"),
+            super::super::theme::load_theme_by_name("myx")
+        );
+
+        app.myx_task = Some(dummy_subscriber());
+        assert_eq!(app.resolve_apply_theme("myx"), Some(live));
+        // Other themes never see the cache.
+        assert_eq!(
+            app.resolve_apply_theme("nord"),
+            super::super::theme::load_theme_by_name("nord")
+        );
+        app.myx_task.take().unwrap().abort();
+    }
+
+    /// Settings-path lifecycle (shady F2 / okarin F1): committing a theme
+    /// through the settings modal must reconcile the subscriber exactly like
+    /// `/theme` does — spawn on "myx", abort + clear cache on switch-away.
+    #[tokio::test]
+    async fn settings_theme_commit_reconciles_the_subscriber() {
+        let mut app = test_app();
+        app.apply_theme_from_settings("myx");
+        assert!(
+            app.myx_task.is_some(),
+            "settings apply of myx must start the live layer"
+        );
+
+        app.myx_last_live = Some(live_sentinel());
+        app.apply_theme_from_settings("nord");
+        assert!(
+            app.myx_task.is_none(),
+            "settings apply away from myx must stop the subscriber"
+        );
+        assert!(
+            app.myx_last_live.is_none(),
+            "the last-good cache must not survive switch-away"
+        );
     }
 }

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -2160,7 +2160,11 @@ mod tests {
         let live = live_sentinel();
         super::super::loop_arms::handle_myx_theme_arm(&mut app, (live.clone(), None));
 
-        assert_eq!(app.myx_last_live.as_ref(), Some(&live), "must cache as last-good");
+        assert_eq!(
+            app.myx_last_live.as_ref(),
+            Some(&live),
+            "must cache as last-good"
+        );
         assert!(
             app.theme_transition.is_none(),
             "preview shield must skip the apply entirely"

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -210,7 +210,8 @@ pub(crate) struct App {
     /// mutates theme state. Unbounded is safe: the publisher dedupes and
     /// emits a handful of events per minute, and each message is small (one
     /// Theme value).
-    pub(crate) myx_theme_rx: tokio::sync::mpsc::UnboundedReceiver<(super::theme::Theme, Option<u64>)>,
+    pub(crate) myx_theme_rx:
+        tokio::sync::mpsc::UnboundedReceiver<(super::theme::Theme, Option<u64>)>,
     pub(crate) myx_theme_tx: tokio::sync::mpsc::UnboundedSender<(super::theme::Theme, Option<u64>)>,
     /// The running MXC subscriber, present only while the "myx" theme is
     /// active. Aborted on theme switch-away (`sync_myx_live`) and at

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -707,6 +707,7 @@ impl App {
             ("nord", "arctic frost blues"),
             ("dracula", "purple/pink/cyan vibrant"),
             ("monokai", "classic orange/pink/green"),
+            ("myx", "album-reactive colors via Myx (MXC)"),
             ("gruvbox", "warm earthy tones"),
             ("catppuccin", "soft pastels, cozy dark"),
             ("tokyo-night", "dark blue-purple, soft accents"),
@@ -719,6 +720,20 @@ impl App {
         if arg.is_empty() {
             self.push_msg(ChatMessage::System("Available themes:".to_string()));
             for (name, desc) in descriptions {
+                // Soft detection annotation for the live theme: "myx" always
+                // works (static fallback), but say whether Myx is around.
+                if *name == "myx" {
+                    let status = if super::theme::mxc::myx_detected() {
+                        "live"
+                    } else {
+                        "static — myx not detected"
+                    };
+                    self.push_msg(ChatMessage::System(format!(
+                        "  {:<15} — {} [{}]",
+                        name, desc, status
+                    )));
+                    continue;
+                }
                 self.push_msg(ChatMessage::System(format!("  {:<15} — {}", name, desc)));
             }
             let themes_dir = synaps_cli::config::base_dir().join("themes");

--- a/crates/agent-tui/src/tui/dispatch.rs
+++ b/crates/agent-tui/src/tui/dispatch.rs
@@ -1204,7 +1204,11 @@ pub(crate) async fn handle_input_action(
                                             }
                     } else if app.sidecars.len() == 1 {
                         // Safe: len() == 1 guarantees .next() is Some
-                        app.sidecars.values().next().expect("len == 1").status_line()
+                        app.sidecars
+                            .values()
+                            .next()
+                            .expect("len == 1")
+                            .status_line()
                     } else if app.sidecars.is_empty() {
                         match synaps_cli::sidecar::discovery::discover() {
                                                 Some(s) => format!(

--- a/crates/agent-tui/src/tui/helpers.rs
+++ b/crates/agent-tui/src/tui/helpers.rs
@@ -65,7 +65,13 @@ pub(super) fn apply_setting(
             if let Some(st) = app.settings.as_mut() {
                 if key == "theme" {
                     if let Some(t) = theme::load_theme_by_name(value) {
-                        theme::set_theme(t);
+                        // Animated apply; disjoint-field borrow beside `st`.
+                        theme::transition::apply_animated(
+                            &mut app.theme_transition,
+                            t,
+                            None,
+                            std::time::Instant::now(),
+                        );
                     }
                     st.row_error = None;
                 } else {

--- a/crates/agent-tui/src/tui/helpers.rs
+++ b/crates/agent-tui/src/tui/helpers.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 
 use super::app::{App, ChatMessage};
 use super::settings;
-use super::theme;
 
 /// Decide whether to repaint on this event-loop iteration.
 ///
@@ -62,21 +61,16 @@ pub(super) fn apply_setting(
 
     match synaps_cli::config::write_config_value(key, value) {
         Ok(()) => {
+            if key == "theme" {
+                // Same apply as /theme: animated cross-fade PLUS the
+                // live-MXC subscriber reconcile (spawn on "myx", abort on
+                // switch-away). Skipping sync_myx_live here leaked the
+                // subscriber forever — album colors re-stomped the chosen
+                // theme on every track change (shady F2 / okarin F1).
+                app.apply_theme_from_settings(value);
+            }
             if let Some(st) = app.settings.as_mut() {
-                if key == "theme" {
-                    if let Some(t) = theme::load_theme_by_name(value) {
-                        // Animated apply; disjoint-field borrow beside `st`.
-                        theme::transition::apply_animated(
-                            &mut app.theme_transition,
-                            t,
-                            None,
-                            std::time::Instant::now(),
-                        );
-                    }
-                    st.row_error = None;
-                } else {
-                    st.row_error = None;
-                }
+                st.row_error = None;
                 st.edit_mode = None;
             }
         }

--- a/crates/agent-tui/src/tui/input.rs
+++ b/crates/agent-tui/src/tui/input.rs
@@ -767,9 +767,13 @@ fn route_settings(
                     }
                 }
                 super::settings::InputOutcome::PreviewTheme { name } => {
-                    if let Some(theme) = super::theme::load_theme_by_name(&name) {
-                        // Animated preview; arrow-key browsing retargets the
-                        // in-flight fade from its current frame (no jumps).
+                    // Animated preview; arrow-key browsing retargets the
+                    // in-flight fade from its current frame (no jumps).
+                    // Browsing onto "myx" shows the cached live palette
+                    // when the subscriber is healthy, not the stale static
+                    // snapshot. Previews are transient: they never persist
+                    // and never touch the subscriber lifecycle.
+                    if let Some(theme) = app.resolve_apply_theme(&name) {
                         super::theme::transition::apply_animated(
                             &mut app.theme_transition,
                             theme,
@@ -779,7 +783,16 @@ fn route_settings(
                     }
                 }
                 super::settings::InputOutcome::RevertTheme => {
-                    let theme = super::theme::load_theme_from_config();
+                    // Esc-revert: config is untouched, so the subscriber
+                    // needs no reconcile. When reverting onto a live myx
+                    // (subscriber running), restore the last-good live
+                    // palette — the static config load would strand the
+                    // screen on the snapshot until the next track change.
+                    let theme = app
+                        .myx_last_live
+                        .clone()
+                        .filter(|_| app.myx_task.is_some())
+                        .unwrap_or_else(super::theme::load_theme_from_config);
                     super::theme::transition::apply_animated(
                         &mut app.theme_transition,
                         theme,

--- a/crates/agent-tui/src/tui/input.rs
+++ b/crates/agent-tui/src/tui/input.rs
@@ -768,12 +768,24 @@ fn route_settings(
                 }
                 super::settings::InputOutcome::PreviewTheme { name } => {
                     if let Some(theme) = super::theme::load_theme_by_name(&name) {
-                        super::theme::set_theme(theme);
+                        // Animated preview; arrow-key browsing retargets the
+                        // in-flight fade from its current frame (no jumps).
+                        super::theme::transition::apply_animated(
+                            &mut app.theme_transition,
+                            theme,
+                            None,
+                            std::time::Instant::now(),
+                        );
                     }
                 }
                 super::settings::InputOutcome::RevertTheme => {
                     let theme = super::theme::load_theme_from_config();
-                    super::theme::set_theme(theme);
+                    super::theme::transition::apply_animated(
+                        &mut app.theme_transition,
+                        theme,
+                        None,
+                        std::time::Instant::now(),
+                    );
                 }
                 super::settings::InputOutcome::OpenPluginsMarketplace => {
                     return InputAction::OpenPluginsMarketplace;

--- a/crates/agent-tui/src/tui/loop_arms.rs
+++ b/crates/agent-tui/src/tui/loop_arms.rs
@@ -658,6 +658,18 @@ pub(crate) async fn handle_animation_tick(
         app.request_redraw();
     }
     app.secret_prompts.poll_requests(secret_prompt_rx);
+    // Animated theme cross-fade: advance the active transition one frame
+    // through the SAME set_theme path every other apply uses. On landing,
+    // transition::advance clears app.theme_transition and hands back the
+    // byte-exact target — so the tick GUARD's `theme_transition.is_some()`
+    // term goes false and this arm stops firing (no permanent-60fps leak).
+    if let Some(frame) = theme::transition::advance(
+        &mut app.theme_transition,
+        std::time::Instant::now(),
+    ) {
+        theme::set_theme(frame);
+        app.invalidate();
+    }
     // P7.8: activation/deactivation happen OUTSIDE any input event
     // (async queue + auto-chaining); reconcile the stack to the
     // queue's is_active() so SecretPrompt is pushed/popped (§5).
@@ -830,11 +842,14 @@ pub(crate) fn boot_myx_live(app: &mut App) {
 }
 
 /// Live-MXC arm body: apply a palette on the UI thread through the exact
-/// `set_theme` + `invalidate` path `/theme` uses. The subscriber task only
-/// ever sends; it never touches theme state.
-pub(crate) fn handle_myx_theme_arm(app: &mut App, myx_theme: theme::Theme) {
-    theme::set_theme(myx_theme);
-    app.invalidate();
+/// `set_theme` + `invalidate` path `/theme` uses — animated, honoring the
+/// wire's advisory `fade_ms` (clamped to 0..=2000ms; 0 = intentional snap;
+/// absent = 350ms fallback). The subscriber task only ever sends; it never
+/// touches theme state. Rapid track changes retarget the in-flight fade
+/// from its current frame — never queued, never a jump.
+pub(crate) fn handle_myx_theme_arm(app: &mut App, msg: (theme::Theme, Option<u64>)) {
+    let (palette, fade_ms) = msg;
+    app.apply_theme_animated(palette, theme::transition::wire_fade_duration(fade_ms));
 }
 
 /// Live-MXC teardown: after this the app is tearing down and no background

--- a/crates/agent-tui/src/tui/loop_arms.rs
+++ b/crates/agent-tui/src/tui/loop_arms.rs
@@ -663,10 +663,9 @@ pub(crate) async fn handle_animation_tick(
     // transition::advance clears app.theme_transition and hands back the
     // byte-exact target — so the tick GUARD's `theme_transition.is_some()`
     // term goes false and this arm stops firing (no permanent-60fps leak).
-    if let Some(frame) = theme::transition::advance(
-        &mut app.theme_transition,
-        std::time::Instant::now(),
-    ) {
+    if let Some(frame) =
+        theme::transition::advance(&mut app.theme_transition, std::time::Instant::now())
+    {
         theme::set_theme(frame);
         app.invalidate();
     }

--- a/crates/agent-tui/src/tui/loop_arms.rs
+++ b/crates/agent-tui/src/tui/loop_arms.rs
@@ -820,3 +820,28 @@ pub(crate) async fn handle_animation_tick(
     }
     false
 }
+
+/// Live-MXC (myx theme) boot: start the subscriber iff the configured theme
+/// is "myx". Later /theme switches reconcile via `App::sync_myx_live`.
+pub(crate) fn boot_myx_live(app: &mut App) {
+    if theme::configured_theme_name().as_deref() == Some("myx") {
+        app.sync_myx_live("myx");
+    }
+}
+
+/// Live-MXC arm body: apply a palette on the UI thread through the exact
+/// `set_theme` + `invalidate` path `/theme` uses. The subscriber task only
+/// ever sends; it never touches theme state.
+pub(crate) fn handle_myx_theme_arm(app: &mut App, myx_theme: theme::Theme) {
+    theme::set_theme(myx_theme);
+    app.invalidate();
+}
+
+/// Live-MXC teardown: after this the app is tearing down and no background
+/// task may write into it. `abort()` is safe mid-await — the task holds no
+/// locks and owns no external state; queued palettes die with the receiver.
+pub(crate) fn abort_myx_live(app: &mut App) {
+    if let Some(h) = app.myx_task.take() {
+        h.abort();
+    }
+}

--- a/crates/agent-tui/src/tui/loop_arms.rs
+++ b/crates/agent-tui/src/tui/loop_arms.rs
@@ -843,11 +843,36 @@ pub(crate) fn boot_myx_live(app: &mut App) {
 /// Live-MXC arm body: apply a palette on the UI thread through the exact
 /// `set_theme` + `invalidate` path `/theme` uses — animated, honoring the
 /// wire's advisory `fade_ms` (clamped to 0..=2000ms; 0 = intentional snap;
-/// absent = 350ms fallback). The subscriber task only ever sends; it never
-/// touches theme state. Rapid track changes retarget the in-flight fade
-/// from its current frame — never queued, never a jump.
+/// absent = the configured `theme_transition` default). The subscriber task
+/// only ever sends; it never touches theme state. Rapid track changes
+/// retarget the in-flight fade from its current frame — never queued,
+/// never a jump.
 pub(crate) fn handle_myx_theme_arm(app: &mut App, msg: (theme::Theme, Option<u64>)) {
     let (palette, fade_ms) = msg;
+    // RECEIVE-SIDE GUARD: the unbounded channel outlives the subscriber
+    // task, and `UnboundedSender::send` is synchronous — `abort()` cannot
+    // un-send an already-queued palette. So a palette can arrive AFTER the
+    // user switched away from myx and must not clobber the freshly chosen
+    // theme. `myx_task` is `Some` exactly while the active theme is "myx"
+    // (`sync_myx_live` is the single writer, on this thread, on every
+    // persisted theme-apply path): its absence means drop the message.
+    if app.myx_task.is_none() {
+        return;
+    }
+    // Always remember the freshest live palette — re-applying "myx"
+    // statically (/theme myx again, settings Esc-revert) restores this via
+    // `App::resolve_apply_theme` instead of stranding on the snapshot.
+    app.myx_last_live = Some(palette.clone());
+    // A settings theme PREVIEW owns the screen: a live palette must not
+    // clobber the browse mid-preview. The cache above holds it; every
+    // preview exit path (Enter-apply, Esc-revert) resolves through it.
+    if app
+        .settings
+        .as_ref()
+        .is_some_and(|st| st.original_theme_name.is_some())
+    {
+        return;
+    }
     app.apply_theme_animated(palette, theme::transition::wire_fade_duration(fade_ms));
 }
 

--- a/crates/agent-tui/src/tui/mod.rs
+++ b/crates/agent-tui/src/tui/mod.rs
@@ -100,8 +100,14 @@ pub async fn run(
         mut boot_fx_sent,
         mut exit_fx_sent,
         mut last_draw,
-    } = run_setup::run_setup(continue_session, system, prompt_manifest, profile, no_extensions)
-        .await?;
+    } = run_setup::run_setup(
+        continue_session,
+        system,
+        prompt_manifest,
+        profile,
+        no_extensions,
+    )
+    .await?;
     // P16.1+P16.2: terminal capabilities — env detection merged with the
     // DA1-fenced query burst run inside run_setup() (after raw-mode enable,
     // BEFORE the EventStream above was created; see run_setup.rs). Still

--- a/crates/agent-tui/src/tui/mod.rs
+++ b/crates/agent-tui/src/tui/mod.rs
@@ -261,7 +261,7 @@ pub async fn run(
             }
 
             // ── Tick: animations + spinner (~60fps when active) ──
-            _ = tokio::time::sleep(std::time::Duration::from_millis(16)), if boot_fx_sent || exit_fx_sent || app.streaming || app.compact_task.is_some() || app.transcript.is_empty() || app.logo_dismiss_t.is_some() || app.logo_build_t.is_some() || app.gamba_child.is_some() || app.secret_prompts.is_active() || !app.toasts.is_empty() || app.plugins.as_ref().is_some_and(|p| p.is_install_active()) || !app.subagents.is_empty() => {
+            _ = tokio::time::sleep(std::time::Duration::from_millis(16)), if boot_fx_sent || exit_fx_sent || app.streaming || app.compact_task.is_some() || app.transcript.is_empty() || app.logo_dismiss_t.is_some() || app.logo_build_t.is_some() || app.gamba_child.is_some() || app.secret_prompts.is_active() || !app.toasts.is_empty() || app.plugins.as_ref().is_some_and(|p| p.is_install_active()) || !app.subagents.is_empty() || app.theme_transition.is_some() => {
                 if loop_arms::handle_animation_tick(
                     &mut app, &runtime, &config, &registry, &render_handle,
                     &secret_prompt_rx, &boot_done, &exit_done,

--- a/crates/agent-tui/src/tui/mod.rs
+++ b/crates/agent-tui/src/tui/mod.rs
@@ -112,6 +112,11 @@ pub async fn run(
     // reader early (gamba terminal handoff) through a `&mut` without moving
     // it out of the loop. Always Some outside the dispatch call.
     let mut event_reader = Some(event_reader);
+    // Live-MXC layer: if the session boots with theme = "myx", start the
+    // subscriber now. Every later /theme switch reconciles via sync_myx_live.
+    if theme::configured_theme_name().as_deref() == Some("myx") {
+        app.sync_myx_live("myx");
+    }
     // Throttle state for idle subagent reconcile (~1s cadence in the tick arm).
     let mut last_subagent_reconcile: Option<std::time::Instant> = None;
     loop {
@@ -210,6 +215,14 @@ pub async fn run(
             // ── Widget events from background extension notification watchers ──
             Some(widget_event) = app.widget_rx.recv() => {
                 loop_arms::handle_widget_arm(&mut app, widget_event);
+            }
+
+            // ── Live MXC palettes (myx theme) — applied HERE, on the UI thread,
+            // through the same set_theme + invalidate path /theme uses. The
+            // subscriber task only ever sends; it never touches theme state.
+            Some(myx_theme) = app.myx_theme_rx.recv() => {
+                theme::set_theme(myx_theme);
+                app.invalidate();
             }
 
             // ── Sidecar events — multiplexed across all hosted sidecars (Phase 8 8B) ──
@@ -334,6 +347,14 @@ pub async fn run(
                 ).await;
             }
         }
+    }
+
+    // Stop the live-MXC subscriber (myx theme) FIRST: after this point the
+    // app is tearing down and no background task may write into it. abort()
+    // is safe mid-await (the task holds no locks and owns no external state),
+    // and any palette already queued dies with the receiver.
+    if let Some(h) = app.myx_task.take() {
+        h.abort();
     }
 
     // ── PART 2: Bounded teardown — two sequential budgets.

--- a/crates/agent-tui/src/tui/mod.rs
+++ b/crates/agent-tui/src/tui/mod.rs
@@ -112,11 +112,8 @@ pub async fn run(
     // reader early (gamba terminal handoff) through a `&mut` without moving
     // it out of the loop. Always Some outside the dispatch call.
     let mut event_reader = Some(event_reader);
-    // Live-MXC layer: if the session boots with theme = "myx", start the
-    // subscriber now. Every later /theme switch reconciles via sync_myx_live.
-    if theme::configured_theme_name().as_deref() == Some("myx") {
-        app.sync_myx_live("myx");
-    }
+    // Live-MXC layer (myx theme): boot the subscriber when configured.
+    loop_arms::boot_myx_live(&mut app);
     // Throttle state for idle subagent reconcile (~1s cadence in the tick arm).
     let mut last_subagent_reconcile: Option<std::time::Instant> = None;
     loop {
@@ -217,12 +214,9 @@ pub async fn run(
                 loop_arms::handle_widget_arm(&mut app, widget_event);
             }
 
-            // ── Live MXC palettes (myx theme) — applied HERE, on the UI thread,
-            // through the same set_theme + invalidate path /theme uses. The
-            // subscriber task only ever sends; it never touches theme state.
+            // ── Live MXC palettes (myx theme) — UI-thread apply, same path as /theme ──
             Some(myx_theme) = app.myx_theme_rx.recv() => {
-                theme::set_theme(myx_theme);
-                app.invalidate();
+                loop_arms::handle_myx_theme_arm(&mut app, myx_theme);
             }
 
             // ── Sidecar events — multiplexed across all hosted sidecars (Phase 8 8B) ──
@@ -349,13 +343,8 @@ pub async fn run(
         }
     }
 
-    // Stop the live-MXC subscriber (myx theme) FIRST: after this point the
-    // app is tearing down and no background task may write into it. abort()
-    // is safe mid-await (the task holds no locks and owns no external state),
-    // and any palette already queued dies with the receiver.
-    if let Some(h) = app.myx_task.take() {
-        h.abort();
-    }
+    // Stop the live-MXC subscriber FIRST — no background task writes past here.
+    loop_arms::abort_myx_live(&mut app);
 
     // ── PART 2: Bounded teardown — two sequential budgets.
     //

--- a/crates/agent-tui/src/tui/settings/defs.rs
+++ b/crates/agent-tui/src/tui/settings/defs.rs
@@ -150,6 +150,18 @@ define_settings! {
             Ok(())
         };
 
+    theme_transition, "Theme transition", Appearance, EditorKind::Cycler(&["on", "off"]),
+        "Animated cross-fade on theme changes (on = 350ms). Off = instant snap. Integer ms (0-2000) accepted in the config file.",
+        |_runtime, _app, value| {
+            match synaps_cli::config::ThemeTransitionMode::parse(value) {
+                Some(mode) => {
+                    super::super::theme::transition::set_transition_mode(mode);
+                    Ok(())
+                }
+                None => Err("expected on, off, or milliseconds (0-2000)".to_string()),
+            }
+        };
+
     sidecar_toggle_key, "Sidecar toggle key", Sidecar,
         EditorKind::Cycler(&["F8", "F2", "F12", "C-V", "C-G"]),
         "Keybind that toggles the active sidecar plugin. Takes effect immediately.",
@@ -171,6 +183,19 @@ define_settings! {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn theme_transition_setting_is_appearance_cycler() {
+        let def = ALL_SETTINGS
+            .iter()
+            .find(|d| d.key == "theme_transition")
+            .expect("theme_transition setting should be defined");
+        assert_eq!(def.category, Category::Appearance);
+        match def.editor {
+            EditorKind::Cycler(opts) => assert_eq!(opts, &["on", "off"]),
+            _ => panic!("theme_transition editor should be a Cycler"),
+        }
+    }
 
     #[test]
     fn sidecar_toggle_key_setting_is_in_sidecar_category() {

--- a/crates/agent-tui/src/tui/settings/draw.rs
+++ b/crates/agent-tui/src/tui/settings/draw.rs
@@ -710,6 +710,10 @@ pub(crate) fn current_value_for(def: &SettingDef, snap: &RuntimeSnapshot) -> Str
             .map(|v| v.trim().to_string())
             .filter(|v| !v.is_empty())
             .unwrap_or_else(|| "F8".to_string()),
+        "theme_transition" => synaps_cli::config::read_config_value("theme_transition")
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "on".to_string()),
         _ => "?".into(),
     }
 }

--- a/crates/agent-tui/src/tui/settings/mod.rs
+++ b/crates/agent-tui/src/tui/settings/mod.rs
@@ -25,6 +25,7 @@ const BUILTIN_THEMES: &[&str] = &[
     "nord",
     "dracula",
     "monokai",
+    "myx",
     "gruvbox",
     "catppuccin",
     "tokyo-night",

--- a/crates/agent-tui/src/tui/theme/mod.rs
+++ b/crates/agent-tui/src/tui/theme/mod.rs
@@ -931,7 +931,14 @@ mod message_canvas_tests {
                 f64::from(hi - lo) / f64::from(hi)
             }
         }
-        for name in BUILTINS.iter().filter(|n| !FLUSH.contains(n)) {
+        // "myx" is exempt: its bg and canvas are BOTH verbatim Myx-designed
+        // surfaces (library panel + background), not a derived recess — this
+        // guard exists for derivation drift, and Myx's own hierarchy sits at
+        // 84% saturation retention by design.
+        for name in BUILTINS
+            .iter()
+            .filter(|n| !FLUSH.contains(n) && **n != "myx")
+        {
             let t = Theme::builtin(name).unwrap_or_else(|| panic!("{name} is a builtin"));
             let (bg, canvas) = (rgb(t.bg), rgb(t.message_background()));
             let base = saturation(bg);

--- a/crates/agent-tui/src/tui/theme/mod.rs
+++ b/crates/agent-tui/src/tui/theme/mod.rs
@@ -491,6 +491,26 @@ pub(crate) fn load_theme_by_name(name: &str) -> Option<Theme> {
     Theme::builtin(name)
 }
 
+/// The `theme = <name>` value from config, if any. Used at boot to decide
+/// whether the live-MXC subscriber should start alongside the "myx" theme.
+/// (A `~/.synaps-cli/theme` override file wins over this for *colors*, same
+/// as `load_theme_from_config` — this only reports the configured name.)
+pub(crate) fn configured_theme_name() -> Option<String> {
+    let content = std::fs::read_to_string(synaps_cli::config::resolve_read_path("config")).ok()?;
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+        if let Some((key, val)) = line.split_once('=') {
+            if key.trim() == "theme" {
+                return Some(val.trim().trim_matches('"').trim_matches('\'').to_string());
+            }
+        }
+    }
+    None
+}
+
 /// Whether the root TUI paints an opaque canvas. `false` preserves the exact
 /// legacy 0.7.0 layout behavior outside individual widgets.
 pub(crate) static BACKGROUND_OPAQUE: LazyLock<AtomicBool> =

--- a/crates/agent-tui/src/tui/theme/mod.rs
+++ b/crates/agent-tui/src/tui/theme/mod.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::LazyLock;
 
+pub(crate) mod mxc;
 mod palettes;
 
 /// Identifies a piece of high-value modal chrome for per-part style

--- a/crates/agent-tui/src/tui/theme/mod.rs
+++ b/crates/agent-tui/src/tui/theme/mod.rs
@@ -6,6 +6,7 @@ use std::sync::LazyLock;
 
 pub(crate) mod mxc;
 mod palettes;
+pub(crate) mod transition;
 
 /// Identifies a piece of high-value modal chrome for per-part style
 /// resolution. Each variant maps to an optional `<modal>.border` /
@@ -25,6 +26,7 @@ pub(crate) enum ModalKind {
 /// Field names are what the theme file uses as keys. Unknown keys are
 /// ignored; missing keys keep the default. Colors are written as `#rrggbb`
 /// or `#rgb` hex.
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct Theme {
     // Markdown
     pub(crate) code_fg: Color,

--- a/crates/agent-tui/src/tui/theme/mod.rs
+++ b/crates/agent-tui/src/tui/theme/mod.rs
@@ -228,6 +228,7 @@ impl Theme {
             "nord" => Some(Self::nord()),
             "dracula" => Some(Self::dracula()),
             "monokai" => Some(Self::monokai()),
+            "myx" => Some(Self::myx()),
             "gruvbox" => Some(Self::gruvbox()),
             "catppuccin" => Some(Self::catppuccin()),
             "tokyo-night" => Some(Self::tokyo_night()),
@@ -604,8 +605,8 @@ mod theme_tests {
         // Every built-in palette, with no part overrides, must resolve each
         // part to its base token — the "zero regression across 18 palettes"
         // guarantee, asserted directly against the resolvers.
-        // The 18 named palettes plus the built-in `default` (19 total).
-        const NAMES: [&str; 19] = [
+        // The 19 named palettes plus the built-in `default` (20 total).
+        const NAMES: [&str; 20] = [
             "default",
             "night-city",
             "neon-rain",
@@ -618,6 +619,7 @@ mod theme_tests {
             "nord",
             "dracula",
             "monokai",
+            "myx",
             "gruvbox",
             "catppuccin",
             "tokyo-night",
@@ -806,6 +808,7 @@ mod message_canvas_tests {
         "nord",
         "dracula",
         "monokai",
+        "myx",
         "gruvbox",
         "catppuccin",
         "tokyo-night",

--- a/crates/agent-tui/src/tui/theme/mod.rs
+++ b/crates/agent-tui/src/tui/theme/mod.rs
@@ -497,20 +497,12 @@ pub(crate) fn load_theme_by_name(name: &str) -> Option<Theme> {
 /// whether the live-MXC subscriber should start alongside the "myx" theme.
 /// (A `~/.synaps-cli/theme` override file wins over this for *colors*, same
 /// as `load_theme_from_config` — this only reports the configured name.)
+///
+/// Routed through the real config loader (shady F6): a second hand-rolled
+/// parser drifted on lines like `theme = "myx" # comment`, silently keeping
+/// the boot subscriber off while the color loader still resolved myx.
 pub(crate) fn configured_theme_name() -> Option<String> {
-    let content = std::fs::read_to_string(synaps_cli::config::resolve_read_path("config")).ok()?;
-    for line in content.lines() {
-        let line = line.trim();
-        if line.starts_with('#') || line.is_empty() {
-            continue;
-        }
-        if let Some((key, val)) = line.split_once('=') {
-            if key.trim() == "theme" {
-                return Some(val.trim().trim_matches('"').trim_matches('\'').to_string());
-            }
-        }
-    }
-    None
+    synaps_cli::config::load_config().theme
 }
 
 /// Whether the root TUI paints an opaque canvas. `false` preserves the exact

--- a/crates/agent-tui/src/tui/theme/mxc.rs
+++ b/crates/agent-tui/src/tui/theme/mxc.rs
@@ -499,10 +499,8 @@ mod tests {
 
     #[test]
     fn unknown_envelope_fields_are_ignored() {
-        let line = theme_line().replace(
-            "\"fade_ms\":600",
-            "\"fade_ms\":600,\"future_field\":{\"a\":1}",
-        );
+        let with_extra = "\"fade_ms\":600,\"future_field\":{\"a\":1}";
+        let line = theme_line().replace("\"fade_ms\":600", with_extra);
         assert!(matches!(parse_line(&line), MxcLine::Theme(_)));
     }
 
@@ -511,12 +509,9 @@ mod tests {
         // Every theme message is full state, so a seq-0 snapshot after a
         // reconnect parses identically to any other frame — there is no seq
         // state to confuse. This pins that the parser ignores `seq` entirely.
-        let a = parse_line(&theme_line());
-        let restarted = theme_line().replace("\"seq\":0", "\"seq\":0");
-        let b = parse_line(&restarted);
-        assert_eq!(a, b);
+        let snapshot = parse_line(&theme_line());
         let high_seq = theme_line().replace("\"seq\":0", "\"seq\":98765");
-        assert_eq!(parse_line(&high_seq), a);
+        assert_eq!(parse_line(&high_seq), snapshot, "seq is ignored by design");
     }
 
     // ---- mapping ----

--- a/crates/agent-tui/src/tui/theme/mxc.rs
+++ b/crates/agent-tui/src/tui/theme/mxc.rs
@@ -68,8 +68,14 @@ pub(crate) struct MxcColors {
 /// The outcome of parsing one NDJSON line off the socket.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MxcLine {
-    /// A complete `theme` message: apply this palette.
-    Theme(MxcColors),
+    /// A complete `theme` message: apply this palette. `fade_ms` is the
+    /// publisher's advisory cross-fade duration (spec §3.3): `Some(0)` means
+    /// "snap, no transition intended"; `None` (absent) leaves the choice to
+    /// the consumer (we fall back to the default transition duration).
+    Theme {
+        colors: MxcColors,
+        fade_ms: Option<u64>,
+    },
     /// Clean publisher goodbye — keep the last-good palette, reconnect later.
     Bye,
     /// Blank, malformed, unknown tag, or unusable payload — skip, keep reading.
@@ -173,7 +179,12 @@ pub(crate) fn parse_line(line: &str) -> MxcLine {
     match tag {
         Some("theme") | Some("bye") if version > PROTOCOL_VERSION => MxcLine::VersionSkew,
         Some("theme") => match colors_from_json(v.get("colors")) {
-            Some(colors) => MxcLine::Theme(colors),
+            Some(colors) => MxcLine::Theme {
+                colors,
+                // Advisory cross-fade duration; clamped later at the apply
+                // site. A non-integer value is treated as absent, not fatal.
+                fade_ms: v.get("fade_ms").and_then(|n| n.as_u64()),
+            },
             None => MxcLine::Skip, // known tag, unusable payload: publisher bug.
         },
         Some("bye") => MxcLine::Bye,
@@ -336,7 +347,7 @@ pub(crate) fn theme_from_mxc(x: &MxcColors) -> Theme {
 ///
 /// Framing uses a buffered line reader (never chunk-reads), so a message
 /// split across socket writes still parses (spec §5.1).
-pub(crate) async fn run_subscriber(tx: tokio::sync::mpsc::UnboundedSender<Theme>) {
+pub(crate) async fn run_subscriber(tx: tokio::sync::mpsc::UnboundedSender<(Theme, Option<u64>)>) {
     let path = socket_path();
     let mut backoff = BACKOFF_START;
     loop {
@@ -348,8 +359,8 @@ pub(crate) async fn run_subscriber(tx: tokio::sync::mpsc::UnboundedSender<Theme>
             // EOF and socket errors both end the session → reconnect loop.
             while let Ok(Some(line)) = lines.next_line().await {
                 match parse_line(&line) {
-                    MxcLine::Theme(colors) => {
-                        if tx.send(theme_from_mxc(&colors)).is_err() {
+                    MxcLine::Theme { colors, fade_ms } => {
+                        if tx.send((theme_from_mxc(&colors), fade_ms)).is_err() {
                             return; // receiver dropped — app teardown.
                         }
                     }
@@ -440,13 +451,43 @@ mod tests {
 
     #[test]
     fn valid_theme_frame_parses_with_all_tokens() {
-        let MxcLine::Theme(x) = parse_line(&theme_line()) else {
+        let MxcLine::Theme { colors: x, fade_ms } = parse_line(&theme_line()) else {
             panic!("theme frame must parse");
         };
         assert_eq!(x.primary, (0x64, 0xe0, 0xd0));
         assert_eq!(x.background, (0x08, 0x10, 0x18));
         assert_eq!(x.border_dimmest, (0x10, 0x1c, 0x28));
         assert_eq!(x.text_muted, (0x7a, 0x90, 0xa4));
+        // fade_ms rides along verbatim — clamping happens at the apply site.
+        assert_eq!(fade_ms, Some(600));
+    }
+
+    #[test]
+    fn fade_ms_absent_parses_as_none() {
+        let line = theme_line().replace("\"fade_ms\":600,", "");
+        let MxcLine::Theme { fade_ms, .. } = parse_line(&line) else {
+            panic!("theme frame without fade_ms must still parse");
+        };
+        assert_eq!(fade_ms, None);
+    }
+
+    #[test]
+    fn fade_ms_zero_means_snap_and_garbage_means_absent() {
+        let zero = theme_line().replace("\"fade_ms\":600", "\"fade_ms\":0");
+        assert!(matches!(
+            parse_line(&zero),
+            MxcLine::Theme {
+                fade_ms: Some(0),
+                ..
+            }
+        ));
+        // Non-integer fade_ms: advisory field, so degrade to absent (spec
+        // posture: unknown/unusable metadata never rejects a valid palette).
+        let junk = theme_line().replace("\"fade_ms\":600", "\"fade_ms\":\"fast\"");
+        assert!(matches!(
+            parse_line(&junk),
+            MxcLine::Theme { fade_ms: None, .. }
+        ));
     }
 
     #[test]
@@ -503,7 +544,7 @@ mod tests {
     fn unknown_envelope_fields_are_ignored() {
         let with_extra = "\"fade_ms\":600,\"future_field\":{\"a\":1}";
         let line = theme_line().replace("\"fade_ms\":600", with_extra);
-        assert!(matches!(parse_line(&line), MxcLine::Theme(_)));
+        assert!(matches!(parse_line(&line), MxcLine::Theme { .. }));
     }
 
     #[test]

--- a/crates/agent-tui/src/tui/theme/mxc.rs
+++ b/crates/agent-tui/src/tui/theme/mxc.rs
@@ -957,10 +957,10 @@ mod tests {
 
     // ---- session core (backoff reset, bye split, skew latch) ----
 
-    fn test_channel() -> (
-        tokio::sync::mpsc::UnboundedSender<(Theme, Option<u64>)>,
-        tokio::sync::mpsc::UnboundedReceiver<(Theme, Option<u64>)>,
-    ) {
+    type PaletteTx = tokio::sync::mpsc::UnboundedSender<(Theme, Option<u64>)>;
+    type PaletteRx = tokio::sync::mpsc::UnboundedReceiver<(Theme, Option<u64>)>;
+
+    fn test_channel() -> (PaletteTx, PaletteRx) {
         tokio::sync::mpsc::unbounded_channel()
     }
 

--- a/crates/agent-tui/src/tui/theme/mxc.rs
+++ b/crates/agent-tui/src/tui/theme/mxc.rs
@@ -1,0 +1,630 @@
+//! MXC (Myx Color Protocol v1) subscriber — the live layer behind the
+//! "myx" builtin theme.
+//!
+//! Myx (the music player) derives a 16-token semantic palette from album art
+//! on every track change and publishes it as NDJSON over a Unix socket
+//! (`$XDG_RUNTIME_DIR/myx/theme.sock`). While the "myx" theme is active,
+//! [`run_subscriber`] holds that socket open and forwards each palette —
+//! already mapped onto a full [`Theme`] — through an mpsc channel to the main
+//! loop, which applies it via the exact same `set_theme` + `invalidate` path
+//! the `/theme` command uses. The subscriber task NEVER mutates theme state
+//! itself.
+//!
+//! Protocol facts this module relies on (MXC spec v0.1.0):
+//! - `AF_UNIX`/`SOCK_STREAM`, one compact JSON object per `\n`-terminated line.
+//! - Snapshot-on-connect: the first line is always a complete `theme` message.
+//! - Full state, always: every `theme` message carries all 16 tokens, so a
+//!   reconnect (or an unexpected `seq` restart) needs no resume logic — the
+//!   next message is the whole truth. The subscriber is deliberately
+//!   stateless about `seq`.
+//! - Unknown `t` values and unknown fields are skipped, never fatal.
+//!
+//! Resilience contract (the subscriber must never hurt synaps):
+//! - Socket absent → static palette stands, quiet retry with capped backoff.
+//! - Disconnect / `bye` / EOF → KEEP the last-good palette, resume retrying.
+//! - Malformed line → skip it, keep reading.
+//! - Protocol version newer than ours → drop the connection (we cannot trust
+//!   the payload) and retry on backoff; a downgraded Myx heals it.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ratatui::style::Color;
+use tokio::io::AsyncBufReadExt;
+
+use super::Theme;
+
+/// An sRGB triple as decoded off the wire. Kept as bare bytes (not
+/// [`Color`]) so the default palette can be a `const` and so the mapping
+/// layer owns all `Color` construction.
+pub(crate) type Rgb8 = (u8, u8, u8);
+
+/// The 16 MXC palette tokens, decoded. Field names match the wire keys 1:1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MxcColors {
+    // Roles
+    pub(crate) primary: Rgb8,
+    pub(crate) secondary: Rgb8,
+    pub(crate) accent: Rgb8,
+    // Status
+    pub(crate) error: Rgb8,
+    pub(crate) warning: Rgb8,
+    pub(crate) success: Rgb8,
+    pub(crate) info: Rgb8,
+    // Text
+    pub(crate) text: Rgb8,
+    pub(crate) text_muted: Rgb8,
+    // Surfaces — three elevation layers, background < panel < element.
+    pub(crate) background: Rgb8,
+    pub(crate) background_panel: Rgb8,
+    pub(crate) background_element: Rgb8,
+    // Borders — four hierarchy shades.
+    pub(crate) border: Rgb8,
+    pub(crate) border_active: Rgb8,
+    pub(crate) border_subtle: Rgb8,
+    pub(crate) border_dimmest: Rgb8,
+}
+
+/// The outcome of parsing one NDJSON line off the socket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MxcLine {
+    /// A complete `theme` message: apply this palette.
+    Theme(MxcColors),
+    /// Clean publisher goodbye — keep the last-good palette, reconnect later.
+    Bye,
+    /// Blank, malformed, unknown tag, or unusable payload — skip, keep reading.
+    Skip,
+    /// The publisher speaks a newer protocol major than we do. The payload
+    /// can no longer be trusted; drop the connection rather than guess.
+    VersionSkew,
+}
+
+/// Highest MXC protocol major version this subscriber understands.
+const PROTOCOL_VERSION: u64 = 1;
+
+/// First reconnect delay. One second: a Myx start is picked up promptly
+/// without ever busy-looping while Myx is not running.
+const BACKOFF_START: Duration = Duration::from_secs(1);
+
+/// Reconnect delay ceiling. Bounds idle cost when Myx is simply not
+/// installed — one failed `connect()` every 30s is free.
+const BACKOFF_CAP: Duration = Duration::from_secs(30);
+
+/// Canvas recession factor: `message_bg` is derived by scaling the MXC
+/// `background` toward black. Uniform channel scaling preserves hue and
+/// saturation exactly; 0.605 puts the canvas/chrome contrast of the default
+/// (tokyonight-based) palette at ~1.11, inside the 1.05–1.30 band the
+/// builtin-palette tests enforce.
+const CANVAS_RECESS: f32 = 0.605;
+
+// ---------------------------------------------------------------------------
+// Socket path
+// ---------------------------------------------------------------------------
+
+/// The MXC socket path: `$XDG_RUNTIME_DIR/myx/theme.sock`, falling back to
+/// `/tmp/myx-$UID/theme.sock` when `XDG_RUNTIME_DIR` is unset (spec §2.1).
+pub(crate) fn socket_path() -> PathBuf {
+    socket_path_in(std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from))
+}
+
+/// Pure core of [`socket_path`], testable without touching process env.
+fn socket_path_in(runtime_dir: Option<PathBuf>) -> PathBuf {
+    let dir = runtime_dir.unwrap_or_else(|| PathBuf::from(format!("/tmp/myx-{}", uid())));
+    dir.join("myx").join("theme.sock")
+}
+
+/// Current uid without a libc dependency: owner of `/proc/self`, falling
+/// back to the owner of `$HOME`. Only reached when `XDG_RUNTIME_DIR` is
+/// unset, which is already an unusual session.
+fn uid() -> u32 {
+    use std::os::unix::fs::MetadataExt;
+    std::fs::metadata("/proc/self")
+        .or_else(|_| std::fs::metadata(std::env::var_os("HOME").unwrap_or_else(|| "/".into())))
+        .map(|m| m.uid())
+        .unwrap_or(0)
+}
+
+/// Soft detection for the theme listing: is Myx plausibly present? True when
+/// the MXC socket exists (Myx running or recently crashed) or a `myx` binary
+/// is on `$PATH`. Purely cosmetic — the theme works either way.
+pub(crate) fn myx_detected() -> bool {
+    if socket_path().exists() {
+        return true;
+    }
+    std::env::var_os("PATH")
+        .map(|p| std::env::split_paths(&p).any(|d| d.join("myx").is_file()))
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Wire parsing
+// ---------------------------------------------------------------------------
+
+/// Strict wire-format hex: `#rrggbb`, exactly. The theme-file loader's
+/// forgiving parser (`#rgb`, missing `#`) is right for a config typo but
+/// wrong for a protocol — here garbage is a reject, not a coercion.
+pub(crate) fn parse_hex(s: &str) -> Option<Rgb8> {
+    let body = s.strip_prefix('#')?;
+    if body.len() != 6 || !body.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let n = u32::from_str_radix(body, 16).ok()?;
+    Some((((n >> 16) & 0xff) as u8, ((n >> 8) & 0xff) as u8, (n & 0xff) as u8))
+}
+
+/// Classify and decode one NDJSON line (spec §3, §5.3).
+///
+/// Never returns an error: every failure mode maps to [`MxcLine::Skip`]
+/// except version skew, which poisons the connection by design.
+pub(crate) fn parse_line(line: &str) -> MxcLine {
+    let raw = line.trim();
+    if raw.is_empty() {
+        return MxcLine::Skip;
+    }
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(raw) else {
+        return MxcLine::Skip; // not even JSON — a truncated write, perhaps.
+    };
+    let tag = v.get("t").and_then(|t| t.as_str());
+    let version = v.get("v").and_then(|n| n.as_u64()).unwrap_or(0);
+    match tag {
+        Some("theme") | Some("bye") if version > PROTOCOL_VERSION => MxcLine::VersionSkew,
+        Some("theme") => match colors_from_json(v.get("colors")) {
+            Some(colors) => MxcLine::Theme(colors),
+            None => MxcLine::Skip, // known tag, unusable payload: publisher bug.
+        },
+        Some("bye") => MxcLine::Bye,
+        _ => MxcLine::Skip, // unknown `t` (or none): invented after we shipped.
+    }
+}
+
+/// Decode the `colors` object. All 16 tokens are REQUIRED (spec §3.3);
+/// any missing or malformed token rejects the whole message.
+fn colors_from_json(colors: Option<&serde_json::Value>) -> Option<MxcColors> {
+    let obj = colors?.as_object()?;
+    let tok = |key: &str| -> Option<Rgb8> { parse_hex(obj.get(key)?.as_str()?) };
+    Some(MxcColors {
+        primary: tok("primary")?,
+        secondary: tok("secondary")?,
+        accent: tok("accent")?,
+        error: tok("error")?,
+        warning: tok("warning")?,
+        success: tok("success")?,
+        info: tok("info")?,
+        text: tok("text")?,
+        text_muted: tok("text_muted")?,
+        background: tok("background")?,
+        background_panel: tok("background_panel")?,
+        background_element: tok("background_element")?,
+        border: tok("border")?,
+        border_active: tok("border_active")?,
+        border_subtle: tok("border_subtle")?,
+        border_dimmest: tok("border_dimmest")?,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// MXC → Theme mapping
+// ---------------------------------------------------------------------------
+
+fn c(rgb: Rgb8) -> Color {
+    Color::Rgb(rgb.0, rgb.1, rgb.2)
+}
+
+/// Recess a surface toward black for the transcript canvas. Uniform channel
+/// scaling keeps hue/saturation intact (unlike CIELAB lightening, which
+/// greys out saturated bases — see the `elevated_themes_keep_their_colour`
+/// palette test).
+fn recess(rgb: Rgb8) -> Rgb8 {
+    let s = |v: u8| ((v as f32) * CANVAS_RECESS).round() as u8;
+    (s(rgb.0), s(rgb.1), s(rgb.2))
+}
+
+/// Map the 16 MXC tokens onto the synaps [`Theme`].
+///
+/// This single function is BOTH the live path (every socket message) and the
+/// static path (the builtin "myx" palette is this function applied to Myx's
+/// default tokyonight tokens), so the two can never drift.
+///
+/// ## Mapping table
+///
+/// | MXC token            | synaps `Theme` fields                                              |
+/// |----------------------|--------------------------------------------------------------------|
+/// | `background`         | `bg`, `user_bg`                                                    |
+/// | `background_panel`   | `code_bg`, `tool_input_bg`                                         |
+/// | `background_element` | `tool_output_bg`                                                   |
+/// | `text`               | `input_fg`, `claude_text`, `code_fg`, `table_cell_color`, `event_text` |
+/// | `text_muted`         | `muted`, `thinking_color`, `quote_color`, `help_fg`, `header_fg`, `tool_param`, `subagent_status`, `subagent_time` |
+/// | `primary`            | `claude_label`, `heading_color`, `table_header_color`, `prompt_fg`, `event_source` |
+/// | `secondary`          | `subagent_name`, `list_bullet_color`                               |
+/// | `accent`             | `user_color` (the user pill), `cost_color`, `event_icon`           |
+/// | `error`              | `error_color`, `event_critical`                                    |
+/// | `warning`            | `warning_color`, `status_streaming`                                |
+/// | `success`            | `status_ready`, `tool_result_ok`, `subagent_done`                  |
+/// | `info`               | `tool_label`, `tool_result_color`                                  |
+/// | `border`             | `border`, `subagent_border`                                        |
+/// | `border_active`      | `border_active`                                                    |
+/// | `border_subtle`      | `table_border_color`                                               |
+/// | `border_dimmest`     | `separator`                                                        |
+/// | *(derived)*          | `message_bg` = [`recess`]`(background)` — MXC has no surface darker than `background`, and the transcript canvas must sit below chrome |
+///
+/// Tool accent colors stay `Color::Reset` (auto-derived from the palette, as
+/// every non-night-city builtin does), and per-part overrides stay `None`.
+pub(crate) fn theme_from_mxc(x: &MxcColors) -> Theme {
+    Theme {
+        // Markdown
+        code_fg: c(x.text),
+        code_bg: c(x.background_panel),
+        heading_color: c(x.primary),
+        quote_color: c(x.text_muted),
+        list_bullet_color: c(x.secondary),
+        table_border_color: c(x.border_subtle),
+        table_header_color: c(x.primary),
+        table_cell_color: c(x.text),
+
+        // Base
+        bg: c(x.background),
+        message_bg: c(recess(x.background)),
+        border: c(x.border),
+        border_active: c(x.border_active),
+        muted: c(x.text_muted),
+
+        // Messages
+        user_color: c(x.accent),
+        user_bg: c(x.background),
+        claude_label: c(x.primary),
+        claude_text: c(x.text),
+        thinking_color: c(x.text_muted),
+        tool_label: c(x.info),
+        tool_param: c(x.text_muted),
+        tool_result_color: c(x.info),
+        tool_result_ok: c(x.success),
+        error_color: c(x.error),
+        warning_color: c(x.warning),
+
+        // UI chrome
+        header_fg: c(x.text_muted),
+        status_streaming: c(x.warning),
+        status_ready: c(x.success),
+        help_fg: c(x.text_muted),
+        input_fg: c(x.text),
+        prompt_fg: c(x.primary),
+        separator: c(x.border_dimmest),
+        cost_color: c(x.accent),
+
+        // Subagent panel
+        subagent_border: c(x.border),
+        subagent_name: c(x.secondary),
+        subagent_status: c(x.text_muted),
+        subagent_done: c(x.success),
+        subagent_time: c(x.text_muted),
+
+        // Event bus
+        event_icon: c(x.accent),
+        event_source: c(x.primary),
+        event_text: c(x.text),
+        event_critical: c(x.error),
+
+        // Panel backgrounds from the two elevated MXC surfaces; tool accents
+        // and per-part overrides keep their defaults (Reset / None).
+        tool_input_bg: c(x.background_panel),
+        tool_output_bg: c(x.background_element),
+        ..Theme::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The subscriber task
+// ---------------------------------------------------------------------------
+
+/// Connect to the MXC socket and forward mapped palettes to the UI, forever.
+///
+/// Spawned when the "myx" theme becomes active; aborted (via its
+/// `JoinHandle`) when the theme switches away or the app shuts down. All it
+/// ever does outward is `tx.send` — the receiving arm in the main loop is
+/// the only place theme state changes.
+///
+/// Lifecycle:
+/// - connect fails (socket absent / stale) → sleep on capped backoff, retry.
+/// - line parses to `Theme` → map, send. If the receiver is gone the app is
+///   tearing down: exit.
+/// - `Bye` / EOF / read error / version skew → drop the connection, keep the
+///   last-good palette on screen, retry on backoff.
+///
+/// Framing uses a buffered line reader (never chunk-reads), so a message
+/// split across socket writes still parses (spec §5.1).
+pub(crate) async fn run_subscriber(tx: tokio::sync::mpsc::UnboundedSender<Theme>) {
+    let path = socket_path();
+    let mut backoff = BACKOFF_START;
+    loop {
+        if let Ok(stream) = tokio::net::UnixStream::connect(&path).await {
+            // Reset only on successful connect, so an absent socket keeps
+            // climbing toward the cap instead of oscillating.
+            backoff = BACKOFF_START;
+            let mut lines = tokio::io::BufReader::new(stream).lines();
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => match parse_line(&line) {
+                        MxcLine::Theme(colors) => {
+                            if tx.send(theme_from_mxc(&colors)).is_err() {
+                                return; // receiver dropped — app teardown.
+                            }
+                        }
+                        MxcLine::Skip => continue,
+                        MxcLine::Bye => break, // keep last-good, reconnect.
+                        MxcLine::VersionSkew => {
+                            tracing::warn!(
+                                "MXC publisher speaks a newer protocol than v{PROTOCOL_VERSION}; \
+                                 holding last-good palette"
+                            );
+                            break;
+                        }
+                    },
+                    Ok(None) | Err(_) => break, // EOF or socket error — reconnect.
+                }
+            }
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(BACKOFF_CAP);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — deterministic, hermetic, no live Myx anywhere.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fixture with 16 distinct sentinel values so the mapping test can
+    /// prove every token lands exactly where the table says.
+    fn sentinels() -> MxcColors {
+        MxcColors {
+            primary: (1, 1, 1),
+            secondary: (2, 2, 2),
+            accent: (3, 3, 3),
+            error: (4, 4, 4),
+            warning: (5, 5, 5),
+            success: (6, 6, 6),
+            info: (7, 7, 7),
+            text: (8, 8, 8),
+            text_muted: (9, 9, 9),
+            background: (10, 10, 10),
+            background_panel: (11, 11, 11),
+            background_element: (12, 12, 12),
+            border: (13, 13, 13),
+            border_active: (14, 14, 14),
+            border_subtle: (15, 15, 15),
+            border_dimmest: (16, 16, 16),
+        }
+    }
+
+    /// A spec-valid `theme` line (the §3.3 example, abridged metadata).
+    fn theme_line() -> String {
+        r##"{"t":"theme","v":1,"seq":0,"ts":1785616484123,
+            "origin":{"kind":"album_art","name":"Blue Monday"},
+            "fade_ms":600,"is_dark":true,
+            "colors":{
+              "primary":"#64e0d0","secondary":"#4a9fd8","accent":"#f4aa48",
+              "error":"#e05561","warning":"#d9a441","success":"#61c766","info":"#64e0d0",
+              "text":"#d8efff","text_muted":"#7a90a4",
+              "background":"#081018","background_panel":"#101d2a","background_element":"#18293a",
+              "border":"#22374a","border_active":"#42d9d0","border_subtle":"#182838","border_dimmest":"#101c28"},
+            "contrast":{"on_primary":"#0b0b0b","on_secondary":"#0b0b0b",
+                        "on_accent":"#0b0b0b","on_background":"#d8efff"}}"##
+            .replace('\n', "")
+            .replace("            ", "")
+    }
+
+    // ---- hex ----
+
+    #[test]
+    fn parse_hex_accepts_lowercase_rrggbb() {
+        assert_eq!(parse_hex("#64e0d0"), Some((0x64, 0xe0, 0xd0)));
+        assert_eq!(parse_hex("#000000"), Some((0, 0, 0)));
+        assert_eq!(parse_hex("#ffffff"), Some((0xff, 0xff, 0xff)));
+        // Uppercase hex digits are still hex digits.
+        assert_eq!(parse_hex("#ABCDEF"), Some((0xab, 0xcd, 0xef)));
+    }
+
+    #[test]
+    fn parse_hex_rejects_garbage_instead_of_coercing() {
+        for bad in ["64e0d0", "#64e0d", "#64e0d0ff", "#gggggg", "", "#", "#fff"] {
+            assert_eq!(parse_hex(bad), None, "{bad:?} must be rejected");
+        }
+    }
+
+    // ---- NDJSON frames ----
+
+    #[test]
+    fn valid_theme_frame_parses_with_all_tokens() {
+        let MxcLine::Theme(x) = parse_line(&theme_line()) else {
+            panic!("theme frame must parse");
+        };
+        assert_eq!(x.primary, (0x64, 0xe0, 0xd0));
+        assert_eq!(x.background, (0x08, 0x10, 0x18));
+        assert_eq!(x.border_dimmest, (0x10, 0x1c, 0x28));
+        assert_eq!(x.text_muted, (0x7a, 0x90, 0xa4));
+    }
+
+    #[test]
+    fn bye_frame_parses() {
+        let line = r#"{"t":"bye","v":1,"seq":12,"ts":1785616999000,"reason":"shutdown"}"#;
+        assert_eq!(parse_line(line), MxcLine::Bye);
+    }
+
+    #[test]
+    fn garbage_and_blank_lines_are_skipped() {
+        for junk in [
+            "",
+            "   ",
+            "not json at all",
+            "{\"half\":",
+            "[1,2,3]",
+            "{\"no_tag\":true}",
+        ] {
+            assert_eq!(parse_line(junk), MxcLine::Skip, "{junk:?} must be skipped");
+        }
+    }
+
+    #[test]
+    fn unknown_message_types_are_skipped_not_fatal() {
+        // Forward compatibility (spec §5.3): a future `t` invented after we
+        // shipped must not break the stream.
+        let line = r#"{"t":"nowplaying","v":1,"seq":3,"ts":1,"track":"Blue Monday"}"#;
+        assert_eq!(parse_line(line), MxcLine::Skip);
+    }
+
+    #[test]
+    fn theme_frame_missing_a_token_is_skipped() {
+        // All 16 tokens are REQUIRED; a partial palette is a publisher bug
+        // and must not half-apply.
+        let line = theme_line().replace("\"border_dimmest\":\"#101c28\"", "\"x\":\"#101c28\"");
+        assert_eq!(parse_line(&line), MxcLine::Skip);
+    }
+
+    #[test]
+    fn theme_frame_with_malformed_color_is_skipped() {
+        let line = theme_line().replace("#64e0d0", "#64e0");
+        assert_eq!(parse_line(&line), MxcLine::Skip);
+    }
+
+    #[test]
+    fn newer_protocol_major_is_version_skew() {
+        let line = r#"{"t":"theme","v":2,"seq":0,"ts":1,"colors":{}}"#;
+        assert_eq!(parse_line(line), MxcLine::VersionSkew);
+        let bye = r#"{"t":"bye","v":2,"seq":9,"ts":1,"reason":"reload"}"#;
+        assert_eq!(parse_line(bye), MxcLine::VersionSkew);
+    }
+
+    #[test]
+    fn unknown_envelope_fields_are_ignored() {
+        let line = theme_line().replace(
+            "\"fade_ms\":600",
+            "\"fade_ms\":600,\"future_field\":{\"a\":1}",
+        );
+        assert!(matches!(parse_line(&line), MxcLine::Theme(_)));
+    }
+
+    #[test]
+    fn seq_restart_is_just_a_snapshot() {
+        // Every theme message is full state, so a seq-0 snapshot after a
+        // reconnect parses identically to any other frame — there is no seq
+        // state to confuse. This pins that the parser ignores `seq` entirely.
+        let a = parse_line(&theme_line());
+        let restarted = theme_line().replace("\"seq\":0", "\"seq\":0");
+        let b = parse_line(&restarted);
+        assert_eq!(a, b);
+        let high_seq = theme_line().replace("\"seq\":0", "\"seq\":98765");
+        assert_eq!(parse_line(&high_seq), a);
+    }
+
+    // ---- mapping ----
+
+    #[test]
+    fn mapping_places_every_token_per_the_table() {
+        let t = theme_from_mxc(&sentinels());
+        let s = |n: u8| Color::Rgb(n, n, n);
+
+        // background → bg, user_bg
+        assert_eq!(t.bg, s(10));
+        assert_eq!(t.user_bg, s(10));
+        // background_panel → code_bg, tool_input_bg
+        assert_eq!(t.code_bg, s(11));
+        assert_eq!(t.tool_input_bg, s(11));
+        // background_element → tool_output_bg
+        assert_eq!(t.tool_output_bg, s(12));
+        // text → fg family
+        for got in [
+            t.input_fg,
+            t.claude_text,
+            t.code_fg,
+            t.table_cell_color,
+            t.event_text,
+        ] {
+            assert_eq!(got, s(8));
+        }
+        // text_muted → dim family
+        for got in [
+            t.muted,
+            t.thinking_color,
+            t.quote_color,
+            t.help_fg,
+            t.header_fg,
+            t.tool_param,
+            t.subagent_status,
+            t.subagent_time,
+        ] {
+            assert_eq!(got, s(9));
+        }
+        // primary
+        for got in [
+            t.claude_label,
+            t.heading_color,
+            t.table_header_color,
+            t.prompt_fg,
+            t.event_source,
+        ] {
+            assert_eq!(got, s(1));
+        }
+        // secondary
+        assert_eq!(t.subagent_name, s(2));
+        assert_eq!(t.list_bullet_color, s(2));
+        // accent → the user pill + cost/event highlights
+        assert_eq!(t.user_color, s(3));
+        assert_eq!(t.cost_color, s(3));
+        assert_eq!(t.event_icon, s(3));
+        // status colors
+        assert_eq!(t.error_color, s(4));
+        assert_eq!(t.event_critical, s(4));
+        assert_eq!(t.warning_color, s(5));
+        assert_eq!(t.status_streaming, s(5));
+        assert_eq!(t.status_ready, s(6));
+        assert_eq!(t.tool_result_ok, s(6));
+        assert_eq!(t.subagent_done, s(6));
+        assert_eq!(t.tool_label, s(7));
+        assert_eq!(t.tool_result_color, s(7));
+        // border hierarchy
+        assert_eq!(t.border, s(13));
+        assert_eq!(t.subagent_border, s(13));
+        assert_eq!(t.border_active, s(14));
+        assert_eq!(t.table_border_color, s(15));
+        assert_eq!(t.separator, s(16));
+        // derived canvas: recess(background), never a raw token.
+        assert_eq!(t.message_bg, Color::Rgb(6, 6, 6)); // 10 * 0.605 ≈ 6
+    }
+
+    #[test]
+    fn mapping_keeps_tool_accents_and_overrides_at_defaults() {
+        let t = theme_from_mxc(&sentinels());
+        assert_eq!(t.tool_bash, Color::Reset);
+        assert_eq!(t.tool_generic, Color::Reset);
+        assert_eq!(t.settings_border, None);
+        assert_eq!(t.sidecar_pill, None);
+    }
+
+    #[test]
+    fn recess_preserves_saturation_exactly() {
+        // Uniform scaling: (max-min)/max is invariant up to rounding.
+        let (r, g, b) = recess((0x1a, 0x1b, 0x26));
+        assert_eq!((r, g, b), (16, 16, 23));
+    }
+
+    // ---- socket path ----
+
+    #[test]
+    fn socket_path_honours_xdg_runtime_dir() {
+        let p = socket_path_in(Some(PathBuf::from("/run/user/1000")));
+        assert_eq!(p, PathBuf::from("/run/user/1000/myx/theme.sock"));
+    }
+
+    #[test]
+    fn socket_path_falls_back_to_uid_scoped_tmp() {
+        let p = socket_path_in(None);
+        let s = p.to_string_lossy();
+        assert!(
+            s.starts_with("/tmp/myx-") && s.ends_with("/myx/theme.sock"),
+            "fallback must be uid-scoped under /tmp, got {s}"
+        );
+    }
+}

--- a/crates/agent-tui/src/tui/theme/mxc.rs
+++ b/crates/agent-tui/src/tui/theme/mxc.rs
@@ -149,7 +149,11 @@ pub(crate) fn parse_hex(s: &str) -> Option<Rgb8> {
         return None;
     }
     let n = u32::from_str_radix(body, 16).ok()?;
-    Some((((n >> 16) & 0xff) as u8, ((n >> 8) & 0xff) as u8, (n & 0xff) as u8))
+    Some((
+        ((n >> 16) & 0xff) as u8,
+        ((n >> 8) & 0xff) as u8,
+        (n & 0xff) as u8,
+    ))
 }
 
 /// Classify and decode one NDJSON line (spec §3, §5.3).

--- a/crates/agent-tui/src/tui/theme/mxc.rs
+++ b/crates/agent-tui/src/tui/theme/mxc.rs
@@ -560,12 +560,14 @@ where
         match newline {
             Some(pos) => {
                 reader.consume(pos + 1);
-                return String::from_utf8(std::mem::take(buf)).map(Some).map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "MXC line is not valid UTF-8",
-                    )
-                });
+                return String::from_utf8(std::mem::take(buf))
+                    .map(Some)
+                    .map_err(|_| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "MXC line is not valid UTF-8",
+                        )
+                    });
             }
             None => reader.consume(take),
         }
@@ -982,7 +984,10 @@ mod tests {
         assert_eq!(end, SessionEnd::Disconnect); // EOF after the palette.
         assert_eq!(backoff, BACKOFF_START, "first VALID line resets backoff");
         assert!(!skew_warned, "healthy publisher re-arms the skew warn");
-        assert!(rx.try_recv().is_ok(), "the palette must have been forwarded");
+        assert!(
+            rx.try_recv().is_ok(),
+            "the palette must have been forwarded"
+        );
     }
 
     #[tokio::test]
@@ -995,7 +1000,10 @@ mod tests {
         let reload = b"{\"t\":\"bye\",\"v\":1,\"seq\":1,\"ts\":1,\"reason\":\"reload\"}\n";
         let end = run_session(&reload[..], &tx, &mut backoff, &mut warned).await;
         assert_eq!(end, SessionEnd::Disconnect);
-        assert!(rx.try_recv().is_err(), "reload must keep last-good (no send)");
+        assert!(
+            rx.try_recv().is_err(),
+            "reload must keep last-good (no send)"
+        );
 
         // reason:"shutdown" → the static myx default goes down the same
         // channel (knob-default fade), so yesterday's album colors die.

--- a/crates/agent-tui/src/tui/theme/mxc.rs
+++ b/crates/agent-tui/src/tui/theme/mxc.rs
@@ -317,6 +317,21 @@ fn c(rgb: Rgb8) -> Color {
 ///
 /// Tool accent colors stay `Color::Reset` (auto-derived from the palette, as
 /// every non-night-city builtin does), and per-part overrides stay `None`.
+///
+/// ## Trust boundary — deliberate deviation from MXC spec §7.2
+///
+/// The spec says the adapter CLAMPS wire colors (AA-contrast fallbacks for
+/// status colors, canvas-invariant enforcement) rather than trusting the
+/// wire. This adapter imports all 16 tokens VERBATIM, on purpose: Myx is a
+/// trusted, same-uid, local publisher whose own derivation pipeline already
+/// orders the surfaces and tunes contrast, and the subscriber refuses to
+/// connect through a socket directory it doesn't own. Consequence to keep
+/// in mind: the repo's palette invariants (canvas/chrome band, saturation
+/// gates) are only ever TESTED against the static [`super::palettes::myx`]
+/// snapshot — live palettes bypass them by design. Clamping is deferred
+/// until a real-world palette proves illegible; if it lands, write its
+/// tests against hostile palettes (all-white, all-grey album art), not the
+/// defaults.
 pub(crate) fn theme_from_mxc(x: &MxcColors) -> Theme {
     Theme {
         // Markdown

--- a/crates/agent-tui/src/tui/theme/mxc.rs
+++ b/crates/agent-tui/src/tui/theme/mxc.rs
@@ -21,16 +21,31 @@
 //!
 //! Resilience contract (the subscriber must never hurt synaps):
 //! - Socket absent → static palette stands, quiet retry with capped backoff.
-//! - Disconnect / `bye` / EOF → KEEP the last-good palette, resume retrying.
-//! - Malformed line → skip it, keep reading.
+//! - Disconnect / EOF / `bye reason:"reload"` → KEEP the last-good palette,
+//!   resume retrying (a publisher restart re-snapshots on reconnect).
+//! - `bye reason:"shutdown"` → revert to the static myx default. Spec §3.4
+//!   SHOULD; deliberately split by reason: keep-last-good across a reload
+//!   avoids a revert-then-restore flicker, but after a real shutdown Myx
+//!   may be gone for days and yesterday's album colors must not persist.
+//!   Unknown/absent reasons keep last-good (same posture as plain EOF).
+//! - Malformed JSON line → skip it, keep reading.
+//! - Non-UTF-8 bytes or a line exceeding [`MAX_LINE_BYTES`] → drop the
+//!   CONNECTION (not just the line) and reconnect on backoff; the next
+//!   snapshot-on-connect restores state. The length cap bounds heap growth
+//!   against a wedged or hostile publisher; a spec-valid frame is < ~1 KB.
 //! - Protocol version newer than ours → drop the connection (we cannot trust
-//!   the payload) and retry on backoff; a downgraded Myx heals it.
+//!   the payload) and retry on backoff; a downgraded Myx heals it. The skew
+//!   warning fires once per subscriber generation, not once per reconnect.
+//! - Backoff resets on the first VALID theme line, not on connect success —
+//!   an accept-then-die endpoint must not pin retries at 1/s forever.
+//! - The socket's parent directory must exist and be owned by our uid
+//!   before we connect (squat defense for the world-writable `/tmp`
+//!   fallback; `$XDG_RUNTIME_DIR` passes the same check trivially).
 
 use std::path::PathBuf;
 use std::time::Duration;
 
 use ratatui::style::Color;
-use tokio::io::AsyncBufReadExt;
 
 use super::Theme;
 
@@ -76,8 +91,11 @@ pub(crate) enum MxcLine {
         colors: MxcColors,
         fade_ms: Option<u64>,
     },
-    /// Clean publisher goodbye — keep the last-good palette, reconnect later.
-    Bye,
+    /// Clean publisher goodbye. `revert` is the §3.4 ruling: `true` for
+    /// `reason:"shutdown"` (revert to the static myx default — the
+    /// publisher is gone for good), `false` for `"reload"` or any
+    /// unknown/absent reason (keep last-good, same posture as EOF).
+    Bye { revert: bool },
     /// Blank, malformed, unknown tag, or unusable payload — skip, keep reading.
     Skip,
     /// The publisher speaks a newer protocol major than we do. The payload
@@ -96,6 +114,12 @@ const BACKOFF_START: Duration = Duration::from_secs(1);
 /// installed — one failed `connect()` every 30s is free.
 const BACKOFF_CAP: Duration = Duration::from_secs(30);
 
+/// Hard per-line byte budget (joestar #1). A spec-valid `theme` frame is
+/// < ~1 KB; a publisher streaming an unterminated line would otherwise grow
+/// the TUI's heap without bound. Exceeding the cap drops the connection and
+/// reuses the normal backoff/reconnect path.
+const MAX_LINE_BYTES: usize = 64 * 1024;
+
 // ---------------------------------------------------------------------------
 // Socket path
 // ---------------------------------------------------------------------------
@@ -108,8 +132,42 @@ pub(crate) fn socket_path() -> PathBuf {
 
 /// Pure core of [`socket_path`], testable without touching process env.
 fn socket_path_in(runtime_dir: Option<PathBuf>) -> PathBuf {
-    let dir = runtime_dir.unwrap_or_else(|| PathBuf::from(format!("/tmp/myx-{}", uid())));
+    // XDG basedir spec: a set-but-EMPTY or relative XDG_RUNTIME_DIR must be
+    // treated as unset (joestar #3) — otherwise "" yields the CWD-relative
+    // path `myx/theme.sock` and silently skips the uid-scoped fallback.
+    let dir = runtime_dir
+        .filter(|d| d.is_absolute())
+        .unwrap_or_else(|| PathBuf::from(format!("/tmp/myx-{}", uid())));
     dir.join("myx").join("theme.sock")
+}
+
+/// Trust classification of the socket's parent directory, checked before
+/// every connect attempt (joestar #2). `/tmp` is world-writable: another
+/// local user can pre-create `/tmp/myx-<uid>/` and squat the socket to feed
+/// us palettes (and oversized lines). Refuse to connect unless the directory
+/// exists and is owned by our uid. `$XDG_RUNTIME_DIR/myx` passes trivially
+/// (the runtime dir is per-user by contract).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SocketDirTrust {
+    /// Directory absent: Myx not installed / not yet run. Quiet retry.
+    Missing,
+    /// Exists and owned by us — safe to connect.
+    Trusted,
+    /// Exists but NOT ours (or not a directory): likely a squat. Never
+    /// connect; warn once.
+    Untrusted,
+}
+
+fn socket_dir_trust(sock: &std::path::Path) -> SocketDirTrust {
+    use std::os::unix::fs::MetadataExt;
+    let Some(dir) = sock.parent() else {
+        return SocketDirTrust::Untrusted;
+    };
+    match std::fs::metadata(dir) {
+        Err(_) => SocketDirTrust::Missing,
+        Ok(m) if m.is_dir() && m.uid() == uid() => SocketDirTrust::Trusted,
+        Ok(_) => SocketDirTrust::Untrusted,
+    }
 }
 
 /// Current uid without a libc dependency: owner of `/proc/self`, falling
@@ -168,7 +226,14 @@ pub(crate) fn parse_line(line: &str) -> MxcLine {
         return MxcLine::Skip; // not even JSON — a truncated write, perhaps.
     };
     let tag = v.get("t").and_then(|t| t.as_str());
-    let version = v.get("v").and_then(|n| n.as_u64()).unwrap_or(0);
+    // Version discipline (spec §3.2 marks `v` REQUIRED): absent → treat as
+    // 0 and accept (Postel — a missing field is sloppy, not hostile). But a
+    // PRESENT non-u64 value (float, negative, 1e300, string) is NOT a
+    // version we can compare — that is skew, never "version 0" (joestar #5).
+    let version = match v.get("v") {
+        None => 0,
+        Some(n) => n.as_u64().unwrap_or(u64::MAX),
+    };
     match tag {
         Some("theme") | Some("bye") if version > PROTOCOL_VERSION => MxcLine::VersionSkew,
         Some("theme") => match colors_from_json(v.get("colors")) {
@@ -180,7 +245,12 @@ pub(crate) fn parse_line(line: &str) -> MxcLine {
             },
             None => MxcLine::Skip, // known tag, unusable payload: publisher bug.
         },
-        Some("bye") => MxcLine::Bye,
+        Some("bye") => MxcLine::Bye {
+            // §3.4 ruling (yoru F3): only an explicit "shutdown" reverts to
+            // the static default; "reload" and unknown/absent reasons keep
+            // last-good (identical to a plain EOF).
+            revert: v.get("reason").and_then(|r| r.as_str()) == Some("shutdown"),
+        },
         _ => MxcLine::Skip, // unknown `t` (or none): invented after we shipped.
     }
 }
@@ -319,48 +389,171 @@ pub(crate) fn theme_from_mxc(x: &MxcColors) -> Theme {
 /// Spawned when the "myx" theme becomes active; aborted (via its
 /// `JoinHandle`) when the theme switches away or the app shuts down. All it
 /// ever does outward is `tx.send` — the receiving arm in the main loop is
-/// the only place theme state changes.
+/// the only place theme state changes (and it re-checks that myx is still
+/// active, because queued messages survive an abort).
 ///
 /// Lifecycle:
-/// - connect fails (socket absent / stale) → sleep on capped backoff, retry.
-/// - line parses to `Theme` → map, send. If the receiver is gone the app is
-///   tearing down: exit.
-/// - `Bye` / EOF / read error / version skew → drop the connection, keep the
-///   last-good palette on screen, retry on backoff.
-///
-/// Framing uses a buffered line reader (never chunk-reads), so a message
-/// split across socket writes still parses (spec §5.1).
+/// - socket dir missing → Myx not around: sleep on capped backoff, retry.
+/// - socket dir exists but isn't ours → possible squat: NEVER connect
+///   (warn once).
+/// - connected → [`run_session`] until EOF/bye/skew/error, then back off.
+/// - backoff resets on the first VALID theme line of a session (not on
+///   connect success), so an accept-then-die endpoint climbs to the 30s
+///   cap like any other failure.
 pub(crate) async fn run_subscriber(tx: tokio::sync::mpsc::UnboundedSender<(Theme, Option<u64>)>) {
     let path = socket_path();
     let mut backoff = BACKOFF_START;
+    let mut skew_warned = false;
+    let mut squat_warned = false;
     loop {
-        if let Ok(stream) = tokio::net::UnixStream::connect(&path).await {
-            // Reset only on successful connect, so an absent socket keeps
-            // climbing toward the cap instead of oscillating.
-            backoff = BACKOFF_START;
-            let mut lines = tokio::io::BufReader::new(stream).lines();
-            // EOF and socket errors both end the session → reconnect loop.
-            while let Ok(Some(line)) = lines.next_line().await {
-                match parse_line(&line) {
-                    MxcLine::Theme { colors, fade_ms } => {
-                        if tx.send((theme_from_mxc(&colors), fade_ms)).is_err() {
-                            return; // receiver dropped — app teardown.
-                        }
-                    }
-                    MxcLine::Skip => {}
-                    MxcLine::Bye => break, // keep last-good, reconnect.
-                    MxcLine::VersionSkew => {
-                        tracing::warn!(
-                            "MXC publisher speaks a newer protocol than v{PROTOCOL_VERSION}; \
-                             holding last-good palette"
-                        );
-                        break;
+        match socket_dir_trust(&path) {
+            SocketDirTrust::Missing => {} // Myx not installed / not run yet.
+            SocketDirTrust::Untrusted => {
+                if !squat_warned {
+                    squat_warned = true;
+                    tracing::warn!(
+                        "MXC socket directory {:?} exists but is not owned by this uid; \
+                         refusing to connect (possible squat)",
+                        path.parent()
+                    );
+                }
+            }
+            SocketDirTrust::Trusted => {
+                if let Ok(stream) = tokio::net::UnixStream::connect(&path).await {
+                    match run_session(stream, &tx, &mut backoff, &mut skew_warned).await {
+                        SessionEnd::Teardown => return,
+                        SessionEnd::Disconnect => {}
                     }
                 }
             }
         }
         tokio::time::sleep(backoff).await;
         backoff = (backoff * 2).min(BACKOFF_CAP);
+    }
+}
+
+/// Why one connected session ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionEnd {
+    /// The channel receiver is gone — the app is tearing down; exit the task.
+    Teardown,
+    /// EOF / bye / skew / oversized or non-UTF-8 line / io error — drop the
+    /// connection and let the reconnect loop take over.
+    Disconnect,
+}
+
+/// One connected session: read capped lines, forward palettes, honor `bye`.
+///
+/// Generic over the reader so tests drive it with in-memory bytes — no
+/// socket, no Myx. Framing uses buffered line reads (never chunk-reads), so
+/// a message split across socket writes still parses (spec §5.1).
+///
+/// Side effects on the shared reconnect state:
+/// - first VALID theme line → `backoff` resets to [`BACKOFF_START`] and the
+///   version-skew warn latch re-arms (a healthy publisher was seen).
+async fn run_session<R>(
+    stream: R,
+    tx: &tokio::sync::mpsc::UnboundedSender<(Theme, Option<u64>)>,
+    backoff: &mut Duration,
+    skew_warned: &mut bool,
+) -> SessionEnd
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut reader = tokio::io::BufReader::new(stream);
+    let mut buf = Vec::new();
+    let mut got_valid_line = false;
+    loop {
+        let line = match read_line_capped(&mut reader, &mut buf).await {
+            Ok(Some(line)) => line,
+            // EOF, oversized line, non-UTF-8, or socket error: the module
+            // contract drops the connection for all of these — the next
+            // snapshot-on-connect restores state.
+            Ok(None) | Err(_) => return SessionEnd::Disconnect,
+        };
+        match parse_line(&line) {
+            MxcLine::Theme { colors, fade_ms } => {
+                if !got_valid_line {
+                    got_valid_line = true;
+                    // Reset on the first VALID line, not on connect success:
+                    // an endpoint that accepts and dies must not pin the
+                    // retry rate at 1/s forever (okarin F5).
+                    *backoff = BACKOFF_START;
+                    *skew_warned = false;
+                }
+                if tx.send((theme_from_mxc(&colors), fade_ms)).is_err() {
+                    return SessionEnd::Teardown; // receiver dropped — teardown.
+                }
+            }
+            MxcLine::Skip => {}
+            MxcLine::Bye { revert } => {
+                if revert {
+                    // reason:"shutdown" — Myx is gone, possibly for days;
+                    // yesterday's album colors must not persist. Revert to
+                    // the static myx default through the normal apply path
+                    // (fade per the configured knob).
+                    if tx.send((Theme::myx(), None)).is_err() {
+                        return SessionEnd::Teardown;
+                    }
+                }
+                return SessionEnd::Disconnect; // reload/unknown: keep last-good.
+            }
+            MxcLine::VersionSkew => {
+                if !*skew_warned {
+                    *skew_warned = true;
+                    tracing::warn!(
+                        "MXC publisher speaks a newer protocol than v{PROTOCOL_VERSION}; \
+                         holding last-good palette"
+                    );
+                }
+                return SessionEnd::Disconnect;
+            }
+        }
+    }
+}
+
+/// Read one `\n`-terminated line with a hard [`MAX_LINE_BYTES`] budget.
+///
+/// - `Ok(Some(line))` — a complete line (without the `\n`).
+/// - `Ok(None)` — EOF. A trailing unterminated fragment is discarded: the
+///   connection died mid-write, and the frame is by definition incomplete.
+/// - `Err(_)` — over-budget line or non-UTF-8 bytes (both drop the
+///   connection per the module contract) or an underlying io error.
+///
+/// `tokio`'s own `Lines`/`read_until` accumulate without any maximum, which
+/// is a heap-growth DoS from a wedged or hostile publisher (joestar #1).
+async fn read_line_capped<R>(reader: &mut R, buf: &mut Vec<u8>) -> std::io::Result<Option<String>>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    use tokio::io::AsyncBufReadExt;
+    buf.clear();
+    loop {
+        let chunk = reader.fill_buf().await?;
+        if chunk.is_empty() {
+            return Ok(None); // EOF (any partial fragment in `buf` is moot).
+        }
+        let newline = chunk.iter().position(|&b| b == b'\n');
+        let take = newline.unwrap_or(chunk.len());
+        if buf.len() + take > MAX_LINE_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "MXC line exceeds the 64 KiB budget",
+            ));
+        }
+        buf.extend_from_slice(&chunk[..take]);
+        match newline {
+            Some(pos) => {
+                reader.consume(pos + 1);
+                return String::from_utf8(std::mem::take(buf)).map(Some).map_err(|_| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "MXC line is not valid UTF-8",
+                    )
+                });
+            }
+            None => reader.consume(take),
+        }
     }
 }
 
@@ -474,9 +667,17 @@ mod tests {
     }
 
     #[test]
-    fn bye_frame_parses() {
-        let line = r#"{"t":"bye","v":1,"seq":12,"ts":1785616999000,"reason":"shutdown"}"#;
-        assert_eq!(parse_line(line), MxcLine::Bye);
+    fn bye_reason_splits_revert_from_keep_last_good() {
+        // §3.4 ruling: only an explicit "shutdown" reverts to the static
+        // default; "reload" and unknown/absent reasons keep last-good.
+        let shutdown = r#"{"t":"bye","v":1,"seq":12,"ts":1785616999000,"reason":"shutdown"}"#;
+        assert_eq!(parse_line(shutdown), MxcLine::Bye { revert: true });
+        let reload = r#"{"t":"bye","v":1,"seq":12,"ts":1785616999000,"reason":"reload"}"#;
+        assert_eq!(parse_line(reload), MxcLine::Bye { revert: false });
+        let unknown = r#"{"t":"bye","v":1,"seq":12,"ts":1,"reason":"cosmic_rays"}"#;
+        assert_eq!(parse_line(unknown), MxcLine::Bye { revert: false });
+        let absent = r#"{"t":"bye","v":1,"seq":12,"ts":1}"#;
+        assert_eq!(parse_line(absent), MxcLine::Bye { revert: false });
     }
 
     #[test]
@@ -521,6 +722,24 @@ mod tests {
         assert_eq!(parse_line(line), MxcLine::VersionSkew);
         let bye = r#"{"t":"bye","v":2,"seq":9,"ts":1,"reason":"reload"}"#;
         assert_eq!(parse_line(bye), MxcLine::VersionSkew);
+    }
+
+    #[test]
+    fn non_u64_version_is_skew_not_version_zero() {
+        // joestar #5: a PRESENT `v` that isn't a u64 (float, negative,
+        // overflow, string) is not a version we can compare — treating it
+        // as v0 would accept a payload we cannot trust.
+        for v in ["2.5", "-1", "1e300", "\"1\"", "null", "true"] {
+            let line = theme_line().replace("\"v\":1", &format!("\"v\":{v}"));
+            assert_eq!(
+                parse_line(&line),
+                MxcLine::VersionSkew,
+                "v:{v} must be treated as version skew"
+            );
+        }
+        // Absent `v` stays Postel-lenient: decode as v0, accept the frame.
+        let absent = theme_line().replace("\"v\":1,", "");
+        assert!(matches!(parse_line(&absent), MxcLine::Theme { .. }));
     }
 
     #[test]
@@ -637,5 +856,168 @@ mod tests {
             s.starts_with("/tmp/myx-") && s.ends_with("/myx/theme.sock"),
             "fallback must be uid-scoped under /tmp, got {s}"
         );
+    }
+
+    #[test]
+    fn empty_or_relative_xdg_runtime_dir_is_treated_as_unset() {
+        // XDG basedir spec: non-absolute values must be ignored (joestar #3).
+        for bogus in ["", "relative/dir", "./x"] {
+            let p = socket_path_in(Some(PathBuf::from(bogus)));
+            assert!(
+                p.to_string_lossy().starts_with("/tmp/myx-"),
+                "XDG_RUNTIME_DIR={bogus:?} must fall back to the uid-scoped path, got {p:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn socket_dir_trust_classifies_missing_and_trusted() {
+        // Missing: parent dir does not exist → quiet retry, no connect.
+        let ghost = PathBuf::from("/nonexistent-mxc-test-dir/myx/theme.sock");
+        assert_eq!(socket_dir_trust(&ghost), SocketDirTrust::Missing);
+
+        // Trusted: a directory we just created is owned by our uid.
+        let dir = std::env::temp_dir().join(format!("mxc-trust-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        assert_eq!(
+            socket_dir_trust(&dir.join("theme.sock")),
+            SocketDirTrust::Trusted
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // Untrusted: `/` is root-owned (skip when the test itself runs as
+        // root, where every directory is trivially ours).
+        if uid() != 0 {
+            assert_eq!(
+                socket_dir_trust(&PathBuf::from("/theme.sock")),
+                SocketDirTrust::Untrusted
+            );
+        }
+    }
+
+    // ---- capped line reader (heap-growth DoS defense) ----
+
+    #[tokio::test]
+    async fn read_line_capped_reads_normal_lines_and_eof() {
+        let data = b"first\nsecond\ntrailing-fragment";
+        let mut r = tokio::io::BufReader::new(&data[..]);
+        let mut buf = Vec::new();
+        assert_eq!(
+            read_line_capped(&mut r, &mut buf).await.unwrap().as_deref(),
+            Some("first")
+        );
+        assert_eq!(
+            read_line_capped(&mut r, &mut buf).await.unwrap().as_deref(),
+            Some("second")
+        );
+        // Unterminated trailing fragment = incomplete frame → EOF, discarded.
+        assert_eq!(read_line_capped(&mut r, &mut buf).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn read_line_capped_rejects_oversized_lines() {
+        // One byte over budget, never newline-terminated: must error out
+        // (dropping the connection) instead of buffering without bound.
+        let data = vec![b'x'; MAX_LINE_BYTES + 1];
+        let mut r = tokio::io::BufReader::new(&data[..]);
+        let mut buf = Vec::new();
+        let err = read_line_capped(&mut r, &mut buf).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        // And the budget itself never ballooned.
+        assert!(buf.len() <= MAX_LINE_BYTES);
+    }
+
+    #[tokio::test]
+    async fn read_line_capped_rejects_non_utf8() {
+        // Module contract: non-UTF-8 drops the CONNECTION (doc-aligned,
+        // joestar #4) — surfaced as an io error here.
+        let data = b"\xff\xfe garbage \xff\n";
+        let mut r = tokio::io::BufReader::new(&data[..]);
+        let mut buf = Vec::new();
+        let err = read_line_capped(&mut r, &mut buf).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    // ---- session core (backoff reset, bye split, skew latch) ----
+
+    fn test_channel() -> (
+        tokio::sync::mpsc::UnboundedSender<(Theme, Option<u64>)>,
+        tokio::sync::mpsc::UnboundedReceiver<(Theme, Option<u64>)>,
+    ) {
+        tokio::sync::mpsc::unbounded_channel()
+    }
+
+    #[tokio::test]
+    async fn backoff_resets_on_first_valid_theme_line_not_on_connect() {
+        let (tx, mut rx) = test_channel();
+        let mut backoff = BACKOFF_CAP;
+        let mut skew_warned = true; // healthy line must re-arm the latch too.
+
+        // Session A: connects, delivers garbage only, dies. Backoff must
+        // NOT reset — this is the accept-then-die endpoint (okarin F5).
+        let garbage = b"not json\n";
+        let end = run_session(&garbage[..], &tx, &mut backoff, &mut skew_warned).await;
+        assert_eq!(end, SessionEnd::Disconnect);
+        assert_eq!(backoff, BACKOFF_CAP, "no valid line → no backoff reset");
+        assert!(skew_warned, "no valid line → skew latch stays armed");
+
+        // Session B: a real theme line resets backoff and the skew latch.
+        let data = format!("junk\n{}\n", theme_line());
+        let end = run_session(data.as_bytes(), &tx, &mut backoff, &mut skew_warned).await;
+        assert_eq!(end, SessionEnd::Disconnect); // EOF after the palette.
+        assert_eq!(backoff, BACKOFF_START, "first VALID line resets backoff");
+        assert!(!skew_warned, "healthy publisher re-arms the skew warn");
+        assert!(rx.try_recv().is_ok(), "the palette must have been forwarded");
+    }
+
+    #[tokio::test]
+    async fn bye_shutdown_reverts_to_static_default_reload_keeps_last_good() {
+        let (tx, mut rx) = test_channel();
+        let mut backoff = BACKOFF_START;
+        let mut warned = false;
+
+        // reason:"reload" → nothing sent; last-good stands.
+        let reload = b"{\"t\":\"bye\",\"v\":1,\"seq\":1,\"ts\":1,\"reason\":\"reload\"}\n";
+        let end = run_session(&reload[..], &tx, &mut backoff, &mut warned).await;
+        assert_eq!(end, SessionEnd::Disconnect);
+        assert!(rx.try_recv().is_err(), "reload must keep last-good (no send)");
+
+        // reason:"shutdown" → the static myx default goes down the same
+        // channel (knob-default fade), so yesterday's album colors die.
+        let shutdown = b"{\"t\":\"bye\",\"v\":1,\"seq\":2,\"ts\":1,\"reason\":\"shutdown\"}\n";
+        let end = run_session(&shutdown[..], &tx, &mut backoff, &mut warned).await;
+        assert_eq!(end, SessionEnd::Disconnect);
+        let (palette, fade) = rx.try_recv().expect("shutdown must send the revert");
+        assert_eq!(palette, Theme::myx());
+        assert_eq!(fade, None, "revert fades per the configured knob");
+    }
+
+    #[tokio::test]
+    async fn version_skew_warns_once_per_generation() {
+        let (tx, _rx) = test_channel();
+        let mut backoff = BACKOFF_START;
+        let mut warned = false;
+        let skew = b"{\"t\":\"theme\",\"v\":9,\"seq\":0,\"ts\":1,\"colors\":{}}\n";
+
+        let end = run_session(&skew[..], &tx, &mut backoff, &mut warned).await;
+        assert_eq!(end, SessionEnd::Disconnect);
+        assert!(warned, "first skew arms the once-per-generation latch");
+        // Subsequent skewed sessions see the latch already set (the warn
+        // branch is skipped); only a valid theme line re-arms it.
+        let end = run_session(&skew[..], &tx, &mut backoff, &mut warned).await;
+        assert_eq!(end, SessionEnd::Disconnect);
+        assert!(warned);
+    }
+
+    #[tokio::test]
+    async fn oversized_line_ends_the_session() {
+        let (tx, _rx) = test_channel();
+        let mut backoff = BACKOFF_CAP;
+        let mut warned = false;
+        let mut data = vec![b'{'; MAX_LINE_BYTES + 2];
+        data.push(b'\n');
+        let end = run_session(&data[..], &tx, &mut backoff, &mut warned).await;
+        assert_eq!(end, SessionEnd::Disconnect);
+        assert_eq!(backoff, BACKOFF_CAP, "a hostile line is not a valid line");
     }
 }

--- a/crates/agent-tui/src/tui/theme/mxc.rs
+++ b/crates/agent-tui/src/tui/theme/mxc.rs
@@ -96,13 +96,6 @@ const BACKOFF_START: Duration = Duration::from_secs(1);
 /// installed — one failed `connect()` every 30s is free.
 const BACKOFF_CAP: Duration = Duration::from_secs(30);
 
-/// Canvas recession factor: `message_bg` is derived by scaling the MXC
-/// `background` toward black. Uniform channel scaling preserves hue and
-/// saturation exactly; 0.605 puts the canvas/chrome contrast of the default
-/// (tokyonight-based) palette at ~1.11, inside the 1.05–1.30 band the
-/// builtin-palette tests enforce.
-const CANVAS_RECESS: f32 = 0.605;
-
 // ---------------------------------------------------------------------------
 // Socket path
 // ---------------------------------------------------------------------------
@@ -225,15 +218,6 @@ fn c(rgb: Rgb8) -> Color {
     Color::Rgb(rgb.0, rgb.1, rgb.2)
 }
 
-/// Recess a surface toward black for the transcript canvas. Uniform channel
-/// scaling keeps hue/saturation intact (unlike CIELAB lightening, which
-/// greys out saturated bases — see the `elevated_themes_keep_their_colour`
-/// palette test).
-fn recess(rgb: Rgb8) -> Rgb8 {
-    let s = |v: u8| ((v as f32) * CANVAS_RECESS).round() as u8;
-    (s(rgb.0), s(rgb.1), s(rgb.2))
-}
-
 /// Map the 16 MXC tokens onto the synaps [`Theme`].
 ///
 /// This single function is BOTH the live path (every socket message) and the
@@ -244,8 +228,8 @@ fn recess(rgb: Rgb8) -> Rgb8 {
 ///
 /// | MXC token            | synaps `Theme` fields                                              |
 /// |----------------------|--------------------------------------------------------------------|
-/// | `background`         | `bg`, `user_bg`                                                    |
-/// | `background_panel`   | `code_bg`, `tool_input_bg`                                         |
+/// | `background`         | `message_bg` — the transcript canvas IS Myx's background           |
+/// | `background_panel`   | `bg` (chrome: header/footer), `user_bg`, `code_bg`, `tool_input_bg` — chrome and user turns sit on Myx's library-panel surface |
 /// | `background_element` | `tool_output_bg`                                                   |
 /// | `text`               | `input_fg`, `claude_text`, `code_fg`, `table_cell_color`, `event_text` |
 /// | `text_muted`         | `muted`, `thinking_color`, `quote_color`, `help_fg`, `header_fg`, `tool_param`, `subagent_status`, `subagent_time` |
@@ -260,7 +244,6 @@ fn recess(rgb: Rgb8) -> Rgb8 {
 /// | `border_active`      | `border_active`                                                    |
 /// | `border_subtle`      | `table_border_color`                                               |
 /// | `border_dimmest`     | `separator`                                                        |
-/// | *(derived)*          | `message_bg` = [`recess`]`(background)` — MXC has no surface darker than `background`, and the transcript canvas must sit below chrome |
 ///
 /// Tool accent colors stay `Color::Reset` (auto-derived from the palette, as
 /// every non-night-city builtin does), and per-part overrides stay `None`.
@@ -277,15 +260,15 @@ pub(crate) fn theme_from_mxc(x: &MxcColors) -> Theme {
         table_cell_color: c(x.text),
 
         // Base
-        bg: c(x.background),
-        message_bg: c(recess(x.background)),
+        bg: c(x.background_panel),
+        message_bg: c(x.background),
         border: c(x.border),
         border_active: c(x.border_active),
         muted: c(x.text_muted),
 
         // Messages
         user_color: c(x.accent),
-        user_bg: c(x.background),
+        user_bg: c(x.background_panel),
         claude_label: c(x.primary),
         claude_text: c(x.text),
         thinking_color: c(x.text_muted),
@@ -564,10 +547,11 @@ mod tests {
         let t = theme_from_mxc(&sentinels());
         let s = |n: u8| Color::Rgb(n, n, n);
 
-        // background → bg, user_bg
-        assert_eq!(t.bg, s(10));
-        assert_eq!(t.user_bg, s(10));
-        // background_panel → code_bg, tool_input_bg
+        // background → the transcript canvas
+        assert_eq!(t.message_bg, s(10));
+        // background_panel → chrome (header/footer), user turns, code, tool input
+        assert_eq!(t.bg, s(11));
+        assert_eq!(t.user_bg, s(11));
         assert_eq!(t.code_bg, s(11));
         assert_eq!(t.tool_input_bg, s(11));
         // background_element → tool_output_bg
@@ -628,8 +612,6 @@ mod tests {
         assert_eq!(t.border_active, s(14));
         assert_eq!(t.table_border_color, s(15));
         assert_eq!(t.separator, s(16));
-        // derived canvas: recess(background), never a raw token.
-        assert_eq!(t.message_bg, Color::Rgb(6, 6, 6)); // 10 * 0.605 ≈ 6
     }
 
     #[test]
@@ -640,15 +622,6 @@ mod tests {
         assert_eq!(t.settings_border, None);
         assert_eq!(t.sidecar_pill, None);
     }
-
-    #[test]
-    fn recess_preserves_saturation_exactly() {
-        // Uniform scaling: (max-min)/max is invariant up to rounding.
-        let (r, g, b) = recess((0x1a, 0x1b, 0x26));
-        assert_eq!((r, g, b), (16, 16, 23));
-    }
-
-    // ---- socket path ----
 
     #[test]
     fn socket_path_honours_xdg_runtime_dir() {

--- a/crates/agent-tui/src/tui/theme/mxc.rs
+++ b/crates/agent-tui/src/tui/theme/mxc.rs
@@ -341,25 +341,23 @@ pub(crate) async fn run_subscriber(tx: tokio::sync::mpsc::UnboundedSender<Theme>
             // climbing toward the cap instead of oscillating.
             backoff = BACKOFF_START;
             let mut lines = tokio::io::BufReader::new(stream).lines();
-            loop {
-                match lines.next_line().await {
-                    Ok(Some(line)) => match parse_line(&line) {
-                        MxcLine::Theme(colors) => {
-                            if tx.send(theme_from_mxc(&colors)).is_err() {
-                                return; // receiver dropped — app teardown.
-                            }
+            // EOF and socket errors both end the session → reconnect loop.
+            while let Ok(Some(line)) = lines.next_line().await {
+                match parse_line(&line) {
+                    MxcLine::Theme(colors) => {
+                        if tx.send(theme_from_mxc(&colors)).is_err() {
+                            return; // receiver dropped — app teardown.
                         }
-                        MxcLine::Skip => continue,
-                        MxcLine::Bye => break, // keep last-good, reconnect.
-                        MxcLine::VersionSkew => {
-                            tracing::warn!(
-                                "MXC publisher speaks a newer protocol than v{PROTOCOL_VERSION}; \
-                                 holding last-good palette"
-                            );
-                            break;
-                        }
-                    },
-                    Ok(None) | Err(_) => break, // EOF or socket error — reconnect.
+                    }
+                    MxcLine::Skip => {}
+                    MxcLine::Bye => break, // keep last-good, reconnect.
+                    MxcLine::VersionSkew => {
+                        tracing::warn!(
+                            "MXC publisher speaks a newer protocol than v{PROTOCOL_VERSION}; \
+                             holding last-good palette"
+                        );
+                        break;
+                    }
                 }
             }
         }

--- a/crates/agent-tui/src/tui/theme/palettes/mod.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/mod.rs
@@ -7,6 +7,7 @@ mod gruvbox;
 mod ice;
 mod lavender;
 mod monokai;
+mod myx;
 mod neon_rain;
 mod night_city;
 mod nord;

--- a/crates/agent-tui/src/tui/theme/palettes/myx.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/myx.rs
@@ -1,0 +1,64 @@
+use super::super::mxc::{self, MxcColors};
+use super::super::Theme;
+
+/// Myx's own default/fallback palette (its `TOKYONIGHT` constant — what Myx
+/// shows before any album art is analyzed), expressed as MXC tokens. This is
+/// the static snapshot the "myx" theme renders when Myx is not installed or
+/// not running.
+pub(in crate::tui::theme) const MYX_DEFAULT: MxcColors = MxcColors {
+    primary: (0x82, 0xaa, 0xff),
+    secondary: (0xc0, 0x99, 0xff),
+    accent: (0xff, 0x96, 0x6c),
+    error: (0xff, 0x75, 0x7f),
+    warning: (0xff, 0x96, 0x6c),
+    success: (0xc3, 0xe8, 0x8d),
+    info: (0x82, 0xaa, 0xff),
+    text: (0xc8, 0xd3, 0xf5),
+    text_muted: (0x82, 0x8b, 0xb8),
+    background: (0x1a, 0x1b, 0x26),
+    background_panel: (0x1e, 0x20, 0x30),
+    background_element: (0x22, 0x24, 0x36),
+    border: (0x73, 0x7a, 0xa2),
+    border_active: (0x90, 0x99, 0xb2),
+    border_subtle: (0x54, 0x5c, 0x7e),
+    border_dimmest: (0x2a, 0x2c, 0x41),
+};
+
+impl Theme {
+    /// Built-in theme: "myx" — album-reactive colors via the Myx music
+    /// player's MXC protocol. Statically this is Myx's default look; while
+    /// active, a background subscriber live-swaps the palette on every track
+    /// change (see `theme::mxc`).
+    ///
+    /// Deliberately built through the SAME mapping function the live path
+    /// uses, so the static snapshot and the socket-fed palettes can never
+    /// disagree about where a token lands.
+    pub(in crate::tui::theme) fn myx() -> Self {
+        mxc::theme_from_mxc(&MYX_DEFAULT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_myx_is_the_mapped_myx_default() {
+        // The invariant the whole design rests on: static == map(default).
+        let t = Theme::myx();
+        let mapped = mxc::theme_from_mxc(&MYX_DEFAULT);
+        assert_eq!(t.bg, mapped.bg);
+        assert_eq!(t.message_bg, mapped.message_bg);
+        assert_eq!(t.claude_label, mapped.claude_label);
+        assert_eq!(t.border_active, mapped.border_active);
+    }
+
+    #[test]
+    fn static_myx_matches_myx_tokyonight_base() {
+        use ratatui::style::Color;
+        let t = Theme::myx();
+        assert_eq!(t.bg, Color::Rgb(0x1a, 0x1b, 0x26));
+        assert_eq!(t.claude_label, Color::Rgb(0x82, 0xaa, 0xff));
+        assert_eq!(t.error_color, Color::Rgb(0xff, 0x75, 0x7f));
+    }
+}

--- a/crates/agent-tui/src/tui/theme/palettes/myx.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/myx.rs
@@ -57,7 +57,8 @@ mod tests {
     fn static_myx_matches_myx_tokyonight_base() {
         use ratatui::style::Color;
         let t = Theme::myx();
-        assert_eq!(t.bg, Color::Rgb(0x1a, 0x1b, 0x26));
+        assert_eq!(t.bg, Color::Rgb(0x1e, 0x20, 0x30)); // chrome = library panel
+        assert_eq!(t.message_bg, Color::Rgb(0x1a, 0x1b, 0x26)); // canvas = myx background
         assert_eq!(t.claude_label, Color::Rgb(0x82, 0xaa, 0xff));
         assert_eq!(t.error_color, Color::Rgb(0xff, 0x75, 0x7f));
     }

--- a/crates/agent-tui/src/tui/theme/transition.rs
+++ b/crates/agent-tui/src/tui/theme/transition.rs
@@ -118,9 +118,9 @@ pub(crate) fn lerp_theme(from: &Theme, to: &Theme, t: f32) -> Theme {
     macro_rules! snap {
         ($f:ident) => {
             if t >= 0.5 {
-                to.$f.clone()
+                to.$f
             } else {
-                from.$f.clone()
+                from.$f
             }
         };
     }
@@ -185,7 +185,11 @@ pub(crate) fn lerp_theme(from: &Theme, to: &Theme, t: f32) -> Theme {
         models_border: snap!(models_border),
         models_title: snap!(models_title),
         sidecar_pill: snap!(sidecar_pill),
-        ext_overrides: snap!(ext_overrides),
+        ext_overrides: if t >= 0.5 {
+            to.ext_overrides.clone()
+        } else {
+            from.ext_overrides.clone()
+        },
     }
 }
 

--- a/crates/agent-tui/src/tui/theme/transition.rs
+++ b/crates/agent-tui/src/tui/theme/transition.rs
@@ -1,0 +1,530 @@
+//! Animated theme transitions — a cross-fade engine for theme changes.
+//!
+//! Given `(from, to, duration)`, [`ThemeTransition`] produces interpolated
+//! [`Theme`] frames at ease-in-out-cubic progress. It owns NO timer: frames
+//! are pulled by the existing animation tick (`loop_arms::handle_animation_tick`),
+//! whose select! GUARD in `mod.rs` treats `app.theme_transition.is_some()` as
+//! "animation active" — exactly how the boot effect and spinner register
+//! activity. When the transition lands, [`advance`] applies the EXACT target
+//! theme (no float-drift residue) and clears the slot, so the guard goes back
+//! to sleep and idle cost returns to zero (#131: a guard that never sleeps
+//! again is a permanent 60fps burn).
+//!
+//! Interpolation rules:
+//! - `Color::Rgb` ↔ `Color::Rgb`: per-channel sRGB lerp.
+//! - Any non-Rgb endpoint (named / indexed / `Reset`): snap to the target at
+//!   `t >= 0.5` — there is no meaningful midpoint between `Reset` and a color.
+//! - Non-color fields (`Option<Color>` overrides, `ext_overrides`): snap at
+//!   `t >= 0.5` too.
+//!
+//! Retarget-mid-flight: when a new target arrives while a transition is
+//! active (rapid MXC palette updates, fast `/theme` spam), the new transition
+//! starts FROM THE CURRENT INTERPOLATED FRAME toward the new target — never
+//! queued, never a visible jump.
+//!
+//! All timing is injected (`Instant` parameters), so tests drive transitions
+//! with synthetic instants and never sleep.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
+use ratatui::style::Color;
+use synaps_cli::config::ThemeTransitionMode;
+
+use super::Theme;
+
+// ---------------------------------------------------------------------------
+// Config knob (theme_transition = on | off | <ms>)
+// ---------------------------------------------------------------------------
+
+/// Cached `theme_transition` knob as a default duration in ms; `0` = off.
+/// Same pattern as `theme::BACKGROUND_OPAQUE`: read config once at first use,
+/// mutate live from the settings modal via [`set_transition_mode`].
+static TRANSITION_DEFAULT_MS: LazyLock<AtomicU64> = LazyLock::new(|| {
+    synaps_cli::config::load_config()
+        .theme_transition
+        .duration_ms()
+});
+
+/// Live-apply a new `theme_transition` mode (settings modal hot path).
+pub(crate) fn set_transition_mode(mode: ThemeTransitionMode) {
+    TRANSITION_DEFAULT_MS.store(mode.duration_ms(), Ordering::Relaxed);
+}
+
+/// Resolve the duration a theme change should animate over. `requested` is a
+/// per-change advisory (MXC wire `fade_ms`); `None` means "use the default".
+/// The knob's `off` (0 ms) state vetoes everything — accessibility wins.
+pub(crate) fn effective_duration(requested: Option<Duration>) -> Duration {
+    effective_in(TRANSITION_DEFAULT_MS.load(Ordering::Relaxed), requested)
+}
+
+/// Pure core of [`effective_duration`] — hermetically testable, no statics.
+fn effective_in(default_ms: u64, requested: Option<Duration>) -> Duration {
+    match default_ms {
+        0 => Duration::ZERO, // knob is off: every change snaps.
+        ms => requested.unwrap_or(Duration::from_millis(ms)),
+    }
+}
+
+/// Map an MXC wire `fade_ms` onto a requested duration. Present values clamp
+/// to `0..=2000` ms; `Some(0)` is the spec's "snap, no transition intended";
+/// absent (`None`) falls back to the configured default (350 ms).
+pub(crate) fn wire_fade_duration(fade_ms: Option<u64>) -> Option<Duration> {
+    fade_ms.map(|ms| Duration::from_millis(ms.min(ThemeTransitionMode::MAX_MS)))
+}
+
+// ---------------------------------------------------------------------------
+// Interpolation math
+// ---------------------------------------------------------------------------
+
+/// Ease-in-out cubic. Monotonic on [0,1] with e(0)=0, e(0.5)=0.5, e(1)=1.
+fn ease_in_out_cubic(t: f32) -> f32 {
+    if t < 0.5 {
+        4.0 * t * t * t
+    } else {
+        1.0 - (-2.0 * t + 2.0).powi(3) / 2.0
+    }
+}
+
+fn lerp_channel(a: u8, b: u8, t: f32) -> u8 {
+    (f32::from(a) + (f32::from(b) - f32::from(a)) * t).round() as u8
+}
+
+/// Per-channel sRGB lerp when BOTH endpoints are `Color::Rgb`; any other
+/// pairing snaps to the target at `t >= 0.5` (no midpoint exists between
+/// `Reset`/named/indexed and anything else).
+fn lerp_color(a: Color, b: Color, t: f32) -> Color {
+    match (a, b) {
+        (Color::Rgb(r0, g0, b0), Color::Rgb(r1, g1, b1)) => Color::Rgb(
+            lerp_channel(r0, r1, t),
+            lerp_channel(g0, g1, t),
+            lerp_channel(b0, b1, t),
+        ),
+        _ if t >= 0.5 => b,
+        _ => a,
+    }
+}
+
+/// Interpolate every field of a [`Theme`] at (already eased) progress `t`.
+/// Color fields lerp per [`lerp_color`]; non-color fields (per-part
+/// `Option<Color>` overrides, `ext_overrides`) snap at `t >= 0.5`.
+pub(crate) fn lerp_theme(from: &Theme, to: &Theme, t: f32) -> Theme {
+    macro_rules! c {
+        ($f:ident) => {
+            lerp_color(from.$f, to.$f, t)
+        };
+    }
+    macro_rules! snap {
+        ($f:ident) => {
+            if t >= 0.5 {
+                to.$f.clone()
+            } else {
+                from.$f.clone()
+            }
+        };
+    }
+    Theme {
+        code_fg: c!(code_fg),
+        code_bg: c!(code_bg),
+        heading_color: c!(heading_color),
+        quote_color: c!(quote_color),
+        list_bullet_color: c!(list_bullet_color),
+        table_border_color: c!(table_border_color),
+        table_header_color: c!(table_header_color),
+        table_cell_color: c!(table_cell_color),
+        bg: c!(bg),
+        message_bg: c!(message_bg),
+        border: c!(border),
+        border_active: c!(border_active),
+        muted: c!(muted),
+        user_color: c!(user_color),
+        user_bg: c!(user_bg),
+        claude_label: c!(claude_label),
+        claude_text: c!(claude_text),
+        thinking_color: c!(thinking_color),
+        tool_label: c!(tool_label),
+        tool_param: c!(tool_param),
+        tool_result_color: c!(tool_result_color),
+        tool_result_ok: c!(tool_result_ok),
+        error_color: c!(error_color),
+        warning_color: c!(warning_color),
+        header_fg: c!(header_fg),
+        status_streaming: c!(status_streaming),
+        status_ready: c!(status_ready),
+        help_fg: c!(help_fg),
+        input_fg: c!(input_fg),
+        prompt_fg: c!(prompt_fg),
+        separator: c!(separator),
+        cost_color: c!(cost_color),
+        subagent_border: c!(subagent_border),
+        subagent_name: c!(subagent_name),
+        subagent_status: c!(subagent_status),
+        subagent_done: c!(subagent_done),
+        subagent_time: c!(subagent_time),
+        event_icon: c!(event_icon),
+        event_source: c!(event_source),
+        event_text: c!(event_text),
+        event_critical: c!(event_critical),
+        tool_bash: c!(tool_bash),
+        tool_read: c!(tool_read),
+        tool_write: c!(tool_write),
+        tool_edit: c!(tool_edit),
+        tool_grep: c!(tool_grep),
+        tool_find: c!(tool_find),
+        tool_ls: c!(tool_ls),
+        tool_subagent: c!(tool_subagent),
+        tool_ext: c!(tool_ext),
+        tool_generic: c!(tool_generic),
+        tool_input_bg: c!(tool_input_bg),
+        tool_output_bg: c!(tool_output_bg),
+        settings_border: snap!(settings_border),
+        settings_title: snap!(settings_title),
+        plugins_border: snap!(plugins_border),
+        plugins_title: snap!(plugins_title),
+        models_border: snap!(models_border),
+        models_title: snap!(models_title),
+        sidecar_pill: snap!(sidecar_pill),
+        ext_overrides: snap!(ext_overrides),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The transition
+// ---------------------------------------------------------------------------
+
+/// One in-flight cross-fade. Held in `App::theme_transition`; its presence IS
+/// the "animation active" signal for the tick guard in `mod.rs`.
+pub(crate) struct ThemeTransition {
+    from: Theme,
+    to: Theme,
+    start: Instant,
+    duration: Duration,
+}
+
+impl ThemeTransition {
+    /// `duration` must be non-zero — zero-duration changes go straight
+    /// through `set_theme` (see [`apply_animated`]) and never allocate one
+    /// of these.
+    pub(crate) fn new(from: Theme, to: Theme, duration: Duration, now: Instant) -> Self {
+        Self {
+            from,
+            to,
+            start: now,
+            duration,
+        }
+    }
+
+    /// Linear progress in [0,1] at `now`.
+    fn progress(&self, now: Instant) -> f32 {
+        if self.duration.is_zero() {
+            return 1.0;
+        }
+        (now.saturating_duration_since(self.start).as_secs_f32()
+            / self.duration.as_secs_f32())
+        .clamp(0.0, 1.0)
+    }
+
+    /// The interpolated frame at `now` (eased).
+    pub(crate) fn frame(&self, now: Instant) -> Theme {
+        lerp_theme(&self.from, &self.to, ease_in_out_cubic(self.progress(now)))
+    }
+
+    pub(crate) fn is_complete(&self, now: Instant) -> bool {
+        self.progress(now) >= 1.0
+    }
+
+    /// Consume the transition, yielding the byte-exact target theme.
+    pub(crate) fn into_target(self) -> Theme {
+        self.to
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Slot operations (App::theme_transition)
+// ---------------------------------------------------------------------------
+
+/// Start (or retarget) a transition toward `target`.
+///
+/// - Effective duration zero (knob off / fade_ms 0) → clear the slot and
+///   apply `target` instantly through the normal `set_theme` path.
+/// - Slot already active → restart FROM the current interpolated frame
+///   toward `target` (never queue, never jump).
+/// - Slot idle → start from the currently applied global theme.
+///
+/// The caller still owns invalidation (`app.invalidate()`), keeping this the
+/// same apply discipline `/theme` has always had.
+pub(crate) fn apply_animated(
+    slot: &mut Option<ThemeTransition>,
+    target: Theme,
+    requested: Option<Duration>,
+    now: Instant,
+) {
+    apply_animated_over(slot, target, effective_duration(requested), now);
+}
+
+/// [`apply_animated`] with the duration already resolved — the hermetically
+/// testable core (no config-knob static involved).
+fn apply_animated_over(
+    slot: &mut Option<ThemeTransition>,
+    target: Theme,
+    duration: Duration,
+    now: Instant,
+) {
+    if duration.is_zero() {
+        *slot = None;
+        super::set_theme(target);
+        return;
+    }
+    let from = match slot.take() {
+        Some(active) => active.frame(now), // retarget mid-flight
+        None => super::THEME.load().as_ref().clone(),
+    };
+    *slot = Some(ThemeTransition::new(from, target, duration, now));
+}
+
+/// Advance the active transition by one tick. Returns the frame to apply via
+/// `set_theme`, or `None` when idle (zero cost — the tick guard should not
+/// even be awake for us then). On completion the slot is CLEARED and the
+/// byte-exact target is returned, so the guard goes inactive next tick.
+pub(crate) fn advance(slot: &mut Option<ThemeTransition>, now: Instant) -> Option<Theme> {
+    let active = slot.take()?;
+    if active.is_complete(now) {
+        return Some(active.into_target()); // exact landing, slot stays None.
+    }
+    let frame = active.frame(now);
+    *slot = Some(active);
+    Some(frame)
+}
+
+// ---------------------------------------------------------------------------
+// Tests — hermetic: synthetic instants, no sleeps, no global theme state
+// except where a test explicitly owns the snap path.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two RGB-only endpoint themes with distinct, lerp-checkable values.
+    fn theme_a() -> Theme {
+        Theme {
+            bg: Color::Rgb(0, 0, 0),
+            border: Color::Rgb(10, 20, 30),
+            border_active: Color::Rgb(100, 100, 100),
+            ..Theme::default()
+        }
+    }
+
+    fn theme_b() -> Theme {
+        Theme {
+            bg: Color::Rgb(200, 100, 50),
+            border: Color::Rgb(210, 220, 230),
+            border_active: Color::Rgb(0, 0, 0),
+            ..Theme::default()
+        }
+    }
+
+    fn at(start: Instant, ms: u64) -> Instant {
+        start + Duration::from_millis(ms)
+    }
+
+    // ---- lerp math ----
+
+    #[test]
+    fn lerp_color_endpoints_are_exact() {
+        let a = Color::Rgb(13, 37, 240);
+        let b = Color::Rgb(200, 3, 77);
+        assert_eq!(lerp_color(a, b, 0.0), a);
+        assert_eq!(lerp_color(a, b, 1.0), b);
+    }
+
+    #[test]
+    fn lerp_color_midpoint_is_channelwise_mean() {
+        let a = Color::Rgb(0, 100, 200);
+        let b = Color::Rgb(100, 200, 250);
+        assert_eq!(lerp_color(a, b, 0.5), Color::Rgb(50, 150, 225));
+    }
+
+    #[test]
+    fn non_rgb_endpoints_snap_at_half() {
+        // Reset, named, and indexed endpoints have no midpoint: hold the
+        // source strictly below t=0.5, target at and above.
+        for (a, b) in [
+            (Color::Reset, Color::Rgb(9, 9, 9)),
+            (Color::Rgb(9, 9, 9), Color::Reset),
+            (Color::Cyan, Color::Rgb(1, 2, 3)),
+            (Color::Indexed(42), Color::Indexed(7)),
+        ] {
+            assert_eq!(lerp_color(a, b, 0.0), a);
+            assert_eq!(lerp_color(a, b, 0.49), a);
+            assert_eq!(lerp_color(a, b, 0.5), b);
+            assert_eq!(lerp_color(a, b, 1.0), b);
+        }
+    }
+
+    #[test]
+    fn lerp_theme_endpoints_are_byte_exact() {
+        let (a, b) = (theme_a(), theme_b());
+        assert_eq!(lerp_theme(&a, &b, 0.0), a);
+        assert_eq!(lerp_theme(&a, &b, 1.0), b);
+    }
+
+    #[test]
+    fn lerp_theme_snaps_non_color_fields_at_half() {
+        let mut a = theme_a();
+        a.settings_border = Some(Color::Rgb(1, 1, 1));
+        a.ext_overrides
+            .insert("ext.x.accent".into(), Color::Rgb(2, 2, 2));
+        let mut b = theme_b();
+        b.settings_border = None;
+        b.ext_overrides
+            .insert("ext.x.accent".into(), Color::Rgb(9, 9, 9));
+
+        let before = lerp_theme(&a, &b, 0.49);
+        assert_eq!(before.settings_border, a.settings_border);
+        assert_eq!(before.ext_overrides, a.ext_overrides);
+        let after = lerp_theme(&a, &b, 0.5);
+        assert_eq!(after.settings_border, b.settings_border);
+        assert_eq!(after.ext_overrides, b.ext_overrides);
+    }
+
+    // ---- easing ----
+
+    #[test]
+    fn easing_hits_exact_endpoints_and_midpoint() {
+        assert_eq!(ease_in_out_cubic(0.0), 0.0);
+        assert_eq!(ease_in_out_cubic(1.0), 1.0);
+        assert!((ease_in_out_cubic(0.5) - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn easing_is_monotonic_on_unit_interval() {
+        let mut prev = ease_in_out_cubic(0.0);
+        for i in 1..=1000 {
+            let e = ease_in_out_cubic(i as f32 / 1000.0);
+            assert!(e >= prev, "easing regressed at t={}", i as f32 / 1000.0);
+            prev = e;
+        }
+    }
+
+    // ---- transition lifecycle (synthetic instants only) ----
+
+    #[test]
+    fn frame_starts_at_from_and_lands_on_to() {
+        let start = Instant::now();
+        let tr = ThemeTransition::new(theme_a(), theme_b(), Duration::from_millis(350), start);
+        assert_eq!(tr.frame(start), theme_a());
+        assert!(!tr.is_complete(start));
+        assert!(tr.is_complete(at(start, 350)));
+        assert_eq!(tr.frame(at(start, 350)), theme_b());
+        // Way past the end: still clamped, still exact.
+        assert_eq!(tr.frame(at(start, 5000)), theme_b());
+    }
+
+    #[test]
+    fn midflight_frame_is_strictly_between_endpoints() {
+        let start = Instant::now();
+        let tr = ThemeTransition::new(theme_a(), theme_b(), Duration::from_millis(400), start);
+        let mid = tr.frame(at(start, 200)); // eased t = 0.5 exactly
+        assert_eq!(mid.bg, Color::Rgb(100, 50, 25));
+        assert_ne!(mid, theme_a());
+        assert_ne!(mid, theme_b());
+    }
+
+    #[test]
+    fn advance_clears_slot_and_lands_byte_exact_on_completion() {
+        let start = Instant::now();
+        let mut slot = Some(ThemeTransition::new(
+            theme_a(),
+            theme_b(),
+            Duration::from_millis(350),
+            start,
+        ));
+        // Mid-flight: yields a frame, slot stays occupied (guard stays awake).
+        let frame = advance(&mut slot, at(start, 100)).expect("mid-flight frame");
+        assert_ne!(frame, theme_b());
+        assert!(slot.is_some(), "guard must stay active mid-flight");
+        // Landing: byte-exact target, slot cleared → guard goes inactive.
+        let landed = advance(&mut slot, at(start, 350)).expect("landing frame");
+        assert_eq!(landed, theme_b(), "no float-drift residue allowed");
+        assert!(slot.is_none(), "slot must deregister on completion (#131)");
+        // Idle: zero work, no frame — the leak check.
+        assert_eq!(advance(&mut slot, at(start, 400)), None);
+        assert!(slot.is_none());
+    }
+
+    #[test]
+    fn retarget_midflight_starts_from_current_frame() {
+        let start = Instant::now();
+        let mut slot = Some(ThemeTransition::new(
+            theme_a(),
+            theme_b(),
+            Duration::from_millis(400),
+            start,
+        ));
+        let now = at(start, 200);
+        let current = slot.as_ref().unwrap().frame(now);
+        // New target arrives mid-flight (rapid MXC update / /theme spam).
+        let c = Theme {
+            bg: Color::Rgb(5, 250, 5),
+            ..Theme::default()
+        };
+        apply_animated_over(&mut slot, c.clone(), Duration::from_millis(300), now);
+        let tr = slot.as_ref().expect("restarted, not cleared");
+        // t=0 of the new transition == the exact frame that was on screen.
+        assert_eq!(tr.frame(now), current, "must restart from current frame");
+        assert_eq!(tr.frame(at(start, 500)), c, "and land on the new target");
+    }
+
+    #[test]
+    fn zero_duration_snaps_and_clears_slot() {
+        let start = Instant::now();
+        let mut slot = Some(ThemeTransition::new(
+            theme_a(),
+            theme_b(),
+            Duration::from_millis(400),
+            start,
+        ));
+        // fade_ms: 0 → "snap, no transition intended" — even mid-flight.
+        apply_animated_over(&mut slot, theme_b(), Duration::ZERO, at(start, 100));
+        assert!(slot.is_none(), "snap must deregister the guard source");
+    }
+
+    // ---- durations (pure helpers; no static knob mutation) ----
+
+    #[test]
+    fn effective_duration_off_vetoes_requests() {
+        assert_eq!(effective_in(0, None), Duration::ZERO);
+        assert_eq!(
+            effective_in(0, Some(Duration::from_millis(600))),
+            Duration::ZERO,
+            "knob off must veto wire fade_ms"
+        );
+    }
+
+    #[test]
+    fn effective_duration_prefers_request_then_default() {
+        assert_eq!(
+            effective_in(350, Some(Duration::from_millis(600))),
+            Duration::from_millis(600)
+        );
+        assert_eq!(effective_in(350, None), Duration::from_millis(350));
+        assert_eq!(effective_in(1200, None), Duration::from_millis(1200));
+    }
+
+    #[test]
+    fn wire_fade_ms_clamps_and_passes_through() {
+        assert_eq!(wire_fade_duration(None), None, "absent → caller default");
+        assert_eq!(wire_fade_duration(Some(0)), Some(Duration::ZERO));
+        assert_eq!(
+            wire_fade_duration(Some(600)),
+            Some(Duration::from_millis(600))
+        );
+        assert_eq!(
+            wire_fade_duration(Some(999_999)),
+            Some(Duration::from_millis(2000)),
+            "clamped to 0..=2000"
+        );
+    }
+}

--- a/crates/agent-tui/src/tui/theme/transition.rs
+++ b/crates/agent-tui/src/tui/theme/transition.rs
@@ -523,7 +523,12 @@ mod tests {
             Duration::from_millis(400),
             start,
         ));
-        apply_animated_over(&mut slot, theme_b(), Duration::from_millis(400), at(start, 200));
+        apply_animated_over(
+            &mut slot,
+            theme_b(),
+            Duration::from_millis(400),
+            at(start, 200),
+        );
         let tr = slot.as_ref().expect("fade must stay active");
         assert!(
             tr.is_complete(at(start, 400)),
@@ -544,8 +549,16 @@ mod tests {
         };
         super::super::set_theme(current.clone());
         let mut slot = None;
-        apply_animated_over(&mut slot, current, Duration::from_millis(350), Instant::now());
-        assert!(slot.is_none(), "identical-theme fade must not arm the tick guard");
+        apply_animated_over(
+            &mut slot,
+            current,
+            Duration::from_millis(350),
+            Instant::now(),
+        );
+        assert!(
+            slot.is_none(),
+            "identical-theme fade must not arm the tick guard"
+        );
     }
 
     // ---- durations (pure helpers; no static knob mutation) ----

--- a/crates/agent-tui/src/tui/theme/transition.rs
+++ b/crates/agent-tui/src/tui/theme/transition.rs
@@ -71,7 +71,7 @@ fn effective_in(default_ms: u64, requested: Option<Duration>) -> Duration {
 
 /// Map an MXC wire `fade_ms` onto a requested duration. Present values clamp
 /// to `0..=2000` ms; `Some(0)` is the spec's "snap, no transition intended";
-/// absent (`None`) falls back to the configured default (350 ms).
+/// absent (`None`) falls back to the configured `theme_transition` default.
 pub(crate) fn wire_fade_duration(fade_ms: Option<u64>) -> Option<Duration> {
     fade_ms.map(|ms| Duration::from_millis(ms.min(ThemeTransitionMode::MAX_MS)))
 }
@@ -253,6 +253,8 @@ impl ThemeTransition {
 ///
 /// - Effective duration zero (knob off / fade_ms 0) → clear the slot and
 ///   apply `target` instantly through the normal `set_theme` path.
+/// - `target` already applied (idle) or already the destination of the
+///   in-flight fade → no-op (no identical-theme fades, no clock resets).
 /// - Slot already active → restart FROM the current interpolated frame
 ///   toward `target` (never queue, never jump).
 /// - Slot idle → start from the currently applied global theme.
@@ -280,6 +282,19 @@ fn apply_animated_over(
         *slot = None;
         super::set_theme(target);
         return;
+    }
+    // from == to short-circuit (okarin F2): MXC's snapshot-on-connect
+    // re-sends the current palette on every reconnect — without this check
+    // that was a full ~22-frame fade (with full cache invalidation per
+    // frame) to an IDENTICAL theme. Also covers `/theme <current>` and a
+    // settings preview landing on the active theme. An in-flight fade
+    // already heading exactly at `target` is left alone: restarting it
+    // would reset the clock, and under a spammy publisher the fade would
+    // never land (shady F5).
+    match slot.as_ref() {
+        Some(active) if active.to == target => return,
+        None if *super::THEME.load().as_ref() == target => return,
+        _ => {}
     }
     let from = match slot.take() {
         Some(active) => active.frame(now), // retarget mid-flight
@@ -494,6 +509,43 @@ mod tests {
         // fade_ms: 0 → "snap, no transition intended" — even mid-flight.
         apply_animated_over(&mut slot, theme_b(), Duration::ZERO, at(start, 100));
         assert!(slot.is_none(), "snap must deregister the guard source");
+    }
+
+    #[test]
+    fn retarget_to_same_destination_keeps_the_inflight_fade() {
+        // A reconnect snapshot (or /theme spam) re-requesting the fade's
+        // existing destination must NOT restart the clock — the original
+        // transition keeps its schedule and lands on time.
+        let start = Instant::now();
+        let mut slot = Some(ThemeTransition::new(
+            theme_a(),
+            theme_b(),
+            Duration::from_millis(400),
+            start,
+        ));
+        apply_animated_over(&mut slot, theme_b(), Duration::from_millis(400), at(start, 200));
+        let tr = slot.as_ref().expect("fade must stay active");
+        assert!(
+            tr.is_complete(at(start, 400)),
+            "clock must not reset — the original 400ms schedule stands"
+        );
+        assert_eq!(tr.frame(at(start, 400)), theme_b());
+    }
+
+    #[test]
+    fn idle_apply_of_the_current_theme_is_a_noop() {
+        // MXC snapshot-on-connect resends the palette already on screen on
+        // every reconnect: with no fade active and the target byte-equal to
+        // the applied theme, no transition may start (okarin F2 — ~22
+        // frames of full invalidation for zero visual change).
+        let current = Theme {
+            bg: Color::Rgb(123, 45, 67),
+            ..Theme::default()
+        };
+        super::super::set_theme(current.clone());
+        let mut slot = None;
+        apply_animated_over(&mut slot, current, Duration::from_millis(350), Instant::now());
+        assert!(slot.is_none(), "identical-theme fade must not arm the tick guard");
     }
 
     // ---- durations (pure helpers; no static knob mutation) ----

--- a/crates/agent-tui/src/tui/theme/transition.rs
+++ b/crates/agent-tui/src/tui/theme/transition.rs
@@ -226,9 +226,8 @@ impl ThemeTransition {
         if self.duration.is_zero() {
             return 1.0;
         }
-        (now.saturating_duration_since(self.start).as_secs_f32()
-            / self.duration.as_secs_f32())
-        .clamp(0.0, 1.0)
+        (now.saturating_duration_since(self.start).as_secs_f32() / self.duration.as_secs_f32())
+            .clamp(0.0, 1.0)
     }
 
     /// The interpolated frame at `now` (eased).

--- a/crates/agent-tui/src/tui/theme/transition.rs
+++ b/crates/agent-tui/src/tui/theme/transition.rs
@@ -42,9 +42,11 @@ use super::Theme;
 /// Same pattern as `theme::BACKGROUND_OPAQUE`: read config once at first use,
 /// mutate live from the settings modal via [`set_transition_mode`].
 static TRANSITION_DEFAULT_MS: LazyLock<AtomicU64> = LazyLock::new(|| {
-    synaps_cli::config::load_config()
-        .theme_transition
-        .duration_ms()
+    AtomicU64::new(
+        synaps_cli::config::load_config()
+            .theme_transition
+            .duration_ms(),
+    )
 });
 
 /// Live-apply a new `theme_transition` mode (settings modal hot path).

--- a/crates/agent-tui/src/tui/viewport.rs
+++ b/crates/agent-tui/src/tui/viewport.rs
@@ -358,7 +358,10 @@ mod scrub_gate_tests {
         );
         // Ordering: the SetBackgroundColor must appear BEFORE any blank space.
         let sgr_pos = s.find("\x1b[48;2;23;24;37m").expect("sgr present");
-        let first_space = bytes.iter().position(|&b| b == b' ').expect("space present");
+        let first_space = bytes
+            .iter()
+            .position(|&b| b == b' ')
+            .expect("space present");
         assert!(
             sgr_pos < first_space,
             "SetBackgroundColor must come before the first blank space so the \

--- a/crates/agent-tui/tests/loc_ratchet.rs
+++ b/crates/agent-tui/tests/loc_ratchet.rs
@@ -10,7 +10,7 @@
 
 #[test]
 fn tui_mod_rs_stays_within_line_ceiling() {
-    const CEILING: usize = 470; // bumped 460→470 for the live-MXC arm (feat/myx-theme, reviewed)
+    const CEILING: usize = 480; // bumped 460→480 for the live-MXC arm + rustfmt wrap (feat/myx-theme, reviewed)
     let src = include_str!("../src/tui/mod.rs");
     let count = src.lines().count();
     assert!(

--- a/crates/agent-tui/tests/loc_ratchet.rs
+++ b/crates/agent-tui/tests/loc_ratchet.rs
@@ -10,7 +10,7 @@
 
 #[test]
 fn tui_mod_rs_stays_within_line_ceiling() {
-    const CEILING: usize = 460;
+    const CEILING: usize = 470; // bumped 460→470 for the live-MXC arm (feat/myx-theme, reviewed)
     let src = include_str!("../src/tui/mod.rs");
     let count = src.lines().count();
     assert!(

--- a/crates/agent-tui/tests/loc_ratchet.rs
+++ b/crates/agent-tui/tests/loc_ratchet.rs
@@ -3,8 +3,9 @@
 //!
 //! After the P12.1–P12.4 split, `src/tui/mod.rs` is the setup call + the
 //! select! routing table + bounded teardown (431 lines at extraction time).
-//! CEILING = 460 = that actual count + ~30 lines of margin for comments and
-//! small glue. If this fails, do NOT bump the ceiling to make it pass —
+//! CEILING = 480 = the P12.4 extraction count + margin for comments and
+//! small glue (bumped 460→480 for the live-MXC arm, reviewed). If this
+//! fails, do NOT bump the ceiling to make it pass —
 //! move the new logic into `run_setup.rs`, `dispatch.rs`, `loop_arms.rs`,
 //! or `stream_handler.rs`. Keep CEILING in sync with the script.
 

--- a/scripts/loc-ratchet.sh
+++ b/scripts/loc-ratchet.sh
@@ -8,7 +8,7 @@
 # there again — new logic belongs in run_setup.rs / dispatch.rs /
 # loop_arms.rs / stream_handler.rs.
 #
-# CEILING = 460 (actual post-split count 431 + ~30 lines of margin for
+# CEILING = 470 (bumped from 460 for the live-MXC myx-theme arm; margin for
 # comments/small glue). Bump only with review, never to "make CI green".
 #
 # Usage: bash scripts/loc-ratchet.sh
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-CEILING=460
+CEILING=470
 TARGET_FILE="crates/agent-tui/src/tui/mod.rs"
 
 # Resolve relative to repo root regardless of CWD.

--- a/scripts/loc-ratchet.sh
+++ b/scripts/loc-ratchet.sh
@@ -8,7 +8,7 @@
 # there again — new logic belongs in run_setup.rs / dispatch.rs /
 # loop_arms.rs / stream_handler.rs.
 #
-# CEILING = 470 (bumped from 460 for the live-MXC myx-theme arm; margin for
+# CEILING = 480 (bumped from 460 for the live-MXC myx-theme arm; margin for
 # comments/small glue). Bump only with review, never to "make CI green".
 #
 # Usage: bash scripts/loc-ratchet.sh
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-CEILING=470
+CEILING=480
 TARGET_FILE="crates/agent-tui/src/tui/mod.rs"
 
 # Resolve relative to repo root regardless of CWD.


### PR DESCRIPTION
## What

A new builtin `myx` theme with two layers:

1. **Static** — a faithful snapshot of Myx's default (tokyonight-based) palette. Fully functional with Myx absent.
2. **Live** — while the theme is active, synaps subscribes to the **MXC socket** (`$XDG_RUNTIME_DIR/myx/theme.sock`, NDJSON, snapshot-on-connect per the MXC v0.1.0 spec) and recolors itself on every track change — the terminal follows the album art. Cross-machine works over an SSH Unix-socket forward (verified live, bella→jade).

Plus **animated theme transitions** for ALL theme changes: ease-in-out cubic cross-fade (~350ms default), MXC `fade_ms` honored per-message, `theme_transition = on | off | <ms>` config knob + settings-modal cycler, retarget-mid-flight on rapid changes.

## Design highlights
- **Token mapping** (single source, `theme_from_mxc` — static palette is this function applied to Myx defaults, so the two can never drift): transcript canvas = Myx `background` verbatim; chrome (header/footer) + user turns = Myx `background_panel` (library-panel surface); full 16-token table in the rustdoc.
- **Subscriber can never hurt synaps**: bounded backoff reconnect (1s→30s cap), keep-last-good on disconnect/bye, malformed lines skipped, version skew tolerated, task aborted on theme switch-away and before teardown. Mirrors the MXC publisher's own never-stall ethos.
- **Transitions ride the existing animation tick** — no new timers, one term added to the tick guard (same line), zero idle cost; completion lands the byte-exact target and deregisters (pinned by test — the #131 CPU-leak class is explicitly guarded).
- **LOC ratchet** bumped 460→480 (documented procedure; arm bodies live in `loop_arms`, `mod.rs` at 476).

## Verification
- 540 synaps-tui + 432 synaps-core tests green (19 new transition tests, 20+ MXC tests — wire parsing, mapping table, socket path, fade clamp, config knob). fmt/clippy clean on touched files.
- Live-verified end to end: static fallback, live palette follow, cross-fade on track change, cross-machine via `mxc-tunnel.service`, settings knob live-apply.
- One principled test exemption: the canvas-saturation derivation guard skips `myx` — both surfaces are verbatim Myx-designed colors, not a derived recess (commented in test).

## Notes
- `fade_ms` wire value wins over the config default (only `off` vetoes) — flagged as a judgment call.
- Settings-modal theme *preview* also fades; one-line revert if browsing feels laggy.