### PR TITLE
fix: Kimi Code quota 403 surfacing, Grok effort clamp on model switch, xAI capacity retry

### DIFF
--- a/crates/agent-core/src/core/auth/broker.rs
+++ b/crates/agent-core/src/core/auth/broker.rs
@@ -1724,6 +1724,33 @@ async fn read_body_capped(resp: reqwest::Response, cap: usize) -> Result<String,
         .map_err(|_| BrokerError::Transport("response body was not valid UTF-8".into()))
 }
 
+/// Cap on how much of a non-2xx upstream body is read for *classification*
+/// only (spec §5.1). Error envelopes are tiny; anything larger is cut off
+/// and simply fails to classify.
+const MAX_PROXY_ERROR_CLASSIFY_BYTES: usize = 8 * 1024;
+
+/// Read at most `cap` bytes of an untrusted error body for classification.
+/// Never fails: overflow truncates (so JSON no longer parses → no label),
+/// transport errors and non-UTF-8 yield `None`. The returned text must only
+/// ever be fed to a vetted classifier — never to an error string or log.
+async fn read_error_body_for_classification(resp: reqwest::Response, cap: usize) -> Option<String> {
+    use futures::StreamExt;
+    let mut buf: Vec<u8> = Vec::with_capacity(cap.min(1024));
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.ok()?;
+        let room = cap.saturating_sub(buf.len());
+        if chunk.len() >= room {
+            buf.extend_from_slice(&chunk[..room]);
+            // Drop the rest unread: truncated JSON cannot classify, which is
+            // the intended fail-closed outcome for oversized bodies.
+            return String::from_utf8(buf).ok();
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    String::from_utf8(buf).ok()
+}
+
 /// Legacy discovery for a static key: login config first, then env vars.
 /// Only callable from inside the broker boundary.
 fn discover_legacy_static_key(spec: &StaticProviderSpec) -> Option<String> {
@@ -1886,14 +1913,27 @@ impl CredentialBroker for LocalBroker {
         let status = resp.status();
         if !status.is_success() {
             // Spec §5.1: the upstream may echo the full request (prompts,
-            // tool schemas, credentials) in its error body. Drop the body
-            // unread — only the typed status reaches the error. The stable
-            // `provider request failed: {status}` prefix (with canonical
-            // reason phrase, e.g. `429 Too Many Requests`) is the transport
-            // contract engine-side classifiers parse.
-            drop(resp);
+            // tool schemas, credentials) in its error body. The body is read
+            // (bounded) for *classification only*: it selects one of OUR
+            // static labels or nothing — no provider bytes reach the error
+            // or the log. The stable `provider request failed: {status}`
+            // prefix (with canonical reason phrase, e.g. `429 Too Many
+            // Requests`) is the transport contract engine-side classifiers
+            // parse; the optional ` [label]` suffix follows it and contains
+            // no ':' so `redact_provider_proxy_error` keeps it intact.
+            let label = read_error_body_for_classification(resp, MAX_PROXY_ERROR_CLASSIFY_BYTES)
+                .await
+                .as_deref()
+                .and_then(crate::error::vetted_proxy_error_label);
+            tracing::warn!(
+                provider = %request.provider,
+                status = status.as_u16(),
+                label = label.unwrap_or("-"),
+                "provider request failed"
+            );
+            let label_suffix = label.map(|l| format!(" [{l}]")).unwrap_or_default();
             return Err(BrokerError::Transport(format!(
-                "provider request failed: {status}"
+                "provider request failed: {status}{label_suffix}"
             )));
         }
         use futures::StreamExt;
@@ -3328,6 +3368,148 @@ mod tests {
             "escapes must not reach errors: {msg}"
         );
         assert_no_hostile_bytes(&msg);
+    }
+
+    /// Drive `proxy_stream` against an upstream that answers `/chat/completions`
+    /// with `status` + `body`, returning the Transport error message.
+    async fn stream_error_message(status: axum::http::StatusCode, body: String) -> String {
+        use axum::routing::post;
+        let app = axum::Router::new().route(
+            "/chat/completions",
+            post(move || async move { (status, body) }),
+        );
+        let url = spawn_upstream(app).await;
+        let broker = LocalBroker::with_local_base_url(reqwest::Client::new(), url);
+        let err = broker
+            .proxy_stream(ProxyRequest {
+                provider: LOCAL_PROVIDER_KEY.into(),
+                method: ProxyMethod::Post,
+                path: "/chat/completions".into(),
+                body: None,
+                stream: true,
+                body_bytes: None,
+            })
+            .await
+            .err()
+            .expect("non-2xx upstream must not yield a stream");
+        assert!(matches!(err, BrokerError::Transport(_)));
+        format!("{err}")
+    }
+
+    /// Everything after the `provider request failed: ` marker.
+    fn after_marker(msg: &str) -> &str {
+        let marker = "provider request failed: ";
+        let idx = msg.find(marker).expect("marker present");
+        &msg[idx + marker.len()..]
+    }
+
+    /// Kimi Code weekly-quota 403: the vetted `access_terminated_error`
+    /// class is surfaced as OUR static label so callers can tell quota
+    /// exhaustion from an auth failure — while none of the body's text
+    /// reaches the error, and the suffix stays ':'-free so engine-side
+    /// `redact_provider_proxy_error` / `broker_error_status` keep parsing.
+    #[tokio::test]
+    async fn local_broker_stream_403_kimi_quota_surfaces_vetted_label_only() {
+        let kimi_body = "{\"error\":{\"type\":\"access_terminated_error\",\"message\":\
+                         \"You've reached your weekly (7-day) usage limit. Your quota will \
+                         reset when the current 7-day window ends. \"}}";
+        let msg = stream_error_message(axum::http::StatusCode::FORBIDDEN, kimi_body.into()).await;
+        assert!(
+            msg.ends_with("provider request failed: 403 Forbidden [access_terminated_error]"),
+            "expected exact labelled prefix: {msg}"
+        );
+        assert!(!msg.contains("weekly"), "body text leaked: {msg}");
+        assert!(!msg.contains("quota"), "body text leaked: {msg}");
+        assert!(!msg.contains('{'), "raw JSON leaked: {msg}");
+        assert!(
+            !after_marker(&msg).contains(':'),
+            "suffix must not contain ':' (engine truncates there): {msg}"
+        );
+    }
+
+    /// Hostile/unvetted `error.type` never becomes a label and its bytes
+    /// never reach the error.
+    #[tokio::test]
+    async fn local_broker_stream_429_unvetted_type_yields_no_label() {
+        let body = format!(
+            "{{\"error\":{{\"type\":\"<script>ECHO:secret\",\"message\":\"ECHOED {HOSTILE_SENTINEL}\"}}}}"
+        );
+        let msg = stream_error_message(axum::http::StatusCode::TOO_MANY_REQUESTS, body).await;
+        assert!(
+            msg.ends_with("provider request failed: 429 Too Many Requests"),
+            "no label expected: {msg}"
+        );
+        assert!(!msg.contains('['), "unexpected label: {msg}");
+        assert!(!msg.contains("script"), "hostile type leaked: {msg}");
+        assert!(!msg.contains("secret"), "hostile type leaked: {msg}");
+        assert!(!after_marker(&msg).contains(':'), "got: {msg}");
+        assert_no_hostile_bytes(&msg);
+    }
+
+    /// Non-JSON (HTML) error page → no label, no leak.
+    #[tokio::test]
+    async fn local_broker_stream_html_body_yields_no_label() {
+        let body =
+            format!("<html><body>ECHOED {HOSTILE_SENTINEL} access_terminated_error</body></html>");
+        let msg = stream_error_message(axum::http::StatusCode::BAD_GATEWAY, body).await;
+        assert!(
+            msg.ends_with("provider request failed: 502 Bad Gateway"),
+            "no label expected: {msg}"
+        );
+        assert!(!msg.contains("html"), "body leaked: {msg}");
+        assert!(!msg.contains('['), "unexpected label: {msg}");
+        assert_no_hostile_bytes(&msg);
+    }
+
+    /// Body larger than the classification cap: truncated read, no label,
+    /// no panic, no error from the reader itself.
+    #[tokio::test]
+    async fn local_broker_stream_oversized_body_yields_no_label_without_panic() {
+        // Valid vetted envelope, but padded far past the cap so the read is
+        // cut off before the closing braces → cannot parse → no label.
+        let pad = "x".repeat(MAX_PROXY_ERROR_CLASSIFY_BYTES * 4);
+        let body = format!(
+            "{{\"error\":{{\"message\":\"ECHOED {HOSTILE_SENTINEL} {pad}\",\"type\":\"access_terminated_error\"}}}}"
+        );
+        let msg = stream_error_message(axum::http::StatusCode::FORBIDDEN, body).await;
+        assert!(
+            msg.ends_with("provider request failed: 403 Forbidden"),
+            "no label expected for oversized body: {msg}"
+        );
+        assert!(!msg.contains('['), "unexpected label: {msg}");
+        assert!(
+            msg.len() < 200,
+            "oversized body leaked: {} bytes",
+            msg.len()
+        );
+        assert_no_hostile_bytes(&msg);
+    }
+
+    /// The truncating reader itself: overflow returns the first `cap` bytes
+    /// (never an error), and a multibyte char split at the cap yields `None`
+    /// rather than panicking.
+    #[tokio::test]
+    async fn read_error_body_for_classification_truncates_and_never_fails() {
+        use axum::routing::get;
+        let app = axum::Router::new()
+            .route("/big", get(|| async { "a".repeat(100) }))
+            .route("/utf8", get(|| async { format!("{}é", "a".repeat(9)) }));
+        let url = spawn_upstream(app).await;
+        let client = reqwest::Client::new();
+
+        let resp = client.get(format!("{url}/big")).send().await.unwrap();
+        let got = read_error_body_for_classification(resp, 10).await;
+        assert_eq!(got.as_deref(), Some("aaaaaaaaaa"));
+
+        // 'é' is 2 bytes at offset 9..11; cap 10 splits it.
+        let resp = client.get(format!("{url}/utf8")).send().await.unwrap();
+        let got = read_error_body_for_classification(resp, 10).await;
+        assert_eq!(got, None);
+
+        // Under the cap: whole body.
+        let resp = client.get(format!("{url}/utf8")).send().await.unwrap();
+        let got = read_error_body_for_classification(resp, 1024).await;
+        assert_eq!(got.as_deref(), Some("aaaaaaaaaé"));
     }
 
     /// LocalBroker::anthropic_usage: a non-2xx usage-endpoint body must never

--- a/crates/agent-core/src/core/error.rs
+++ b/crates/agent-core/src/core/error.rs
@@ -132,8 +132,7 @@ pub fn humanize_proxy_status_error(
             );
             if provider == "kimi-code" {
                 msg.push_str(
-                    " Kimi Code quotas are weekly; `synaps status` or the Kimi membership page \
-                     shows the reset time.",
+                    " Kimi Code quotas are weekly; the Kimi membership page shows the reset time.",
                 );
             }
             Some(msg)
@@ -364,7 +363,7 @@ mod tests {
         );
         assert!(msg.contains("/model"), "got: {msg}");
         assert!(msg.contains("weekly"), "kimi-specific hint missing: {msg}");
-        assert!(msg.contains("synaps status"), "got: {msg}");
+        assert!(msg.contains("membership page"), "got: {msg}");
         assert!(
             !msg.contains("login"),
             "quota must not be misreported as auth: {msg}"

--- a/crates/agent-core/src/core/error.rs
+++ b/crates/agent-core/src/core/error.rs
@@ -57,6 +57,103 @@ fn vetted_error_type(body: &str) -> Option<&'static str> {
     VETTED_ERROR_TYPES.iter().find(|t| **t == ty).copied()
 }
 
+/// Wire error classes we recognise on broker-proxied (OpenAI-compatible)
+/// non-2xx responses. Superset of [`VETTED_ERROR_TYPES`]: it adds the
+/// OpenAI/Kimi/xAI-style `error.type` / `error.code` values so a proxied
+/// failure can be named via OUR static label — never the provider's bytes.
+///
+/// INVARIANT: no label may contain `':'`. Engine-side
+/// `redact_provider_proxy_error` truncates the transport message at the
+/// first `':'` after the `provider request failed: {status}` marker, so a
+/// colon in a label would silently strip it.
+pub const VETTED_PROXY_ERROR_TYPES: &[&str] = &[
+    // Anthropic classes (kept in sync with `VETTED_ERROR_TYPES`).
+    "invalid_request_error",
+    "authentication_error",
+    "permission_error",
+    "not_found_error",
+    "request_too_large",
+    "rate_limit_error",
+    "api_error",
+    "overloaded_error",
+    "billing_error",
+    "timeout_error",
+    // OpenAI-compatible / Kimi / xAI classes.
+    "access_terminated_error",
+    "invalid_authentication_error",
+    "insufficient_quota",
+    "quota_exceeded",
+    "server_error",
+    "model_not_found",
+    "invalid_api_key",
+];
+
+/// Classify an untrusted proxied error body onto a vetted static label.
+///
+/// Parses `body` as JSON and reads, in order, `error.type`, `error.code`,
+/// then top-level `type` / `code` (each must be a JSON string). Returns OUR
+/// constant only on an exact match; the untrusted value itself is never
+/// surfaced. Non-JSON, oversized-truncated, or unrecognised bodies yield
+/// `None` — classification never fails loudly.
+pub fn vetted_proxy_error_label(body: &str) -> Option<&'static str> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    let candidates = [
+        v.get("error").and_then(|e| e.get("type")),
+        v.get("error").and_then(|e| e.get("code")),
+        v.get("type"),
+        v.get("code"),
+    ];
+    let label = candidates
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .find_map(|ty| VETTED_PROXY_ERROR_TYPES.iter().find(|t| **t == ty).copied());
+    label
+}
+
+/// User-actionable message for a broker-proxied non-2xx response when the
+/// (status, vetted label) pair is one we understand; `None` otherwise so the
+/// caller keeps the raw `provider request failed: …` prefix.
+///
+/// `provider` is a runtime-owned key (e.g. `kimi-code`, `xai-auth`) — never
+/// provider bytes. `label` must be one of OUR constants (typically from
+/// [`vetted_proxy_error_label`]); an unknown label is treated as absent.
+pub fn humanize_proxy_status_error(
+    provider: &str,
+    status: u16,
+    label: Option<&str>,
+) -> Option<String> {
+    let label = label.and_then(|l| VETTED_PROXY_ERROR_TYPES.iter().find(|t| **t == l).copied());
+    match (status, label?) {
+        (403, "access_terminated_error") => {
+            let mut msg = format!(
+                "{provider}: usage quota exhausted (HTTP 403). Your plan's usage window is used up — \
+                 wait for the reset or upgrade, or switch models with /model."
+            );
+            if provider == "kimi-code" {
+                msg.push_str(
+                    " Kimi Code quotas are weekly; `synaps status` or the Kimi membership page \
+                     shows the reset time.",
+                );
+            }
+            Some(msg)
+        }
+        (401, "invalid_authentication_error" | "authentication_error" | "invalid_api_key") => {
+            Some(format!(
+                "{provider}: authentication rejected (HTTP 401). Run `synaps login --provider {provider}`."
+            ))
+        }
+        (429, "rate_limit_error") => Some(format!(
+            "{provider}: rate limited (HTTP 429). Wait for the limit to reset, or switch models with /model."
+        )),
+        (429, "insufficient_quota" | "quota_exceeded") => Some(format!(
+            "{provider}: usage quota exhausted (HTTP 429). Add credit or wait for the quota to reset, \
+             or switch models with /model."
+        )),
+        _ => None,
+    }
+}
+
 /// Classification-only peek at the untrusted error body: true when it
 /// contains the given fixed pattern. The body text itself is never emitted.
 fn body_mentions(body: &str, pattern: &str) -> bool {
@@ -179,6 +276,160 @@ pub type Result<T> = std::result::Result<T, RuntimeError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const KIMI_403_BODY: &str = r#"{"error":{"type":"access_terminated_error","message":"You've reached your weekly (7-day) usage limit. Your quota will reset when the current 7-day window ends."}}"#;
+
+    #[test]
+    fn proxy_labels_never_contain_colon_and_are_superset_of_anthropic() {
+        for label in VETTED_PROXY_ERROR_TYPES {
+            assert!(
+                !label.contains(':'),
+                "label {label:?} would be truncated by the engine"
+            );
+            assert!(
+                !label.contains('['),
+                "label {label:?} breaks the [label] suffix"
+            );
+        }
+        for label in VETTED_ERROR_TYPES {
+            assert!(
+                VETTED_PROXY_ERROR_TYPES.contains(label),
+                "proxy list must be a superset: missing {label}"
+            );
+        }
+    }
+
+    #[test]
+    fn proxy_label_reads_error_type() {
+        assert_eq!(
+            vetted_proxy_error_label(KIMI_403_BODY),
+            Some("access_terminated_error")
+        );
+    }
+
+    #[test]
+    fn proxy_label_falls_back_to_error_code_then_top_level() {
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"code":"invalid_api_key","message":"x"}}"#),
+            Some("invalid_api_key")
+        );
+        // error.type present but unvetted → fall through to error.code.
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"type":"weird","code":"insufficient_quota"}}"#),
+            Some("insufficient_quota")
+        );
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"type":"server_error"}"#),
+            Some("server_error")
+        );
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"code":"model_not_found"}"#),
+            Some("model_not_found")
+        );
+    }
+
+    #[test]
+    fn proxy_label_rejects_non_string_non_json_and_hostile_values() {
+        assert_eq!(vetted_proxy_error_label(r#"{"error":{"type":42}}"#), None);
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"code":["a"]}}"#),
+            None
+        );
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"type":"<script>ECHO:secret"}}"#),
+            None
+        );
+        // Prefix/suffix variants must not match — exact only.
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"type":"access_terminated_error2"}}"#),
+            None
+        );
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"type":"Access_Terminated_Error"}}"#),
+            None
+        );
+        assert_eq!(vetted_proxy_error_label("<html>403 Forbidden</html>"), None);
+        assert_eq!(vetted_proxy_error_label(""), None);
+        // Truncated JSON (oversized body cut at the cap) must not parse.
+        assert_eq!(vetted_proxy_error_label(&KIMI_403_BODY[..40]), None);
+    }
+
+    #[test]
+    fn humanize_proxy_403_access_terminated_is_quota_not_auth() {
+        let msg = humanize_proxy_status_error("kimi-code", 403, Some("access_terminated_error"))
+            .expect("known combo");
+        assert!(
+            msg.starts_with("kimi-code: usage quota exhausted (HTTP 403)"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("/model"), "got: {msg}");
+        assert!(msg.contains("weekly"), "kimi-specific hint missing: {msg}");
+        assert!(msg.contains("synaps status"), "got: {msg}");
+        assert!(
+            !msg.contains("login"),
+            "quota must not be misreported as auth: {msg}"
+        );
+
+        let generic = humanize_proxy_status_error("xai-auth", 403, Some("access_terminated_error"))
+            .expect("known combo");
+        assert!(
+            generic.starts_with("xai-auth: usage quota exhausted (HTTP 403)"),
+            "got: {generic}"
+        );
+        assert!(
+            !generic.contains("weekly"),
+            "kimi hint leaked to other provider: {generic}"
+        );
+    }
+
+    #[test]
+    fn humanize_proxy_401_points_to_provider_login() {
+        for label in [
+            "invalid_authentication_error",
+            "authentication_error",
+            "invalid_api_key",
+        ] {
+            let msg = humanize_proxy_status_error("xai-auth", 401, Some(label)).expect(label);
+            assert!(msg.contains("HTTP 401"), "got: {msg}");
+            assert!(
+                msg.contains("synaps login --provider xai-auth"),
+                "got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn humanize_proxy_429_distinguishes_rate_limit_from_quota() {
+        let rl = humanize_proxy_status_error("groq", 429, Some("rate_limit_error")).unwrap();
+        let q1 = humanize_proxy_status_error("groq", 429, Some("insufficient_quota")).unwrap();
+        let q2 = humanize_proxy_status_error("groq", 429, Some("quota_exceeded")).unwrap();
+        assert!(rl.contains("rate limited"), "got: {rl}");
+        assert!(q1.contains("quota exhausted"), "got: {q1}");
+        assert_eq!(q1, q2);
+        assert_ne!(rl, q1);
+    }
+
+    #[test]
+    fn humanize_proxy_unknown_combos_return_none() {
+        assert_eq!(humanize_proxy_status_error("kimi-code", 403, None), None);
+        assert_eq!(
+            humanize_proxy_status_error("kimi-code", 403, Some("rate_limit_error")),
+            None
+        );
+        assert_eq!(
+            humanize_proxy_status_error("kimi-code", 500, Some("server_error")),
+            None
+        );
+        assert_eq!(
+            humanize_proxy_status_error("kimi-code", 401, Some("access_terminated_error")),
+            None
+        );
+        // Unvetted label strings are treated as absent, never echoed.
+        assert_eq!(
+            humanize_proxy_status_error("kimi-code", 403, Some("<script>ECHO")),
+            None
+        );
+    }
 
     #[test]
     fn test_humanize_529_overloaded() {

--- a/crates/agent-engine/src/engine/commands.rs
+++ b/crates/agent-engine/src/engine/commands.rs
@@ -53,9 +53,12 @@ pub enum CommandResult {
     /// Error message.
     Error(String),
 
-    /// Model was changed.
+    /// Model was changed. `reasoning_clamped` is populated when the runtime
+    /// had to substitute the active reasoning level because the new model does
+    /// not support it (see `Runtime::try_set_model`).
     ModelChanged {
         model: String,
+        reasoning_clamped: Option<crate::runtime::ReasoningClamp>,
     },
 
     /// Thinking level was changed.
@@ -190,9 +193,12 @@ pub fn handle_engine_command(
         "memory" => return Some(memory_command(arg, runtime)),
         _ => {}
     }
-    let result = evaluate_engine_command(cmd, arg)?;
-    match &result {
-        CommandResult::ModelChanged { model } => runtime.set_model(model.clone()),
+    let mut result = evaluate_engine_command(cmd, arg)?;
+    match &mut result {
+        CommandResult::ModelChanged {
+            model,
+            reasoning_clamped,
+        } => *reasoning_clamped = runtime.set_model(model.clone()),
         CommandResult::ThinkingChanged { spec } => {
             // Validate and apply the spec against model capabilities BEFORE
             // mutating runtime. State is unchanged on Err.
@@ -222,6 +228,7 @@ pub fn evaluate_engine_command(cmd: &str, arg: &str) -> Option<CommandResult> {
     match cmd {
         "model" | "models" if !arg.is_empty() => Some(CommandResult::ModelChanged {
             model: arg.to_string(),
+            reasoning_clamped: None,
         }),
         "thinking" if !arg.is_empty() => match parse_thinking_arg(arg) {
             Ok(spec) => Some(CommandResult::ThinkingChanged { spec }),
@@ -385,7 +392,9 @@ mod tests {
     #[test]
     fn model_command_carries_model_name() {
         match evaluate_engine_command("model", "claude-sonnet-4-6") {
-            Some(CommandResult::ModelChanged { model }) => assert_eq!(model, "claude-sonnet-4-6"),
+            Some(CommandResult::ModelChanged { model, .. }) => {
+                assert_eq!(model, "claude-sonnet-4-6")
+            }
             other => panic!("expected ModelChanged, got {:?}", other),
         }
         assert!(matches!(
@@ -745,6 +754,40 @@ mod tests {
         }
         assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
         assert!(rt.is_reasoning_explicit());
+    }
+
+    /// `/model` onto a model that rejects the explicit level reports the clamp
+    /// so surfaces can tell the user, and leaves the runtime in a usable state.
+    #[test]
+    fn model_command_reports_reasoning_clamp_for_unsupported_explicit_level() {
+        let mut rt = crate::Runtime::new_headless();
+        handle_engine_command("thinking", "xhigh", &mut rt).expect("thinking applies");
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::XHigh);
+        match handle_engine_command("model", "xai-auth/grok-4.6", &mut rt) {
+            Some(CommandResult::ModelChanged {
+                model,
+                reasoning_clamped,
+            }) => {
+                assert_eq!(model, "xai-auth/grok-4.6");
+                assert_eq!(
+                    reasoning_clamped,
+                    Some(crate::runtime::ReasoningClamp {
+                        from: ReasoningLevel::XHigh,
+                        to: ReasoningLevel::High,
+                    })
+                );
+            }
+            other => panic!("expected ModelChanged, got {:?}", other),
+        }
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(rt.is_reasoning_explicit());
+        // Supported explicit level: no clamp reported.
+        match handle_engine_command("model", "xai-auth/grok-4.5", &mut rt) {
+            Some(CommandResult::ModelChanged {
+                reasoning_clamped, ..
+            }) => assert_eq!(reasoning_clamped, None),
+            other => panic!("expected ModelChanged, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/api.rs
+++ b/crates/agent-engine/src/runtime/api.rs
@@ -1026,7 +1026,8 @@ impl ApiMethods {
         {
             // Classify honestly: transport blips are API failures, not
             // config problems (incident: session 20260714-025948-3dab).
-            return result.map_err(crate::runtime::openai::net::provider_error_to_runtime);
+            return result
+                .map_err(|e| crate::runtime::openai::net::provider_error_to_runtime_for(model, e));
         }
         // Provider qualification is application identity; Anthropic's wire API
         // still receives its native bare model id.

--- a/crates/agent-engine/src/runtime/api_sync.rs
+++ b/crates/agent-engine/src/runtime/api_sync.rs
@@ -127,7 +127,8 @@ impl ApiMethods {
         {
             drop(tx);
             let _ = drain.await;
-            return result.map_err(crate::runtime::openai::net::provider_error_to_runtime);
+            return result
+                .map_err(|e| crate::runtime::openai::net::provider_error_to_runtime_for(model, e));
         }
         let qualified_model = model;
         let execution_plan = options
@@ -563,8 +564,9 @@ impl ApiMethods {
         {
             drop(tx);
             let _ = drain.await;
-            let response =
-                result.map_err(crate::runtime::openai::net::provider_error_to_runtime)?;
+            let response = result.map_err(|e| {
+                crate::runtime::openai::net::provider_error_to_runtime_for(model, e)
+            })?;
             return Ok(Self::concat_response_text(&response));
         }
         let model = model.strip_prefix("anthropic/").unwrap_or(model);

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -207,6 +207,14 @@ pub async fn emit_after_tool_call(
     crate::runtime::helpers::HelperMethods::truncate_tool_result(&post_hook, max_tool_output)
 }
 
+/// A reasoning-level substitution performed during a model change because the
+/// newly selected model does not support the previously active level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReasoningClamp {
+    pub from: agent_core::reasoning::ReasoningLevel,
+    pub to: agent_core::reasoning::ReasoningLevel,
+}
+
 /// The core runtime — manages API communication, tool execution, authentication,
 /// and streaming for all SynapsCLI binaries (chat, chatui, server, agent, watcher).
 #[derive(Clone)]
@@ -1104,15 +1112,23 @@ impl Runtime {
             .grant_worker_model(model)
     }
 
-    pub fn set_model(&mut self, model: String) {
-        let _ = self.try_set_model(model);
+    /// Infallible model change. Returns the reasoning clamp applied (if any)
+    /// when the current level is not supported by the new model; errors from
+    /// `try_set_model` are swallowed (model left unchanged).
+    pub fn set_model(&mut self, model: String) -> Option<ReasoningClamp> {
+        self.try_set_model(model).ok().flatten()
     }
 
     /// Apply a model change while preserving orchestration lifecycle invariants.
     /// Returns an error instead of mutating either model or policy when active
     /// workers still require collection/reconciliation or when the replacement
     /// foreground cannot produce a trusted manifestless policy snapshot.
-    pub fn try_set_model(&mut self, model: String) -> std::result::Result<(), String> {
+    /// On success, returns `Some(ReasoningClamp)` when an explicit reasoning
+    /// level had to be substituted because the new model does not support it.
+    pub fn try_set_model(
+        &mut self,
+        model: String,
+    ) -> std::result::Result<Option<ReasoningClamp>, String> {
         // Older model pickers passed the rendered health row back here, e.g.
         // `✅  339ms  groq/llama-3.3-70b`. Remove that exact decoration shape,
         // rather than searching inside the ID: provider-qualified IDs may
@@ -1185,7 +1201,39 @@ impl Runtime {
                 self.set_reasoning_level(level);
             }
         }
-        Ok(())
+        // An explicit level that the new model rejects would otherwise make
+        // every subsequent turn fail pre-network until the user runs
+        // `/thinking`. Substitute the nearest documented level instead, keeping
+        // the explicit provenance flag so later switches still honor the user.
+        Ok(self.clamp_reasoning_to_model())
+    }
+
+    /// If the current effective reasoning level fails validation against the
+    /// current model, replace it with the model's documented default (or the
+    /// first documented option that validates). The `explicit_reasoning` flag
+    /// is preserved. Returns the substitution performed, if any; leaves state
+    /// untouched (and returns `None`) when nothing validates.
+    fn clamp_reasoning_to_model(&mut self) -> Option<ReasoningClamp> {
+        use crate::runtime::openai::catalog::validation::{
+            default_level_for_model, thinking_options_for_model, validate_reasoning_mutation,
+        };
+        let model = self.model.as_str();
+        let from = self.reasoning_level();
+        if validate_reasoning_mutation(model, from).is_ok() {
+            return None;
+        }
+        let to = default_level_for_model(model)
+            .filter(|level| validate_reasoning_mutation(model, *level).is_ok())
+            .or_else(|| {
+                thinking_options_for_model(model)
+                    .iter()
+                    .filter_map(|opt| agent_core::reasoning::ReasoningLevel::parse(opt))
+                    .find(|level| validate_reasoning_mutation(model, *level).is_ok())
+            })?;
+        let explicit = self.explicit_reasoning;
+        self.set_reasoning_level(to);
+        self.explicit_reasoning = explicit;
+        Some(ReasoningClamp { from, to })
     }
 
     pub fn set_tools(&mut self, tools: ToolRegistry) {
@@ -1921,6 +1969,16 @@ impl Runtime {
             self.set_reasoning_level_explicit(level);
         } else if let Some(budget) = config.thinking_budget {
             self.set_thinking_budget_explicit(budget);
+        }
+        // A configured level the configured model rejects would boot into a
+        // permanently failing state; clamp exactly as `/model` does.
+        if let Some(clamp) = self.clamp_reasoning_to_model() {
+            tracing::warn!(
+                from = clamp.from.as_str(),
+                to = clamp.to.as_str(),
+                model = %self.model,
+                "configured reasoning level not supported by model; clamped"
+            );
         }
         self.context_window_override = config.context_window;
         self.compaction_model = config.compaction_model.clone();
@@ -4652,6 +4710,102 @@ mod set_reasoning_level_checked_tests {
             ReasoningLevel::Low,
             "explicit level must not be overwritten by the model default"
         );
+    }
+
+    /// Explicit level the new model rejects is clamped to the model default;
+    /// provenance stays explicit so later switches still honor the user.
+    #[test]
+    fn explicit_unsupported_level_is_clamped_to_model_default_on_switch() {
+        let mut rt = Runtime::new_headless();
+        rt.set_reasoning_level_explicit(ReasoningLevel::XHigh);
+        let clamp = rt
+            .try_set_model("xai-auth/grok-4.6".to_string())
+            .expect("model switch succeeds");
+        assert_eq!(
+            clamp,
+            Some(ReasoningClamp {
+                from: ReasoningLevel::XHigh,
+                to: ReasoningLevel::High,
+            })
+        );
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(
+            rt.is_reasoning_explicit(),
+            "clamp keeps explicit provenance"
+        );
+        assert_eq!(rt.model(), "xai-auth/grok-4.6");
+    }
+
+    /// Explicit level the new model supports is left alone: no clamp reported.
+    #[test]
+    fn explicit_supported_level_is_not_clamped_on_switch() {
+        let mut rt = Runtime::new_headless();
+        rt.set_reasoning_level_explicit(ReasoningLevel::High);
+        let clamp = rt.try_set_model("xai-auth/grok-4.6".to_string()).unwrap();
+        assert_eq!(clamp, None);
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(rt.is_reasoning_explicit());
+    }
+
+    /// Non-explicit levels keep taking the new model's default (unchanged
+    /// behavior) and report no clamp — the default is applied, not substituted.
+    #[test]
+    fn non_explicit_default_application_reports_no_clamp() {
+        let mut rt = Runtime::new_headless();
+        rt.set_reasoning_level(ReasoningLevel::XHigh);
+        let clamp = rt.try_set_model("xai-auth/grok-4.6".to_string()).unwrap();
+        assert_eq!(clamp, None);
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(!rt.is_reasoning_explicit());
+    }
+
+    /// Explicit Max on an xAI model without Max support clamps to a level that
+    /// validates for that exact model (documented default Adaptive).
+    #[test]
+    fn explicit_max_clamps_to_validating_option_on_multi_agent_model() {
+        let model = "xai-auth/grok-4.20-multi-agent-0309";
+        let mut rt = Runtime::new_headless();
+        rt.set_reasoning_level_explicit(ReasoningLevel::Max);
+        let clamp = rt
+            .try_set_model(model.to_string())
+            .unwrap()
+            .expect("Max is not supported: must clamp");
+        assert_eq!(clamp.from, ReasoningLevel::Max);
+        assert!(
+            crate::runtime::openai::catalog::validation::validate_reasoning_mutation(
+                model, clamp.to
+            )
+            .is_ok(),
+            "clamped level {} must validate",
+            clamp.to
+        );
+        assert_eq!(rt.reasoning_level(), clamp.to);
+        assert!(rt.is_reasoning_explicit());
+    }
+
+    /// `set_model` (infallible wrapper) still surfaces the clamp.
+    #[test]
+    fn set_model_returns_clamp() {
+        let mut rt = Runtime::new_headless();
+        rt.set_reasoning_level_explicit(ReasoningLevel::XHigh);
+        let clamp = rt.set_model("xai-auth/grok-4.6".to_string());
+        assert_eq!(clamp.map(|c| c.to), Some(ReasoningLevel::High));
+    }
+
+    /// Boot path: config `model` + unsupported explicit `thinking` no longer
+    /// boots into a permanently failing state.
+    #[test]
+    fn apply_config_clamps_unsupported_explicit_level_against_config_model() {
+        let mut rt = Runtime::new_headless();
+        rt.apply_config(&crate::config::SynapsConfig {
+            model: Some("xai-auth/grok-4.6".to_string()),
+            thinking_level: Some(ReasoningLevel::XHigh),
+            ..Default::default()
+        });
+        assert_eq!(rt.model(), "xai-auth/grok-4.6");
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(rt.is_reasoning_explicit());
+        assert!(rt.set_reasoning_level_checked(rt.reasoning_level()).is_ok());
     }
 }
 

--- a/crates/agent-engine/src/runtime/openai/mod.rs
+++ b/crates/agent-engine/src/runtime/openai/mod.rs
@@ -290,6 +290,10 @@ pub async fn try_route(
                     max_tokens,
                     reasoning_level,
                     cancel,
+                    // In-stream capacity errors (HTTP 200 + lone `error`
+                    // event) are transient; re-send identical bytes with
+                    // the configured retry budget.
+                    max_retries,
                     trace,
                     exact_wire_bytes,
                 )

--- a/crates/agent-engine/src/runtime/openai/net.rs
+++ b/crates/agent-engine/src/runtime/openai/net.rs
@@ -24,7 +24,22 @@ pub type BoxedProviderError = Box<dyn std::error::Error + Send + Sync>;
 /// Classify an error escaping the OpenAI/Codex provider route into the
 /// right `RuntimeError` variant. Also logs the full cause chain at WARN —
 /// provider-route failures were previously invisible in the logs.
+///
+/// Provider-agnostic form: broker status labels are classified but not
+/// humanized. Prefer [`provider_error_to_runtime_for`] when the qualified
+/// model (and therefore the provider key) is known.
 pub fn provider_error_to_runtime(e: BoxedProviderError) -> RuntimeError {
+    provider_error_to_runtime_for("", e)
+}
+
+/// Like [`provider_error_to_runtime`], but `qualified_model` (e.g.
+/// `kimi-code/k3`) lets a vetted broker status label such as
+/// `provider request failed: 403 Forbidden [access_terminated_error]` be
+/// rendered as an actionable, provider-aware message. The label is one of
+/// OUR static constants (selected broker-side, never provider bytes) and the
+/// humanizer only ever returns our own text; the raw prefix message is kept
+/// for the log line.
+pub fn provider_error_to_runtime_for(qualified_model: &str, e: BoxedProviderError) -> RuntimeError {
     // Transport-level failure (connect / timeout / mid-stream drop)?
     if let Some(re) = find_reqwest_error(e.as_ref()) {
         let msg = humanize_provider_network_error(re);
@@ -45,11 +60,44 @@ pub fn provider_error_to_runtime(e: BoxedProviderError) -> RuntimeError {
         || is_responses_terminal_failure_message(&msg)
     {
         tracing::warn!(error = %msg, "provider API error");
+        if let Some(human) = humanize_broker_status_message(qualified_model, &msg) {
+            return RuntimeError::ApiStatus(human);
+        }
         return RuntimeError::ApiStatus(msg);
     }
 
     tracing::warn!(error = %msg, "provider config error");
     RuntimeError::Config(format!("openai provider: {msg}"))
+}
+
+/// Render a broker status failure carrying a vetted label as an actionable
+/// message. `None` when the message has no label, the label is unknown to
+/// the humanizer, or the provider key cannot be derived from the model.
+fn humanize_broker_status_message(qualified_model: &str, msg: &str) -> Option<String> {
+    let provider = qualified_model.split_once('/')?.0;
+    if provider.is_empty() {
+        return None;
+    }
+    let status = crate::runtime::trace::openai::broker_error_status(msg)?;
+    let label = broker_error_label(msg)?;
+    crate::core::error::humanize_proxy_status_error(provider, status, Some(label))
+}
+
+/// Extract the `[label]` the broker appends after the canonical reason
+/// phrase (`provider request failed: 403 Forbidden [access_terminated_error]`).
+/// Only identifier-shaped labels are accepted; anything else is `None`.
+pub(crate) fn broker_error_label(msg: &str) -> Option<&str> {
+    const MARKER: &str = "provider request failed: ";
+    let rest = &msg[msg.find(MARKER)? + MARKER.len()..];
+    let open = rest.find(" [")?;
+    let after = &rest[open + 2..];
+    let close = after.find(']')?;
+    let label = &after[..close];
+    (!label.is_empty()
+        && label
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_'))
+    .then_some(label)
 }
 
 /// Responses-API terminal stream failures are `"{label}{suffix}"` where the
@@ -270,6 +318,86 @@ mod tests {
                 .to_string()
                 .starts_with("Config error: openai provider: "),
             "must keep the historical prefix for genuine config errors: {runtime_err}"
+        );
+    }
+
+    /// A broker status failure carrying a vetted label is humanized into an
+    /// actionable, provider-aware message when the qualified model is known
+    /// — and never echoes anything but our own text.
+    #[test]
+    fn vetted_kimi_quota_label_is_humanized_for_known_provider() {
+        let raw = "openai request failed: broker transport error: provider request failed: 403 Forbidden [access_terminated_error]";
+        let err: BoxedProviderError = raw.into();
+        let runtime_err = provider_error_to_runtime_for("kimi-code/k3", err);
+        let RuntimeError::ApiStatus(msg) = runtime_err else {
+            panic!("expected ApiStatus, got {runtime_err:?}");
+        };
+        assert!(
+            msg.starts_with("kimi-code: usage quota exhausted (HTTP 403)"),
+            "{msg}"
+        );
+        assert!(msg.contains("weekly"), "{msg}");
+        assert!(
+            !msg.contains("login"),
+            "quota must not read as an auth failure: {msg}"
+        );
+        assert!(
+            !msg.contains("[access_terminated_error]"),
+            "label must be rendered, not leaked: {msg}"
+        );
+    }
+
+    /// Without a provider key (legacy entry point) or without a label the
+    /// raw, status-only prefix message is preserved verbatim.
+    #[test]
+    fn broker_status_without_label_or_provider_keeps_raw_message() {
+        let labelled = "openai request failed: broker transport error: provider request failed: 403 Forbidden [access_terminated_error]";
+        match provider_error_to_runtime(labelled.into()) {
+            RuntimeError::ApiStatus(msg) => assert_eq!(msg, labelled),
+            other => panic!("expected ApiStatus, got {other:?}"),
+        }
+        let plain =
+            "openai request failed: broker transport error: provider request failed: 403 Forbidden";
+        match provider_error_to_runtime_for("kimi-code/k3", plain.into()) {
+            RuntimeError::ApiStatus(msg) => assert_eq!(msg, plain),
+            other => panic!("expected ApiStatus, got {other:?}"),
+        }
+        // Unknown (status, label) combos also fall through unchanged.
+        let unknown =
+            "openai request failed: provider request failed: 418 I'm a teapot [server_error]";
+        match provider_error_to_runtime_for("groq/llama", unknown.into()) {
+            RuntimeError::ApiStatus(msg) => assert_eq!(msg, unknown),
+            other => panic!("expected ApiStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn broker_error_label_accepts_only_identifier_shaped_labels() {
+        assert_eq!(
+            broker_error_label(
+                "x: provider request failed: 403 Forbidden [access_terminated_error]"
+            ),
+            Some("access_terminated_error")
+        );
+        assert_eq!(
+            broker_error_label("provider request failed: 403 Forbidden"),
+            None
+        );
+        assert_eq!(
+            broker_error_label("provider request failed: 403 Forbidden []"),
+            None
+        );
+        assert_eq!(
+            broker_error_label("provider request failed: 403 Forbidden [<script>ECHO]"),
+            None
+        );
+        assert_eq!(
+            broker_error_label("provider request failed: 403 Forbidden [Mixed-Case]"),
+            None
+        );
+        assert_eq!(
+            broker_error_label("no marker here [access_terminated_error]"),
+            None
         );
     }
 }

--- a/crates/agent-engine/src/runtime/openai/net.rs
+++ b/crates/agent-engine/src/runtime/openai/net.rs
@@ -42,10 +42,7 @@ pub fn provider_error_to_runtime(e: BoxedProviderError) -> RuntimeError {
     // terminal stream failure — API failures, not configuration errors.
     if msg.starts_with("codex request failed:")
         || msg.starts_with("openai request failed:")
-        || msg.starts_with("Codex response failed in stream.")
-        || msg.starts_with("Codex response was incomplete.")
-        || msg.starts_with("Codex completed without text or tool output.")
-        || msg.starts_with("Codex response stream ended without a terminal event.")
+        || is_responses_terminal_failure_message(&msg)
     {
         tracing::warn!(error = %msg, "provider API error");
         return RuntimeError::ApiStatus(msg);
@@ -53,6 +50,29 @@ pub fn provider_error_to_runtime(e: BoxedProviderError) -> RuntimeError {
 
     tracing::warn!(error = %msg, "provider config error");
     RuntimeError::Config(format!("openai provider: {msg}"))
+}
+
+/// Responses-API terminal stream failures are `"{label}{suffix}"` where the
+/// label is a provider display name ("Codex", "xAI") and the suffix is one of
+/// the static templates in `stream.rs`. Match label-independently on the
+/// suffix so every provider label classifies as an API failure.
+fn is_responses_terminal_failure_message(msg: &str) -> bool {
+    use super::stream::{
+        RESPONSES_CAPACITY_SUFFIX, RESPONSES_CONTEXT_SUFFIX, RESPONSES_EMPTY_SUFFIX,
+        RESPONSES_FAILED_SUFFIX, RESPONSES_INCOMPLETE_SUFFIX, RESPONSES_MISSING_TERMINAL_SUFFIX,
+    };
+    const SUFFIXES: &[&str] = &[
+        RESPONSES_FAILED_SUFFIX,
+        RESPONSES_CAPACITY_SUFFIX,
+        RESPONSES_CONTEXT_SUFFIX,
+        RESPONSES_INCOMPLETE_SUFFIX,
+        RESPONSES_EMPTY_SUFFIX,
+        RESPONSES_MISSING_TERMINAL_SUFFIX,
+    ];
+    SUFFIXES.iter().any(|suffix| {
+        msg.strip_suffix(suffix)
+            .is_some_and(|label| !label.is_empty() && !label.contains(char::is_whitespace))
+    })
 }
 
 /// Walk the boxed error and its source chain looking for a `reqwest::Error`.
@@ -166,6 +186,13 @@ mod tests {
             "Codex response was incomplete. Retry the request or reduce the requested output/context size.",
             "Codex completed without text or tool output. Retry the request.",
             "Codex response stream ended without a terminal event. Retry the request.",
+            "Codex rejected the request: the conversation exceeds this model's context window. Run /compact or start a fresh session to continue.",
+            // xAI-labelled variants (xai-auth Responses route).
+            "xAI response failed in stream. Provider error details withheld because they can echo request content.",
+            "xAI reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model.",
+            "xAI completed without text or tool output. Retry the request.",
+            "xAI response stream ended without a terminal event. Retry the request.",
+            "xAI response was incomplete. Retry the request or reduce the requested output/context size.",
         ] {
             let err = provider_error_to_runtime(msg.into());
             assert!(
@@ -174,6 +201,21 @@ mod tests {
             );
             assert!(!err.to_string().starts_with("Config error"));
         }
+    }
+
+    /// A message that merely mentions a suffix mid-sentence (or carries a
+    /// non-label prefix) must not be mistaken for a Responses terminal.
+    #[test]
+    fn responses_terminal_matcher_requires_bare_label_prefix() {
+        assert!(!is_responses_terminal_failure_message(
+            "No API key for 'xai'. response failed in stream."
+        ));
+        assert!(!is_responses_terminal_failure_message(
+            " response failed in stream. Provider error details withheld because they can echo request content."
+        ));
+        assert!(is_responses_terminal_failure_message(
+            "xAI reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model."
+        ));
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/openai/stream.rs
+++ b/crates/agent-engine/src/runtime/openai/stream.rs
@@ -883,14 +883,65 @@ fn codex_input_messages(messages: Vec<ChatMessage>) -> Vec<Value> {
     out
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct ResponsesStreamFailure {
     code: &'static str,
-    message: &'static str,
+    /// User-facing text built from OUR static templates plus the provider
+    /// display label — never provider free-text.
+    message: String,
 }
 
-#[derive(Default)]
+impl ResponsesStreamFailure {
+    /// Terminal failures that are transient by nature and safe to re-send
+    /// with identical request bytes: provider capacity exhaustion, an empty
+    /// completion, or a stream that ended without any terminal event.
+    fn is_retryable(&self) -> bool {
+        matches!(
+            self.code,
+            "responses_capacity" | "responses_empty" | "responses_missing_terminal"
+        )
+    }
+}
+
+/// Sanitized provider error codes that mean "try again later" on the
+/// Responses wire. Classification-only: the code is matched against this
+/// fixed set, never echoed beyond the local sanitized log line.
+const CAPACITY_ERROR_CODES: &[&str] = &[
+    "rate_limit_exceeded",
+    "server_overloaded",
+    "overloaded",
+    "capacity",
+    "server_error",
+];
+
+/// Fixed substrings that mark a provider free-text error message as a
+/// transient capacity condition (xAI: "The model is currently at capacity
+/// due to high demand. Please try again in a few minutes…"). The message is
+/// consulted ONLY to produce a boolean — it is never logged, stored, or
+/// surfaced (privacy invariant: provider bodies can echo request content).
+const CAPACITY_MESSAGE_PATTERNS: &[&str] = &[
+    "at capacity",
+    "high demand",
+    "try again in a few minutes",
+    "overloaded",
+];
+
+/// Classification-only capacity check. `error_code` is already sanitized;
+/// `message` is raw provider text used solely as a boolean signal.
+fn is_capacity_failure(error_code: &str, message: Option<&str>) -> bool {
+    if CAPACITY_ERROR_CODES.contains(&error_code) {
+        return true;
+    }
+    message.is_some_and(|m| {
+        let lower = m.to_ascii_lowercase();
+        CAPACITY_MESSAGE_PATTERNS.iter().any(|p| lower.contains(p))
+    })
+}
+
 struct CodexSseDecoder {
+    /// Provider display label used in user-facing terminal messages
+    /// ("Codex", "xAI"). Static, ours — never provider-supplied.
+    provider_label: &'static str,
     buffer: String,
     active_tools: Vec<CodexToolAccumulator>,
     completed_tools: Vec<ToolCall>,
@@ -906,6 +957,12 @@ struct CodexSseDecoder {
     /// Trace (Task 10A): provider-reported usage from `response.completed`
     /// (input including cached, output, cached slice). `None` until observed.
     observed_usage: Option<(u64, u64, u64)>,
+}
+
+impl Default for CodexSseDecoder {
+    fn default() -> Self {
+        Self::for_provider("Codex")
+    }
 }
 
 #[derive(Default)]
@@ -966,21 +1023,67 @@ fn sanitize_error_identifier(raw: Option<&str>) -> &str {
     }
 }
 
-/// Map a Codex terminal failure to a user-facing message. Only reacts to the
-/// already-sanitized enum identifiers (`error.type` / `error.code`) — never to
-/// provider free-text — so no request content can leak. Known, user-actionable
-/// conditions get a specific remedy; everything else keeps the neutral,
-/// details-withheld default.
-fn user_message_for_terminal_failure(error_kind: &str, error_code: &str) -> &'static str {
+/// Static message suffixes for Responses terminal failures. The provider
+/// display label is prefixed at construction; `net.rs` classifies on these
+/// label-independent suffixes so every label maps to `ApiStatus`.
+pub(crate) const RESPONSES_FAILED_SUFFIX: &str =
+    " response failed in stream. Provider error details withheld because they can echo request content.";
+pub(crate) const RESPONSES_CONTEXT_SUFFIX: &str = " rejected the request: the conversation exceeds this model's context window. Run /compact or start a fresh session to continue.";
+pub(crate) const RESPONSES_CAPACITY_SUFFIX: &str = " reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model.";
+pub(crate) const RESPONSES_INCOMPLETE_SUFFIX: &str =
+    " response was incomplete. Retry the request or reduce the requested output/context size.";
+pub(crate) const RESPONSES_EMPTY_SUFFIX: &str =
+    " completed without text or tool output. Retry the request.";
+pub(crate) const RESPONSES_MISSING_TERMINAL_SUFFIX: &str =
+    " response stream ended without a terminal event. Retry the request.";
+
+/// Map a Responses terminal failure to a user-facing message. Only reacts to
+/// the already-sanitized enum identifiers (`error.type` / `error.code`) and
+/// the boolean capacity classification — never to provider free-text — so no
+/// request content can leak. Known, user-actionable conditions get a specific
+/// remedy; everything else keeps the neutral, details-withheld default.
+fn user_message_for_terminal_failure(
+    label: &str,
+    error_kind: &str,
+    error_code: &str,
+    capacity: bool,
+) -> String {
     // Context-window overflow is deterministic and user-fixable: the turn
     // cannot succeed until the conversation is smaller.
     if error_code == "context_length_exceeded" || error_kind == "context_length_exceeded" {
-        return "Codex rejected the request: the conversation exceeds this model's context window. Run /compact or start a fresh session to continue.";
+        return format!("{label}{RESPONSES_CONTEXT_SUFFIX}");
     }
-    "Codex response failed in stream. Provider error details withheld because they can echo request content."
+    if capacity {
+        return format!("{label}{RESPONSES_CAPACITY_SUFFIX}");
+    }
+    format!("{label}{RESPONSES_FAILED_SUFFIX}")
 }
 
 impl CodexSseDecoder {
+    /// Decoder whose user-facing messages name `label` as the provider.
+    fn for_provider(label: &'static str) -> Self {
+        Self {
+            provider_label: label,
+            buffer: String::new(),
+            active_tools: Vec::new(),
+            completed_tools: Vec::new(),
+            saw_model_event: false,
+            terminal_success: false,
+            terminal_failure: None,
+            emitted_output: false,
+            observed_usage: None,
+        }
+    }
+
+    /// True once anything was streamed to the UI for this attempt (text
+    /// deltas, tool starts, or completed tools). A retry after this point
+    /// would duplicate output, so callers must treat the failure as terminal.
+    fn emitted_any_output(&self) -> bool {
+        self.emitted_output
+            || !self.completed_tools.is_empty()
+            || self.active_tools.iter().any(|tool| tool.started)
+    }
+
     fn push_line(
         &mut self,
         line: &str,
@@ -1099,10 +1202,17 @@ impl CodexSseDecoder {
                 // identifiers (`type` / `code`) after sanitizing them down to a
                 // short identifier charset. The free-text `message` field is
                 // never logged or surfaced — it can echo request content.
+                //
+                // Two envelope shapes are accepted: the nested Responses form
+                // (`response.error.{type,code,message}` / `error.{…}`) and
+                // xAI's flat form (`{"type":"error","code":…,"message":…}`)
+                // where the event's own `type` is just "error", so only the
+                // top-level `code` is a meaningful identifier there.
                 let error_obj = event
                     .get("response")
                     .and_then(|r| r.get("error"))
-                    .or_else(|| event.get("error"));
+                    .or_else(|| event.get("error"))
+                    .filter(|e| e.is_object());
                 let error_kind = sanitize_error_identifier(
                     error_obj
                         .and_then(|e| e.get("type"))
@@ -1111,17 +1221,38 @@ impl CodexSseDecoder {
                 let error_code = sanitize_error_identifier(
                     error_obj
                         .and_then(|e| e.get("code"))
+                        .or_else(|| event.get("code"))
+                        .and_then(Value::as_str),
+                );
+                // Provider free-text: classification-only boolean, never
+                // retained past this expression.
+                let capacity = is_capacity_failure(
+                    error_code,
+                    error_obj
+                        .and_then(|e| e.get("message"))
+                        .or_else(|| event.get("message"))
                         .and_then(Value::as_str),
                 );
                 tracing::warn!(
+                    provider = self.provider_label,
                     event_type,
                     error_kind,
                     error_code,
-                    "codex stream terminal failure (provider message withheld)"
+                    capacity,
+                    "responses stream terminal failure (provider message withheld)"
                 );
                 self.terminal_failure = Some(ResponsesStreamFailure {
-                    code: "responses_failed",
-                    message: user_message_for_terminal_failure(error_kind, error_code),
+                    code: if capacity {
+                        "responses_capacity"
+                    } else {
+                        "responses_failed"
+                    },
+                    message: user_message_for_terminal_failure(
+                        self.provider_label,
+                        error_kind,
+                        error_code,
+                        capacity,
+                    ),
                 });
                 self.finish();
             }
@@ -1134,10 +1265,14 @@ impl CodexSseDecoder {
                         .and_then(|d| d.get("reason"))
                         .and_then(Value::as_str),
                 );
-                tracing::warn!(reason, "codex stream terminal incomplete");
+                tracing::warn!(
+                    provider = self.provider_label,
+                    reason,
+                    "responses stream terminal incomplete"
+                );
                 self.terminal_failure = Some(ResponsesStreamFailure {
                     code: "responses_incomplete",
-                    message: "Codex response was incomplete. Retry the request or reduce the requested output/context size.",
+                    message: format!("{}{RESPONSES_INCOMPLETE_SUFFIX}", self.provider_label),
                 });
                 self.finish();
             }
@@ -1150,8 +1285,8 @@ impl CodexSseDecoder {
     }
 
     fn terminal_result(&self) -> Result<(), ResponsesStreamFailure> {
-        if let Some(failure) = self.terminal_failure {
-            return Err(failure);
+        if let Some(failure) = &self.terminal_failure {
+            return Err(failure.clone());
         }
         if self.terminal_success {
             if self.emitted_output || !self.completed_tools.is_empty() {
@@ -1159,13 +1294,13 @@ impl CodexSseDecoder {
             } else {
                 Err(ResponsesStreamFailure {
                     code: "responses_empty",
-                    message: "Codex completed without text or tool output. Retry the request.",
+                    message: format!("{}{RESPONSES_EMPTY_SUFFIX}", self.provider_label),
                 })
             }
         } else {
             Err(ResponsesStreamFailure {
                 code: "responses_missing_terminal",
-                message: "Codex response stream ended without a terminal event. Retry the request.",
+                message: format!("{}{RESPONSES_MISSING_TERMINAL_SUFFIX}", self.provider_label),
             })
         }
     }
@@ -1886,19 +2021,133 @@ mod codex_decoder_tests {
     #[test]
     fn terminal_failure_user_message_is_specific_only_for_known_codes() {
         assert!(user_message_for_terminal_failure(
+            "Codex",
             "invalid_request_error",
-            "context_length_exceeded"
+            "context_length_exceeded",
+            false
         )
         .contains("/compact"));
         // Code carried on `type` rather than `code` still maps.
-        assert!(
-            user_message_for_terminal_failure("context_length_exceeded", "absent")
-                .contains("context window")
-        );
+        assert!(user_message_for_terminal_failure(
+            "Codex",
+            "context_length_exceeded",
+            "absent",
+            false
+        )
+        .contains("context window"));
         // Unknown/other codes keep the neutral default (no remedy claim).
-        let default = user_message_for_terminal_failure("server_error", "unlisted_identifier");
+        let default = user_message_for_terminal_failure(
+            "Codex",
+            "server_error",
+            "unlisted_identifier",
+            false,
+        );
         assert!(default.starts_with("Codex response failed in stream."));
         assert!(!default.contains("/compact"));
+        // Capacity gets the specific remedy, labelled for the provider.
+        let capacity = user_message_for_terminal_failure("xAI", "absent", "absent", true);
+        assert_eq!(
+            capacity,
+            "xAI reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model."
+        );
+    }
+
+    /// The exact flat envelope xAI emits (HTTP 200, one SSE event, close):
+    /// no nested `error` object, `code` null, free-text `message`. It must
+    /// classify as retryable capacity — labelled for the provider, and the
+    /// provider prose must never reach the surfaced message.
+    #[test]
+    fn xai_flat_capacity_error_is_retryable_capacity_failure() {
+        let lines = [
+            r#"data: {"sequence_number":0,"type":"error","code":null,"message":"The model is currently at capacity due to high demand. Please try again in a few minutes, or use a higher service tier for priority processing: https://docs.x.ai/developers/advanced-api-usage/priority-processing","param":null}"#,
+            "",
+        ];
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut decoder = CodexSseDecoder::for_provider("xAI");
+        let mut text = String::new();
+        for line in lines {
+            decoder.push_line(line, &tx, &mut text);
+        }
+        decoder.finish();
+        let failure = decoder.terminal_result().expect_err("must fail");
+        assert_eq!(failure.code, "responses_capacity");
+        assert!(failure.is_retryable());
+        assert_eq!(
+            failure.message,
+            "xAI reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model."
+        );
+        for banned in ["high demand", "docs.x.ai", "service tier", "Codex"] {
+            assert!(
+                !failure.message.contains(banned),
+                "provider text `{banned}` leaked: {}",
+                failure.message
+            );
+        }
+        assert!(text.is_empty());
+        assert!(!decoder.emitted_any_output());
+        assert!(rx.try_recv().is_err(), "no events for an error-only stream");
+    }
+
+    /// Flat `code` identifiers are honoured when no nested error object is
+    /// present; only vetted codes classify as capacity.
+    #[test]
+    fn flat_code_classifies_capacity_only_for_vetted_codes() {
+        let capacity = [
+            r#"data: {"type":"error","code":"rate_limit_exceeded","message":"private"}"#,
+            "",
+        ];
+        let (decoder, _, _) = drive(&capacity);
+        let failure = decoder.terminal_result().expect_err("must fail");
+        assert_eq!(failure.code, "responses_capacity");
+        assert!(failure.is_retryable());
+
+        let other = [
+            r#"data: {"type":"error","code":"invalid_api_key","message":"private"}"#,
+            "",
+        ];
+        let (decoder, _, _) = drive(&other);
+        let failure = decoder.terminal_result().expect_err("must fail");
+        assert_eq!(failure.code, "responses_failed");
+        assert!(!failure.is_retryable());
+        assert!(!failure.message.contains("private"));
+    }
+
+    #[test]
+    fn provider_label_is_carried_into_every_terminal_message() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut text = String::new();
+        let mut decoder = CodexSseDecoder::for_provider("xAI");
+        decoder.push_line(
+            r#"data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":0}}}"#,
+            &tx,
+            &mut text,
+        );
+        decoder.push_line("", &tx, &mut text);
+        let failure = decoder.terminal_result().expect_err("empty");
+        assert_eq!(failure.code, "responses_empty");
+        assert!(failure.is_retryable());
+        assert_eq!(
+            failure.message,
+            "xAI completed without text or tool output. Retry the request."
+        );
+
+        let decoder = CodexSseDecoder::for_provider("xAI");
+        let failure = decoder.terminal_result().expect_err("missing terminal");
+        assert_eq!(failure.code, "responses_missing_terminal");
+        assert!(failure.is_retryable());
+        assert!(failure.message.starts_with("xAI response stream ended"));
+
+        let mut decoder = CodexSseDecoder::for_provider("xAI");
+        decoder.push_line(
+            r#"data: {"type":"response.incomplete","response":{"incomplete_details":{"reason":"max_output_tokens"}}}"#,
+            &tx,
+            &mut text,
+        );
+        decoder.push_line("", &tx, &mut text);
+        let failure = decoder.terminal_result().expect_err("incomplete");
+        assert_eq!(failure.code, "responses_incomplete");
+        assert!(!failure.is_retryable());
+        assert!(failure.message.starts_with("xAI response was incomplete."));
     }
 
     #[test]
@@ -2209,6 +2458,9 @@ mod broker_stream_tests {
     }
 }
 
+/// Provider display label for the xai-auth Responses route.
+const XAI_PROVIDER_LABEL: &str = "xAI";
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn call_xai_responses_stream_inner(
     cfg: &ProviderConfig,
@@ -2220,6 +2472,7 @@ pub(crate) async fn call_xai_responses_stream_inner(
     max_tokens: Option<u32>,
     reasoning_level: agent_core::reasoning::ReasoningLevel,
     cancel: &tokio_util::sync::CancellationToken,
+    max_retries: u32,
     trace: &crate::runtime::trace::TraceContext,
     exact_wire_bytes: bool,
 ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
@@ -2250,7 +2503,9 @@ pub(crate) async fn call_xai_responses_stream_inner(
     // the very bytes the broker sends upstream (`body_bytes` handoff,
     // LocalBroker verbatim) — `body`/`body_bytes` cannot diverge. On a
     // remote broker the daemon re-serializes out of process → honest
-    // `CloudProxy` kind and no wire-byte claim.
+    // `CloudProxy` kind and no wire-byte claim. Every retry clones this
+    // same request (identical `body` and `body_bytes`), so one wire digest
+    // is honest for all attempt records.
     let (proxy_request, body_bytes) =
         crate::auth::ProxyRequest::post_json_exact("xai-auth", "/responses", body, true)?;
     let tracer = tr::begin_openai_tracer(
@@ -2279,80 +2534,115 @@ pub(crate) async fn call_xai_responses_stream_inner(
         trace.capture_request_content(tracer.request_id(), body_bytes.as_ref());
     }
     let mut attempt = tr::StreamAttempt::new(tracer);
-    let stream = broker
-        .proxy_stream(proxy_request)
-        .await
-        // Privacy (spec §5.1): a broker proxy error may carry an upstream
-        // response-body snippet; redact it to status-only before surfacing.
-        .map_err(|e| super::net::redact_provider_proxy_error(&e.to_string()));
-    let mut stream = match stream {
-        Ok(stream) => {
-            attempt.mark_headers();
-            stream
-        }
-        Err(msg) => {
-            let status = tr::broker_error_status(&msg);
-            let code = status.map_or_else(|| "broker_error".to_string(), |s| format!("http_{s}"));
-            attempt.finish_failed(&code, status, None);
-            return Err(msg.into());
-        }
-    };
-    let mut text = String::new();
-    let mut parser = CodexSseDecoder::default();
-    let mut buf = bytes::BytesMut::new();
-    while let Some(chunk) = tokio::select! {
-        c = stream.next() => c,
-        _ = cancel.cancelled() => {
-            attempt.finish_canceled(None, parser.trace_usage());
-            return Err("request canceled".into());
-        }
-    } {
-        let chunk = match chunk {
-            Ok(chunk) => {
-                attempt.mark_first_byte();
-                chunk
+    let mut stream_retry = 0u32;
+
+    loop {
+        let stream = broker
+            .proxy_stream(proxy_request.clone())
+            .await
+            // Privacy (spec §5.1): a broker proxy error may carry an upstream
+            // response-body snippet; redact it to status-only before surfacing.
+            .map_err(|e| super::net::redact_provider_proxy_error(&e.to_string()));
+        let mut stream = match stream {
+            Ok(stream) => {
+                attempt.mark_headers();
+                stream
             }
-            Err(e) => {
-                attempt.finish_failed("stream_error", None, None);
-                return Err(e.into());
+            Err(msg) => {
+                let status = tr::broker_error_status(&msg);
+                let code =
+                    status.map_or_else(|| "broker_error".to_string(), |s| format!("http_{s}"));
+                attempt.finish_failed(&code, status, None);
+                return Err(msg.into());
             }
         };
-        buf.extend_from_slice(&chunk);
-        while let Some(n) = memchr::memchr(b'\n', &buf) {
-            let line = buf.split_to(n + 1);
-            parser.push_line(std::str::from_utf8(&line[..n]).unwrap_or(""), tx, &mut text);
+        let mut text = String::new();
+        let mut parser = CodexSseDecoder::for_provider(XAI_PROVIDER_LABEL);
+        let mut buf = bytes::BytesMut::new();
+        while let Some(chunk) = tokio::select! {
+            c = stream.next() => c,
+            _ = cancel.cancelled() => {
+                attempt.finish_canceled(None, parser.trace_usage());
+                return Err("request canceled".into());
+            }
+        } {
+            let chunk = match chunk {
+                Ok(chunk) => {
+                    attempt.mark_first_byte();
+                    chunk
+                }
+                Err(e) => {
+                    attempt.finish_failed("stream_error", None, None);
+                    return Err(e.into());
+                }
+            };
+            buf.extend_from_slice(&chunk);
+            while let Some(n) = memchr::memchr(b'\n', &buf) {
+                let line = buf.split_to(n + 1);
+                parser.push_line(std::str::from_utf8(&line[..n]).unwrap_or(""), tx, &mut text);
+            }
+            if parser.saw_model_event {
+                attempt.mark_first_model_event();
+            }
         }
+        if !buf.is_empty() {
+            parser.push_line(std::str::from_utf8(&buf).unwrap_or(""), tx, &mut text);
+        }
+        parser.finish();
+        // Trailing-buffer flush and finish() can surface the first (or only)
+        // model event; mark it so first_model_event_ms is honest for tail-only
+        // streams (mirrors the Codex direct path above).
         if parser.saw_model_event {
             attempt.mark_first_model_event();
         }
+        // Broker paths never observe the upstream HTTP status; the Responses
+        // stream does not yet expose a normalized stop reason — both stay
+        // honest `None` rather than guessed values.
+        if let Err(failure) = parser.terminal_result() {
+            // xAI answers HTTP 200 + a lone `{"type":"error",…}` capacity
+            // event while the model is saturated; a re-send seconds later
+            // usually succeeds. Retry only when NOTHING reached the UI on
+            // this attempt — text or tool events already streamed would be
+            // emitted twice on a re-send, so those failures stay terminal.
+            let output_already_streamed = !text.is_empty() || parser.emitted_any_output();
+            if failure.is_retryable() && !output_already_streamed && stream_retry < max_retries {
+                stream_retry += 1;
+                let delay = retry_delay(stream_retry);
+                attempt.attempt_failed(
+                    crate::runtime::trace::RetryClass::Other,
+                    delay,
+                    None,
+                    None,
+                    failure.code,
+                );
+                tracing::warn!(
+                    code = failure.code,
+                    "xai stream retry {stream_retry}/{max_retries} after {delay:?}"
+                );
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    _ = cancel.cancelled() => {
+                        attempt.finish_canceled(None, None);
+                        return Err("request canceled".into());
+                    }
+                }
+                attempt.restart_clock();
+                continue;
+            }
+            attempt.finish_failed(failure.code, None, None);
+            return Err(failure.message.into());
+        }
+        attempt.finish_success(None, None, None, parser.trace_usage());
+        let mut content = Vec::new();
+        if !text.is_empty() {
+            content.push(json!({"type":"text","text":text}));
+        }
+        content.extend(translate::tool_calls_to_content_blocks(
+            &parser.completed_tools,
+            &names,
+        ));
+        return Ok(json!({"role":"assistant","content":content}));
     }
-    if !buf.is_empty() {
-        parser.push_line(std::str::from_utf8(&buf).unwrap_or(""), tx, &mut text);
-    }
-    parser.finish();
-    // Trailing-buffer flush and finish() can surface the first (or only)
-    // model event; mark it so first_model_event_ms is honest for tail-only
-    // streams (mirrors the Codex direct path above).
-    if parser.saw_model_event {
-        attempt.mark_first_model_event();
-    }
-    // Broker paths never observe the upstream HTTP status; the Responses
-    // stream does not yet expose a normalized stop reason — both stay
-    // honest `None` rather than guessed values.
-    if let Err(failure) = parser.terminal_result() {
-        attempt.finish_failed(failure.code, None, None);
-        return Err(failure.message.into());
-    }
-    attempt.finish_success(None, None, None, parser.trace_usage());
-    let mut content = Vec::new();
-    if !text.is_empty() {
-        content.push(json!({"type":"text","text":text}));
-    }
-    content.extend(translate::tool_calls_to_content_blocks(
-        &parser.completed_tools,
-        &names,
-    ));
-    Ok(json!({"role":"assistant","content":content}))
 }
 
 /// Pure, validated body construction for the xAI Responses API.
@@ -2519,6 +2809,243 @@ mod xai_tests {
         assert!(body.get("input").is_some());
         assert!(body.get("messages").is_none());
         assert!(body.get("max_output_tokens").is_none());
+    }
+}
+
+#[cfg(test)]
+mod xai_capacity_retry_tests {
+    //! Regression tests for the xai-auth Responses route: xAI answers HTTP
+    //! 200 + a lone flat `{"type":"error",…}` capacity event while the model
+    //! is saturated (reproduced live: grok-4.6 failed 3 of 4 turns, a re-send
+    //! seconds later succeeded). The route must retry with identical request
+    //! bytes, label its messages "xAI" (not "Codex"), and never surface the
+    //! provider prose. A scripted fake broker serves the SSE bodies directly
+    //! through `proxy_stream` — no HTTP server involved.
+
+    use super::*;
+    use agent_core::auth::{
+        AccessToken, BrokerError, ProxyByteStream, ProxyRequest, ProxyResponse,
+    };
+    use async_trait::async_trait;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    /// The exact envelope observed on the wire (flat: `type` is the event
+    /// type, `code` null, `message` top-level, no nested `error` object).
+    const XAI_CAPACITY_SSE: &str = "data: {\"sequence_number\":0,\"type\":\"error\",\"code\":null,\"message\":\"The model is currently at capacity due to high demand. Please try again in a few minutes, or use a higher service tier for priority processing: https://docs.x.ai/developers/advanced-api-usage/priority-processing\",\"param\":null}\n\n";
+
+    const XAI_SUCCESS_SSE: &str = concat!(
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\n\n",
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"GROK_OK\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":7,\"output_tokens\":2}}}\n\n",
+    );
+
+    /// Serves `bodies[n]` for the n-th `proxy_stream` call (the last body
+    /// repeats once exhausted) and records every request body it saw.
+    struct ScriptedXaiBroker {
+        bodies: Vec<&'static str>,
+        calls: Arc<AtomicUsize>,
+        seen: Arc<std::sync::Mutex<Vec<ProxyRequest>>>,
+    }
+
+    #[async_trait]
+    impl crate::auth::CredentialBroker for ScriptedXaiBroker {
+        async fn access_token(
+            &self,
+            _p: agent_core::auth::OAuthProviderId,
+        ) -> Result<AccessToken, BrokerError> {
+            Err(BrokerError::Denied(
+                "xai route must use proxy_stream".into(),
+            ))
+        }
+        async fn proxy(&self, _request: ProxyRequest) -> Result<ProxyResponse, BrokerError> {
+            Err(BrokerError::Denied("not implemented in stub".into()))
+        }
+        async fn proxy_stream(
+            &self,
+            request: ProxyRequest,
+        ) -> Result<ProxyByteStream, BrokerError> {
+            request.validate()?;
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            self.seen.lock().unwrap().push(request);
+            let body = self.bodies[n.min(self.bodies.len() - 1)];
+            Ok(Box::pin(futures::stream::iter(vec![Ok(
+                bytes::Bytes::from(body),
+            )])))
+        }
+        async fn anthropic_usage(&self) -> Result<serde_json::Value, BrokerError> {
+            Err(BrokerError::Denied("not implemented in stub".into()))
+        }
+        async fn capabilities(&self) -> Result<Vec<agent_core::auth::ProviderStatus>, BrokerError> {
+            Ok(vec![])
+        }
+    }
+
+    struct Run {
+        result: Result<Value, Box<dyn std::error::Error + Send + Sync>>,
+        calls: usize,
+        seen: Vec<ProxyRequest>,
+        events: Vec<StreamEvent>,
+    }
+
+    async fn run_xai(bodies: Vec<&'static str>, max_retries: u32) -> Run {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let broker: Arc<dyn crate::auth::CredentialBroker> = Arc::new(ScriptedXaiBroker {
+            bodies,
+            calls: Arc::clone(&calls),
+            seen: Arc::clone(&seen),
+        });
+        let cfg = ProviderConfig {
+            base_url: "https://api.x.ai/v1".to_string(),
+            model: "grok-4.5".to_string(),
+            provider: "xai-auth".to_string(),
+        };
+        let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
+        let result = call_xai_responses_stream_inner(
+            &cfg,
+            &broker,
+            &[],
+            &Some("system".to_string()),
+            &[],
+            &tx,
+            None,
+            agent_core::reasoning::ReasoningLevel::Adaptive,
+            &tokio_util::sync::CancellationToken::new(),
+            max_retries,
+            &crate::runtime::trace::TraceContext::disabled(),
+            true,
+        )
+        .await;
+        drop(tx);
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+        let seen = std::mem::take(&mut *seen.lock().unwrap());
+        Run {
+            result,
+            calls: calls.load(Ordering::SeqCst),
+            seen,
+            events,
+        }
+    }
+
+    fn text_events(events: &[StreamEvent]) -> Vec<String> {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::Llm(crate::runtime::types::LlmEvent::Text(t)) => Some(t.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn xai_capacity_error_is_retried_with_identical_bytes_then_succeeds() {
+        let run = run_xai(vec![XAI_CAPACITY_SSE, XAI_SUCCESS_SSE], 3).await;
+        let value = run.result.expect("second attempt must succeed");
+        assert_eq!(value["content"][0]["text"], "GROK_OK");
+        assert_eq!(run.calls, 2, "exactly one retry");
+        assert_eq!(run.seen.len(), 2);
+        assert_eq!(
+            run.seen[0].body_bytes, run.seen[1].body_bytes,
+            "retry must re-send the identical serialized body"
+        );
+        assert_eq!(run.seen[0].body, run.seen[1].body);
+        assert_eq!(run.seen[0].provider, "xai-auth");
+        assert_eq!(run.seen[0].path, "/responses");
+        // No output was streamed twice: the failed attempt emitted nothing.
+        assert_eq!(text_events(&run.events), vec!["GROK_OK".to_string()]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn xai_capacity_error_with_zero_retries_surfaces_xai_capacity_message() {
+        let run = run_xai(vec![XAI_CAPACITY_SSE], 0).await;
+        let err = run.result.expect_err("no retry budget → terminal");
+        let msg = err.to_string();
+        assert_eq!(
+            msg,
+            "xAI reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model."
+        );
+        assert_eq!(run.calls, 1);
+        for banned in ["Codex", "high demand", "docs.x.ai", "service tier"] {
+            assert!(!msg.contains(banned), "`{banned}` leaked: {msg}");
+        }
+        // And the runtime classifies it as an API failure, not a config one.
+        assert!(matches!(
+            super::super::net::provider_error_to_runtime(err),
+            crate::RuntimeError::ApiStatus(_)
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn xai_capacity_error_exhausting_budget_counts_every_attempt() {
+        let run = run_xai(vec![XAI_CAPACITY_SSE], 2).await;
+        let err = run.result.expect_err("persistent capacity → terminal");
+        assert!(err
+            .to_string()
+            .starts_with("xAI reports the model is at capacity"));
+        assert_eq!(run.calls, 3, "initial attempt + 2 retries");
+        assert!(text_events(&run.events).is_empty());
+    }
+
+    /// If the failed attempt already streamed text, a re-send would duplicate
+    /// it in the UI — the failure must stay terminal even with budget left.
+    #[tokio::test(start_paused = true)]
+    async fn xai_does_not_retry_after_partial_text_was_streamed() {
+        const PARTIAL_THEN_ERROR: &str = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n",
+            "data: {\"type\":\"error\",\"code\":null,\"message\":\"at capacity\"}\n\n",
+        );
+        let run = run_xai(vec![PARTIAL_THEN_ERROR, XAI_SUCCESS_SSE], 3).await;
+        let err = run.result.expect_err("must not retry after partial output");
+        assert!(err
+            .to_string()
+            .starts_with("xAI reports the model is at capacity"));
+        assert_eq!(run.calls, 1, "no retry once output reached the UI");
+        assert_eq!(text_events(&run.events), vec!["partial".to_string()]);
+    }
+
+    /// Same guard for tool events: a started tool call must not be replayed.
+    #[tokio::test(start_paused = true)]
+    async fn xai_does_not_retry_after_tool_events_were_emitted() {
+        const TOOL_THEN_EOF: &str = "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"bash\"}}\n\n";
+        let run = run_xai(vec![TOOL_THEN_EOF, XAI_SUCCESS_SSE], 3).await;
+        // EOF without a terminal event is itself retryable
+        // (`responses_missing_terminal`) — but the ToolUseStart already
+        // reached the UI, so the guard must keep it terminal.
+        let err = run
+            .result
+            .expect_err("missing terminal after a tool event stays terminal");
+        assert!(
+            err.to_string()
+                .starts_with("xAI response stream ended without a terminal event."),
+            "got: {err}"
+        );
+        assert_eq!(run.calls, 1, "no retry once a tool event reached the UI");
+        assert!(run.events.iter().any(|e| matches!(
+            e,
+            StreamEvent::Llm(crate::runtime::types::LlmEvent::ToolUseStart { .. })
+        )));
+    }
+
+    /// Deterministic (non-capacity) failures are terminal on the first try
+    /// and keep the neutral, xAI-labelled, details-withheld message.
+    #[tokio::test(start_paused = true)]
+    async fn xai_non_capacity_error_is_terminal_and_labelled_xai() {
+        const OTHER_ERROR: &str = "data: {\"type\":\"error\",\"code\":\"invalid_api_key\",\"message\":\"ECHOED:secret prompt\"}\n\n";
+        let run = run_xai(vec![OTHER_ERROR, XAI_SUCCESS_SSE], 3).await;
+        let err = run.result.expect_err("must fail");
+        let msg = err.to_string();
+        assert_eq!(
+            msg,
+            "xAI response failed in stream. Provider error details withheld because they can echo request content."
+        );
+        assert!(!msg.contains("ECHOED"));
+        assert_eq!(run.calls, 1);
     }
 }
 
@@ -2895,7 +3422,7 @@ mod codex_wire_tests {
         );
         let includes = body.get("include").expect("include must be present");
         assert!(
-            includes.as_array().map_or(false, |a| {
+            includes.as_array().is_some_and(|a| {
                 a.iter()
                     .any(|v| v.as_str() == Some("reasoning.encrypted_content"))
             }),

--- a/crates/agent-engine/src/runtime/trace/openai_wiring_tests.rs
+++ b/crates/agent-engine/src/runtime/trace/openai_wiring_tests.rs
@@ -542,6 +542,7 @@ async fn drive_responses(
         None,
         agent_core::reasoning::ReasoningLevel::Adaptive,
         cancel,
+        0,
         trace,
         true,
     )

--- a/crates/agent-tui/src/tui/commands.rs
+++ b/crates/agent-tui/src/tui/commands.rs
@@ -418,7 +418,9 @@ pub(super) async fn handle_command(
         };
         return match result {
             CommandResult::Quit => CommandAction::Quit,
-            CommandResult::ModelChanged { .. } => {
+            CommandResult::ModelChanged {
+                reasoning_clamped, ..
+            } => {
                 // Use the runtime's cleaned model string, not the raw arg.
                 let applied = runtime.model().to_string();
                 app.session.model = applied.clone();
@@ -427,6 +429,13 @@ pub(super) async fn handle_command(
                     "model set to: {} {}",
                     applied, status
                 )));
+                // Session-only: the user's configured thinking value stays theirs.
+                if let Some(clamp) = reasoning_clamped {
+                    app.session.thinking_level = runtime.thinking_level().to_string();
+                    app.push_msg(ChatMessage::System(reasoning_clamp_notice(
+                        &clamp, &applied,
+                    )));
+                }
                 CommandAction::None
             }
             CommandResult::ThinkingChanged { spec } => {
@@ -1207,6 +1216,19 @@ pub(super) fn handle_streaming_command(
         "quit" | "exit" => CommandAction::Quit,
         _ => CommandAction::None, // unknown — handled by caller as steer/queue
     }
+}
+
+/// Notice shown when a model change forced a reasoning-level substitution.
+pub(crate) fn reasoning_clamp_notice(
+    clamp: &synaps_cli::runtime::ReasoningClamp,
+    model: &str,
+) -> String {
+    format!(
+        "thinking → {} (clamped from {}: not supported by {})",
+        clamp.to.as_str(),
+        clamp.from.as_str(),
+        model
+    )
 }
 
 #[cfg(test)]

--- a/crates/agent-tui/src/tui/dispatch.rs
+++ b/crates/agent-tui/src/tui/dispatch.rs
@@ -1379,7 +1379,7 @@ pub(crate) async fn handle_input_action(
             }
         }
         InputAction::ModelsApply(model) => match runtime.try_set_model(model.clone()) {
-            Ok(()) => {
+            Ok(clamp) => {
                 let applied = runtime.model().to_string();
                 let status = synaps_cli::engine::commands::persist_to_config("model", &applied);
                 app.session.model = applied.clone();
@@ -1387,6 +1387,13 @@ pub(crate) async fn handle_input_action(
                     "model set to: {} {}",
                     applied, status
                 )));
+                // Session-only: the user's configured thinking value stays theirs.
+                if let Some(clamp) = clamp {
+                    app.session.thinking_level = runtime.thinking_level().to_string();
+                    app.push_msg(ChatMessage::System(
+                        crate::tui::commands::reasoning_clamp_notice(&clamp, &applied),
+                    ));
+                }
             }
             Err(error) => app.push_msg(ChatMessage::Error(error)),
         },

--- a/src/cmd/chat.rs
+++ b/src/cmd/chat.rs
@@ -215,9 +215,22 @@ pub async fn run(
                     if let Some(result) = commands::handle_engine_command(cmd, arg, &mut runtime) {
                         match result {
                             CommandResult::Quit => break,
-                            CommandResult::ModelChanged { model } => {
+                            CommandResult::ModelChanged {
+                                model,
+                                reasoning_clamped,
+                            } => {
                                 conv.session.model = runtime.model().to_string();
                                 eprintln!("model → {}", model);
+                                if let Some(clamp) = reasoning_clamped {
+                                    conv.session.thinking_level =
+                                        runtime.thinking_level().to_string();
+                                    eprintln!(
+                                        "thinking → {} (clamped from {}: not supported by {})",
+                                        clamp.to.as_str(),
+                                        clamp.from.as_str(),
+                                        runtime.model()
+                                    );
+                                }
                             }
                             CommandResult::ThinkingChanged { spec } => {
                                 conv.session.thinking_level = spec.config_value();

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -1249,11 +1249,26 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
 
     if let Some(result) = engine_result {
         match result {
-            CommandResult::ModelChanged { model } => {
-                state.conv.write().await.session.model = model.clone();
-                let _ = broadcast.send(ServerMessage::System {
-                    message: format!("model set to: {model}"),
-                });
+            CommandResult::ModelChanged {
+                model,
+                reasoning_clamped,
+            } => {
+                let mut message = format!("model set to: {model}");
+                {
+                    let mut conv = state.conv.write().await;
+                    conv.session.model = model.clone();
+                    if let Some(clamp) = reasoning_clamped {
+                        let rt = state.runtime.lock().await;
+                        conv.session.thinking_level = rt.thinking_level().to_string();
+                        message.push_str(&format!(
+                            "; thinking → {} (clamped from {}: not supported by {})",
+                            clamp.to.as_str(),
+                            clamp.from.as_str(),
+                            rt.model()
+                        ));
+                    }
+                }
+                let _ = broadcast.send(ServerMessage::System { message });
             }
             CommandResult::ThinkingChanged { spec } => {
                 state.conv.write().await.session.thinking_level = spec.config_value();


### PR DESCRIPTION
## Summary

Two provider-level failures that both surfaced as opaque errors — Kimi Code returning a bare `403 Forbidden`, and Grok "not working" after switching models from Claude — traced to four distinct defects. All four fixed, unit-tested, and verified live against the real endpoints (headless `synaps chat` in an isolated base dir, then the installed binary in the TUI).

### Kimi Code

Root cause of the 403 was **not** auth: the account's weekly quota was exhausted (`/usages`: `used 100 / limit 100`, upstream `access_terminated_error`). Auth, refresh, and token rotation all work. The bug was that the broker drops the error body for privacy, so a quota 403 was indistinguishable from an auth failure.

- **`4d5c1f2b` fix(broker):** on a non-2xx proxied response, read a bounded body, extract `error.type`, and map it onto a **vetted static label** appended to the transport error (`provider request failed: 403 Forbidden [access_terminated_error]`). Only our constants are ever emitted — provider bytes never surface (same approach as `vetted_error_type` on the Anthropic path).
- **`6d1dcfb8` fix(openai):** thread the qualified model into `provider_error_to_runtime_for` so the label + provider render as an actionable message:
  > `kimi-code: usage quota exhausted (HTTP 403). Your plan's usage window is used up — wait for the reset or upgrade, or switch models with /model. Kimi Code quotas are weekly; the Kimi membership page shows the reset time.`

### xAI / Grok

- **`acb7934d` fix(runtime):** `/model xai-auth/grok-4.6` while on an explicit `thinking = xhigh` (e.g. carried over from Claude) succeeded silently, then **every turn failed** with `reasoning level 'xhigh' is not supported`. The switch now clamps to the model's documented default and prints a notice:
  > `thinking → high (clamped from xhigh: not supported by xai-auth/grok-4.6)`
- **`cd4de1bf` fix(openai):** xAI reports capacity as HTTP 200 + an in-stream SSE `{"type":"error","code":null,"message":"The model is currently at capacity…"}`. The flat envelope (`code: null`, no nested `error.type`) couldn't be classified, the xAI path had no retry loop at all, and the message was mislabeled *"Codex response failed in stream"*. Now: capacity errors are classified via a fixed-pattern peek (classification only — message never surfaced, same precedent as `body_mentions("Consumer Terms")`), retried with backoff bounded by `api_retries`, **never** after partial text/tool output was already streamed, and terminal messages are labeled per provider ("xAI …"). In testing grok-4.6 hit this on 3 of 4 turns.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `synaps-core` 445, `synaps-engine` 1745 unit + all integration suites, `synaps-tui`, root crate — all green
- [x] New tests: broker label extraction/vetting; humanizer per provider; clamp-on-switch across runtime/engine commands/TUI; xAI retry replaying the exact captured SSE payload (retry-then-succeed, zero budget, budget exhaustion, no-retry-after-partial-output, non-capacity stays terminal)
- [x] Live: grok-4.6 from `xhigh` → clamps, `GROK_OK`; kimi-code/k3 → humanized quota message; real refresh-token rotation OK
- [ ] Not exercised live: xAI capacity retry (xAI was healthy during verification — covered by replay tests)

## Known / out of scope

- `ui_catalog_fetch_github_copilot_returns_prefixed_chat_models` fails on this and on `dev`: it live-fetches the operator's Copilot catalog and asserts `claude-sonnet-4.6` is still listed. Environmental; separate fix.
- Kimi CLI v0.40.1 now sends `thinking:{type:"enabled",effort}` for k3 where Synaps sends top-level `reasoning_effort`. Can't be verified until the quota resets; follow-up.
- `v0.9.0` base has rustfmt drift in 5 unrelated files; left alone to keep this focused.
