### PR TITLE
fix(tui): clippy unnecessary_map_or -> is_ok_and (unblock dev CI)

### DIFF
--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -302,7 +302,7 @@ impl App {
             // SYNAPS_NO_BOOT_FX=1: skip both the tachyonfx boot effect and the
             // ASCII logo build animation (full-screen redraws per frame are
             // brutal over high-latency/SSH links).
-            logo_build_t: if std::env::var("SYNAPS_NO_BOOT_FX").map_or(false, |v| v == "1") {
+            logo_build_t: if std::env::var("SYNAPS_NO_BOOT_FX").is_ok_and(|v| v == "1") {
                 None
             } else {
                 Some(0.0)

--- a/crates/agent-tui/src/tui/loop_arms.rs
+++ b/crates/agent-tui/src/tui/loop_arms.rs
@@ -656,7 +656,7 @@ pub(crate) async fn handle_animation_tick(
         // user disabled boot visuals (SYNAPS_NO_BOOT_FX=1), which also
         // freezes this gradient to stop per-frame redraws over slow links.
         || (app.transcript.is_empty()
-            && !std::env::var("SYNAPS_NO_BOOT_FX").map_or(false, |v| v == "1"))
+            && !std::env::var("SYNAPS_NO_BOOT_FX").is_ok_and(|v| v == "1"))
         || !app.subagents.is_empty()
     {
         app.request_redraw();


### PR DESCRIPTION
## What
Two `std::env::var("SYNAPS_NO_BOOT_FX").map_or(false, |v| v == "1")` calls → `.is_ok_and(|v| v == "1")`.

## Why
`dev` CI is **clippy-red**: clippy 1.95.0 tightened `clippy::unnecessary_map_or`, and `-D warnings` now rejects these two pre-existing calls (`agent-tui/src/tui/app.rs:305`, `loop_arms.rs:659`). This surfaced on #92 but is unrelated to it — **any** PR into `dev` fails the same way until this lands.

## Safety
Pure lint fix, **zero behavior change** (`is_ok_and` is the exact semantic of `map_or(false, …)` on `Result`, stable since 1.70).

## Verified
`cargo clippy --all-targets -- -D warnings` ✅ green (the exact CI command, run on the build host).