### PR TITLE
fix(engine): per-tool digest+provenance validation replaces set-wide generation denial at execution gate

### DIFF
--- a/crates/agent-engine/src/runtime/openai/extension_route.rs
+++ b/crates/agent-engine/src/runtime/openai/extension_route.rs
@@ -312,22 +312,20 @@ pub(crate) async fn route_extension_provider(
             // call the extension provider requests. When the runtime
             // threads its RETAINED per-stream set (Task 17), THAT set's
             // current state — including exact activations — is consumed at
-            // its pinned generation; a stale retained set is DENIED typed,
-            // never silently replaced by a fresh default-core mint. Only
-            // callers with no retained handle at all fall back to a fresh
-            // default-core set with zero activations.
-            let session_tools = match crate::tools::activation::route_session_set(
+            // its pinned generation; a drifted retained set is SERVED (a
+            // wholesale denial would kill the round for an unrelated
+            // catalog mutation) and never silently replaced by a fresh
+            // default-core mint. Only callers with no retained handle at
+            // all fall back to a fresh default-core set with zero
+            // activations. The audit trail is per tool now: each drifted
+            // member's call is denied typed inside the loop by
+            // `ExecutionGate::authorize`, which emits a tracing::warn per
+            // drift denial/survival (see tools/activation.rs).
+            let session_tools = crate::tools::activation::route_session_set(
                 session_tool_set,
                 registry.catalog(),
                 || tool_session_id.cloned().unwrap_or_else(local_gate_session),
-            ) {
-                Ok(session_tools) => session_tools,
-                Err(denial) => {
-                    attempt.finish_failed(trace_ext::EXTENSION_PROVIDER_ERROR_CODE);
-                    emit_audit(false, "error", Some("stale_session_tool_set"), 0);
-                    return Err(format!("extension provider tool loop denied: {denial}").into());
-                }
-            };
+            );
             crate::extensions::runtime::process::complete_provider_with_tools(
                 handler.clone(),
                 params,

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -279,7 +279,8 @@ impl StreamMethods {
         // and the extension-provider route. Built once here, rebuilt only
         // at the top of a provider round when the catalog generation
         // advanced (dynamic registration). Mid-round catalog drift is
-        // DENIED (`StaleSessionSet`), never silently absorbed.
+        // validated PER TOOL at the execution gate (digest + provenance
+        // pins), never silently absorbed.
         let session_tool_set: crate::tools::activation::SharedSessionToolSet = {
             let registry = tools.read().await;
             let set = if progressive_tool_disclosure {
@@ -570,13 +571,18 @@ impl StreamMethods {
                     let session_set = session_tool_set
                         .read()
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    tools_snapshot
-                        .session_tools_schema(&session_set)
-                        .map_err(|err| {
-                            RuntimeError::Tool(format!(
-                                "failed to project the authorized session tool set: {err}"
-                            ))
-                        })?
+                    let report = tools_snapshot.session_tools_schema(&session_set);
+                    // Fail-closed drop report: every pinned member excluded
+                    // from this round's schema is surfaced here (typed),
+                    // not just buried in per-tool log lines.
+                    for (tool_id, reason) in &report.dropped {
+                        tracing::warn!(
+                            tool = %tool_id,
+                            reason = ?reason,
+                            "session schema projection dropped a pinned member for this round"
+                        );
+                    }
+                    report.schema
                 };
                 projected_options = super::api::ApiOptions {
                     request_tools_schema: Some(std::sync::Arc::new(projection)),
@@ -789,13 +795,14 @@ impl StreamMethods {
                     } else if !tool_id.is_empty() && !tool_name.is_empty() {
                         // ═══ EXECUTION GATE (Task 16, spec §7.1) ═══
                         // Resolve wire name → exact ToolId, verify the
-                        // RETAINED session set's snapshot generation + pinned
-                        // schema digest, require core/exact-grant status,
-                        // re-check source trust, and only then acquire the
-                        // implementation — all under ONE registry read guard
-                        // (one consistent snapshot, no TOCTOU). The set is
-                        // never rebuilt here: post-round-top catalog drift
-                        // denies typed (`StaleSessionSet`). Denials are
+                        // RETAINED session set's pinned schema digest and
+                        // pinned trust provenance, require core/exact-grant
+                        // status, re-check source trust, and only then
+                        // acquire the implementation — all under ONE
+                        // registry read guard (one consistent snapshot, no
+                        // TOCTOU). The set is never rebuilt here:
+                        // post-round-top drift of the CALLED tool's record
+                        // denies typed per tool. Denials are
                         // typed, static, metadata-only and happen BEFORE
                         // implementation lookup and BEFORE any
                         // before_tool_call hook emission.

--- a/crates/agent-engine/src/tools/activation.rs
+++ b/crates/agent-engine/src/tools/activation.rs
@@ -41,10 +41,15 @@ pub enum RuntimeLease {
 
 /// One exact activation held by a session: the validated grant plus lease
 /// placeholder metadata. The grant carries the pinned catalog generation and
-/// schema digest.
+/// schema digest; the trust provenance of the catalog record is pinned
+/// engine-side at activation time (the grant type in agent-core is
+/// deliberately untouched) so execution can detect a record that was
+/// removed and re-added under a different — even internally coherent —
+/// source/provenance.
 #[derive(Clone, Debug)]
 pub struct ActivatedTool {
     grant: SessionActivationGrant,
+    provenance: TrustProvenance,
     lease: RuntimeLease,
 }
 
@@ -55,6 +60,11 @@ impl ActivatedTool {
 
     pub fn schema_digest(&self) -> &SchemaDigest {
         self.grant.schema_digest()
+    }
+
+    /// The trust provenance of the catalog record at activation time.
+    pub fn provenance(&self) -> &TrustProvenance {
+        &self.provenance
     }
 
     pub fn catalog_generation(&self) -> CatalogGeneration {
@@ -116,15 +126,38 @@ pub enum ActivationError {
     },
 }
 
+/// Per-tool pins captured when a core tool enters a session's set: the
+/// schema digest AND the trust provenance of the catalog record at build
+/// time. Pinning provenance (not just the digest) closes the coherent-
+/// imposter hole: a tool removed and re-added under the SAME `ToolId` with a
+/// schema-identical body but a different, internally consistent
+/// source/provenance must still be denied at execution time.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CorePin {
+    schema_digest: SchemaDigest,
+    provenance: TrustProvenance,
+}
+
+impl CorePin {
+    pub fn schema_digest(&self) -> &SchemaDigest {
+        &self.schema_digest
+    }
+
+    pub fn provenance(&self) -> &TrustProvenance {
+        &self.provenance
+    }
+}
+
 /// The small configured core set plus exact activated deferred tools for one
 /// session, pinned to the catalog generation it was built against. Core
-/// tools are pinned with the schema digest of their catalog record at build
-/// time, so later drift is detectable per tool, not just per generation.
+/// tools are pinned with the schema digest AND trust provenance of their
+/// catalog record at build time, so later drift is detectable per tool, not
+/// just per generation.
 #[derive(Clone, Debug)]
 pub struct SessionToolSet {
     session: SessionId,
     catalog_generation: CatalogGeneration,
-    core: BTreeMap<ToolId, SchemaDigest>,
+    core: BTreeMap<ToolId, CorePin>,
     activated: BTreeMap<ToolId, ActivatedTool>,
     /// Session schema-generation counter (spec §7.7): advances by exactly
     /// one for every successful nonempty activation batch (a single
@@ -136,8 +169,9 @@ pub struct SessionToolSet {
 impl SessionToolSet {
     /// Build a fresh set for one session. Every configured core id must
     /// exist in the catalog (typed failure otherwise) and its schema digest
-    /// is pinned from the catalog record; the set starts with zero
-    /// activations — nothing is inherited from any other session.
+    /// AND trust provenance are pinned from the catalog record; the set
+    /// starts with zero activations — nothing is inherited from any other
+    /// session.
     pub fn new(
         session: SessionId,
         core: impl IntoIterator<Item = ToolId>,
@@ -148,7 +182,13 @@ impl SessionToolSet {
             let Some(record) = catalog.get(&id) else {
                 return Err(SessionToolSetError::UnknownCoreTool(id));
             };
-            validated.insert(id, record.schema_digest().clone());
+            validated.insert(
+                id,
+                CorePin {
+                    schema_digest: record.schema_digest().clone(),
+                    provenance: record.provenance().clone(),
+                },
+            );
         }
         Ok(Self {
             session,
@@ -248,6 +288,12 @@ impl SessionToolSet {
     /// The schema digest pinned for a configured core tool at build time,
     /// or `None` when the id is not in this session's core set.
     pub fn core_schema_digest(&self, id: &ToolId) -> Option<&SchemaDigest> {
+        self.core.get(id).map(CorePin::schema_digest)
+    }
+
+    /// The full (digest, provenance) pin for a configured core tool, or
+    /// `None` when the id is not in this session's core set.
+    pub fn core_pin(&self, id: &ToolId) -> Option<&CorePin> {
         self.core.get(id)
     }
 
@@ -335,10 +381,16 @@ impl SessionToolSet {
         catalog: &ToolCatalog,
     ) -> Result<(), ActivationError> {
         self.validate_grant(&grant, catalog)?;
+        let provenance = catalog
+            .get(grant.tool_id())
+            .expect("validate_grant verified the record exists")
+            .provenance()
+            .clone();
         self.activated.insert(
             grant.tool_id().clone(),
             ActivatedTool {
                 grant,
+                provenance,
                 lease: RuntimeLease::NotAcquired,
             },
         );
@@ -392,10 +444,16 @@ impl SessionToolSet {
         ordered.sort_by(|a, b| a.tool_id().cmp(b.tool_id()));
         let applied = ordered.len();
         for grant in ordered {
+            let provenance = catalog
+                .get(grant.tool_id())
+                .expect("validate_grant verified the record exists")
+                .provenance()
+                .clone();
             self.activated.insert(
                 grant.tool_id().clone(),
                 ActivatedTool {
                     grant,
+                    provenance,
                     lease: RuntimeLease::NotAcquired,
                 },
             );
@@ -532,21 +590,6 @@ pub enum ToolAuthorizationError {
     /// exact activation grant (the forged deferred-call case).
     #[error("Tool call denied: tool is not activated for this session: {0}")]
     NotActivated(ToolId),
-    /// The session tool set snapshot predates the current catalog
-    /// generation. NOTE: since the per-tool digest-validation fix,
-    /// generation drift alone is NO LONGER a denial reason at execution
-    /// time — [`ExecutionGate::authorize`] and [`route_session_set`] no
-    /// longer construct this variant. It is retained for API stability and
-    /// for any future caller that genuinely requires generation equality.
-    #[error(
-        "Tool call denied: session tool set generation {} is stale against catalog generation {}",
-        set.value(),
-        catalog.value()
-    )]
-    StaleSessionSet {
-        set: CatalogGeneration,
-        catalog: CatalogGeneration,
-    },
     /// The capability's current schema digest differs from the digest the
     /// session pinned at core-build/activation time — a changed tool is
     /// never silently blessed.
@@ -557,9 +600,13 @@ pub enum ToolAuthorizationError {
     /// policy exists.
     #[error("Tool call denied: source provenance is unverified: {0}")]
     UntrustedSource(ToolId),
-    /// The catalog record's source and trust provenance disagree — an
-    /// internally inconsistent record must never authorize.
-    #[error("Tool call denied: catalog source and trust provenance disagree: {0}")]
+    /// Source/trust provenance failure: either the catalog record's source
+    /// and trust provenance disagree (an internally inconsistent record must
+    /// never authorize), or the record's CURRENT provenance differs from the
+    /// provenance the session pinned at core-build/activation time (a tool
+    /// removed and re-added under a different — even internally coherent —
+    /// provenance must never authorize).
+    #[error("Tool call denied: source/trust provenance is inconsistent or drifted from the session's pin: {0}")]
     SourceProvenanceMismatch(ToolId),
 }
 
@@ -575,6 +622,10 @@ pub enum ToolAuthorizationError {
 ///    [`grant_covers_execution`]: catalog generation drift alone does NOT
 ///    deny at execution time; only a real change to the called tool's
 ///    record (digest, presence, provenance) does;
+/// 4. the record's CURRENT trust provenance must equal the provenance the
+///    session PINNED at core-build/activation time — this closes the
+///    coherent-imposter hole (same `ToolId`, schema-identical body,
+///    different but internally consistent source/provenance);
 /// 5. source trust is re-evaluated conservatively — see the honesty note
 ///    on [`check_source_trust`]: this re-checks typed source/provenance
 ///    consistency and denies Unknown/Unverified, but does NOT yet consult
@@ -609,15 +660,23 @@ impl ExecutionGate {
     /// typed [`AuthorizedToolCall`]. Failure acquires nothing and leaves the
     /// session set untouched (the gate never mutates it).
     ///
-    /// SECURITY INVARIANT (per-tool digest validation): no tool executes
-    /// unless its CURRENT catalog record — presence of the exact `ToolId`,
-    /// schema digest, and source/trust provenance — exactly matches what
-    /// the session pinned at core-build/activation time. Catalog
-    /// generation inequality ALONE is no longer a denial reason at
+    /// SECURITY INVARIANT (per-tool digest + provenance validation): no
+    /// tool executes unless its CURRENT catalog record — presence of the
+    /// exact `ToolId`, schema digest, and source/trust provenance — exactly
+    /// matches what the session pinned at core-build/activation time.
+    /// Catalog generation inequality ALONE is no longer a denial reason at
     /// execution time: an unrelated background mutation (e.g. a plugin
-    /// load mid-round) must not kill in-flight calls to byte-identical
+    /// load mid-round) must not kill in-flight calls to schema-identical
     /// tools. Any REAL drift of the called tool's record — changed digest,
-    /// removal, changed provenance — still denies typed and closed.
+    /// removal, changed provenance (even to an internally coherent one) —
+    /// still denies typed and closed.
+    ///
+    /// ACCEPTED RESIDUAL RISK: [`SchemaDigest`] hashes the schema JSON
+    /// only, not the implementation factory. A record replaced in place
+    /// with an identical schema AND identical pinned provenance but a
+    /// different implementation passes this gate; the exposure is bounded
+    /// by the deterministic round-top rebuild (runtime/stream.rs), which
+    /// re-pins the set against the current catalog between provider rounds.
     pub fn authorize(
         catalog: &ToolCatalog,
         session: &SessionToolSet,
@@ -636,10 +695,13 @@ impl ExecutionGate {
         let generation_drift = session.is_stale(catalog);
 
         // Core status or exact activation grant, with pinned-digest
-        // verification either way — unconditional, drift or not.
+        // verification either way — unconditional, drift or not. The pinned
+        // trust provenance is carried out of each branch for the
+        // unconditional pinned-provenance check below.
         let activation_basis;
-        if let Some(pinned) = session.core_schema_digest(&tool_id) {
-            if pinned != record.schema_digest() {
+        let pinned_provenance: &TrustProvenance;
+        if let Some(pin) = session.core_pin(&tool_id) {
+            if pin.schema_digest() != record.schema_digest() {
                 if generation_drift {
                     tracing::warn!(
                         tool = %tool_id,
@@ -651,6 +713,7 @@ impl ExecutionGate {
                 }
                 return Err(ToolAuthorizationError::SchemaDigestMismatch(tool_id));
             }
+            pinned_provenance = pin.provenance();
             activation_basis = ActivationBasis::Core;
         } else if let Some(activated) = session.activation(&tool_id) {
             if activated.schema_digest() != record.schema_digest() {
@@ -677,6 +740,7 @@ impl ExecutionGate {
             ) {
                 return Err(ToolAuthorizationError::NotActivated(tool_id));
             }
+            pinned_provenance = activated.provenance();
             activation_basis = ActivationBasis::Exact {
                 catalog_generation: activated.catalog_generation(),
             };
@@ -684,12 +748,32 @@ impl ExecutionGate {
             return Err(ToolAuthorizationError::NotActivated(tool_id));
         }
 
+        // Unconditional pinned-provenance equality (BLOCKER fix): the
+        // record's CURRENT trust provenance must equal the provenance the
+        // session pinned at core-build/activation time. This — not the
+        // self-consistency check below — is what catches the coherent
+        // imposter: a tool removed and re-added under the same `ToolId`
+        // with a schema-identical body but a different, internally
+        // consistent source/provenance pair.
+        if pinned_provenance != record.provenance() {
+            if generation_drift {
+                tracing::warn!(
+                    tool = %tool_id,
+                    set_generation = session.catalog_generation().value(),
+                    catalog_generation = catalog.generation().value(),
+                    "tool denied under catalog generation drift: current record provenance \
+                     no longer matches the provenance the session pinned"
+                );
+            }
+            return Err(ToolAuthorizationError::SourceProvenanceMismatch(tool_id));
+        }
+
         // Conservative source trust re-check immediately before
-        // acquisition: typed source/provenance consistency only (see
-        // check_source_trust) — live manifest permission/revocation state
-        // is not consulted here yet (Task 20). Unconditional: a tool
-        // removed and re-added under different provenance is caught here
-        // even when its schema digest is unchanged.
+        // acquisition: typed source/provenance SELF-consistency plus the
+        // deny-by-default for Unknown/Unverified (see check_source_trust) —
+        // live manifest permission/revocation state is not consulted here
+        // yet (Task 20). This complements (does not replace) the
+        // pinned-provenance equality above.
         check_source_trust(record)?;
 
         if generation_drift {
@@ -738,7 +822,7 @@ impl ExecutionGate {
 /// execution time the tool's identity and schema are already re-validated
 /// against the CURRENT catalog record, so requiring the pinned generation to
 /// equal the live one only makes unrelated catalog mutations (background
-/// plugin loads) kill in-flight calls to byte-identical tools. `covers()`
+/// plugin loads) kill in-flight calls to schema-identical tools. `covers()`
 /// itself (agent-core) stays exact-tuple and is still what grant ISSUANCE
 /// and activation validation (`validate_grant`) enforce — this relaxation
 /// applies ONLY to re-validation of an already-established authorization.
@@ -951,12 +1035,13 @@ pub fn activate_model_initiated(
 /// re-validates each called tool's current record (presence, digest,
 /// provenance) against the session's pins. Denying the whole retained set
 /// wholesale would let an unrelated background catalog mutation kill an
-/// entire in-flight round of byte-identical tools.
+/// entire in-flight round of schema-identical tools. Infallible: neither
+/// path can be denied anymore, so the return type is the plain set.
 pub fn route_session_set(
     retained: Option<&SharedSessionToolSet>,
     catalog: &ToolCatalog,
     fallback_session: impl FnOnce() -> SessionId,
-) -> Result<SessionToolSet, ToolAuthorizationError> {
+) -> SessionToolSet {
     match retained {
         Some(shared) => {
             let guard = shared
@@ -970,11 +1055,8 @@ pub fn route_session_set(
                      per-call ExecutionGate::authorize still protects execution"
                 );
             }
-            Ok(guard.clone())
+            guard.clone()
         }
-        None => Ok(SessionToolSet::default_core_for_catalog(
-            fallback_session(),
-            catalog,
-        )),
+        None => SessionToolSet::default_core_for_catalog(fallback_session(), catalog),
     }
 }

--- a/crates/agent-engine/src/tools/activation.rs
+++ b/crates/agent-engine/src/tools/activation.rs
@@ -533,8 +533,11 @@ pub enum ToolAuthorizationError {
     #[error("Tool call denied: tool is not activated for this session: {0}")]
     NotActivated(ToolId),
     /// The session tool set snapshot predates the current catalog
-    /// generation; it must be rebuilt deterministically, never silently
-    /// reused.
+    /// generation. NOTE: since the per-tool digest-validation fix,
+    /// generation drift alone is NO LONGER a denial reason at execution
+    /// time — [`ExecutionGate::authorize`] and [`route_session_set`] no
+    /// longer construct this variant. It is retained for API stability and
+    /// for any future caller that genuinely requires generation equality.
     #[error(
         "Tool call denied: session tool set generation {} is stale against catalog generation {}",
         set.value(),
@@ -567,9 +570,11 @@ pub enum ToolAuthorizationError {
 /// 1. resolve wire name → exact live `ToolId` (deterministic reverse
 ///    mapping; aliases cannot pick a different identity);
 /// 2. the identity must be cataloged;
-/// 3. the session tool set snapshot must match the catalog generation;
-/// 4. the identity must be core (pinned digest intact) or hold an exact
-///    session activation grant (session, tool, generation, digest);
+/// 3. the identity must be core (pinned digest intact) or hold an exact
+///    session activation grant covering (session, tool, digest) — see
+///    [`grant_covers_execution`]: catalog generation drift alone does NOT
+///    deny at execution time; only a real change to the called tool's
+///    record (digest, presence, provenance) does;
 /// 5. source trust is re-evaluated conservatively — see the honesty note
 ///    on [`check_source_trust`]: this re-checks typed source/provenance
 ///    consistency and denies Unknown/Unverified, but does NOT yet consult
@@ -603,6 +608,16 @@ impl ExecutionGate {
     /// acquired from the catalog record's factory and returned inside the
     /// typed [`AuthorizedToolCall`]. Failure acquires nothing and leaves the
     /// session set untouched (the gate never mutates it).
+    ///
+    /// SECURITY INVARIANT (per-tool digest validation): no tool executes
+    /// unless its CURRENT catalog record — presence of the exact `ToolId`,
+    /// schema digest, and source/trust provenance — exactly matches what
+    /// the session pinned at core-build/activation time. Catalog
+    /// generation inequality ALONE is no longer a denial reason at
+    /// execution time: an unrelated background mutation (e.g. a plugin
+    /// load mid-round) must not kill in-flight calls to byte-identical
+    /// tools. Any REAL drift of the called tool's record — changed digest,
+    /// removal, changed provenance — still denies typed and closed.
     pub fn authorize(
         catalog: &ToolCatalog,
         session: &SessionToolSet,
@@ -613,33 +628,51 @@ impl ExecutionGate {
             .get(&tool_id)
             .ok_or_else(|| ToolAuthorizationError::NotCataloged(tool_id.clone()))?;
 
-        // Snapshot-generation check first: a stale session set must be
-        // rebuilt deterministically, never consulted for grants.
-        if session.is_stale(catalog) {
-            return Err(ToolAuthorizationError::StaleSessionSet {
-                set: session.catalog_generation(),
-                catalog: catalog.generation(),
-            });
-        }
+        // Generation drift is observed (for logging) but NOT a wholesale
+        // denial: the per-tool checks below are unconditional and judge the
+        // called tool's CURRENT record against the session's pins. The
+        // round-top rebuild (runtime/stream.rs) still uses `is_stale` to
+        // refresh the set deterministically between rounds.
+        let generation_drift = session.is_stale(catalog);
 
         // Core status or exact activation grant, with pinned-digest
-        // verification either way.
+        // verification either way — unconditional, drift or not.
         let activation_basis;
         if let Some(pinned) = session.core_schema_digest(&tool_id) {
             if pinned != record.schema_digest() {
+                if generation_drift {
+                    tracing::warn!(
+                        tool = %tool_id,
+                        set_generation = session.catalog_generation().value(),
+                        catalog_generation = catalog.generation().value(),
+                        "tool denied under catalog generation drift: pinned core schema digest \
+                         no longer matches the current catalog record"
+                    );
+                }
                 return Err(ToolAuthorizationError::SchemaDigestMismatch(tool_id));
             }
             activation_basis = ActivationBasis::Core;
         } else if let Some(activated) = session.activation(&tool_id) {
             if activated.schema_digest() != record.schema_digest() {
+                if generation_drift {
+                    tracing::warn!(
+                        tool = %tool_id,
+                        set_generation = session.catalog_generation().value(),
+                        catalog_generation = catalog.generation().value(),
+                        "tool denied under catalog generation drift: activation grant schema \
+                         digest no longer matches the current catalog record"
+                    );
+                }
                 return Err(ToolAuthorizationError::SchemaDigestMismatch(tool_id));
             }
-            // Exact-tuple grant re-check (session, tool, generation,
-            // digest); any drift invalidates the grant.
-            if !activated.grant().covers(
+            // Execution-time grant re-check on the (session, tool, digest)
+            // tuple — deliberately WITHOUT the generation term (see
+            // `grant_covers_execution`). Grant ISSUANCE and activation stay
+            // generation-strict (`validate_grant`, `covers()`).
+            if !grant_covers_execution(
+                activated.grant(),
                 session.session().as_str(),
                 &tool_id,
-                catalog.generation(),
                 record.schema_digest(),
             ) {
                 return Err(ToolAuthorizationError::NotActivated(tool_id));
@@ -654,8 +687,20 @@ impl ExecutionGate {
         // Conservative source trust re-check immediately before
         // acquisition: typed source/provenance consistency only (see
         // check_source_trust) — live manifest permission/revocation state
-        // is not consulted here yet (Task 20).
+        // is not consulted here yet (Task 20). Unconditional: a tool
+        // removed and re-added under different provenance is caught here
+        // even when its schema digest is unchanged.
         check_source_trust(record)?;
+
+        if generation_drift {
+            tracing::warn!(
+                tool = %tool_id,
+                set_generation = session.catalog_generation().value(),
+                catalog_generation = catalog.generation().value(),
+                "tool call survived catalog generation drift: current record digest, presence \
+                 and provenance exactly match the session's pins"
+            );
+        }
 
         // Effect classes (Task 24) are execution-SCHEDULING policy, not
         // authorization policy: every class may execute once authorized —
@@ -686,6 +731,26 @@ impl ExecutionGate {
         let resolved = Self::resolve(registry, wire_name)?;
         Self::authorize(registry.catalog(), session, resolved)
     }
+}
+
+/// Execution-time grant coverage: (session, tool, digest) equality WITHOUT
+/// the generation term of [`SessionActivationGrant::covers`]. Rationale: at
+/// execution time the tool's identity and schema are already re-validated
+/// against the CURRENT catalog record, so requiring the pinned generation to
+/// equal the live one only makes unrelated catalog mutations (background
+/// plugin loads) kill in-flight calls to byte-identical tools. `covers()`
+/// itself (agent-core) stays exact-tuple and is still what grant ISSUANCE
+/// and activation validation (`validate_grant`) enforce — this relaxation
+/// applies ONLY to re-validation of an already-established authorization.
+fn grant_covers_execution(
+    grant: &SessionActivationGrant,
+    session_id: &str,
+    tool_id: &ToolId,
+    schema_digest: &SchemaDigest,
+) -> bool {
+    grant.session_id() == session_id
+        && grant.tool_id() == tool_id
+        && grant.schema_digest() == schema_digest
 }
 
 /// Conservative per-source trust policy — CONSISTENCY check, not a live
@@ -873,11 +938,20 @@ pub fn activate_model_initiated(
 /// Resolve the session tool set for the extension-provider route (Task 17,
 /// closing the Task 16 policy divergence): when the runtime threads its
 /// RETAINED per-stream set, the route consumes THAT set's current state —
-/// including exact activations — at its pinned generation. A stale retained
-/// set is DENIED typed (`StaleSessionSet`); the route must never silently
-/// mint a fresh default-core set for the same round. Only callers with no
-/// retained handle at all (internal/sync helpers) fall back to a fresh
-/// default-core set with zero activations under a locally minted session.
+/// including exact activations — at its pinned generation. The route must
+/// never silently mint a fresh default-core set for the same round. Only
+/// callers with no retained handle at all (internal/sync helpers) fall back
+/// to a fresh default-core set with zero activations under a locally minted
+/// session.
+///
+/// Generation drift is deliberately SURVIVED here (per-tool digest
+/// validation fix): the retained set is served as-is even when the catalog
+/// generation moved past its snapshot, because every actual execution still
+/// passes through [`ExecutionGate::authorize`], which unconditionally
+/// re-validates each called tool's current record (presence, digest,
+/// provenance) against the session's pins. Denying the whole retained set
+/// wholesale would let an unrelated background catalog mutation kill an
+/// entire in-flight round of byte-identical tools.
 pub fn route_session_set(
     retained: Option<&SharedSessionToolSet>,
     catalog: &ToolCatalog,
@@ -889,10 +963,12 @@ pub fn route_session_set(
                 .read()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             if guard.is_stale(catalog) {
-                return Err(ToolAuthorizationError::StaleSessionSet {
-                    set: guard.catalog_generation(),
-                    catalog: catalog.generation(),
-                });
+                tracing::warn!(
+                    set_generation = guard.catalog_generation().value(),
+                    catalog_generation = catalog.generation().value(),
+                    "serving retained session tool set across catalog generation drift; \
+                     per-call ExecutionGate::authorize still protects execution"
+                );
             }
             Ok(guard.clone())
         }

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -53,7 +53,7 @@ pub use ls::LsTool;
 pub use memory_context::MemoryContextTool;
 pub use powershell::PowerShellTool;
 pub use read::ReadTool;
-pub use registry::ToolRegistry;
+pub use registry::{DroppedSessionMember, SessionSchemaProjection, ToolRegistry};
 pub use respond::RespondTool;
 pub use secret_prompt::SecretPromptQueue;
 pub use secret_prompt::{SecretPromptHandle, SecretPromptRequest};

--- a/crates/agent-engine/src/tools/registry.rs
+++ b/crates/agent-engine/src/tools/registry.rs
@@ -556,20 +556,23 @@ impl ToolRegistry {
     /// capability identity is core or exactly-activated in `session`,
     /// preserving cached byte ordering, API-safe names, and collision
     /// suffixes. Pure read: no catalog insertion, no schema rebuild, no
-    /// factory invocation, no process/network. Catalog generation drift or
-    /// a changed pinned schema digest fails typed instead of serving a
-    /// stale projection. Default runtime exposure (`tools_schema`) is
-    /// unaffected until Task 18 opts in.
+    /// factory invocation, no process/network. Default runtime exposure
+    /// (`tools_schema`) is unaffected until Task 18 opts in.
+    ///
+    /// Drift handling (per-tool digest validation fix): catalog generation
+    /// drift does NOT fail the whole projection — an unrelated background
+    /// mutation must not blank a session's entire tool schema. Instead the
+    /// projection is validated per tool: entries whose CURRENT catalog
+    /// record digest matches the session's pin are included; entries whose
+    /// record drifted (changed digest) or vanished (uncataloged) are
+    /// skipped with a warning — they would be denied by the execution gate
+    /// anyway, so advertising them would be dishonest. The typed
+    /// [`SessionSchemaError`] is retained for genuinely unprojectable
+    /// cases.
     pub fn session_tools_schema(
         &self,
         session: &crate::tools::activation::SessionToolSet,
     ) -> Result<Vec<Value>, SessionSchemaError> {
-        if session.is_stale(&self.catalog) {
-            return Err(SessionSchemaError::StaleSessionSet {
-                set: session.catalog_generation(),
-                catalog: self.catalog.generation(),
-            });
-        }
         let mut projected = Vec::new();
         for entry in self.cached_schema.iter() {
             let Some(api_name) = entry["name"].as_str() else {
@@ -586,12 +589,21 @@ impl ToolRegistry {
             let Some(pinned) = pinned else {
                 continue; // not part of this session's set — absent.
             };
-            let record = self
-                .catalog
-                .get(&id)
-                .ok_or_else(|| SessionSchemaError::NotCataloged(id.clone()))?;
+            let Some(record) = self.catalog.get(&id) else {
+                tracing::warn!(
+                    tool = %id,
+                    "session schema projection skips uncataloged session member \
+                     (removed since the session pinned it)"
+                );
+                continue;
+            };
             if pinned != record.schema_digest() {
-                return Err(SessionSchemaError::SchemaDigestMismatch(id));
+                tracing::warn!(
+                    tool = %id,
+                    "session schema projection skips drifted session member \
+                     (schema digest changed since the session pinned it)"
+                );
+                continue;
             }
             projected.push(entry.clone());
         }
@@ -621,7 +633,10 @@ impl ToolRegistry {
 }
 
 /// Typed failure for [`ToolRegistry::session_tools_schema`]. Metadata-only:
-/// bounded identities and generation counters, never schema bytes.
+/// bounded identities and generation counters, never schema bytes. Since the
+/// per-tool digest-validation fix the projection skips drifted/removed
+/// members instead of failing; these variants are retained for API
+/// stability and genuinely unprojectable future cases.
 #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SessionSchemaError {
     #[error(

--- a/crates/agent-engine/src/tools/registry.rs
+++ b/crates/agent-engine/src/tools/registry.rs
@@ -497,6 +497,22 @@ impl ToolRegistry {
         self.catalog.set_generation_for_tests(generation);
     }
 
+    /// Boundary-test support: upsert one catalog record IN PLACE without
+    /// touching the live tool map — how a hostile/aberrant dynamic source
+    /// could replace a capability record behind a session's back. Doc-hidden
+    /// for the same reason as [`Self::resume_catalog_generation_for_tests`]:
+    /// integration tests run without a `testing` feature.
+    #[doc(hidden)]
+    pub fn upsert_catalog_record_for_tests(
+        &mut self,
+        replaced: Option<&crate::tools::catalog::ToolId>,
+        record: crate::tools::catalog::CapabilityRecord,
+    ) {
+        self.catalog
+            .upsert(replaced, record)
+            .expect("test upsert must be structurally valid");
+    }
+
     pub fn get(&self, name: &str) -> Option<&Arc<dyn Tool>> {
         let runtime_name = self
             .api_to_runtime_names
@@ -559,21 +575,22 @@ impl ToolRegistry {
     /// factory invocation, no process/network. Default runtime exposure
     /// (`tools_schema`) is unaffected until Task 18 opts in.
     ///
-    /// Drift handling (per-tool digest validation fix): catalog generation
-    /// drift does NOT fail the whole projection — an unrelated background
-    /// mutation must not blank a session's entire tool schema. Instead the
-    /// projection is validated per tool: entries whose CURRENT catalog
-    /// record digest matches the session's pin are included; entries whose
-    /// record drifted (changed digest) or vanished (uncataloged) are
-    /// skipped with a warning — they would be denied by the execution gate
-    /// anyway, so advertising them would be dishonest. The typed
-    /// [`SessionSchemaError`] is retained for genuinely unprojectable
-    /// cases.
+    /// Drift handling (per-tool digest + provenance validation fix): catalog
+    /// generation drift does NOT fail the whole projection — an unrelated
+    /// background mutation must not blank a session's entire tool schema.
+    /// Instead the projection is validated per tool: entries whose CURRENT
+    /// catalog record digest AND trust provenance match the session's pins
+    /// are included; entries whose record drifted (changed digest, changed
+    /// provenance — even an internally coherent one) or vanished
+    /// (uncataloged) are dropped fail-closed and REPORTED in the returned
+    /// [`SessionSchemaProjection::dropped`] list — they would be denied by
+    /// the execution gate anyway, so advertising them would be dishonest.
     pub fn session_tools_schema(
         &self,
         session: &crate::tools::activation::SessionToolSet,
-    ) -> Result<Vec<Value>, SessionSchemaError> {
+    ) -> SessionSchemaProjection {
         let mut projected = Vec::new();
+        let mut dropped = Vec::new();
         for entry in self.cached_schema.iter() {
             let Some(api_name) = entry["name"].as_str() else {
                 continue;
@@ -584,30 +601,49 @@ impl ToolRegistry {
             };
             let id = tool_id_for(tool.as_ref());
             let pinned = session
-                .core_schema_digest(&id)
-                .or_else(|| session.activation(&id).map(|a| a.schema_digest()));
-            let Some(pinned) = pinned else {
+                .core_pin(&id)
+                .map(|pin| (pin.schema_digest(), pin.provenance()))
+                .or_else(|| {
+                    session
+                        .activation(&id)
+                        .map(|a| (a.schema_digest(), a.provenance()))
+                });
+            let Some((pinned_digest, pinned_provenance)) = pinned else {
                 continue; // not part of this session's set — absent.
             };
             let Some(record) = self.catalog.get(&id) else {
                 tracing::warn!(
                     tool = %id,
-                    "session schema projection skips uncataloged session member \
+                    "session schema projection drops uncataloged session member \
                      (removed since the session pinned it)"
                 );
+                dropped.push((id, DroppedSessionMember::Uncataloged));
                 continue;
             };
-            if pinned != record.schema_digest() {
+            if pinned_digest != record.schema_digest() {
                 tracing::warn!(
                     tool = %id,
-                    "session schema projection skips drifted session member \
+                    "session schema projection drops drifted session member \
                      (schema digest changed since the session pinned it)"
                 );
+                dropped.push((id, DroppedSessionMember::SchemaDigestMismatch));
+                continue;
+            }
+            if pinned_provenance != record.provenance() {
+                tracing::warn!(
+                    tool = %id,
+                    "session schema projection drops drifted session member \
+                     (trust provenance changed since the session pinned it)"
+                );
+                dropped.push((id, DroppedSessionMember::ProvenanceMismatch));
                 continue;
             }
             projected.push(entry.clone());
         }
-        Ok(projected)
+        SessionSchemaProjection {
+            schema: projected,
+            dropped,
+        }
     }
 
     /// Return runtime names of tools owned by the given extension id, sorted ascending.
@@ -632,26 +668,31 @@ impl ToolRegistry {
     }
 }
 
-/// Typed failure for [`ToolRegistry::session_tools_schema`]. Metadata-only:
-/// bounded identities and generation counters, never schema bytes. Since the
-/// per-tool digest-validation fix the projection skips drifted/removed
-/// members instead of failing; these variants are retained for API
-/// stability and genuinely unprojectable future cases.
-#[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
-pub enum SessionSchemaError {
-    #[error(
-        "session tool set generation {} is stale against catalog generation {}",
-        set.value(),
-        catalog.value()
-    )]
-    StaleSessionSet {
-        set: crate::tools::catalog::CatalogGeneration,
-        catalog: crate::tools::catalog::CatalogGeneration,
-    },
-    #[error("session member is not cataloged: {0}")]
-    NotCataloged(crate::tools::catalog::ToolId),
-    #[error("schema digest changed since the session pinned it: {0}")]
-    SchemaDigestMismatch(crate::tools::catalog::ToolId),
+/// Typed projection report for [`ToolRegistry::session_tools_schema`]: the
+/// projected schema entries PLUS every pinned session member that was
+/// dropped fail-closed, with the typed reason. Metadata-only reasons:
+/// bounded identities, never schema bytes. Callers can surface `dropped`
+/// for audit/telemetry instead of losing the signal to a log line.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionSchemaProjection {
+    /// The entries served to the provider, in cached byte order.
+    pub schema: Vec<Value>,
+    /// Pinned session members excluded from the projection and why. A
+    /// dropped member's schema is NEVER served — the execution gate would
+    /// deny it anyway.
+    pub dropped: Vec<(crate::tools::catalog::ToolId, DroppedSessionMember)>,
+}
+
+/// Why a pinned session member was dropped from a schema projection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DroppedSessionMember {
+    /// The member's `ToolId` is no longer in the catalog.
+    Uncataloged,
+    /// The current record's schema digest differs from the session's pin.
+    SchemaDigestMismatch,
+    /// The current record's trust provenance differs from the session's
+    /// pin (the coherent-imposter case).
+    ProvenanceMismatch,
 }
 
 /// Fail-closed message for infallible compatibility wrappers over typed

--- a/crates/agent-engine/tests/discovery_activation_tools.rs
+++ b/crates/agent-engine/tests/discovery_activation_tools.rs
@@ -336,9 +336,7 @@ async fn activate_tools_confirmed_exact_activation_leaves_siblings_denied() {
 
     // The session projection now contains the activated schema; the sibling
     // remains absent (also covered in session_schema_projection.rs).
-    let projection = registry
-        .session_tools_schema(&set.read().unwrap())
-        .expect("projection of fresh set succeeds");
+    let projection = registry.session_tools_schema(&set.read().unwrap()).schema;
     let names: Vec<&str> = projection
         .iter()
         .filter_map(|s| s["name"].as_str())
@@ -799,13 +797,15 @@ fn catalog_generation_drift_keeps_unchanged_tools_but_blocks_new_grants() {
     registry.register(Arc::new(FixtureTool::builtin("late_tool")));
 
     // Per-tool digest validation: the activated tool's current record is
-    // byte-identical, so execution and projection SURVIVE the unrelated
+    // schema-identical, so execution and projection SURVIVE the unrelated
     // drift (wholesale generation denial would kill the in-flight round).
     ExecutionGate::authorize_wire_call(&registry, &set, "beta_tool")
         .expect("unchanged activated tool survives unrelated drift");
-    registry
-        .session_tools_schema(&set)
-        .expect("projection survives drift, serving only digest-matching pins");
+    let report = registry.session_tools_schema(&set);
+    assert!(
+        report.dropped.is_empty(),
+        "projection survives unrelated drift, dropping nothing"
+    );
 
     // Grant issuance/activation stays generation-STRICT: fresh grants
     // against the old snapshot cannot extend a drifted set.
@@ -834,8 +834,7 @@ fn route_session_set_consumes_retained_set_and_survives_drift() {
 
     // Retained + fresh: the route receives the SAME set state/generation,
     // including the exact activation — not a fresh default-core mint.
-    let routed = route_session_set(Some(&set), registry.catalog(), session_id)
-        .expect("fresh retained set is used");
+    let routed = route_session_set(Some(&set), registry.catalog(), session_id);
     assert_eq!(
         routed.catalog_generation(),
         set.read().unwrap().catalog_generation()
@@ -845,10 +844,9 @@ fn route_session_set_consumes_retained_set_and_survives_drift() {
 
     // Retained + drifted: still served (never a fresh mid-round mint, never
     // a wholesale kill) — per-call gate authorization is what protects
-    // execution, and it still passes for the byte-identical tool.
+    // execution, and it still passes for the schema-identical tool.
     registry.register(Arc::new(FixtureTool::builtin("late_tool")));
-    let routed = route_session_set(Some(&set), registry.catalog(), session_id)
-        .expect("drifted retained set is still served");
+    let routed = route_session_set(Some(&set), registry.catalog(), session_id);
     assert!(routed.is_stale(registry.catalog()));
     assert!(routed.activation(&ToolId::builtin("beta_tool")).is_some());
     ExecutionGate::authorize_wire_call(&registry, &routed, "beta_tool")
@@ -856,8 +854,7 @@ fn route_session_set_consumes_retained_set_and_survives_drift() {
 
     // No retained handle (internal callers): fail closed to a fresh
     // default-core set with zero activations, as before.
-    let fallback =
-        route_session_set(None, registry.catalog(), session_id).expect("fallback minted");
+    let fallback = route_session_set(None, registry.catalog(), session_id);
     assert_eq!(fallback.activated().count(), 0);
     assert!(!fallback.is_stale(registry.catalog()));
 }

--- a/crates/agent-engine/tests/discovery_activation_tools.rs
+++ b/crates/agent-engine/tests/discovery_activation_tools.rs
@@ -788,7 +788,7 @@ fn activate_many_rejects_untrusted_source() {
 // ── Drift invalidation through the public surface ───────────────────────────
 
 #[test]
-fn catalog_generation_drift_invalidates_activation_and_projection() {
+fn catalog_generation_drift_keeps_unchanged_tools_but_blocks_new_grants() {
     let mut registry = fixture_registry();
     let mut set = minimal_set(&registry);
     activate_exact_for_user(&mut set, registry.catalog(), &ToolId::builtin("beta_tool"))
@@ -798,17 +798,17 @@ fn catalog_generation_drift_invalidates_activation_and_projection() {
     // Catalog mutation (dynamic registration) advances the generation.
     registry.register(Arc::new(FixtureTool::builtin("late_tool")));
 
-    let denial = ExecutionGate::authorize_wire_call(&registry, &set, "beta_tool")
-        .expect_err("stale set denies");
-    assert!(matches!(
-        denial,
-        ToolAuthorizationError::StaleSessionSet { .. }
-    ));
+    // Per-tool digest validation: the activated tool's current record is
+    // byte-identical, so execution and projection SURVIVE the unrelated
+    // drift (wholesale generation denial would kill the in-flight round).
+    ExecutionGate::authorize_wire_call(&registry, &set, "beta_tool")
+        .expect("unchanged activated tool survives unrelated drift");
     registry
         .session_tools_schema(&set)
-        .expect_err("stale set fails projection");
+        .expect("projection survives drift, serving only digest-matching pins");
 
-    // Fresh grants against the OLD generation cannot rescue a stale set.
+    // Grant issuance/activation stays generation-STRICT: fresh grants
+    // against the old snapshot cannot extend a drifted set.
     let err = activate_exact_for_user(&mut set, registry.catalog(), &ToolId::builtin("gamma_tool"))
         .expect_err("stale snapshot denies further activation");
     assert!(matches!(
@@ -822,7 +822,7 @@ fn catalog_generation_drift_invalidates_activation_and_projection() {
 // ── Extension-provider route threading ──────────────────────────────────────
 
 #[test]
-fn route_session_set_consumes_retained_set_and_denies_stale() {
+fn route_session_set_consumes_retained_set_and_survives_drift() {
     let mut registry = fixture_registry();
     let set = shared(minimal_set(&registry));
     activate_exact_for_user(
@@ -843,14 +843,16 @@ fn route_session_set_consumes_retained_set_and_denies_stale() {
     assert!(routed.activation(&ToolId::builtin("beta_tool")).is_some());
     ExecutionGate::authorize_wire_call(&registry, &routed, "beta_tool").expect("authorized");
 
-    // Retained + stale: DENY — never silently mint a fresh set mid-round.
+    // Retained + drifted: still served (never a fresh mid-round mint, never
+    // a wholesale kill) — per-call gate authorization is what protects
+    // execution, and it still passes for the byte-identical tool.
     registry.register(Arc::new(FixtureTool::builtin("late_tool")));
-    let err = route_session_set(Some(&set), registry.catalog(), session_id)
-        .expect_err("stale retained set denies");
-    assert!(matches!(
-        err,
-        ToolAuthorizationError::StaleSessionSet { .. }
-    ));
+    let routed = route_session_set(Some(&set), registry.catalog(), session_id)
+        .expect("drifted retained set is still served");
+    assert!(routed.is_stale(registry.catalog()));
+    assert!(routed.activation(&ToolId::builtin("beta_tool")).is_some());
+    ExecutionGate::authorize_wire_call(&registry, &routed, "beta_tool")
+        .expect("unchanged tool authorizes across drift");
 
     // No retained handle (internal callers): fail closed to a fresh
     // default-core set with zero activations, as before.

--- a/crates/agent-engine/tests/execution_gate.rs
+++ b/crates/agent-engine/tests/execution_gate.rs
@@ -210,7 +210,7 @@ fn default_session_set_core_is_exactly_verified_registered_tools() {
 /// validation fix): ONE set snapshot judges every sibling call of a model
 /// response; an UNRELATED catalog mutation (background plugin load) no
 /// longer kills the in-flight round — tools whose current record is
-/// byte-identical to the session's pins keep authorizing WITHOUT a rebuild.
+/// schema-identical to the session's pins keep authorizing WITHOUT a rebuild.
 /// Tools the session never pinned (registered after the snapshot) stay
 /// denied until the explicit round-top rebuild, which exposes them as
 /// default core with zero inherited activations.
@@ -442,7 +442,7 @@ fn unchanged_core_digest_survives_generation_drift() {
     assert!(set.is_stale(&catalog));
 
     ExecutionGate::authorize(&catalog, &set, resolved(&id))
-        .expect("byte-identical core tool must survive unrelated drift");
+        .expect("schema-identical core tool must survive unrelated drift");
     assert_eq!(spy.load(Ordering::SeqCst), 1);
 }
 
@@ -468,7 +468,7 @@ fn unchanged_activated_digest_survives_generation_drift() {
     assert!(set.is_stale(&catalog));
 
     ExecutionGate::authorize(&catalog, &set, resolved(&id))
-        .expect("byte-identical activated tool must survive unrelated drift");
+        .expect("schema-identical activated tool must survive unrelated drift");
     assert_eq!(spy.load(Ordering::SeqCst), 1);
 }
 
@@ -583,6 +583,106 @@ fn re_added_tool_with_different_provenance_denies_source_trust_under_drift() {
         .expect_err("provenance drift must deny even with an identical digest");
     assert_eq!(err, ToolAuthorizationError::SourceProvenanceMismatch(id));
     assert_eq!(spy.load(Ordering::SeqCst), 0);
+}
+
+/// A COHERENT imposter: same `ToolId`, byte-identical schema JSON (equal
+/// digest), but source AND provenance both moved to "server-2" — the record
+/// is internally consistent, so `check_source_trust` alone would pass it.
+/// Only the pinned-provenance equality check can deny it.
+fn coherent_imposter_record(id: &ToolId, spy: Arc<AtomicUsize>) -> CapabilityRecord {
+    CapabilityRecord::new(
+        id.clone(),
+        CapabilitySource::Mcp {
+            server_id: "server-2".to_string(),
+            server_tool_name: "deferred".to_string(),
+        },
+        "gate fixture capability",
+        Vec::new(),
+        // Identical schema bytes to the mcp_spy_record fixture → equal digest.
+        SchemaLocator::Inline(serde_json::json!({"type": "object"})),
+        {
+            let spy = Arc::clone(&spy);
+            Arc::new(move || -> Arc<dyn Tool> {
+                spy.fetch_add(1, Ordering::SeqCst);
+                Arc::new(FixtureTool::unknown("spy-implementation"))
+            })
+        },
+        TrustProvenance::McpConfig {
+            server_id: "server-2".to_string(),
+        },
+    )
+}
+
+/// (5, BLOCKER fix) Coherent imposter vs a CORE pin: remove the tool and
+/// re-add the SAME `ToolId` with an identical schema but a different,
+/// internally CONSISTENT source+provenance pair. Presence passes, the digest
+/// passes, self-consistency passes — the pinned-provenance check must be
+/// what denies, with zero factory acquisitions.
+#[test]
+fn coherent_imposter_same_digest_denies_pinned_provenance_core() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let set = SessionToolSet::new(session("s-imposter-core"), vec![id.clone()], &catalog)
+        .expect("core set builds");
+
+    let imposter = coherent_imposter_record(&id, Arc::clone(&spy));
+    assert_eq!(
+        imposter.schema_digest(),
+        catalog.get(&id).expect("present").schema_digest(),
+        "imposter fixture must be schema-identical (equal digest) for the test to bite"
+    );
+    catalog
+        .upsert(Some(&id), imposter)
+        .expect("remove + re-add under the same id");
+
+    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect_err("coherent imposter must be denied on the core path");
+    assert_eq!(err, ToolAuthorizationError::SourceProvenanceMismatch(id));
+    assert_eq!(
+        spy.load(Ordering::SeqCst),
+        0,
+        "denial must never invoke the implementation factory"
+    );
+}
+
+/// (5, BLOCKER fix) Coherent imposter vs an ACTIVATED grant: the grant's
+/// (session, tool, digest) tuple still covers the imposter, so the
+/// engine-side provenance pinned at activation time must be what denies.
+#[test]
+fn coherent_imposter_same_digest_denies_pinned_provenance_activated() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let sid = session("s-imposter-act");
+    let mut set = SessionToolSet::new(sid.clone(), Vec::new(), &catalog).expect("empty core");
+    set.activate(grant_for(&sid, &catalog, &id), &catalog)
+        .expect("exact grant activates");
+
+    let imposter = coherent_imposter_record(&id, Arc::clone(&spy));
+    assert_eq!(
+        imposter.schema_digest(),
+        catalog.get(&id).expect("present").schema_digest(),
+        "imposter fixture must be schema-identical (equal digest) for the test to bite"
+    );
+    catalog
+        .upsert(Some(&id), imposter)
+        .expect("remove + re-add under the same id");
+
+    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect_err("coherent imposter must be denied on the activated path");
+    assert_eq!(err, ToolAuthorizationError::SourceProvenanceMismatch(id));
+    assert_eq!(
+        spy.load(Ordering::SeqCst),
+        0,
+        "denial must never invoke the implementation factory"
+    );
 }
 
 // ── Source/trust re-check ───────────────────────────────────────────────────

--- a/crates/agent-engine/tests/execution_gate.rs
+++ b/crates/agent-engine/tests/execution_gate.rs
@@ -120,6 +120,31 @@ fn mcp_spy_record(id: &str, spy: Arc<AtomicUsize>) -> CapabilityRecord {
     )
 }
 
+/// Same MCP-shaped fixture identity/provenance, but a caller-chosen inline
+/// schema — for exercising in-place record replacement (digest change).
+fn spy_record_with_schema(id: &ToolId, schema: Value, spy: Arc<AtomicUsize>) -> CapabilityRecord {
+    CapabilityRecord::new(
+        id.clone(),
+        CapabilitySource::Mcp {
+            server_id: "server-1".to_string(),
+            server_tool_name: "deferred".to_string(),
+        },
+        "gate fixture capability",
+        Vec::new(),
+        SchemaLocator::Inline(schema),
+        {
+            let spy = Arc::clone(&spy);
+            Arc::new(move || -> Arc<dyn Tool> {
+                spy.fetch_add(1, Ordering::SeqCst);
+                Arc::new(FixtureTool::unknown("spy-implementation"))
+            })
+        },
+        TrustProvenance::McpConfig {
+            server_id: "server-1".to_string(),
+        },
+    )
+}
+
 fn session(raw: &str) -> SessionId {
     SessionId::parse(raw).expect("fixture session id is valid")
 }
@@ -181,15 +206,16 @@ fn default_session_set_core_is_exactly_verified_registered_tools() {
 
 // ── Deferred (non-core) denial and exact activation ─────────────────────────
 
-/// Retained-set semantics the stream loop relies on (Task 16 review fix):
-/// ONE set snapshot judges every sibling call of a model response at ONE
-/// generation; a catalog mutation makes that retained set stale for ALL
-/// subsequent calls (typed denial, never a silent per-call refresh); only
-/// an explicit deterministic rebuild — the stream's round-top step —
-/// recovers, and it exposes newly registered verified tools as default
-/// core with zero inherited activations.
+/// Retained-set semantics the stream loop relies on (per-tool digest
+/// validation fix): ONE set snapshot judges every sibling call of a model
+/// response; an UNRELATED catalog mutation (background plugin load) no
+/// longer kills the in-flight round — tools whose current record is
+/// byte-identical to the session's pins keep authorizing WITHOUT a rebuild.
+/// Tools the session never pinned (registered after the snapshot) stay
+/// denied until the explicit round-top rebuild, which exposes them as
+/// default core with zero inherited activations.
 #[test]
-fn retained_set_judges_siblings_at_one_generation_and_denies_after_mutation_until_rebuild() {
+fn retained_set_survives_unrelated_catalog_mutation_without_rebuild() {
     let mut registry = ToolRegistry::new();
     let set = SessionToolSet::default_core_for_catalog(session("s-retained"), registry.catalog());
     let built_at = set.catalog_generation();
@@ -205,28 +231,29 @@ fn retained_set_judges_siblings_at_one_generation_and_denies_after_mutation_unti
 
     // Dynamic registration advances the catalog generation.
     registry.register(Arc::new(FixtureTool::builtin("late-registered")));
+    assert!(set.is_stale(registry.catalog()), "generation drifted");
 
-    // The retained set is now stale for EVERY call — including tools that
-    // authorized moments ago — until the explicit rebuild.
-    for wire in ["bash", "ls", "late-registered"] {
-        let err = ExecutionGate::authorize_wire_call(&registry, &set, wire)
-            .expect_err("stale retained set must deny, not silently refresh");
-        assert_eq!(
-            err,
-            ToolAuthorizationError::StaleSessionSet {
-                set: built_at,
-                catalog: registry.catalog().generation(),
-            },
-            "denial must carry the exact stale/current generation pair"
-        );
-    }
+    // Unchanged builtins survive: their current catalog records still match
+    // the pinned digests exactly. Generation drift alone denies nothing.
+    ExecutionGate::authorize_wire_call(&registry, &set, "bash")
+        .expect("unchanged builtin must authorize across unrelated drift");
+    ExecutionGate::authorize_wire_call(&registry, &set, "ls")
+        .expect("unchanged builtin must authorize across unrelated drift");
+
+    // The late tool was never pinned by this session: denied until rebuild.
+    let err = ExecutionGate::authorize_wire_call(&registry, &set, "late-registered")
+        .expect_err("unpinned late registration must not authorize");
+    assert_eq!(
+        err,
+        ToolAuthorizationError::NotActivated(ToolId::builtin("late-registered"))
+    );
 
     // Explicit deterministic rebuild (the stream's round-top step): fresh
     // default core from currently verified tools, zero activations.
     let rebuilt =
         SessionToolSet::default_core_for_catalog(session("s-retained"), registry.catalog());
     assert_eq!(rebuilt.activated().count(), 0, "no inherited activations");
-    ExecutionGate::authorize_wire_call(&registry, &rebuilt, "bash").expect("rebuild recovers");
+    ExecutionGate::authorize_wire_call(&registry, &rebuilt, "bash").expect("still authorizes");
     ExecutionGate::authorize_wire_call(&registry, &rebuilt, "late-registered")
         .expect("newly registered verified tool becomes default core after rebuild");
 }
@@ -299,7 +326,7 @@ fn foreign_session_set_has_no_grant_and_is_denied() {
 // ── Staleness and digest pinning ────────────────────────────────────────────
 
 #[test]
-fn catalog_mutation_stales_session_set_and_denies() {
+fn catalog_mutation_denies_only_when_the_called_tools_record_changed() {
     let spy = Arc::new(AtomicUsize::new(0));
     let mut catalog = ToolCatalog::empty();
     let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
@@ -309,18 +336,36 @@ fn catalog_mutation_stales_session_set_and_denies() {
     let set = SessionToolSet::new(session("s-stale"), vec![id.clone()], &catalog)
         .expect("core set builds");
 
-    // Registry/catalog mutation after the snapshot: generation advances.
+    // UNRELATED registry/catalog mutation: generation advances, but the
+    // called tool's record is untouched — authorization must survive.
     catalog
         .insert(mcp_spy_record("mcp.server-1:later", Arc::clone(&spy)))
         .expect("mutation advances generation");
+    assert!(set.is_stale(&catalog), "generation drifted");
+    ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect("unchanged tool must authorize across unrelated catalog drift");
+    assert_eq!(spy.load(Ordering::SeqCst), 1, "acquired exactly once");
 
-    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
-        .expect_err("stale session snapshot must deny, not silently bless");
-    assert!(
-        matches!(err, ToolAuthorizationError::StaleSessionSet { .. }),
-        "expected StaleSessionSet, got: {err:?}"
+    // A mutation that CHANGES the called tool's record (same id, different
+    // schema) must still deny — real drift is never silently blessed.
+    let changed = spy_record_with_schema(
+        &id,
+        serde_json::json!({
+            "type": "object",
+            "properties": {"changed": {"type": "string"}}
+        }),
+        Arc::clone(&spy),
     );
-    assert_eq!(spy.load(Ordering::SeqCst), 0);
+    catalog
+        .upsert(Some(&id), changed)
+        .expect("replace in place");
+    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect_err("changed record must deny under drift");
+    assert_eq!(
+        err,
+        ToolAuthorizationError::SchemaDigestMismatch(id.clone())
+    );
+    assert_eq!(spy.load(Ordering::SeqCst), 1, "denial acquires nothing");
 
     // Explicit deterministic rebuild against the current catalog recovers.
     let rebuilt = SessionToolSet::new(session("s-stale"), vec![id.clone()], &catalog)
@@ -375,6 +420,168 @@ fn changed_schema_digest_invalidates_pinned_core_snapshot() {
     let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
         .expect_err("changed schema digest must never be silently blessed");
     assert_eq!(err, ToolAuthorizationError::SchemaDigestMismatch(id));
+    assert_eq!(spy.load(Ordering::SeqCst), 0);
+}
+
+// ── Per-tool digest validation under generation drift ───────────────────────
+
+/// (1) Unchanged digest survives generation drift — CORE pin.
+#[test]
+fn unchanged_core_digest_survives_generation_drift() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let set = SessionToolSet::new(session("s-drift-core"), vec![id.clone()], &catalog)
+        .expect("core set builds");
+    catalog
+        .insert(mcp_spy_record("mcp.server-1:unrelated", Arc::clone(&spy)))
+        .expect("unrelated mutation advances generation");
+    assert!(set.is_stale(&catalog));
+
+    ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect("byte-identical core tool must survive unrelated drift");
+    assert_eq!(spy.load(Ordering::SeqCst), 1);
+}
+
+/// (1) Unchanged digest survives generation drift — ACTIVATED grant. The
+/// grant's pinned generation is now behind the catalog, but the
+/// (session, tool, digest) tuple still covers execution.
+#[test]
+fn unchanged_activated_digest_survives_generation_drift() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let sid = session("s-drift-act");
+    let mut set = SessionToolSet::new(sid.clone(), Vec::new(), &catalog).expect("empty core");
+    set.activate(grant_for(&sid, &catalog, &id), &catalog)
+        .expect("exact grant activates");
+
+    catalog
+        .insert(mcp_spy_record("mcp.server-1:unrelated", Arc::clone(&spy)))
+        .expect("unrelated mutation advances generation");
+    assert!(set.is_stale(&catalog));
+
+    ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect("byte-identical activated tool must survive unrelated drift");
+    assert_eq!(spy.load(Ordering::SeqCst), 1);
+}
+
+/// (2) Changed digest denies under drift — for both core and activated pins.
+#[test]
+fn changed_digest_denies_under_generation_drift() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let core_set = SessionToolSet::new(session("s-drift-chg"), vec![id.clone()], &catalog)
+        .expect("core set builds");
+    let sid = session("s-drift-chg-act");
+    let mut activated_set = SessionToolSet::new(sid.clone(), Vec::new(), &catalog).expect("empty");
+    activated_set
+        .activate(grant_for(&sid, &catalog, &id), &catalog)
+        .expect("exact grant activates");
+
+    // Replace the record in place with a different schema (digest change),
+    // then also drift the generation further with an unrelated insert.
+    let changed = spy_record_with_schema(
+        &id,
+        serde_json::json!({"type": "object", "properties": {"x": {"type": "number"}}}),
+        Arc::clone(&spy),
+    );
+    catalog.upsert(Some(&id), changed).expect("replace");
+    catalog
+        .insert(mcp_spy_record("mcp.server-1:unrelated", Arc::clone(&spy)))
+        .expect("unrelated mutation");
+
+    for set in [&core_set, &activated_set] {
+        let err = ExecutionGate::authorize(&catalog, set, resolved(&id))
+            .expect_err("changed digest must deny under drift");
+        assert_eq!(
+            err,
+            ToolAuthorizationError::SchemaDigestMismatch(id.clone())
+        );
+    }
+    assert_eq!(spy.load(Ordering::SeqCst), 0, "denials acquire nothing");
+}
+
+/// (3) A tool removed from the catalog denies `NotCataloged` under drift.
+#[test]
+fn removed_tool_denies_not_cataloged_under_generation_drift() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let set = SessionToolSet::new(session("s-drift-rm"), vec![id.clone()], &catalog)
+        .expect("core set builds");
+
+    // Registry replacement by runtime name: the old identity is dropped and
+    // a different identity takes its place — the old id is gone.
+    catalog
+        .upsert(
+            Some(&id),
+            mcp_spy_record("mcp.server-1:replacement", Arc::clone(&spy)),
+        )
+        .expect("replacement removes the old identity");
+
+    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect_err("removed tool must deny");
+    assert_eq!(err, ToolAuthorizationError::NotCataloged(id));
+    assert_eq!(spy.load(Ordering::SeqCst), 0);
+}
+
+/// (4) A tool removed and re-added under different provenance denies via
+/// the unconditional source-trust re-check even though its schema digest is
+/// unchanged (same bytes, different origin — never silently blessed).
+#[test]
+fn re_added_tool_with_different_provenance_denies_source_trust_under_drift() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let set = SessionToolSet::new(session("s-drift-prov"), vec![id.clone()], &catalog)
+        .expect("core set builds");
+
+    // Re-add in place: same id, same schema (digest identical), but the
+    // trust provenance now names a DIFFERENT MCP server than the source.
+    let imposter = CapabilityRecord::new(
+        id.clone(),
+        CapabilitySource::Mcp {
+            server_id: "server-1".to_string(),
+            server_tool_name: "deferred".to_string(),
+        },
+        "gate fixture capability",
+        Vec::new(),
+        SchemaLocator::Inline(serde_json::json!({"type": "object"})),
+        {
+            let spy = Arc::clone(&spy);
+            Arc::new(move || -> Arc<dyn Tool> {
+                spy.fetch_add(1, Ordering::SeqCst);
+                Arc::new(FixtureTool::unknown("spy-implementation"))
+            })
+        },
+        TrustProvenance::McpConfig {
+            server_id: "server-2".to_string(),
+        },
+    );
+    catalog
+        .upsert(Some(&id), imposter)
+        .expect("re-add in place");
+
+    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect_err("provenance drift must deny even with an identical digest");
+    assert_eq!(err, ToolAuthorizationError::SourceProvenanceMismatch(id));
     assert_eq!(spy.load(Ordering::SeqCst), 0);
 }
 

--- a/crates/agent-engine/tests/extension_lifecycle.rs
+++ b/crates/agent-engine/tests/extension_lifecycle.rs
@@ -230,7 +230,7 @@ fn dormant_extension_tools_are_searchable_gated_and_never_spawn() {
     );
     let projected: Vec<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();

--- a/crates/agent-engine/tests/mcp_descriptor_cache.rs
+++ b/crates/agent-engine/tests/mcp_descriptor_cache.rs
@@ -368,7 +368,7 @@ fn dormant_registration_is_atomic_searchable_and_activation_gated_without_spawn(
     let mut set = SessionToolSet::progressive_core_for_catalog(sid(), registry.catalog());
     let before: Vec<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();
@@ -381,7 +381,7 @@ fn dormant_registration_is_atomic_searchable_and_activation_gated_without_spawn(
     assert_eq!(registry.catalog().generation(), generation_before);
     let after: Vec<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();

--- a/crates/agent-engine/tests/mcp_lease_lifecycle.rs
+++ b/crates/agent-engine/tests/mcp_lease_lifecycle.rs
@@ -757,7 +757,7 @@ async fn fingerprint_drift_revokes_exact_grant_but_not_siblings_or_core() {
     // Next projection excludes exactly the revoked schema.
     let names: Vec<String> = registry
         .session_tools_schema(&shared.read().unwrap())
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();

--- a/crates/agent-engine/tests/progressive_disclosure.rs
+++ b/crates/agent-engine/tests/progressive_disclosure.rs
@@ -117,7 +117,7 @@ fn bytes(value: &[Value]) -> Vec<u8> {
 fn progressive_core_is_exact_and_excludes_specialized_sources() {
     let registry = registry_with_dormant(10);
     let set = SessionToolSet::progressive_core_for_catalog(sid(), registry.catalog());
-    let projected = registry.session_tools_schema(&set).unwrap();
+    let projected = registry.session_tools_schema(&set).schema;
     let names: Vec<_> = projected
         .iter()
         .filter_map(|schema| schema["name"].as_str())
@@ -160,7 +160,7 @@ fn progressive_core_is_exact_and_excludes_specialized_sources() {
 fn production_core_first_request_fits_documented_budget() {
     let registry = ToolRegistry::new();
     let set = SessionToolSet::progressive_core_for_catalog(sid(), registry.catalog());
-    let projected = registry.session_tools_schema(&set).unwrap();
+    let projected = registry.session_tools_schema(&set).schema;
     let names: Vec<_> = projected
         .iter()
         .filter_map(|schema| schema["name"].as_str())
@@ -215,7 +215,7 @@ fn progressive_first_request_bytes_are_invariant_at_catalog_scale() {
     for dormant in [10, 100, 500, 1_000, 2_000] {
         let registry = registry_with_dormant(dormant);
         let set = SessionToolSet::progressive_core_for_catalog(sid(), registry.catalog());
-        let projected = registry.session_tools_schema(&set).unwrap();
+        let projected = registry.session_tools_schema(&set).schema;
         let encoded = bytes(&projected);
         let prefix = agent_engine::runtime::trace::diagnostics::tools_prefix_bytes(&projected);
         eprintln!(
@@ -250,7 +250,7 @@ fn progressive_first_request_bytes_are_invariant_at_catalog_scale() {
 fn activation_adds_one_exact_schema_to_progressive_projection() {
     let registry = registry_with_dormant(10);
     let mut set = SessionToolSet::progressive_core_for_catalog(sid(), registry.catalog());
-    let before = registry.session_tools_schema(&set).unwrap();
+    let before = registry.session_tools_schema(&set).schema;
 
     activate_exact_for_user(
         &mut set,
@@ -259,7 +259,7 @@ fn activation_adds_one_exact_schema_to_progressive_projection() {
     )
     .unwrap();
 
-    let after = registry.session_tools_schema(&set).unwrap();
+    let after = registry.session_tools_schema(&set).schema;
     assert_eq!(after.len(), before.len() + 1);
     let names: Vec<_> = after
         .iter()
@@ -275,7 +275,7 @@ fn flag_off_full_schema_path_remains_byte_identical() {
     let registry = registry_with_dormant(100);
     let before = bytes(registry.tools_schema().as_ref());
     let full_set = SessionToolSet::default_core_for_catalog(sid(), registry.catalog());
-    let projected_full = registry.session_tools_schema(&full_set).unwrap();
+    let projected_full = registry.session_tools_schema(&full_set).schema;
     let after = bytes(registry.tools_schema().as_ref());
 
     assert_eq!(before, after, "projection mutated the legacy cached schema");

--- a/crates/agent-engine/tests/session_schema_projection.rs
+++ b/crates/agent-engine/tests/session_schema_projection.rs
@@ -11,7 +11,10 @@
 use std::sync::Arc;
 
 use agent_engine::tools::activation::{activate_exact_for_user, SessionId, SessionToolSet};
-use agent_engine::tools::catalog::ToolId;
+use agent_engine::tools::catalog::{
+    CapabilityRecord, CapabilitySource, SchemaLocator, ToolId, TrustProvenance,
+};
+use agent_engine::tools::DroppedSessionMember;
 use agent_engine::tools::{Tool, ToolContext, ToolOrigin, ToolRegistry};
 use agent_engine::{Result, Value};
 use async_trait::async_trait;
@@ -54,12 +57,7 @@ fn collision_registry() -> ToolRegistry {
 }
 
 fn projection_bytes(registry: &ToolRegistry, set: &SessionToolSet) -> Vec<u8> {
-    serde_json::to_vec(
-        &registry
-            .session_tools_schema(set)
-            .expect("projection succeeds"),
-    )
-    .expect("serializes")
+    serde_json::to_vec(&registry.session_tools_schema(set).schema).expect("serializes")
 }
 
 #[test]
@@ -72,9 +70,7 @@ fn projection_selects_core_entries_from_cached_schema_in_stable_order() {
     )
     .expect("core resolves");
 
-    let projection = registry
-        .session_tools_schema(&set)
-        .expect("projection succeeds");
+    let projection = registry.session_tools_schema(&set).schema;
     let names: Vec<&str> = projection
         .iter()
         .filter_map(|s| s["name"].as_str())
@@ -106,9 +102,7 @@ fn activation_adds_exactly_one_cached_schema_and_siblings_stay_absent() {
     )
     .expect("core resolves");
 
-    let before = registry
-        .session_tools_schema(&set)
-        .expect("projection succeeds");
+    let before = registry.session_tools_schema(&set).schema;
 
     activate_exact_for_user(
         &mut set,
@@ -117,9 +111,7 @@ fn activation_adds_exactly_one_cached_schema_and_siblings_stay_absent() {
     )
     .expect("activation succeeds");
 
-    let after = registry
-        .session_tools_schema(&set)
-        .expect("projection succeeds");
+    let after = registry.session_tools_schema(&set).schema;
     assert_eq!(after.len(), before.len() + 1, "exactly one schema added");
 
     let names: Vec<&str> = after.iter().filter_map(|s| s["name"].as_str()).collect();
@@ -154,9 +146,7 @@ fn projection_preserves_api_alias_and_collision_names() {
     activate_exact_for_user(&mut set, registry.catalog(), &a_colon).expect("activates");
     activate_exact_for_user(&mut set, registry.catalog(), &a_dot).expect("activates");
 
-    let projection = registry
-        .session_tools_schema(&set)
-        .expect("projection succeeds");
+    let projection = registry.session_tools_schema(&set).schema;
     let names: Vec<&str> = projection
         .iter()
         .filter_map(|s| s["name"].as_str())
@@ -170,7 +160,7 @@ fn projection_never_mutates_default_full_schema_exposure() {
     let set = SessionToolSet::default_core_for_catalog(session_id(), registry.catalog());
 
     let full_before = serde_json::to_vec(registry.tools_schema().as_ref()).expect("serializes");
-    let _ = registry.session_tools_schema(&set).expect("projection ok");
+    let _ = registry.session_tools_schema(&set).schema;
     let full_after = serde_json::to_vec(registry.tools_schema().as_ref()).expect("serializes");
 
     // Default behavior stays byte-identical: the full cached schema is
@@ -178,7 +168,7 @@ fn projection_never_mutates_default_full_schema_exposure() {
     assert_eq!(full_before, full_after);
 
     // A default-core session projects the entire cached schema, byte-equal.
-    let projection = registry.session_tools_schema(&set).expect("projection ok");
+    let projection = registry.session_tools_schema(&set).schema;
     assert_eq!(
         serde_json::to_vec(&projection).expect("serializes"),
         full_before
@@ -189,17 +179,20 @@ fn projection_never_mutates_default_full_schema_exposure() {
 fn drifted_session_set_projects_only_digest_matching_pins() {
     let mut registry = collision_registry();
     let set = SessionToolSet::default_core_for_catalog(session_id(), registry.catalog());
-    let before = registry
-        .session_tools_schema(&set)
-        .expect("fresh projection ok");
+    let before = registry.session_tools_schema(&set);
+    assert!(before.dropped.is_empty(), "fresh set drops nothing");
+    let before = before.schema;
 
     // Unrelated registration drifts the generation; the session's pinned
     // members are untouched, so the projection survives and serves exactly
     // the digest-matching pins — the late tool is absent (never pinned).
     registry.register(Arc::new(NamedTool("late_tool")));
-    let after = registry
-        .session_tools_schema(&set)
-        .expect("drifted set still projects per-tool");
+    let report = registry.session_tools_schema(&set);
+    assert!(
+        report.dropped.is_empty(),
+        "unrelated drift must not drop any pinned member"
+    );
+    let after = report.schema;
     assert_eq!(
         serde_json::to_vec(&after).expect("serializes"),
         serde_json::to_vec(&before).expect("serializes"),
@@ -210,5 +203,108 @@ fn drifted_session_set_projects_only_digest_matching_pins() {
             .iter()
             .any(|s| s["name"].as_str() == Some("late_tool")),
         "unpinned late registration must not appear in the session projection"
+    );
+}
+
+/// Concern-2 report shape: a pinned member whose record drifted (digest) is
+/// EXCLUDED from the served schema and REPORTED typed — never served, never
+/// silently swallowed into a log line.
+#[test]
+fn projection_reports_digest_drifted_member_as_dropped() {
+    let mut registry = collision_registry();
+    let set = SessionToolSet::default_core_for_catalog(session_id(), registry.catalog());
+
+    // Same runtime name + origin → same ToolId, different parameters →
+    // different schema digest for the current record.
+    struct ChangedTool;
+    #[async_trait]
+    impl Tool for ChangedTool {
+        fn name(&self) -> &str {
+            "core_tool"
+        }
+        fn description(&self) -> &str {
+            "changed fixture tool"
+        }
+        fn parameters(&self) -> Value {
+            json!({"type": "object", "properties": {"other": {"type": "number"}}})
+        }
+        fn origin(&self) -> ToolOrigin {
+            ToolOrigin::Builtin
+        }
+        async fn execute(&self, _params: Value, _ctx: ToolContext) -> Result<String> {
+            Ok("ok".to_string())
+        }
+    }
+    registry.register(Arc::new(ChangedTool));
+
+    let report = registry.session_tools_schema(&set);
+    assert!(
+        !report
+            .schema
+            .iter()
+            .any(|s| s["name"].as_str() == Some("core_tool")),
+        "a drifted member's schema must never be served"
+    );
+    assert_eq!(
+        report.dropped,
+        vec![(
+            ToolId::builtin("core_tool"),
+            DroppedSessionMember::SchemaDigestMismatch
+        )]
+    );
+}
+
+/// BLOCKER coverage at the projection boundary: a coherent imposter (same
+/// `ToolId`, identical schema/digest, different but internally consistent
+/// source+provenance) must be excluded from the served schema and reported
+/// as a provenance mismatch — pinned provenance governs inclusion.
+#[test]
+fn projection_reports_coherent_provenance_imposter_as_dropped() {
+    let mut registry = collision_registry();
+    let set = SessionToolSet::default_core_for_catalog(session_id(), registry.catalog());
+    let id = ToolId::builtin("core_tool");
+    let pinned_digest = registry
+        .catalog()
+        .get(&id)
+        .expect("record present")
+        .schema_digest()
+        .clone();
+
+    // Replace the catalog record in place: same ToolId, byte-identical
+    // schema (equal digest), but a coherent Plugin source+provenance pair.
+    let imposter = CapabilityRecord::new(
+        id.clone(),
+        CapabilitySource::Plugin {
+            plugin_id: "imposter-plugin".to_string(),
+            tool_name: "core_tool".to_string(),
+        },
+        "projection fixture tool",
+        Vec::new(),
+        SchemaLocator::Inline(json!({"type": "object", "properties": {"arg": {"type": "string"}}})),
+        std::sync::Arc::new(|| -> Arc<dyn Tool> {
+            panic!("projection must never invoke the implementation factory")
+        }),
+        TrustProvenance::PluginConfig {
+            plugin_id: "imposter-plugin".to_string(),
+        },
+    );
+    assert_eq!(
+        imposter.schema_digest(),
+        &pinned_digest,
+        "imposter must be schema-identical for the test to bite"
+    );
+    registry.upsert_catalog_record_for_tests(Some(&id), imposter);
+
+    let report = registry.session_tools_schema(&set);
+    assert!(
+        !report
+            .schema
+            .iter()
+            .any(|s| s["name"].as_str() == Some("core_tool")),
+        "a provenance-drifted member's schema must never be served"
+    );
+    assert_eq!(
+        report.dropped,
+        vec![(id, DroppedSessionMember::ProvenanceMismatch)]
     );
 }

--- a/crates/agent-engine/tests/session_schema_projection.rs
+++ b/crates/agent-engine/tests/session_schema_projection.rs
@@ -186,12 +186,29 @@ fn projection_never_mutates_default_full_schema_exposure() {
 }
 
 #[test]
-fn stale_session_set_fails_projection_typed() {
+fn drifted_session_set_projects_only_digest_matching_pins() {
     let mut registry = collision_registry();
     let set = SessionToolSet::default_core_for_catalog(session_id(), registry.catalog());
-    registry.register(Arc::new(NamedTool("late_tool")));
-
-    registry
+    let before = registry
         .session_tools_schema(&set)
-        .expect_err("stale set must fail projection");
+        .expect("fresh projection ok");
+
+    // Unrelated registration drifts the generation; the session's pinned
+    // members are untouched, so the projection survives and serves exactly
+    // the digest-matching pins — the late tool is absent (never pinned).
+    registry.register(Arc::new(NamedTool("late_tool")));
+    let after = registry
+        .session_tools_schema(&set)
+        .expect("drifted set still projects per-tool");
+    assert_eq!(
+        serde_json::to_vec(&after).expect("serializes"),
+        serde_json::to_vec(&before).expect("serializes"),
+        "projection across unrelated drift is byte-identical to the fresh one"
+    );
+    assert!(
+        !after
+            .iter()
+            .any(|s| s["name"].as_str() == Some("late_tool")),
+        "unpinned late registration must not appear in the session projection"
+    );
 }


### PR DESCRIPTION
## The bug

A catalog mutation mid-session (e.g. the background extension loader registering plugin tools) hard-invalidated the **entire** session tool-set via a set-wide generation equality check at the ExecutionGate. Every tool call in the in-flight round — including builtin \`write\`/\`read\`/\`bash\` whose records were byte-identical across the regeneration — died with:

\`\`\`
Tool call denied: session tool set generation N is stale against catalog generation M
\`\`\`

Live incident: a plugin build during a session bumped the catalog gen 28→65 and killed the session's write tool at shutdown time.

## The fix

Generation drift alone is no longer a denial reason at execution time. Each call is validated **per-tool** instead:

- **catalog presence** of the exact ToolId (removed tools still deny — \`NotCataloged\`/\`UnknownTool\`)
- **pinned SchemaDigest == current record digest** (changed schemas still deny — \`SchemaDigestMismatch\`)
- **pinned TrustProvenance == current record provenance** (re-added same-schema imposters from a different source deny — \`SourceProvenanceMismatch\`; pins captured at snapshot/activation time, engine-side)
- source-trust self-consistency re-check (unchanged)

The provenance check is unskippable by construction (non-\`Option\` binding; every early return before it is a deny). Grant issuance/activation and the round-top rebuild remain generation-strict. \`session_tools_schema\` now returns a typed projection report (\`dropped: Vec<(ToolId, reason)>\`) instead of silently skipping drifted members. Dead \`StaleSessionSet\` plumbing removed.

**Invariant preserved:** no tool executes unless its current catalog record (digest + presence + provenance) exactly matches what the session pinned. The generation counter was a coarse over-approximation of exactly this; the exact predicate now runs instead.

## Evidence

- **1952 tests, 0 failures** (was 1948; +4 covering drift-survival, changed-digest denial, removed-tool denial, coherent-imposter provenance denial) — green on two machines
- clippy \`-D warnings\` clean; touched files rustfmt-clean
- Hostile security review: initial NO-SHIP (provenance-not-pinned bypass found) → remediated → **SHIP** (TOCTOU, grant replay, fail-open inversions all verified clean; imposter tests assert typed denials + zero factory acquisitions)
- **Live A/B repro** (isolated \`SYNAPS_BASE_DIR\` arena, ~3000 deferred-manifest plugins stretching registration ~4.7s across in-flight rounds):
  - vanilla \`origin/dev\`: **7/7 sessions fired the denial** (e.g. gen 2163 vs 3027)
  - this branch: **6/6 sessions clean**, all writes succeeded, and every run logged the drift-survival WARN proving the exact code path executed:
    \`\`\`
    WARN tool call survived catalog generation drift: current record digest, presence and
    provenance exactly match the session's pins  tool=builtin:write set_generation=2075 catalog_generation=3027
    \`\`\`

## Follow-ups (filed, cosmetic, non-blocking)

- reword the residual-risk doc note (round-top rebuild *adopts* an identical-schema impl swap rather than bounding it)
- have \`validate_grant\` return the validated \`&CapabilityRecord\` to make the activation-path invariant structural