### PR TITLE
feat(tui,session,subagent): session UI overhaul + subagent-preamble.md support

### DIFF
--- a/crates/agent-core/src/core/session.rs
+++ b/crates/agent-core/src/core/session.rs
@@ -408,6 +408,9 @@ fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<Sessio
     }
     let header = read_session_header(dir, file_name)?;
     let meta: SessionMetadata = serde_json::from_str(&header).ok()?;
+    // Cheap message count: each api_message has exactly one "role" field.
+    // Count occurrences without deserializing the full array.
+    let message_count = header.matches("\"role\":").count();
     let mut info = SessionInfo {
         id: meta.id,
         title: meta.title,
@@ -416,7 +419,7 @@ fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<Sessio
         created_at: meta.created_at,
         updated_at: meta.updated_at,
         session_cost: meta.session_cost,
-        message_count: 0,
+        message_count,
     };
     // Journal freshness overlay (Task 35): when an opt-in journal exists,
     // its bounded meta tail is newer than the (possibly lagging) snapshot

--- a/crates/agent-tui/src/tui/commands.rs
+++ b/crates/agent-tui/src/tui/commands.rs
@@ -576,21 +576,49 @@ pub(super) async fn handle_command(
                     sessions.len()
                 )));
                 for s in sessions.iter().take(20) {
-                    let title = if s.title.is_empty() {
-                        "(untitled)"
-                    } else {
-                        &s.title
-                    };
-                    let active = if s.id == app.session.id { " *" } else { "" };
+                    let active_marker = if s.id == app.session.id { " ●" } else { "" };
                     let name_tag = s
                         .name
                         .as_deref()
                         .map(|n| format!(" [@{}]", n))
                         .unwrap_or_default();
+                    let age = {
+                        let secs = chrono::Utc::now()
+                            .signed_duration_since(s.created_at)
+                            .num_seconds();
+                        if secs < 3600 {
+                            format!("{}m ago", secs / 60)
+                        } else if secs < 86400 {
+                            format!("{}h ago", secs / 3600)
+                        } else {
+                            format!("{}d ago", secs / 86400)
+                        }
+                    };
+                    let title_display = if s.title.is_empty() {
+                        "(no title)".to_string()
+                    } else {
+                        s.title.chars().take(60).collect::<String>()
+                    };
+                    // Last 4 chars — more recognizable than a prefix
+                    let id_short = &s.id[s.id.len().saturating_sub(4)..];
+                    let msg_str = if s.message_count > 0 {
+                        format!("{} msgs · ", s.message_count)
+                    } else {
+                        String::new()
+                    };
+                    // Line 1: identity + meta
                     app.push_msg(ChatMessage::System(format!(
-                        "  {}{} — {} [{}] ${:.4}{}",
-                        &s.id, name_tag, title, s.model, s.session_cost, active
+                        "  …{}{}{} · {}{}${:.3} · {}",
+                        id_short, active_marker, name_tag,
+                        msg_str, age, s.session_cost, s.model
                     )));
+                    // Line 2: title
+                    app.push_msg(ChatMessage::System(format!(
+                        "     └ {}",
+                        title_display
+                    )));
+                    // Blank separator between entries
+                    app.push_msg(ChatMessage::System(String::new()));
                 }
             }
             Err(e) => {


### PR DESCRIPTION
## Summary

Three quality-of-life improvements based on real usage friction.

---

### 1. `/sessions` command — structured listing + message count fix

**Before:** one long unreadable line per session, all showing `0 msgs`
**After:** two-line structured format with blank separator

```
  …c3d4 · 14 msgs · 2h ago · $0.031 · claude-opus-4-8
     └ What is the difference between ESVO and MVSEC outdoor...

  …a1b2 ● · 3 msgs · 5m ago · $0.004 · claude-sonnet-4-6
     └ Fix the session listing UI
```

Changes:
- **ID**: last 4 chars instead of first 8 (suffix is more unique/recognizable)
- **Structure**: meta line + indented title line + blank separator
- **Active session**: `●` marker on line 1
- **message_count bug fixed**: was hardcoded to `0` in `parse_session_header`. Now counts `"role":` occurrences in the snapshot JSON — one per api_message, zero extra deserialization cost. Count hidden when 0 (legacy sessions stay clean).

---

### 2. System message color (`theme/`)

System messages (`ChatMessage::System`) were rendered with `muted` color AND `Modifier::DIM` stacked — on dark themes this made them nearly invisible.

- New theme field: `system_msg` (default `Rgb(140, 160, 180)` — readable light blue-gray)
- Removed `Modifier::DIM` from system message rendering
- Propagated to all 19 palette files, mxc mapping, transition lerp
- User-overridable via `/theme set system_msg #rrggbb`

---

### 3. `subagent-preamble.md` support (`subagent/`)

Adds optional shared context for all subagent spawns.

**How it works:** if `~/.synaps-cli/subagent-preamble.md` exists and is non-empty, its contents are prepended to every subagent's system prompt (oneshot, start, resume paths) with a blank-line separator.

**Why useful:** users with custom agent rosters want shared rules (model selection hints, style constraints, project context) without copy-pasting into every `.md` file. Single source of truth.

**Zero breaking change:** missing or empty file = behavior identical to before. No config keys added.

Example `~/.synaps-cli/subagent-preamble.md`:
```markdown
## Model selection
Use claude-sonnet-4-6 for codebase reads. Switch to Opus for reasoning tasks.
```

All three spawn paths (`oneshot.rs`, `start.rs`, `resume.rs`) route through the single `compose_system_prompt()` function in `mod.rs`.

---

### Testing
- `cargo build --bin synaps` — clean, 0 errors 0 warnings
- Preamble logic verified with standalone Rust test (both file-present and file-missing cases)