### PR TITLE
docs(readme): fix 404 on Debian .deb install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ cargo install synaps              # crates.io
 brew install HaseebKhalid1507/tap/synaps    # macOS / Linux
 yay -S synaps                               # Arch / EndeavourOS
 
-# Debian/Ubuntu
-curl -LO https://github.com/HaseebKhalid1507/SynapsCLI/releases/latest/download/synaps_amd64.deb
-sudo dpkg -i synaps_amd64.deb
+# Debian/Ubuntu — .deb is attached to every release:
+# https://github.com/HaseebKhalid1507/SynapsCLI/releases/latest
 
 # Shell installer (any platform)
 curl -sSL https://github.com/HaseebKhalid1507/SynapsCLI/releases/latest/download/synaps-installer.sh | sh


### PR DESCRIPTION
Pre-launch install-path audit turned up a dead link in the README.

**Bug:** the README tells Debian/Ubuntu users to fetch `synaps_amd64.deb`, but releases publish it version-stamped as `synaps_0.8.0-1_amd64.deb`. The unversioned URL 404s.

**Verified:**

| URL | status |
|---|---|
| `synaps-installer.sh` | 200 |
| `synaps_0.8.0-1_amd64.deb` | 200 |
| `synaps_amd64.deb` (in README) | **404** |

**Fix:** point Debian users at the release page rather than a hardcoded filename — any pinned name re-breaks on the next tag. The shell installer already covers a copy-pasteable path for that platform.

Docs-only, no code touched.