### PR TITLE
feat(xai): add grok-4.6 to the model catalog

### DIFF
--- a/crates/agent-engine/src/runtime/openai/catalog/validation.rs
+++ b/crates/agent-engine/src/runtime/openai/catalog/validation.rs
@@ -438,7 +438,6 @@ mod tests {
             "xai-auth/grok-4.5",
             "xai-auth/grok-4.5-latest",
             "xai-auth/grok-4.6",
-            "xai-auth/grok-4.6-latest",
         ] {
             for level in [Adaptive, Low, Medium, High] {
                 assert!(
@@ -622,10 +621,6 @@ mod tests {
             Some(High)
         );
         assert_eq!(default_level_for_model("xai-auth/grok-4.6"), Some(High));
-        assert_eq!(
-            default_level_for_model("xai-auth/grok-4.6-latest"),
-            Some(High)
-        );
         assert_eq!(
             default_level_for_model("xai-auth/grok-4.20-multi-agent-0309"),
             Some(Adaptive)

--- a/crates/agent-engine/src/runtime/openai/catalog/validation.rs
+++ b/crates/agent-engine/src/runtime/openai/catalog/validation.rs
@@ -433,8 +433,13 @@ mod tests {
     // ── xAI mutation matrix ──────────────────────────────────────────────────
 
     #[test]
-    fn xai_45_accepts_exact_efforts_and_rejects_off_xhigh_max_ultra() {
-        for model in ["xai-auth/grok-4.5", "xai-auth/grok-4.5-latest"] {
+    fn xai_45_and_46_accept_exact_efforts_and_reject_off_xhigh_max_ultra() {
+        for model in [
+            "xai-auth/grok-4.5",
+            "xai-auth/grok-4.5-latest",
+            "xai-auth/grok-4.6",
+            "xai-auth/grok-4.6-latest",
+        ] {
             for level in [Adaptive, Low, Medium, High] {
                 assert!(
                     validate_reasoning_mutation(model, level).is_ok(),
@@ -616,6 +621,11 @@ mod tests {
             default_level_for_model("xai-auth/grok-4.5-latest"),
             Some(High)
         );
+        assert_eq!(default_level_for_model("xai-auth/grok-4.6"), Some(High));
+        assert_eq!(
+            default_level_for_model("xai-auth/grok-4.6-latest"),
+            Some(High)
+        );
         assert_eq!(
             default_level_for_model("xai-auth/grok-4.20-multi-agent-0309"),
             Some(Adaptive)
@@ -638,6 +648,10 @@ mod tests {
     fn xai_options_derive_from_exact_capabilities() {
         assert_eq!(
             thinking_options_for_model("xai-auth/grok-4.5"),
+            vec!["adaptive", "low", "medium", "high"]
+        );
+        assert_eq!(
+            thinking_options_for_model("xai-auth/grok-4.6"),
             vec!["adaptive", "low", "medium", "high"]
         );
         assert_eq!(
@@ -673,6 +687,7 @@ mod tests {
         );
         // xAI: documented effort control / intrinsic / non-reasoning.
         assert_eq!(reasoning_type_for_model("xai-auth/grok-4.5"), "effort");
+        assert_eq!(reasoning_type_for_model("xai-auth/grok-4.6"), "effort");
         assert_eq!(reasoning_type_for_model("xai-auth/grok-4.3"), "intrinsic");
         assert_eq!(
             reasoning_type_for_model("xai-auth/grok-4.20-0309-non-reasoning"),

--- a/crates/agent-engine/src/runtime/openai/catalog/xai.rs
+++ b/crates/agent-engine/src/runtime/openai/catalog/xai.rs
@@ -67,6 +67,18 @@ pub const XAI_TEXT_MODELS: &[XaiModelDescriptor] = &[
         context_tokens: None,
         reasoning: true,
     },
+    XaiModelDescriptor {
+        id: "grok-4.6",
+        label: "Grok 4.6",
+        context_tokens: None,
+        reasoning: true,
+    },
+    XaiModelDescriptor {
+        id: "grok-4.6-latest",
+        label: "Grok 4.6 (latest alias)",
+        context_tokens: None,
+        reasoning: true,
+    },
 ];
 
 pub fn xai_model(id: &str) -> Option<&'static XaiModelDescriptor> {
@@ -77,10 +89,11 @@ pub fn xai_model(id: &str) -> Option<&'static XaiModelDescriptor> {
 
 /// Documented reasoning capability for an exact xAI model id.
 ///
-/// Evidence: official xAI docs. `grok-4.5`/`grok-4.5-latest` support
-/// low/medium/high effort, default high, and reasoning cannot be disabled.
-/// `grok-4.20-multi-agent-0309` supports low/medium/high/xhigh where effort
-/// controls agent count. No other exact id has documented effort support.
+/// Evidence: official xAI docs. `grok-4.5`/`grok-4.5-latest` and
+/// `grok-4.6`/`grok-4.6-latest` support low/medium/high effort, default high,
+/// and reasoning cannot be disabled. `grok-4.20-multi-agent-0309` supports
+/// low/medium/high/xhigh where effort controls agent count. No other exact id
+/// has documented effort support.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum XaiReasoningCapability {
     /// Documented named-effort control (`reasoning:{effort:"..."}` on the
@@ -103,11 +116,13 @@ pub enum XaiReasoningCapability {
 pub fn xai_static_capability(model_id: &str) -> Option<XaiReasoningCapability> {
     use agent_core::reasoning::ReasoningLevel::*;
     match model_id {
-        "grok-4.5" | "grok-4.5-latest" => Some(XaiReasoningCapability::Effort {
-            supported: &[Low, Medium, High],
-            default_level: Some(High),
-            can_disable: false,
-        }),
+        "grok-4.5" | "grok-4.5-latest" | "grok-4.6" | "grok-4.6-latest" => {
+            Some(XaiReasoningCapability::Effort {
+                supported: &[Low, Medium, High],
+                default_level: Some(High),
+                can_disable: false,
+            })
+        }
         "grok-4.20-multi-agent-0309" => Some(XaiReasoningCapability::Effort {
             supported: &[Low, Medium, High, XHigh],
             // Effort controls agent count; no documented default level.
@@ -164,6 +179,8 @@ mod tests {
                 "grok-4.20-multi-agent-0309",
                 "grok-4.5",
                 "grok-4.5-latest",
+                "grok-4.6",
+                "grok-4.6-latest",
             ]
         );
     }
@@ -185,6 +202,8 @@ mod tests {
                 "grok-4.20-multi-agent-0309",
                 "grok-4.5",
                 "grok-4.5-latest",
+                "grok-4.6",
+                "grok-4.6-latest",
             ]
         );
     }
@@ -192,9 +211,9 @@ mod tests {
     // ── Exact-id reasoning capability table (spec: anthropic-xai-reasoning-modes) ──
 
     #[test]
-    fn grok_45_family_effort_capability_is_exact() {
+    fn grok_45_and_46_family_effort_capability_is_exact() {
         use agent_core::reasoning::ReasoningLevel::*;
-        for id in ["grok-4.5", "grok-4.5-latest"] {
+        for id in ["grok-4.5", "grok-4.5-latest", "grok-4.6", "grok-4.6-latest"] {
             match xai_static_capability(id) {
                 Some(XaiReasoningCapability::Effort {
                     supported,
@@ -225,11 +244,13 @@ mod tests {
             }
             other => panic!("expected Effort capability, got {other:?}"),
         }
-        // 4.5 has no documented xhigh — must not appear in its set.
-        if let Some(XaiReasoningCapability::Effort { supported, .. }) =
-            xai_static_capability("grok-4.5")
-        {
-            assert!(!supported.contains(&XHigh));
+        // 4.5/4.6 have no documented xhigh — must not appear in their sets.
+        for id in ["grok-4.5", "grok-4.6"] {
+            if let Some(XaiReasoningCapability::Effort { supported, .. }) =
+                xai_static_capability(id)
+            {
+                assert!(!supported.contains(&XHigh), "{id}");
+            }
         }
     }
 

--- a/crates/agent-engine/src/runtime/openai/catalog/xai.rs
+++ b/crates/agent-engine/src/runtime/openai/catalog/xai.rs
@@ -73,12 +73,6 @@ pub const XAI_TEXT_MODELS: &[XaiModelDescriptor] = &[
         context_tokens: None,
         reasoning: true,
     },
-    XaiModelDescriptor {
-        id: "grok-4.6-latest",
-        label: "Grok 4.6 (latest alias)",
-        context_tokens: None,
-        reasoning: true,
-    },
 ];
 
 pub fn xai_model(id: &str) -> Option<&'static XaiModelDescriptor> {
@@ -89,9 +83,11 @@ pub fn xai_model(id: &str) -> Option<&'static XaiModelDescriptor> {
 
 /// Documented reasoning capability for an exact xAI model id.
 ///
-/// Evidence: official xAI docs. `grok-4.5`/`grok-4.5-latest` and
-/// `grok-4.6`/`grok-4.6-latest` support low/medium/high effort, default high,
-/// and reasoning cannot be disabled. `grok-4.20-multi-agent-0309` supports
+/// Evidence: official xAI docs and a live `GET /v1/models` probe
+/// (2026-08-14). `grok-4.5`/`grok-4.5-latest` and `grok-4.6` support
+/// low/medium/high effort, default high, and reasoning cannot be disabled.
+/// xAI has not published a `grok-4.6-latest` alias (upstream 404), so only
+/// the bare id is cataloged. `grok-4.20-multi-agent-0309` supports
 /// low/medium/high/xhigh where effort controls agent count. No other exact id
 /// has documented effort support.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -116,13 +112,11 @@ pub enum XaiReasoningCapability {
 pub fn xai_static_capability(model_id: &str) -> Option<XaiReasoningCapability> {
     use agent_core::reasoning::ReasoningLevel::*;
     match model_id {
-        "grok-4.5" | "grok-4.5-latest" | "grok-4.6" | "grok-4.6-latest" => {
-            Some(XaiReasoningCapability::Effort {
-                supported: &[Low, Medium, High],
-                default_level: Some(High),
-                can_disable: false,
-            })
-        }
+        "grok-4.5" | "grok-4.5-latest" | "grok-4.6" => Some(XaiReasoningCapability::Effort {
+            supported: &[Low, Medium, High],
+            default_level: Some(High),
+            can_disable: false,
+        }),
         "grok-4.20-multi-agent-0309" => Some(XaiReasoningCapability::Effort {
             supported: &[Low, Medium, High, XHigh],
             // Effort controls agent count; no documented default level.
@@ -180,7 +174,6 @@ mod tests {
                 "grok-4.5",
                 "grok-4.5-latest",
                 "grok-4.6",
-                "grok-4.6-latest",
             ]
         );
     }
@@ -203,7 +196,6 @@ mod tests {
                 "grok-4.5",
                 "grok-4.5-latest",
                 "grok-4.6",
-                "grok-4.6-latest",
             ]
         );
     }
@@ -213,7 +205,7 @@ mod tests {
     #[test]
     fn grok_45_and_46_family_effort_capability_is_exact() {
         use agent_core::reasoning::ReasoningLevel::*;
-        for id in ["grok-4.5", "grok-4.5-latest", "grok-4.6", "grok-4.6-latest"] {
+        for id in ["grok-4.5", "grok-4.5-latest", "grok-4.6"] {
             match xai_static_capability(id) {
                 Some(XaiReasoningCapability::Effort {
                     supported,

--- a/crates/agent-engine/src/runtime/openai/stream.rs
+++ b/crates/agent-engine/src/runtime/openai/stream.rs
@@ -2443,7 +2443,6 @@ mod xai_tests {
             "grok-4.5",
             "grok-4.5-latest",
             "grok-4.6",
-            "grok-4.6-latest",
             "grok-4.3",
             "grok-4.20-0309-non-reasoning",
         ] {
@@ -2458,7 +2457,6 @@ mod xai_tests {
             "grok-4.5",
             "grok-4.5-latest",
             "grok-4.6",
-            "grok-4.6-latest",
             "grok-4.20-multi-agent-0309",
             "grok-4.3",
         ] {

--- a/crates/agent-engine/src/runtime/openai/stream.rs
+++ b/crates/agent-engine/src/runtime/openai/stream.rs
@@ -2423,10 +2423,27 @@ mod xai_tests {
     }
 
     #[test]
+    fn grok46_emits_exact_documented_efforts() {
+        for (level, effort) in [
+            (ReasoningLevel::Low, "low"),
+            (ReasoningLevel::Medium, "medium"),
+            (ReasoningLevel::High, "high"),
+        ] {
+            let body = body_for("grok-4.6", level).expect("supported effort");
+            assert_eq!(body["reasoning"], json!({"effort": effort}), "{level}");
+            assert_eq!(body["model"], "grok-4.6");
+            assert_eq!(body["stream"], json!(true));
+            assert_eq!(body["max_output_tokens"], json!(1024));
+        }
+    }
+
+    #[test]
     fn adaptive_omits_reasoning_field_provider_default() {
         for model in [
             "grok-4.5",
             "grok-4.5-latest",
+            "grok-4.6",
+            "grok-4.6-latest",
             "grok-4.3",
             "grok-4.20-0309-non-reasoning",
         ] {
@@ -2440,6 +2457,8 @@ mod xai_tests {
         for model in [
             "grok-4.5",
             "grok-4.5-latest",
+            "grok-4.6",
+            "grok-4.6-latest",
             "grok-4.20-multi-agent-0309",
             "grok-4.3",
         ] {
@@ -2453,13 +2472,14 @@ mod xai_tests {
 
     #[test]
     fn unsupported_named_efforts_are_rejected_pre_network() {
-        // 4.5 has no documented xhigh; max/ultra never exist on xAI.
+        // 4.5/4.6 have no documented xhigh; max/ultra never exist on xAI.
         for level in [
             ReasoningLevel::XHigh,
             ReasoningLevel::Max,
             ReasoningLevel::Ultra,
         ] {
             assert!(body_for("grok-4.5", level).is_err(), "{level}");
+            assert!(body_for("grok-4.6", level).is_err(), "{level}");
         }
         // Intrinsic-reasoning models have no documented effort control.
         assert!(body_for("grok-4.3", ReasoningLevel::Medium).is_err());


### PR DESCRIPTION
## Summary

Adds `grok-4.6` to the xAI static model catalog so it autoloads in the model picker and manual `xai-auth/grok-4.6` selection validates (previously it failed closed as an unknown ID).

## Changes

**`catalog/xai.rs`**
- New `grok-4.6` descriptor in `XAI_TEXT_MODELS` → appears in the picker and passes validation.
- Reasoning capability: named effort low/medium/high, default high, cannot be disabled, no xhigh (same profile as `grok-4.5`).

**`catalog/validation.rs`** — mutation matrix, defaults, thinking options, reasoning type for 4.6.

**`stream.rs`** — wire-body test: 4.6 emits `{"reasoning":{"effort":...}}`; added to adaptive-omission and off-rejection matrices.

## Why no `-latest` alias

A live probe against `api.x.ai` (`GET /v1/models` + `POST /v1/responses`, 2026-08-14) shows xAI published only the **bare `grok-4.6`** id. Unlike `grok-4.5-latest`/`grok-4.3-latest`, there is no `grok-4.6-latest` — it returns upstream 404 *"The model grok-4.6-latest does not exist"*. The alias was briefly added by analogy and removed in the second commit; the capability-table comment documents the probe evidence so it isn't re-added.

## Verification

- Live xAI probe: `grok-4.6` → 200 on both `/responses` and `/chat/completions`
- `cargo test -p synaps-engine --lib`: 1725 passed, 0 failed
- `cargo check -p synaps-tui`: clean
