### PR TITLE
OpenAI ZDR: assert store:false on chat/completions (api.openai.com-gated)

### DIFF
--- a/crates/agent-engine/src/runtime/openai/stream.rs
+++ b/crates/agent-engine/src/runtime/openai/stream.rs
@@ -230,6 +230,15 @@ pub(crate) async fn call_oai_stream_inner(
     body.insert("model".to_string(), json!(cfg.model.clone()));
     body.insert("messages".to_string(), serde_json::to_value(oai_messages)?);
     body.insert("stream".to_string(), json!(true));
+    // ZDR: OpenAI's Zero Data Retention requires `store:false` on the wire.
+    // Chat Completions already defaults to false, but we assert it explicitly so the
+    // guarantee is provable in request logs (parity with the Codex Responses path,
+    // build_codex_body). Gated to api.openai.com (covers eu.api.openai.com) so we
+    // never send an unknown field to OpenAI-compatible providers that strict-validate
+    // the body (Groq/xAI/Google), mirroring the googleapis stream_options carve-out.
+    if cfg.base_url.contains("api.openai.com") {
+        body.insert("store".to_string(), json!(false));
+    }
     if let Some(stream_options) = stream_options {
         body.insert(
             "stream_options".to_string(),


### PR DESCRIPTION
## What
The generic OpenAI `/chat/completions` body now explicitly asserts `store: false`, matching the Codex/Responses path (`build_codex_body`) which already did.

## Why
OpenAI **Zero Data Retention** wants `store:false` provable on the wire. Chat Completions defaults to `false`, but asserting it explicitly makes the ZDR guarantee **visible in request logs** — the same bar the Praxis-side fix held.

## Safety / blast radius
Gated to `api.openai.com` (covers `eu.api.openai.com`) so we **never** send an unknown `store` field to OpenAI-compatible providers that strict-validate the body (Groq / xAI / Google). Mirrors the existing `googleapis.com` `stream_options` carve-out a few lines above.

## ZDR status of Synaps (context)
- `store:false` now on **both** OpenAI paths (Chat Completions + Codex Responses)
- `previous_response_id` is unused repo-wide → all OpenAI requests are **stateless**
- Remaining ZDR requirements are **out of code**: a ZDR-enrolled org API key + not routing through consumer OAuth (ChatGPT/Codex, Claude Max)

## Verification
- `cargo check -p synaps-engine` ✅ (on the dev base)

## Follow-up (not in this PR)
`call_oai_stream_inner` builds the body inline (async, needs broker) so it isn't unit-testable like `build_codex_body`. A small refactor to a pure body-builder + a test asserting `store:false` present for `api.openai.com` and **absent** for other hosts would lock this in. Filed as a follow-up rather than bloating this one-liner.