### PR TITLE
feat(read): return PNG/JPEG/GIF/WebP as image content blocks — the model can see images (#341)

### DIFF
--- a/crates/agent-engine/src/lib.rs
+++ b/crates/agent-engine/src/lib.rs
@@ -36,7 +36,7 @@ pub use session::{
     resolve_session, validate_name, Session, SessionInfo,
 };
 pub use tokio_util::sync::CancellationToken;
-pub use tools::{Tool, ToolContext, ToolRegistry};
+pub use tools::{Tool, ToolContext, ToolOutput, ToolRegistry};
 pub use watcher_types::{
     AgentConfig, AgentStatusInfo, ExitReason, HandoffState, SessionLimits, SessionStats,
     WatcherCommand, WatcherResponse,

--- a/crates/agent-engine/src/runtime/context.rs
+++ b/crates/agent-engine/src/runtime/context.rs
@@ -49,6 +49,14 @@ pub const SAFETY_MARGIN_PERCENT: u64 = 15;
 /// is what prevents recompaction loops without frontend-local bookkeeping.
 pub const MIN_COMPACTION_MESSAGES: usize = 4;
 
+/// Flat charge per base64 image block. Anthropic bills ≈ w·h/750 tokens
+/// AFTER its 1568-px / ~1.15 MP downscale, so 1,600 is the per-image
+/// ceiling (Goose uses the same figure; gemini-cli uses 3,000; Codex
+/// subtracts the payload and adds a ~7 KB estimate). Serialized base64 at
+/// 2.5 chars/token would charge ~1.9 M tokens for a 3.5 MiB image and trip
+/// compaction every turn.
+pub const IMAGE_TOKEN_ESTIMATE: u64 = 1_600;
+
 /// Provider-side per-message framing charge (role tags, message boundaries)
 /// on top of the serialized content itself.
 const PER_MESSAGE_FRAMING_TOKENS: u64 = 4;
@@ -266,7 +274,7 @@ pub fn assess(inputs: &ContextBudgetInputs<'_>) -> ContextAssessment {
     let history_tokens: u64 = inputs
         .messages
         .iter()
-        .map(|msg| estimate_serialized(&estimator, msg))
+        .map(|msg| estimate_message(&estimator, msg))
         .sum();
     let framing_tokens = PER_MESSAGE_FRAMING_TOKENS * inputs.messages.len() as u64;
 
@@ -327,11 +335,123 @@ fn estimate_serialized(estimator: &TokenEstimator, value: &Value) -> u64 {
     }
 }
 
+/// Like `estimate_serialized` but charges base64 image blocks at a flat
+/// `IMAGE_TOKEN_ESTIMATE` instead of by payload length. Walks
+/// `content[]` and nested `tool_result.content[]`; every other block is
+/// still charged on its serialized form.
+fn estimate_message(estimator: &TokenEstimator, msg: &Value) -> u64 {
+    let Some(blocks) = msg["content"].as_array() else {
+        return estimate_serialized(estimator, msg);
+    };
+    let mut total = 0u64;
+    for block in blocks {
+        if is_base64_image(block) {
+            total += IMAGE_TOKEN_ESTIMATE;
+            continue;
+        }
+        if block["type"] == "tool_result" {
+            if let Some(inner) = block["content"].as_array() {
+                total += 8; // wrapper keys: type, tool_use_id
+                for b in inner {
+                    total += if is_base64_image(b) {
+                        IMAGE_TOKEN_ESTIMATE
+                    } else {
+                        estimate_serialized(estimator, b)
+                    };
+                }
+                continue;
+            }
+        }
+        total += estimate_serialized(estimator, block);
+    }
+    total
+}
+
+fn is_base64_image(b: &Value) -> bool {
+    b["type"] == "image" && b["source"]["type"] == "base64"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
     use std::sync::Arc;
+
+    fn history_tokens_of(messages: &[SharedMessage]) -> u64 {
+        let inputs = ContextBudgetInputs {
+            model: "claude-sonnet-4-6",
+            provider_window: 200_000,
+            system_prompt: None,
+            tools_schema: &[],
+            messages,
+            skill_contents: &[],
+            memory_contents: &[],
+            thinking_budget_tokens: 0,
+            next_tool_result_bytes: 0,
+            output_reserve_tokens: 0,
+        };
+        assess(&inputs).breakdown.history_tokens
+    }
+
+    fn image_block(len: usize) -> Value {
+        json!({
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "A".repeat(len)}
+        })
+    }
+
+    #[test]
+    fn image_block_in_tool_result_charged_flat() {
+        let messages: Vec<SharedMessage> = vec![Arc::new(json!({
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_1",
+                "content": [
+                    {"type": "text", "text": "Image: /tmp/x.png (1024x1536, image/png, 2292 KB)"},
+                    image_block(3_000_000),
+                ]
+            }]
+        }))];
+        let tokens = history_tokens_of(&messages);
+        assert!(tokens >= IMAGE_TOKEN_ESTIMATE, "{tokens}");
+        assert!(tokens <= IMAGE_TOKEN_ESTIMATE + 200, "{tokens}");
+        assert!(tokens < 10_000, "{tokens}");
+    }
+
+    #[test]
+    fn user_message_image_charged_flat() {
+        let messages: Vec<SharedMessage> = vec![Arc::new(json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this?"},
+                image_block(3_000_000),
+            ]
+        }))];
+        let tokens = history_tokens_of(&messages);
+        assert!(tokens >= IMAGE_TOKEN_ESTIMATE, "{tokens}");
+        assert!(tokens <= IMAGE_TOKEN_ESTIMATE + 200, "{tokens}");
+    }
+
+    #[test]
+    fn string_content_unchanged() {
+        let msg = json!({"role": "user", "content": "plain string content, no blocks here"});
+        let estimator = estimator_for_model("claude-sonnet-4-6");
+        assert_eq!(
+            estimate_message(&estimator, &msg),
+            estimate_serialized(&estimator, &msg)
+        );
+    }
+
+    #[test]
+    fn non_image_blocks_still_charged_by_payload() {
+        // A big text block must NOT get the flat image discount.
+        let msg = json!({"role": "user", "content": [
+            {"type": "text", "text": "A".repeat(100_000)}
+        ]});
+        let estimator = estimator_for_model("claude-sonnet-4-6");
+        assert!(estimate_message(&estimator, &msg) > 10_000);
+    }
 
     #[test]
     fn ascii_is_charged_at_the_dense_bpe_rate() {

--- a/crates/agent-engine/src/runtime/context.rs
+++ b/crates/agent-engine/src/runtime/context.rs
@@ -343,6 +343,12 @@ fn estimate_message(estimator: &TokenEstimator, msg: &Value) -> u64 {
     let Some(blocks) = msg["content"].as_array() else {
         return estimate_serialized(estimator, msg);
     };
+    // Zero drift for messages without images: charge exactly as before.
+    if !blocks.iter().any(|b| {
+        is_base64_image(b) || b["content"].as_array().is_some_and(|a| a.iter().any(is_base64_image))
+    }) {
+        return estimate_serialized(estimator, msg);
+    }
     let mut total = 0u64;
     for block in blocks {
         if is_base64_image(block) {
@@ -441,6 +447,31 @@ mod tests {
             estimate_message(&estimator, &msg),
             estimate_serialized(&estimator, &msg)
         );
+    }
+
+    #[test]
+    fn array_content_without_images_unchanged() {
+        let estimator = estimator_for_model("claude-sonnet-4-6");
+        for msg in [
+            json!({"role": "assistant", "content": [
+                {"type": "text", "text": "let me look"},
+                {"type": "tool_use", "id": "toolu_1", "name": "read", "input": {"path": "x"}}
+            ]}),
+            json!({"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_1", "content": "1\tfoo\n2\tbar"}
+            ]}),
+            json!({"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_1", "content": [
+                    {"type": "text", "text": "nested text only"}
+                ]}
+            ]}),
+        ] {
+            assert_eq!(
+                estimate_message(&estimator, &msg),
+                estimate_serialized(&estimator, &msg),
+                "{msg}"
+            );
+        }
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/google_gemini/runtime.rs
+++ b/crates/agent-engine/src/runtime/google_gemini/runtime.rs
@@ -120,6 +120,14 @@ fn messages_to_gemini_turns(messages: &[crate::SharedMessage]) -> Vec<ChatTurn> 
                                         let text = arr
                                             .iter()
                                             .filter_map(|b| {
+                                                if b["type"] == "image" {
+                                                    let mt = b["source"]["media_type"]
+                                                        .as_str()
+                                                        .unwrap_or("image");
+                                                    return Some(format!(
+                                                        "\n[image omitted: {mt} — this provider does not accept images in tool results]"
+                                                    ));
+                                                }
                                                 b.get("text")
                                                     .and_then(|t| t.as_str())
                                                     .map(String::from)

--- a/crates/agent-engine/src/runtime/google_gemini/runtime_tests.rs
+++ b/crates/agent-engine/src/runtime/google_gemini/runtime_tests.rs
@@ -312,6 +312,32 @@ Begin now and continue autonomously until the exercise reaches a verified safe o
 }
 
 #[test]
+fn messages_to_gemini_turns_degrades_image_tool_result_with_omission_note() {
+    let b64 = "iVBORw0KGgo".repeat(200);
+    let msgs: Vec<crate::SharedMessage> = vec![
+        Arc::new(json!({"role":"assistant","content":[
+            {"type":"tool_use","id":"t1","name":"read","input":{"path":"x.png"}}
+        ]})),
+        Arc::new(json!({"role":"user","content":[
+            {"type":"tool_result","tool_use_id":"t1","content":[
+                {"type":"text","text":"Image: x"},
+                {"type":"image","source":{"type":"base64","media_type":"image/png","data":b64}}
+            ]}
+        ]})),
+    ];
+    let turns = messages_to_gemini_turns(&msgs);
+    let ChatTurn::ToolResult { name, result } = &turns[1] else {
+        panic!("expected ToolResult, got {:?}", turns.len());
+    };
+    assert_eq!(name, "read");
+    assert_eq!(
+        result,
+        &json!({"output": "Image: x\n[image omitted: image/png — this provider does not accept images in tool results]"})
+    );
+    assert!(!result.to_string().contains("iVBORw0KGgo"));
+}
+
+#[test]
 fn messages_to_gemini_turns_preserves_object_tool_results_and_error_metadata() {
     let msgs: Vec<crate::SharedMessage> = vec![
         Arc::new(json!({"role":"assistant","content":[

--- a/crates/agent-engine/src/runtime/helpers.rs
+++ b/crates/agent-engine/src/runtime/helpers.rs
@@ -320,6 +320,8 @@ impl HelperMethods {
     /// shared [`agent_core::BoundedText`] helper (T2; the legacy code applied
     /// a char budget, so multibyte output could exceed the byte cap). Marker
     /// format intentionally changed from "total chars" to "total bytes".
+    // Rich (array) tool_result content never passes through here — see
+    // stream.rs `select_tool_result_content`.
     pub(crate) fn truncate_tool_result(result: &str, max_bytes: usize) -> String {
         let bounded = agent_core::BoundedText::new(result, max_bytes);
         if !bounded.truncated {

--- a/crates/agent-engine/src/runtime/openai/translate.rs
+++ b/crates/agent-engine/src/runtime/openai/translate.rs
@@ -255,6 +255,14 @@ pub fn messages_to_oai(
                                         Some(Value::Array(arr)) => arr
                                             .iter()
                                             .filter_map(|b| {
+                                                if b["type"] == "image" {
+                                                    let mt = b["source"]["media_type"]
+                                                        .as_str()
+                                                        .unwrap_or("image");
+                                                    return Some(format!(
+                                                        "\n[image omitted: {mt} — this provider does not accept images in tool results]"
+                                                    ));
+                                                }
                                                 b.get("text")
                                                     .and_then(|t| t.as_str())
                                                     .map(String::from)
@@ -429,6 +437,31 @@ pub fn tool_calls_to_content_blocks(calls: &[ToolCall], name_map: &ToolNameMap) 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn image_tool_result_degrades_to_text_with_omission_note() {
+        let b64 = "iVBORw0KGgo".repeat(200);
+        let msgs: Vec<crate::SharedMessage> = vec![
+            std::sync::Arc::new(json!({"role":"user","content":"look"})),
+            std::sync::Arc::new(json!({"role":"assistant","content":[
+                {"type":"tool_use","id":"t1","name":"read","input":{"path":"x.png"}}
+            ]})),
+            std::sync::Arc::new(json!({"role":"user","content":[
+                {"type":"tool_result","tool_use_id":"t1","content":[
+                    {"type":"text","text":"Image: x"},
+                    {"type":"image","source":{"type":"base64","media_type":"image/png","data":b64}}
+                ]}
+            ]})),
+        ];
+        let out = messages_to_oai(&msgs, &None, &ToolNameMap::default());
+        let tool_msg = out.iter().find(|m| m.role == "tool").expect("tool message");
+        let content = tool_msg.content.as_deref().unwrap();
+        assert_eq!(
+            content,
+            "Image: x\n[image omitted: image/png — this provider does not accept images in tool results]"
+        );
+        assert!(!content.contains("iVBORw0KGgo"));
+    }
 
     /// Regression fixture from session 20260429-235559-094c: the lsrf-manager
     /// extension exposed `managerApi_cloudfrontInvalidate` whose `paths`

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -2033,6 +2033,8 @@ mod rich_output_tests {
                     (StatusCode::OK, [("content-type", "text/event-stream")], sse).into_response()
                 }),
             )
+            // Axum defaults to a 2 MB body limit (413) — image histories are bigger.
+            .layer(axum::extract::DefaultBodyLimit::max(64 * 1024 * 1024))
             .with_state(state.clone());
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -2293,6 +2293,14 @@ mod rich_output_tests {
 
     // ── S1: history image byte cap ─────────────────────────────────────────
 
+    fn user_msg(content: Value) -> SharedMessage {
+        Arc::new(json!({"role": "user", "content": content}))
+    }
+
+    fn assistant_msg(text: &str) -> SharedMessage {
+        Arc::new(json!({"role": "assistant", "content": [{"type": "text", "text": text}]}))
+    }
+
     fn image_tool_result_msg(id: &str, b64_len: usize) -> SharedMessage {
         user_msg(json!([{
             "type": "tool_result", "tool_use_id": id,

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -825,7 +825,7 @@ impl StreamMethods {
                         let mut production_output: Option<crate::tools::output::OutputHandle> =
                             None;
                         let mut execution_identity = None;
-                        let result = match gate_outcome {
+                        let (result, rich_blocks) = match gate_outcome {
                             Ok((authorized, input)) => {
                                 let tool = authorized.implementation();
                                 execution_identity = Some((
@@ -882,7 +882,7 @@ impl StreamMethods {
                                 )
                                 .await;
                                 if let BeforeToolCallDecision::Block { reason } = decision {
-                                    format!("Tool call blocked by extension: {}", reason)
+                                    (format!("Tool call blocked by extension: {}", reason), None)
                                 } else {
                                     let BeforeToolCallDecision::Continue { input } = decision
                                     else {
@@ -890,24 +890,28 @@ impl StreamMethods {
                                     };
                                     let input_for_hook = input.clone();
                                     tokio::select! {
-                                        res = tool.execute(input, crate::ToolContext {
+                                        res = tool.execute_rich(input, crate::ToolContext {
                                             channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx.clone()) },
                                             capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()), delegation_parent: delegation_parent.clone(), secret_prompt: secret_prompt.clone(), orchestration: orchestration.clone(), tool_activation: Some(crate::tools::discovery::ActivationCapability::new(catalog_snapshot.clone(), std::sync::Arc::clone(&session_tool_set), activation_authority)), mcp_leases: mcp_lease_capability.clone(), extension_leases: extension_lease_capability.clone(), memory_context: None /* TODO(task A5): host wiring of MemoryContextCapability */ },
                                             limits: crate::tools::ToolLimits { max_tool_output, max_tool_buffer: 256 * 1024, bash_timeout, bash_max_timeout, subagent_timeout },
                                         }) => {
-                                            let output = match res {
-                                                Ok(output) => output,
-                                                Err(e) => e.to_string(),
+                                            let (output, rich_blocks) = match res {
+                                                Ok(o) => o.into_parts(),
+                                                Err(e) => (e.to_string(), None),
                                             };
-                                            let output = emit_after_tool_call(
+                                            let hooked_output = emit_after_tool_call(
                                                 &hook_bus,
                                                 &tool_name,
                                                 Some(&runtime_name),
                                                 input_for_hook,
-                                                output,
+                                                output.clone(),
                                                 max_tool_output,
                                             ).await;
-                                            output
+                                            // Hook policy: a Replace transform wins over the rich
+                                            // blocks — the hook saw only the summary, so keeping
+                                            // the image would desync text and image.
+                                            let rich_blocks = if hooked_output == output { rich_blocks } else { None };
+                                            (hooked_output, rich_blocks)
                                         }
                                         _ = cancel.cancelled() => {
                                             canceled = true;
@@ -926,14 +930,14 @@ impl StreamMethods {
                                             {
                                                 interrupted_side_effect = Some(tool_id.clone());
                                             }
-                                            "Canceled by user".to_string()
+                                            ("Canceled by user".to_string(), None)
                                         }
                                     }
                                 }
                             }
                             // Typed, bounded, metadata-only gate denial — no
                             // implementation was looked up, no hook emitted.
-                            Err(denial) => denial.to_string(),
+                            Err(denial) => (denial.to_string(), None),
                         };
 
                         let history_result = production_output
@@ -972,10 +976,18 @@ impl StreamMethods {
                             result: ui_result,
                         }));
 
+                        // Rich blocks bypass `truncate_tool_result` by construction:
+                        // the image cap is the image's own budget.
+                        let content = select_tool_result_content(
+                            rich_blocks,
+                            history_result.map(|bounded| bounded.text),
+                            &result,
+                            max_tool_output,
+                        );
                         tool_results.push(json!({
                             "type": "tool_result",
                             "tool_use_id": tool_id,
-                            "content": history_result.map(|bounded| bounded.text).unwrap_or_else(|| HelperMethods::truncate_tool_result(&result, max_tool_output))
+                            "content": content
                         }));
                     }
                 } else {
@@ -1135,7 +1147,7 @@ impl StreamMethods {
                         );
 
                         join_set.spawn(async move {
-                            let mut lane_results: Vec<(String, bool, Option<String>, String)> = Vec::new();
+                            let mut lane_results: Vec<(String, bool, Option<String>, Value)> = Vec::new();
                             for (model_order, tool_id, tool_name, prepared) in lane {
                             let gate_outcome = match prepared {
                                 PreparedCall::ParseError(err) => {
@@ -1143,7 +1155,7 @@ impl StreamMethods {
                                         tool_id: tool_id.clone(),
                                         result: err.clone(),
                                     }));
-                                    lane_results.push((tool_id, false, None, err));
+                                    lane_results.push((tool_id, false, None, Value::String(err)));
                                     continue;
                                 }
                                 PreparedCall::Gate(gate_outcome) => gate_outcome,
@@ -1170,7 +1182,7 @@ impl StreamMethods {
                                         auto_approve_inner,
                                     ).await;
                                     if let BeforeToolCallDecision::Block { reason } = decision {
-                                        (false, Some(call_effect), format!("Tool call blocked by extension: {}", reason), None, None)
+                                        (false, Some(call_effect), format!("Tool call blocked by extension: {}", reason), None, None, None)
                                     } else {
                                     let BeforeToolCallDecision::Continue { input } = decision else { unreachable!() };
                                     let input_for_hook = input.clone();
@@ -1199,34 +1211,36 @@ impl StreamMethods {
                                     let tx_d = delta_channel.sender;
 
                                     tokio::select! {
-                                        res = t.execute(input, crate::ToolContext {
+                                        res = t.execute_rich(input, crate::ToolContext {
                                             channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx_stream.clone()) },
                                             capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()), delegation_parent: delegation_parent_inner.clone(), secret_prompt: prompt_inner.clone(), orchestration: orchestration_inner.clone(), tool_activation: Some(activation_inner.clone()), mcp_leases: mcp_leases_inner.clone(), extension_leases: extension_leases_inner.clone(), memory_context: None /* TODO(task A5): host wiring of MemoryContextCapability */ },
                                             limits: crate::tools::ToolLimits { max_tool_output, max_tool_buffer: 256 * 1024, bash_timeout, bash_max_timeout, subagent_timeout },
                                         }) => {
-                                            let output = match res {
-                                                Ok(output) => output,
-                                                Err(e) => e.to_string(),
+                                            let (output, rich_blocks) = match res {
+                                                Ok(o) => o.into_parts(),
+                                                Err(e) => (e.to_string(), None),
                                             };
-                                            let output = emit_after_tool_call(
+                                            let hooked_output = emit_after_tool_call(
                                                 &hook_bus_inner,
                                                 &tool_name_for_hook,
                                                 Some(&runtime_name_for_hook),
                                                 input_for_hook,
-                                                output,
+                                                output.clone(),
                                                 max_tool_output,
                                             ).await;
-                                            (false, Some(call_effect), output, Some(output_handle), Some((stable_tool_id, activation_basis, tool_call_started)))
+                                            // Hook Replace wins over rich blocks (see single-tool site).
+                                            let rich_blocks = if hooked_output == output { rich_blocks } else { None };
+                                            (false, Some(call_effect), hooked_output, Some(output_handle), Some((stable_tool_id, activation_basis, tool_call_started)), rich_blocks)
                                         }
                                         _ = cancel_token.cancelled() => {
-                                            (true, Some(call_effect), "Canceled by user".to_string(), Some(output_handle), Some((stable_tool_id, activation_basis, tool_call_started)))
+                                            (true, Some(call_effect), "Canceled by user".to_string(), Some(output_handle), Some((stable_tool_id, activation_basis, tool_call_started)), None)
                                         }
                                     }
                                     } // close else from Block check
                                 }
                                 // Typed, bounded, metadata-only gate denial —
                                 // no implementation lookup, no hook emission.
-                                Err(denial) => (false, None, denial.to_string(), None, None),
+                                Err(denial) => (false, None, denial.to_string(), None, None, None),
                             };
 
                             let _ = tx_stream.send(StreamEvent::Llm(LlmEvent::ToolResult {
@@ -1257,9 +1271,12 @@ impl StreamMethods {
                             let history_bounded = result.3.as_ref()
                                 .map(crate::tools::output::OutputHandle::model_history)
                                 .filter(|bounded| bounded.original_bytes > 0);
-                            let history = history_bounded.as_ref()
-                                .map(|bounded| bounded.text.clone())
-                                .unwrap_or_else(|| HelperMethods::truncate_tool_result(&result.2, max_tool_output));
+                            let history: Value = select_tool_result_content(
+                                result.5,
+                                history_bounded.as_ref().map(|bounded| bounded.text.clone()),
+                                &result.2,
+                                max_tool_output,
+                            );
                             if let (Some(request), Some((stable_tool_id, activation_basis, tool_call_started)), Some(call_effect)) = (request_correlation_inner.as_ref(), result.4, result.1) {
                                 let correlation =
                                     crate::runtime::trace::ExecutionCorrelation::from_request(
@@ -1310,7 +1327,8 @@ impl StreamMethods {
                     }
 
                     // Collect results
-                    let mut results_map = std::collections::HashMap::new();
+                    let mut results_map: std::collections::HashMap<String, Value> =
+                        std::collections::HashMap::new();
                     while let Some(res) = join_set.join_next().await {
                         match res {
                             Ok(lane_results) => {
@@ -1333,13 +1351,15 @@ impl StreamMethods {
                     // Build tool_results in original order
                     for tool_use in &tool_uses {
                         if let Some(tool_id) = tool_use["id"].as_str() {
-                            let result = results_map
+                            // Strings were already truncated at lane time; arrays
+                            // never pass through `truncate_tool_result`.
+                            let content = results_map
                                 .remove(tool_id)
-                                .unwrap_or_else(|| "Canceled by user".to_string());
+                                .unwrap_or_else(|| Value::String("Canceled by user".to_string()));
                             tool_results.push(json!({
                                 "type": "tool_result",
                                 "tool_use_id": tool_id,
-                                "content": HelperMethods::truncate_tool_result(&result, max_tool_output)
+                                "content": content
                             }));
                         }
                     }
@@ -1418,10 +1438,7 @@ impl StreamMethods {
                 if tool_call_budget_hit {
                     finish_budget_exceeded!(agent_core::BudgetDimension::ToolCalls);
                 }
-                let round_result_bytes: usize = tool_results
-                    .iter()
-                    .map(|r| r["content"].as_str().map(str::len).unwrap_or(0))
-                    .sum();
+                let round_result_bytes: usize = tool_results.iter().map(tool_result_bytes).sum();
                 if let Err(dimension) = budget_meter.charge_tool_result_bytes(round_result_bytes) {
                     finish_budget_exceeded!(dimension);
                 }
@@ -1437,6 +1454,32 @@ impl StreamMethods {
                 return Err(RuntimeError::Tool("Invalid response format".to_string()));
             }
         }
+    }
+}
+
+/// Pick the `tool_result.content` value. Rich blocks win outright (they
+/// carry their own budget and never see `truncate_tool_result`); otherwise
+/// the bounded delta-lane text, otherwise the truncated summary.
+fn select_tool_result_content(
+    rich_blocks: Option<Vec<Value>>,
+    history_text: Option<String>,
+    result: &str,
+    max_tool_output: usize,
+) -> Value {
+    match (rich_blocks, history_text) {
+        (Some(blocks), _) => Value::Array(blocks),
+        (None, Some(text)) => Value::String(text),
+        (None, None) => Value::String(HelperMethods::truncate_tool_result(result, max_tool_output)),
+    }
+}
+
+/// Wire bytes a single `tool_result` charges against the turn byte budget.
+/// Array content (image blocks) is charged on its serialized form — the
+/// base64 *is* re-sent every round.
+fn tool_result_bytes(r: &Value) -> usize {
+    match &r["content"] {
+        Value::String(s) => s.len(),
+        other => serde_json::to_vec(other).map(|v| v.len()).unwrap_or(0),
     }
 }
 
@@ -1700,6 +1743,444 @@ mod tests {
         assert_eq!(
             entry1, prefix2,
             "durable prefix must be byte-identical across turns or the cache entry is dead"
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rich tool output through the REAL stream loop (image-read feature).
+//
+// A tiny axum server plays Anthropic: round 1 answers with scripted
+// `tool_use` blocks, round 2 with `end_turn`. Every request body is recorded
+// so the assertions run against the bytes that would have hit the wire —
+// `tool_result.content` as an ARRAY for rich tools, a STRING for legacy ones.
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod rich_output_tests {
+    use super::*;
+    use crate::extensions::hooks::events::{HookKind, HookResult};
+    use crate::extensions::permissions::PermissionSet;
+    use crate::runtime::api::ApiOptions;
+    use crate::runtime::types::AuthState;
+    use crate::tools::{Tool, ToolContext, ToolOutput};
+    use agent_core::{LlmEvent, SessionEvent, StreamEvent};
+    use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::post, Router};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const PNG_B64_PREFIX: &str = "iVBORw0KGgo";
+
+    fn fake_b64(len: usize) -> String {
+        let mut s = String::with_capacity(len);
+        while s.len() < len {
+            s.push_str(PNG_B64_PREFIX);
+        }
+        s.truncate(len);
+        s
+    }
+
+    /// Rich stub: `[text, image]` blocks + summary, like `read` on a PNG.
+    struct RichTool;
+    #[async_trait::async_trait]
+    impl Tool for RichTool {
+        fn name(&self) -> &str {
+            "rich_stub"
+        }
+        fn description(&self) -> &str {
+            "returns an image"
+        }
+        fn parameters(&self) -> Value {
+            json!({"type":"object","properties":{}})
+        }
+        fn origin(&self) -> crate::tools::ToolOrigin {
+            crate::tools::ToolOrigin::Builtin
+        }
+        fn effect(&self) -> crate::tools::catalog::ToolEffect {
+            crate::tools::catalog::ToolEffect::ReadOnly
+        }
+        async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
+            self.execute_rich(params, ctx)
+                .await
+                .map(ToolOutput::into_summary)
+        }
+        async fn execute_rich(&self, _params: Value, _ctx: ToolContext) -> Result<ToolOutput> {
+            let summary = "Image: /tmp/x.png (1x1, image/png, 1 KB)".to_string();
+            Ok(ToolOutput::Blocks {
+                blocks: vec![
+                    json!({"type":"text","text":summary}),
+                    json!({"type":"image","source":{"type":"base64","media_type":"image/png","data":fake_b64(2_000)}}),
+                ],
+                summary,
+            })
+        }
+    }
+
+    /// Legacy stub: plain `execute` only.
+    struct TextTool;
+    #[async_trait::async_trait]
+    impl Tool for TextTool {
+        fn name(&self) -> &str {
+            "text_stub"
+        }
+        fn description(&self) -> &str {
+            "returns text"
+        }
+        fn parameters(&self) -> Value {
+            json!({"type":"object","properties":{}})
+        }
+        fn origin(&self) -> crate::tools::ToolOrigin {
+            crate::tools::ToolOrigin::Builtin
+        }
+        fn effect(&self) -> crate::tools::catalog::ToolEffect {
+            crate::tools::catalog::ToolEffect::ReadOnly
+        }
+        async fn execute(&self, _params: Value, _ctx: ToolContext) -> Result<String> {
+            Ok("plain text result".to_string())
+        }
+    }
+
+    /// after_tool_call hook that replaces every output.
+    struct ReplaceHook;
+    #[async_trait::async_trait]
+    impl crate::extensions::runtime::ExtensionHandler for ReplaceHook {
+        fn id(&self) -> &str {
+            "replace-hook"
+        }
+        async fn handle(&self, _event: &HookEvent) -> HookResult {
+            HookResult::Replace {
+                output: "REPLACED BY HOOK".to_string(),
+            }
+        }
+        async fn shutdown(&self) {}
+    }
+
+    fn sse_tool_use_round(tool_uses: &[(&str, &str)]) -> String {
+        let mut s = String::new();
+        s.push_str(r#"data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-haiku-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#);
+        s.push_str("\n\n");
+        for (i, (id, name)) in tool_uses.iter().enumerate() {
+            s.push_str(&format!(
+                r#"data: {{"type":"content_block_start","index":{i},"content_block":{{"type":"tool_use","id":"{id}","name":"{name}"}}}}"#
+            ));
+            s.push_str("\n\n");
+            s.push_str(&format!(
+                r#"data: {{"type":"content_block_delta","index":{i},"delta":{{"type":"input_json_delta","partial_json":"{{}}"}}}}"#
+            ));
+            s.push_str("\n\n");
+            s.push_str(&format!(
+                r#"data: {{"type":"content_block_stop","index":{i}}}"#
+            ));
+            s.push_str("\n\n");
+        }
+        s.push_str(r#"data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}"#);
+        s.push_str("\n\ndata: {\"type\":\"message_stop\"}\n\n");
+        s
+    }
+
+    const SSE_END_TURN: &str = concat!(
+        "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_02\",\"type\":\"message\",",
+        "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-haiku-4-5\",\"stop_reason\":null,",
+        "\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,",
+        "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n",
+        "data: {\"type\":\"content_block_start\",\"index\":0,",
+        "\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,",
+        "\"delta\":{\"type\":\"text_delta\",\"text\":\"done\"}}\n\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+        "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",",
+        "\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":1,",
+        "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}\n\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+
+    #[derive(Clone)]
+    struct MockState {
+        calls: Arc<AtomicUsize>,
+        bodies: Arc<Mutex<Vec<Value>>>,
+        first_round: Arc<String>,
+    }
+
+    async fn spawn_mock(first_round: String) -> (String, MockState) {
+        let state = MockState {
+            calls: Arc::new(AtomicUsize::new(0)),
+            bodies: Arc::new(Mutex::new(Vec::new())),
+            first_round: Arc::new(first_round),
+        };
+        let app = Router::new()
+            .route(
+                "/v1/messages",
+                post(|State(st): State<MockState>, body: String| async move {
+                    let n = st.calls.fetch_add(1, Ordering::SeqCst);
+                    if let Ok(v) = serde_json::from_str::<Value>(&body) {
+                        st.bodies.lock().unwrap().push(v);
+                    }
+                    let sse = if n == 0 {
+                        st.first_round.as_str().to_string()
+                    } else {
+                        SSE_END_TURN.to_string()
+                    };
+                    (StatusCode::OK, [("content-type", "text/event-stream")], sse).into_response()
+                }),
+            )
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (format!("http://{addr}"), state)
+    }
+
+    struct Driven {
+        /// Final durable history (from the last `MessageHistory` event).
+        history: Vec<SharedMessage>,
+        /// Every `ToolResult` UI preview string.
+        ui_results: Vec<String>,
+        /// Request bodies the mock saw, in order.
+        bodies: Vec<Value>,
+    }
+
+    async fn drive(
+        tools_to_register: Vec<Arc<dyn Tool>>,
+        tool_uses: &[(&str, &str)],
+        hook_bus: Arc<crate::extensions::hooks::HookBus>,
+    ) -> Driven {
+        let (base_url, mock) = spawn_mock(sse_tool_use_round(tool_uses)).await;
+
+        let mut registry = ToolRegistry::new();
+        for t in tools_to_register {
+            registry.register(t);
+        }
+        let tools = Arc::new(RwLock::new(registry));
+        let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
+        let session_manager =
+            crate::tools::shell::SessionManager::new(crate::tools::shell::ShellConfig::default());
+        let tool_session_id = crate::tools::activation::SessionId::parse(&format!(
+            "test-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ))
+        .unwrap();
+
+        let session = StreamSession {
+            auth: Arc::new(RwLock::new(AuthState {
+                auth_token: "test-token".into(),
+                auth_type: "api_key".into(),
+                refresh_token: None,
+                token_expires: Some(9_999_999_999_999),
+            })),
+            client: Client::new(),
+            credential_source: crate::auth::CredentialSource::Local,
+            token_cache: crate::auth::TokenCache::new(),
+            options: ApiOptions {
+                anthropic_base_url: Some(base_url),
+                ..Default::default()
+            },
+            api_retries: 0,
+            refusal_retries: 0,
+            model: "claude-haiku-4-5".into(),
+            tools,
+            system_prompt: None,
+            thinking_budget: 0,
+            reasoning_level: agent_core::reasoning::ReasoningLevel::Adaptive,
+            tx,
+            cancel: CancellationToken::new(),
+            steering_rx: None,
+            watcher_exit_path: None,
+            max_tool_output: 30_000,
+            bash_timeout: 30,
+            bash_max_timeout: 300,
+            subagent_timeout: 300,
+            session_manager,
+            subagent_registry: Arc::new(Mutex::new(
+                crate::runtime::subagent::SubagentRegistry::new(),
+            )),
+            event_queue: Arc::new(crate::events::EventQueue::new(100)),
+            hook_bus,
+            secret_prompt: None,
+            auto_approve_confirms: true,
+            telemetry_level: crate::runtime::telemetry::TelemetryLevel::Off,
+            orchestration: None,
+            delegation_parent: None,
+            turn_correlation_id: "turn-test".into(),
+            progressive_tool_disclosure: false,
+            tool_session_id,
+            mcp_runtime: None,
+            mcp_session_scope: None,
+            extension_runtime: None,
+            extension_session_scope: None,
+            turn_budget: crate::runtime::budget::TurnBudget::for_role(
+                crate::runtime::budget::TurnRole::Foreground,
+            ),
+        };
+
+        let messages = vec![Arc::new(json!({"role":"user","content":"go"})) as SharedMessage];
+        let run = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            StreamMethods::run_stream_internal(session, messages),
+        )
+        .await
+        .expect("stream loop must finish");
+        run.expect("stream loop ok");
+
+        let mut history = Vec::new();
+        let mut ui_results = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                StreamEvent::Session(SessionEvent::MessageHistory(m)) => history = m,
+                StreamEvent::Llm(LlmEvent::ToolResult { result, .. }) => ui_results.push(result),
+                _ => {}
+            }
+        }
+        // Give the mock a beat to finish recording the last body.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let bodies = mock.bodies.lock().unwrap().clone();
+        assert_eq!(mock.calls.load(Ordering::SeqCst), 2, "two provider rounds");
+        Driven {
+            history,
+            ui_results,
+            bodies,
+        }
+    }
+
+    /// The user message carrying tool results, from the round-2 request body.
+    fn tool_result_message(body: &Value) -> &Value {
+        body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .rev()
+            .find(|m| m["role"] == "user" && m["content"][0]["type"] == "tool_result")
+            .expect("tool_result user message on the wire")
+    }
+
+    #[tokio::test]
+    async fn rich_tool_output_lands_as_array_content() {
+        let d = drive(
+            vec![Arc::new(RichTool)],
+            &[("toolu_1", "rich_stub")],
+            Arc::new(crate::extensions::hooks::HookBus::new()),
+        )
+        .await;
+
+        // On the wire (round-2 body).
+        let msg = tool_result_message(&d.bodies[1]);
+        let tr = &msg["content"][0];
+        assert_eq!(tr["tool_use_id"], "toolu_1");
+        let blocks = tr["content"].as_array().expect("array content");
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0]["type"], "text");
+        assert_eq!(
+            blocks[0]["text"],
+            "Image: /tmp/x.png (1x1, image/png, 1 KB)"
+        );
+        assert_eq!(blocks[1]["type"], "image");
+        assert_eq!(blocks[1]["source"]["type"], "base64");
+        assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+        assert!(blocks[1]["source"]["data"]
+            .as_str()
+            .unwrap()
+            .starts_with(PNG_B64_PREFIX));
+
+        // In durable history too.
+        let hist_msg = d
+            .history
+            .iter()
+            .find(|m| m["role"] == "user" && m["content"][0]["type"] == "tool_result")
+            .expect("history tool_result");
+        assert!(hist_msg["content"][0]["content"].is_array());
+    }
+
+    #[tokio::test]
+    async fn rich_output_and_hook_replace() {
+        let bus = Arc::new(crate::extensions::hooks::HookBus::new());
+        let mut perms = PermissionSet::new();
+        perms.grant(crate::extensions::permissions::Permission::ToolsIntercept);
+        perms.grant(crate::extensions::permissions::Permission::ToolsTransformOutput);
+        bus.subscribe(
+            HookKind::AfterToolCall,
+            Arc::new(ReplaceHook),
+            None,
+            None,
+            perms,
+        )
+        .await
+        .unwrap();
+
+        let d = drive(vec![Arc::new(RichTool)], &[("toolu_1", "rich_stub")], bus).await;
+        let tr = &tool_result_message(&d.bodies[1])["content"][0];
+        assert!(
+            tr["content"].is_string(),
+            "Replace wins; rich blocks dropped"
+        );
+        assert_eq!(tr["content"], Value::String("REPLACED BY HOOK".into()));
+    }
+
+    #[tokio::test]
+    async fn parallel_lane_preserves_rich_content() {
+        let d = drive(
+            vec![Arc::new(RichTool), Arc::new(TextTool)],
+            &[("toolu_a", "rich_stub"), ("toolu_b", "text_stub")],
+            Arc::new(crate::extensions::hooks::HookBus::new()),
+        )
+        .await;
+        let msg = tool_result_message(&d.bodies[1]);
+        let results = msg["content"].as_array().unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0]["tool_use_id"], "toolu_a");
+        assert!(results[0]["content"].is_array(), "{}", results[0]);
+        assert_eq!(results[0]["content"][1]["type"], "image");
+        assert_eq!(results[1]["tool_use_id"], "toolu_b");
+        assert_eq!(
+            results[1]["content"],
+            Value::String("plain text result".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn ui_preview_never_contains_base64() {
+        let d = drive(
+            vec![Arc::new(RichTool), Arc::new(TextTool)],
+            &[("toolu_a", "rich_stub"), ("toolu_b", "text_stub")],
+            Arc::new(crate::extensions::hooks::HookBus::new()),
+        )
+        .await;
+        assert_eq!(d.ui_results.len(), 2);
+        let rich = d
+            .ui_results
+            .iter()
+            .find(|r| r.starts_with("Image: "))
+            .expect("rich preview");
+        assert_eq!(rich, "Image: /tmp/x.png (1x1, image/png, 1 KB)");
+        for r in &d.ui_results {
+            assert!(r.len() < 512);
+            assert!(!r.contains(PNG_B64_PREFIX));
+        }
+    }
+
+    #[tokio::test]
+    async fn round_result_bytes_counts_array_content() {
+        assert_eq!(
+            tool_result_bytes(&json!({"type":"tool_result","tool_use_id":"x","content":"ok"})),
+            2
+        );
+        let arr = json!({"type":"tool_result","tool_use_id":"x","content":[
+            {"type":"text","text":"Image: x"},
+            {"type":"image","source":{"type":"base64","media_type":"image/png","data":fake_b64(1_000)}}
+        ]});
+        assert!(tool_result_bytes(&arr) >= 1_000);
+        // Legacy behaviour would have been 0 for arrays.
+        assert_ne!(tool_result_bytes(&arr), 0);
+    }
+
+    #[test]
+    fn select_content_prefers_rich_then_bounded_then_truncated() {
+        let blocks = vec![json!({"type":"text","text":"s"})];
+        assert!(select_tool_result_content(Some(blocks), Some("b".into()), "s", 10).is_array());
+        assert_eq!(
+            select_tool_result_content(None, Some("bounded".into()), "s", 10),
+            Value::String("bounded".into())
+        );
+        assert_eq!(
+            select_tool_result_content(None, None, "short", 10),
+            Value::String("short".into())
         );
     }
 }

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -559,6 +559,21 @@ impl StreamMethods {
                 None => &messages,
             };
 
+            // History image byte cap: the per-turn byte budget resets every
+            // turn but base64 images live in history forever. Bound the wire
+            // by degrading the OLDEST image blocks to a text label once the
+            // total crosses `HISTORY_IMAGE_BYTE_CAP`. Request-local like the
+            // injection above — durable history is untouched.
+            let capped_messages: Vec<SharedMessage>;
+            let request_messages: &[SharedMessage] =
+                match cap_history_image_bytes(request_messages, HISTORY_IMAGE_BYTE_CAP) {
+                    Some(capped) => {
+                        capped_messages = capped;
+                        &capped_messages
+                    }
+                    None => request_messages,
+                };
+
             // Flag-off: borrow the turn's options untouched — no per-round
             // clone, exactly the pre-Task-18 request path. Flag-on: build one
             // per-round options value carrying the session projection.
@@ -910,7 +925,7 @@ impl StreamMethods {
                                             // Hook policy: a Replace transform wins over the rich
                                             // blocks — the hook saw only the summary, so keeping
                                             // the image would desync text and image.
-                                            let rich_blocks = if hooked_output == output { rich_blocks } else { None };
+                                            let rich_blocks = drop_rich_if_rewritten(rich_blocks, &hooked_output, &output);
                                             (hooked_output, rich_blocks)
                                         }
                                         _ = cancel.cancelled() => {
@@ -1229,7 +1244,7 @@ impl StreamMethods {
                                                 max_tool_output,
                                             ).await;
                                             // Hook Replace wins over rich blocks (see single-tool site).
-                                            let rich_blocks = if hooked_output == output { rich_blocks } else { None };
+                                            let rich_blocks = drop_rich_if_rewritten(rich_blocks, &hooked_output, &output);
                                             (false, Some(call_effect), hooked_output, Some(output_handle), Some((stable_tool_id, activation_basis, tool_call_started)), rich_blocks)
                                         }
                                         _ = cancel_token.cancelled() => {
@@ -1457,6 +1472,29 @@ impl StreamMethods {
     }
 }
 
+/// Hook policy: a `Replace` transform wins over rich blocks — the hook saw
+/// only the summary, so keeping the image would desync text and image.
+/// Note `emit_after_tool_call` also runs `truncate_tool_result`, so a
+/// summary longer than `max_tool_output` trips this too; log it so the
+/// dropped image isn't a silent mystery.
+fn drop_rich_if_rewritten(
+    rich_blocks: Option<Vec<Value>>,
+    hooked_output: &str,
+    output: &str,
+) -> Option<Vec<Value>> {
+    if hooked_output == output {
+        return rich_blocks;
+    }
+    if rich_blocks.is_some() {
+        tracing::debug!(
+            summary_len = output.len(),
+            hooked_len = hooked_output.len(),
+            "rich tool blocks dropped: after_tool_call rewrote (or truncated) the summary"
+        );
+    }
+    None
+}
+
 /// Pick the `tool_result.content` value. Rich blocks win outright (they
 /// carry their own budget and never see `truncate_tool_result`); otherwise
 /// the bounded delta-lane text, otherwise the truncated summary.
@@ -1471,6 +1509,80 @@ fn select_tool_result_content(
         (None, Some(text)) => Value::String(text),
         (None, None) => Value::String(HelperMethods::truncate_tool_result(result, max_tool_output)),
     }
+}
+
+/// Total base64 image payload bytes allowed across the whole request
+/// history. Anthropic caps a request at 32 MB; leave headroom for text.
+pub(crate) const HISTORY_IMAGE_BYTE_CAP: usize = 20 * 1024 * 1024;
+
+/// Label left in place of an image block dropped by the history byte cap.
+pub(crate) const IMAGE_DROPPED_LABEL: &str =
+    "[image dropped: history byte cap — re-read the file if needed]";
+
+fn is_base64_image(b: &Value) -> bool {
+    b["type"] == "image" && b["source"]["type"] == "base64"
+}
+
+fn base64_image_len(b: &Value) -> usize {
+    b["source"]["data"].as_str().map_or(0, str::len)
+}
+
+/// Enforce `cap` on the sum of base64 image payload bytes across `messages`.
+/// Returns `None` when nothing needs to change (no allocation). Otherwise a
+/// request-local copy where the OLDEST image blocks — top-level `content[]`
+/// or nested in `tool_result.content[]` — are replaced with a text block
+/// carrying `IMAGE_DROPPED_LABEL`, until the remainder fits. Only touched
+/// messages are cloned (`Arc::make_mut`); `tool_result.content[0]` (the
+/// text summary) is never an image, so the text-first invariant holds.
+fn cap_history_image_bytes(
+    messages: &[SharedMessage],
+    cap: usize,
+) -> Option<Vec<SharedMessage>> {
+    // (msg index, outer block index, Option<inner block index>, len), oldest first.
+    let mut images: Vec<(usize, usize, Option<usize>, usize)> = Vec::new();
+    for (mi, msg) in messages.iter().enumerate() {
+        let Some(blocks) = msg["content"].as_array() else {
+            continue;
+        };
+        for (bi, block) in blocks.iter().enumerate() {
+            if is_base64_image(block) {
+                images.push((mi, bi, None, base64_image_len(block)));
+            } else if let Some(inner) = block["content"].as_array() {
+                for (ii, b) in inner.iter().enumerate() {
+                    if is_base64_image(b) {
+                        images.push((mi, bi, Some(ii), base64_image_len(b)));
+                    }
+                }
+            }
+        }
+    }
+    let mut total: usize = images.iter().map(|i| i.3).sum();
+    if total <= cap {
+        return None;
+    }
+    let mut out = messages.to_vec();
+    let mut dropped = 0usize;
+    for (mi, bi, ii, len) in images {
+        if total <= cap {
+            break;
+        }
+        let label = json!({"type": "text", "text": IMAGE_DROPPED_LABEL});
+        let msg = Arc::make_mut(&mut out[mi]);
+        let slot = match ii {
+            Some(ii) => &mut msg["content"][bi]["content"][ii],
+            None => &mut msg["content"][bi],
+        };
+        *slot = label;
+        total -= len;
+        dropped += 1;
+    }
+    tracing::info!(
+        dropped,
+        remaining_bytes = total,
+        cap,
+        "history image byte cap: oldest image blocks degraded to text labels"
+    );
+    Some(out)
 }
 
 /// Wire bytes a single `tool_result` charges against the turn byte budget.
@@ -1942,6 +2054,16 @@ mod rich_output_tests {
         tool_uses: &[(&str, &str)],
         hook_bus: Arc<crate::extensions::hooks::HookBus>,
     ) -> Driven {
+        let initial = vec![Arc::new(json!({"role":"user","content":"go"})) as SharedMessage];
+        drive_with_history(initial, tools_to_register, tool_uses, hook_bus).await
+    }
+
+    async fn drive_with_history(
+        messages: Vec<SharedMessage>,
+        tools_to_register: Vec<Arc<dyn Tool>>,
+        tool_uses: &[(&str, &str)],
+        hook_bus: Arc<crate::extensions::hooks::HookBus>,
+    ) -> Driven {
         let (base_url, mock) = spawn_mock(sse_tool_use_round(tool_uses)).await;
 
         let mut registry = ToolRegistry::new();
@@ -2011,7 +2133,6 @@ mod rich_output_tests {
             ),
         };
 
-        let messages = vec![Arc::new(json!({"role":"user","content":"go"})) as SharedMessage];
         let run = tokio::time::timeout(
             std::time::Duration::from_secs(20),
             StreamMethods::run_stream_internal(session, messages),
@@ -2168,6 +2289,138 @@ mod rich_output_tests {
         assert!(tool_result_bytes(&arr) >= 1_000);
         // Legacy behaviour would have been 0 for arrays.
         assert_ne!(tool_result_bytes(&arr), 0);
+    }
+
+    // ── S1: history image byte cap ─────────────────────────────────────────
+
+    fn image_tool_result_msg(id: &str, b64_len: usize) -> SharedMessage {
+        user_msg(json!([{
+            "type": "tool_result", "tool_use_id": id,
+            "content": [
+                {"type": "text", "text": format!("Image: /tmp/{id}.png")},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": fake_b64(b64_len)}}
+            ]
+        }]))
+    }
+
+    fn image_history(n: usize, b64_len: usize) -> Vec<SharedMessage> {
+        let mut h = vec![user_msg(json!("look at these"))];
+        for i in 0..n {
+            let id = format!("toolu_{i}");
+            h.push(Arc::new(json!({"role":"assistant","content":[
+                {"type":"tool_use","id":id,"name":"read","input":{"path":format!("/tmp/{id}.png")}}
+            ]})));
+            h.push(image_tool_result_msg(&id, b64_len));
+        }
+        h
+    }
+
+    #[test]
+    fn history_cap_noop_under_cap() {
+        let h = image_history(3, 1_000);
+        assert!(cap_history_image_bytes(&h, 10_000).is_none());
+        assert!(cap_history_image_bytes(&h, 3_000).is_none());
+    }
+
+    #[test]
+    fn history_cap_drops_oldest_first_keeps_text_and_durable_history() {
+        // 5 images × 1000 bytes, cap 2500 → drop the 3 oldest, keep 2 newest.
+        let h = image_history(5, 1_000);
+        let out = cap_history_image_bytes(&h, 2_500).expect("over cap");
+        assert_eq!(out.len(), h.len());
+        let images: Vec<&Value> = out
+            .iter()
+            .filter(|m| m["content"][0]["type"] == "tool_result")
+            .map(|m| &m["content"][0]["content"][1])
+            .collect();
+        assert_eq!(images.len(), 5);
+        for (i, b) in images.iter().enumerate() {
+            if i < 3 {
+                assert_eq!(b["type"], "text", "image {i} should be dropped");
+                assert_eq!(b["text"], IMAGE_DROPPED_LABEL);
+            } else {
+                assert_eq!(b["type"], "image", "image {i} should survive");
+            }
+        }
+        // Text-first summary untouched on every message.
+        for m in &out {
+            if m["content"][0]["type"] == "tool_result" {
+                assert_eq!(m["content"][0]["content"][0]["type"], "text");
+                assert!(m["content"][0]["content"][0]["text"]
+                    .as_str()
+                    .unwrap()
+                    .starts_with("Image: "));
+            }
+        }
+        // Durable history untouched; untouched messages share the Arc.
+        for m in &h {
+            if m["content"][0]["type"] == "tool_result" {
+                assert_eq!(m["content"][0]["content"][1]["type"], "image");
+            }
+        }
+        assert!(Arc::ptr_eq(&h[0], &out[0]));
+        assert!(Arc::ptr_eq(&h[h.len() - 1], &out[out.len() - 1]));
+        assert!(!Arc::ptr_eq(&h[2], &out[2]));
+    }
+
+    #[test]
+    fn history_cap_handles_top_level_user_images() {
+        let h = vec![
+            user_msg(json!([{"type":"text","text":"a"}, {"type":"image","source":{"type":"base64","media_type":"image/png","data":fake_b64(600)}}])),
+            assistant_msg("ok"),
+            user_msg(json!([{"type":"image","source":{"type":"base64","media_type":"image/png","data":fake_b64(600)}}])),
+        ];
+        let out = cap_history_image_bytes(&h, 1_000).unwrap();
+        assert_eq!(out[0]["content"][1]["text"], IMAGE_DROPPED_LABEL);
+        assert_eq!(out[2]["content"][0]["type"], "image");
+    }
+
+    /// Wire-level: history carrying N images over the cap → the request body
+    /// that hits the provider holds only the newest images under the cap.
+    #[tokio::test]
+    async fn history_cap_applied_to_request_body() {
+        // 7 × 3.5 MiB = 24.5 MiB > 20 MiB → 2 oldest dropped, 5 newest kept.
+        let per = 3_670_016usize;
+        let d = drive_with_history(
+            image_history(7, per),
+            vec![Arc::new(TextTool)],
+            &[("toolu_z", "text_stub")],
+            Arc::new(crate::extensions::hooks::HookBus::new()),
+        )
+        .await;
+        for body in &d.bodies {
+            let msgs = body["messages"].as_array().unwrap();
+            let mut kept = 0usize;
+            let mut dropped = 0usize;
+            let mut bytes = 0usize;
+            for m in msgs {
+                let Some(blocks) = m["content"].as_array() else { continue };
+                for b in blocks {
+                    if let Some(inner) = b["content"].as_array() {
+                        for x in inner {
+                            if is_base64_image(x) {
+                                kept += 1;
+                                bytes += base64_image_len(x);
+                            } else if x["text"] == IMAGE_DROPPED_LABEL {
+                                dropped += 1;
+                            }
+                        }
+                    }
+                }
+            }
+            assert_eq!((dropped, kept), (2, 5), "{}", body["messages"].as_array().unwrap().len());
+            assert!(bytes <= HISTORY_IMAGE_BYTE_CAP, "{bytes}");
+            // Oldest two are the dropped ones.
+            let first = msgs.iter().find(|m| m["content"][0]["type"] == "tool_result").unwrap();
+            assert_eq!(first["content"][0]["content"][1]["text"], IMAGE_DROPPED_LABEL);
+        }
+        // Durable history (what gets saved) still carries every image.
+        let images_in_history = d
+            .history
+            .iter()
+            .filter(|m| m["content"][0]["content"][1]["type"] == "image")
+            .count();
+        assert_eq!(images_in_history, 7);
     }
 
     #[test]

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -204,10 +204,18 @@ impl ToolOutput {
     }
 
     /// `(summary, Some(blocks))` for rich output, `(text, None)` for plain.
+    /// Debug builds assert the `blocks[0]` text-first invariant here — this
+    /// is the one choke point every rich result passes through.
     pub fn into_parts(self) -> (String, Option<Vec<Value>>) {
         match self {
             Self::Text(s) => (s, None),
-            Self::Blocks { blocks, summary } => (summary, Some(blocks)),
+            Self::Blocks { blocks, summary } => {
+                debug_assert!(
+                    blocks.first().is_some_and(|b| b["type"] == "text" && b["text"] == summary),
+                    "ToolOutput::Blocks invariant: blocks[0] must be a text block equal to summary"
+                );
+                (summary, Some(blocks))
+            }
         }
     }
 
@@ -235,6 +243,10 @@ pub trait Tool: Send + Sync {
     /// keep returning `String` via `execute` and never see this. Tools that
     /// need to place non-text content blocks (images) into the model history
     /// override this and make `execute` delegate to it.
+    ///
+    /// RECURSION TRAP: the default delegates to `execute`. If you make
+    /// `execute` delegate here (as `ReadTool` does) you MUST override this
+    /// method too, or the pair recurses until the stack blows.
     async fn execute_rich(&self, params: Value, ctx: ToolContext) -> Result<ToolOutput> {
         self.execute(params, ctx).await.map(ToolOutput::Text)
     }

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -181,6 +181,41 @@ pub enum ConcurrencyKey {
     Serialize,
 }
 
+/// Structured tool output. `Text` is the legacy contract (what `execute`
+/// returns). `Blocks` carries Anthropic-shaped content blocks destined for
+/// `tool_result.content`, plus a plain-text `summary` used everywhere a
+/// `String` is expected today: UI preview, `after_tool_call` hooks, trace
+/// ledger byte counts, headless logs, and providers that cannot carry the
+/// blocks. INVARIANT: `blocks[0]` MUST be a `{"type":"text"}` block whose
+/// `text` == `summary` (compaction reads `blocks[0].text`; non-Anthropic
+/// translators join only text sub-blocks).
+#[derive(Debug, Clone)]
+pub enum ToolOutput {
+    Text(String),
+    Blocks { blocks: Vec<Value>, summary: String },
+}
+
+impl ToolOutput {
+    pub fn summary(&self) -> &str {
+        match self {
+            Self::Text(s) => s,
+            Self::Blocks { summary, .. } => summary,
+        }
+    }
+
+    /// `(summary, Some(blocks))` for rich output, `(text, None)` for plain.
+    pub fn into_parts(self) -> (String, Option<Vec<Value>>) {
+        match self {
+            Self::Text(s) => (s, None),
+            Self::Blocks { blocks, summary } => (summary, Some(blocks)),
+        }
+    }
+
+    pub fn into_summary(self) -> String {
+        self.into_parts().0
+    }
+}
+
 /// The core trait for all tools. Implement this to add a new tool.
 #[async_trait::async_trait]
 pub trait Tool: Send + Sync {
@@ -195,6 +230,14 @@ pub trait Tool: Send + Sync {
 
     /// Execute the tool with the given parameters.
     async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String>;
+
+    /// Structured variant of [`Tool::execute`]. DEFAULTED — existing tools
+    /// keep returning `String` via `execute` and never see this. Tools that
+    /// need to place non-text content blocks (images) into the model history
+    /// override this and make `execute` delegate to it.
+    async fn execute_rich(&self, params: Value, ctx: ToolContext) -> Result<ToolOutput> {
+        self.execute(params, ctx).await.map(ToolOutput::Text)
+    }
 
     /// Owning extension id for tools registered by an extension. Built-in tools return `None`.
     fn extension_id(&self) -> Option<&str> {

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -8,6 +8,10 @@ pub(crate) const MAX_IMAGE_BYTES: usize = 3_670_016;
 const MAX_IMAGE_SIDE_PX: u32 = 8000;
 /// Above this long edge Anthropic downscales server-side (coordinate caveat).
 const PROVIDER_DOWNSCALE_LONG_EDGE: u32 = 1568;
+/// Seatbelt: refuse to load anything larger than this into memory at all.
+/// Checked via `fs::metadata` BEFORE the read, so a 200 MB `.tif` or a
+/// device file never gets pulled in.
+pub(crate) const MAX_READ_BYTES: u64 = 64 * 1024 * 1024;
 
 pub struct ReadTool;
 
@@ -61,6 +65,25 @@ impl Tool for ReadTool {
             .as_str()
             .ok_or_else(|| RuntimeError::Tool("Missing path parameter".to_string()))?;
         let path = expand_path(raw_path);
+
+        // Size guard BEFORE reading: one stat, no bytes loaded.
+        let meta = tokio::fs::metadata(&path).await.map_err(|e| {
+            RuntimeError::Tool(format!("Failed to read file '{}': {}", path.display(), e))
+        })?;
+        if !meta.is_file() {
+            return Err(RuntimeError::Tool(format!(
+                "'{}' is not a regular file. Use `bash` (ls, file, head) to inspect it.",
+                path.display()
+            )));
+        }
+        if meta.len() > MAX_READ_BYTES {
+            return Err(RuntimeError::Tool(format!(
+                "File '{}' is {} KB; the read tool refuses files over {} KB. Use `bash` with `head`, `tail`, `xxd`, or `sed -n` to read a slice, or shrink an image with `convert`.",
+                path.display(),
+                meta.len().div_ceil(1024),
+                MAX_READ_BYTES / 1024
+            )));
+        }
 
         // Read raw bytes first to detect binary files
         let bytes = tokio::fs::read(&path).await.map_err(|e| {
@@ -121,8 +144,8 @@ pub(crate) fn sniff_image_mime(b: &[u8]) -> Option<&'static str> {
     None
 }
 
-/// Header-only dimension parse. Best effort: `None` → label shows `?x?`.
-/// Never a hard failure — dims are for the label and the 8000px guard only.
+/// Header-only dimension parse. `None` → `image_output` rejects the file
+/// (an unsized image bypasses the 8000 px guard → provider 400 → poison pill).
 pub(crate) fn image_dimensions(mime: &str, b: &[u8]) -> Option<(u32, u32)> {
     match mime {
         "image/png" if b.len() >= 24 => Some((be32(&b[16..20]), be32(&b[20..24]))),
@@ -193,6 +216,45 @@ fn le16(b: &[u8]) -> u16 {
 fn le24(b: &[u8]) -> u32 {
     u32::from_le_bytes([b[0], b[1], b[2], 0])
 }
+fn le32(b: &[u8]) -> u32 {
+    u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+}
+
+/// Cheap structural integrity check — trailer/size sanity only, no decode.
+/// A truncated or corrupt image shipped to the provider is a poison pill:
+/// the 400 repeats on every request until the session is cleared, because
+/// a `tool_result` user message always survives history repair. Reject here.
+pub(crate) fn image_integrity_error(mime: &str, b: &[u8]) -> Option<&'static str> {
+    match mime {
+        "image/png" => {
+            if b.len() < 16 || &b[12..16] != b"IHDR" {
+                return Some("first chunk is not IHDR");
+            }
+            if !b.ends_with(b"IEND\xAE\x42\x60\x82") {
+                return Some("missing IEND trailer (truncated?)");
+            }
+        }
+        "image/jpeg" => {
+            if !b.ends_with(&[0xFF, 0xD9]) {
+                return Some("missing EOI marker (truncated?)");
+            }
+        }
+        "image/gif" => {
+            if !b.ends_with(&[0x3B]) {
+                return Some("missing GIF trailer (truncated?)");
+            }
+        }
+        "image/webp" => {
+            let riff = le32(&b[4..8]) as usize;
+            // RIFF size = file length − 8; allow a single pad byte of slack.
+            if riff + 8 != b.len() && riff + 9 != b.len() {
+                return Some("RIFF size does not match file length (truncated?)");
+            }
+        }
+        _ => {}
+    }
+    None
+}
 
 fn image_output(path: &std::path::Path, mime: &'static str, bytes: &[u8]) -> Result<ToolOutput> {
     use base64::Engine as _;
@@ -208,24 +270,33 @@ fn image_output(path: &std::path::Path, mime: &'static str, bytes: &[u8]) -> Res
             cap = MAX_IMAGE_BYTES / 1024
         )));
     }
-    let dims = image_dimensions(mime, bytes);
-    if let Some((w, h)) = dims {
-        if w > MAX_IMAGE_SIDE_PX || h > MAX_IMAGE_SIDE_PX {
-            return Err(RuntimeError::Tool(format!(
-                "Image '{}' is {w}x{h}; the provider rejects images with any side over {MAX_IMAGE_SIDE_PX} px. \
-                 Downscale it with bash (e.g. `convert ... -resize 1568x1568\\>`) and read the new file.",
-                path.display()
-            )));
-        }
+    if let Some(why) = image_integrity_error(mime, bytes) {
+        return Err(RuntimeError::Tool(format!(
+            "Image '{}' ({mime}, {kb} KB) appears truncated or corrupt: {why}. \
+             Not sent to the model. Verify with `file` / `identify`, or re-export it and read the new file.",
+            path.display()
+        )));
     }
-    let dims_label = dims
-        .map(|(w, h)| format!("{w}x{h}"))
-        .unwrap_or_else(|| "?x?".into());
-    let mut summary = format!("Image: {} ({dims_label}, {mime}, {kb} KB)", path.display());
-    if let Some((w, h)) = dims {
-        if w.max(h) > PROVIDER_DOWNSCALE_LONG_EDGE {
-            summary.push_str("\nNote: long edge exceeds 1568 px; the provider downscales before viewing, so pixel coordinates read from the image are approximate.");
-        }
+    // Unknown dims → reject. Shipping an image we cannot size means the
+    // 8000 px guard is bypassed and a provider 400 poisons the session.
+    let Some((w, h)) = image_dimensions(mime, bytes) else {
+        return Err(RuntimeError::Tool(format!(
+            "Image '{}' ({mime}, {kb} KB): could not parse dimensions from the header. \
+             Not sent to the model. Re-export it (e.g. `convert '{}' /tmp/fixed.png`) and read the new file.",
+            path.display(),
+            path.display()
+        )));
+    };
+    if w > MAX_IMAGE_SIDE_PX || h > MAX_IMAGE_SIDE_PX {
+        return Err(RuntimeError::Tool(format!(
+            "Image '{}' is {w}x{h}; the provider rejects images with any side over {MAX_IMAGE_SIDE_PX} px. \
+             Downscale it with bash (e.g. `convert ... -resize 1568x1568\\>`) and read the new file.",
+            path.display()
+        )));
+    }
+    let mut summary = format!("Image: {} ({w}x{h}, {mime}, {kb} KB)", path.display());
+    if w.max(h) > PROVIDER_DOWNSCALE_LONG_EDGE {
+        summary.push_str("\nNote: long edge exceeds 1568 px; the provider downscales before viewing, so pixel coordinates read from the image are approximate.");
     }
     let data = base64::engine::general_purpose::STANDARD.encode(bytes);
     Ok(ToolOutput::Blocks {
@@ -343,12 +414,20 @@ mod tests {
         v
     }
 
-    /// Minimal 1×1 PNG: header + IHDR body tail + (fake) CRC.
-    fn tiny_png() -> Vec<u8> {
-        let mut v = png_header(1, 1);
+    const PNG_IEND: [u8; 12] = [0, 0, 0, 0, b'I', b'E', b'N', b'D', 0xAE, 0x42, 0x60, 0x82];
+
+    /// Structurally complete PNG with the given dims: IHDR + IEND, no IDAT.
+    fn png_with_dims(w: u32, h: u32) -> Vec<u8> {
+        let mut v = png_header(w, h);
         v.extend_from_slice(&[8, 6, 0, 0, 0]); // depth, color, comp, filter, interlace
         v.extend_from_slice(&[0, 0, 0, 0]); // crc (not validated)
+        v.extend_from_slice(&PNG_IEND);
         v
+    }
+
+    /// Minimal 1×1 PNG.
+    fn tiny_png() -> Vec<u8> {
+        png_with_dims(1, 1)
     }
 
     fn tmp(name: &str, bytes: &[u8]) -> std::path::PathBuf {
@@ -528,7 +607,7 @@ mod tests {
 
     #[tokio::test]
     async fn image_over_8000px_rejected() {
-        let p = tmp("wide.png", &png_header(8001, 10));
+        let p = tmp("wide.png", &png_with_dims(8001, 10));
         let err = ReadTool
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
             .await
@@ -562,7 +641,7 @@ mod tests {
         );
         let _ = std::fs::remove_file(p);
 
-        let p = tmp("wide2.png", &png_header(2000, 100));
+        let p = tmp("wide2.png", &png_with_dims(2000, 100));
         let out = ReadTool
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
             .await
@@ -584,7 +663,7 @@ mod tests {
         };
         let p = std::path::PathBuf::from(home).join("Jawz/media/jawz-avatar-v1.png");
         if !p.exists() {
-            eprintln!("skip: {} absent", p.display());
+            eprintln!("SKIPPED real_avatar_png_round_trips_as_image_blocks: {} absent", p.display());
             return;
         }
         let out = ReadTool
@@ -606,10 +685,6 @@ mod tests {
         let data = blocks[1]["source"]["data"].as_str().unwrap();
         assert!(data.starts_with("iVBORw0KGgo"));
         assert!(serde_json::to_vec(&blocks[1]).unwrap().len() < 5_000_000);
-        eprintln!(
-            "INTEGRATION summary={summary:?} base64[..40]={}",
-            &data[..40]
-        );
     }
 
     /// Integration evidence: a real .rs file still reads as numbered text,
@@ -626,18 +701,182 @@ mod tests {
             .unwrap();
         let ToolOutput::Text(text) = out else { panic!("expected Text") };
         assert!(text.starts_with("1\tuse super::"), "{text}");
-        eprintln!("INTEGRATION rs_read_first_line={:?}", text.lines().next().unwrap());
 
-        if let Ok(big) = std::env::var("SYNAPS_TEST_BIG_IMAGE") {
+        let Ok(big) = std::env::var("SYNAPS_TEST_BIG_IMAGE") else {
+            eprintln!("SKIPPED big-image half of real_rs_file_and_optional_big_image: SYNAPS_TEST_BIG_IMAGE unset");
+            return;
+        };
+        let err = ReadTool
+            .execute_rich(json!({"path": big}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("accepts images up to 3584 KB"), "{err}");
+        assert!(err.contains("convert"));
+        assert!(err.len() < 1024);
+    }
+
+    // ── S2: poison-pill integrity checks ────────────────────────────────────
+
+    #[test]
+    fn integrity_check_per_format() {
+        // PNG
+        assert_eq!(image_integrity_error("image/png", &tiny_png()), None);
+        assert!(image_integrity_error("image/png", &png_header(1, 1)).is_some()); // no IEND
+        let mut bad_chunk = tiny_png();
+        bad_chunk[12..16].copy_from_slice(b"iTXt");
+        assert!(image_integrity_error("image/png", &bad_chunk).is_some());
+        assert!(image_integrity_error("image/png", &PNG_SIG).is_some());
+        // JPEG
+        assert_eq!(image_integrity_error("image/jpeg", &[0xFF, 0xD8, 0xFF, 0xD9]), None);
+        assert!(image_integrity_error("image/jpeg", &[0xFF, 0xD8, 0xFF, 0xE0, 0, 0]).is_some());
+        // GIF
+        assert_eq!(image_integrity_error("image/gif", b"GIF89a\x01\x00\x01\x00\x3B"), None);
+        assert!(image_integrity_error("image/gif", b"GIF89a\x01\x00\x01\x00").is_some());
+        // WebP: RIFF size must equal len - 8.
+        let mut webp = b"RIFF\x00\x00\x00\x00WEBPVP8 ".to_vec();
+        webp.extend_from_slice(&[0u8; 20]);
+        assert!(image_integrity_error("image/webp", &webp).is_some());
+        let riff = (webp.len() - 8) as u32;
+        webp[4..8].copy_from_slice(&riff.to_le_bytes());
+        assert_eq!(image_integrity_error("image/webp", &webp), None);
+        webp.pop();
+        assert!(image_integrity_error("image/webp", &webp).is_some());
+    }
+
+    #[tokio::test]
+    async fn truncated_png_rejected_no_image_block() {
+        // Header + 3 KB of zeros, no IEND — the "half-written screenshot" case.
+        let mut bytes = png_header(10, 10);
+        bytes.resize(3_000, 0);
+        let p = tmp("trunc.png", &bytes);
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err();
+        let RuntimeError::Tool(msg) = err else {
+            panic!("expected Tool error, got {err:?}");
+        };
+        assert!(msg.contains("truncated or corrupt"), "{msg}");
+        assert!(msg.contains("IEND"), "{msg}");
+        assert!(!msg.contains("iVBORw0KGgo"), "no base64 in error");
+        assert!(msg.len() < 1024);
+        // Legacy path: same rejection, plain string, no image anywhere.
+        let s = ReadTool
+            .execute(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(s.contains("truncated or corrupt"), "{s}");
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn truncated_jpeg_and_gif_rejected() {
+        let jpeg = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, b'J', b'F', b'I', b'F', 0, 1, 1, 0, 0, 1, 0, 1, 0, 0];
+        let p = tmp("trunc.jpg", &jpeg);
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("EOI"), "{err}");
+        let _ = std::fs::remove_file(p);
+
+        let p = tmp("trunc.gif", b"GIF89a\x01\x00\x01\x00\x00\x00\x00");
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("GIF trailer"), "{err}");
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn unparseable_dims_rejected_not_shipped() {
+        // Structurally complete JPEG (SOI … EOI) but SOS before any SOF →
+        // dims None → must NOT become an image block.
+        let jpeg = [0xFF, 0xD8, 0xFF, 0xDA, 0x00, 0x08, 0, 0, 0, 0, 0, 0, 0xFF, 0xD9];
+        let p = tmp("nodims.jpg", &jpeg);
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("could not parse dimensions"), "{err}");
+        assert!(err.contains("Not sent to the model"), "{err}");
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn complete_gif_and_jpeg_round_trip_through_execute_rich() {
+        let p = tmp("ok.gif", b"GIF89a\x02\x00\x03\x00\x00\x00\x00\x3B");
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        assert!(out.summary().contains("(2x3, image/gif, 1 KB)"), "{}", out.summary());
+        assert!(matches!(out, ToolOutput::Blocks { .. }));
+        let _ = std::fs::remove_file(p);
+
+        let mut j = vec![0xFF, 0xD8, 0xFF, 0xC0, 0x00, 0x11, 0x08];
+        j.extend_from_slice(&480u16.to_be_bytes());
+        j.extend_from_slice(&640u16.to_be_bytes());
+        j.extend_from_slice(&[3, 1, 0x22, 0, 2, 0x11, 1, 3, 0x11, 1, 0xFF, 0xD9]);
+        let p = tmp("ok.jpg", &j);
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        assert!(out.summary().contains("(640x480, image/jpeg, 1 KB)"), "{}", out.summary());
+        let _ = std::fs::remove_file(p);
+    }
+
+    // ── S4: metadata guard before the read ──────────────────────────────────
+
+    #[tokio::test]
+    async fn oversize_file_rejected_by_metadata_without_reading() {
+        // Sparse file: set_len allocates no blocks, so this is instant on
+        // disk but would be a 65 MiB read if the guard ran after the read.
+        let p = std::env::temp_dir().join(format!("read_sparse_{}.bin", std::process::id()));
+        let f = std::fs::File::create(&p).unwrap();
+        f.set_len(MAX_READ_BYTES + 1).unwrap();
+        drop(f);
+        let start = std::time::Instant::now();
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("refuses files over"), "{err}");
+        assert!(err.contains("head"), "{err}");
+        assert!(start.elapsed() < std::time::Duration::from_secs(2));
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn directory_and_device_rejected_as_not_regular_file() {
+        let err = ReadTool
+            .execute_rich(
+                json!({"path": std::env::temp_dir().to_string_lossy()}),
+                create_tool_context(),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not a regular file"), "{err}");
+
+        #[cfg(unix)]
+        if std::path::Path::new("/dev/zero").exists() {
+            let start = std::time::Instant::now();
             let err = ReadTool
-                .execute_rich(json!({"path": big}), create_tool_context())
+                .execute_rich(json!({"path": "/dev/zero"}), create_tool_context())
                 .await
                 .unwrap_err()
                 .to_string();
-            assert!(err.contains("accepts images up to 3584 KB"), "{err}");
-            assert!(err.contains("convert"));
-            assert!(err.len() < 1024);
-            eprintln!("INTEGRATION big_image_rejected={err:?}");
+            assert!(err.contains("not a regular file"), "{err}");
+            assert!(start.elapsed() < std::time::Duration::from_secs(2));
         }
     }
 

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -234,15 +234,11 @@ pub(crate) fn image_integrity_error(mime: &str, b: &[u8]) -> Option<&'static str
                 return Some("missing IEND trailer (truncated?)");
             }
         }
-        "image/jpeg" => {
-            if !b.ends_with(&[0xFF, 0xD9]) {
-                return Some("missing EOI marker (truncated?)");
-            }
+        "image/jpeg" if !b.ends_with(&[0xFF, 0xD9]) => {
+            return Some("missing EOI marker (truncated?)");
         }
-        "image/gif" => {
-            if !b.ends_with(&[0x3B]) {
-                return Some("missing GIF trailer (truncated?)");
-            }
+        "image/gif" if !b.ends_with(&[0x3B]) => {
+            return Some("missing GIF trailer (truncated?)");
         }
         "image/webp" => {
             let riff = le32(&b[4..8]) as usize;

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -612,6 +612,35 @@ mod tests {
         );
     }
 
+    /// Integration evidence: a real .rs file still reads as numbered text,
+    /// and (when `SYNAPS_TEST_BIG_IMAGE` points at a >3.5 MiB image) the
+    /// oversize path rejects in-slot with the shrink hint and no base64.
+    #[tokio::test]
+    async fn real_rs_file_and_optional_big_image() {
+        let out = ReadTool
+            .execute_rich(
+                json!({"path": concat!(env!("CARGO_MANIFEST_DIR"), "/src/tools/read.rs"), "limit": 3}),
+                create_tool_context(),
+            )
+            .await
+            .unwrap();
+        let ToolOutput::Text(text) = out else { panic!("expected Text") };
+        assert!(text.starts_with("1\tuse super::"), "{text}");
+        eprintln!("INTEGRATION rs_read_first_line={:?}", text.lines().next().unwrap());
+
+        if let Ok(big) = std::env::var("SYNAPS_TEST_BIG_IMAGE") {
+            let err = ReadTool
+                .execute_rich(json!({"path": big}), create_tool_context())
+                .await
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("accepts images up to 3584 KB"), "{err}");
+            assert!(err.contains("convert"));
+            assert!(err.len() < 1024);
+            eprintln!("INTEGRATION big_image_rejected={err:?}");
+        }
+    }
+
     #[tokio::test]
     async fn non_image_binary_mentions_image_support() {
         let p = tmp("blob.bin", &[0xFF, 0xFE, 0x00, 0x80, 0x81]);

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -1,6 +1,13 @@
-use super::{expand_path, Tool, ToolContext};
+use super::{expand_path, Tool, ToolContext, ToolOutput};
 use crate::{Result, RuntimeError};
 use serde_json::{json, Value};
+
+/// Raw-byte cap. 3.5 MiB × 4/3 base64 = 4.89 MB < Anthropic's 5 MB/image.
+pub(crate) const MAX_IMAGE_BYTES: usize = 3_670_016;
+/// Anthropic rejects any side > 8000 px.
+const MAX_IMAGE_SIDE_PX: u32 = 8000;
+/// Above this long edge Anthropic downscales server-side (coordinate caveat).
+const PROVIDER_DOWNSCALE_LONG_EDGE: u32 = 1568;
 
 pub struct ReadTool;
 
@@ -19,7 +26,7 @@ impl Tool for ReadTool {
     }
 
     fn description(&self) -> &str {
-        "Read the contents of a file. Returns lines with line numbers. Reads up to 500 lines by default. For large files, use offset and limit to read in sections."
+        "Read the contents of a file. Returns lines with line numbers. Reads up to 500 lines by default. For large files, use offset and limit to read in sections. Image files (PNG, JPEG, GIF, WebP) are returned as an image the model can see, up to 3.5 MB."
     }
 
     fn parameters(&self) -> Value {
@@ -43,7 +50,13 @@ impl Tool for ReadTool {
         })
     }
 
-    async fn execute(&self, params: Value, _ctx: ToolContext) -> Result<String> {
+    async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
+        self.execute_rich(params, ctx)
+            .await
+            .map(ToolOutput::into_summary)
+    }
+
+    async fn execute_rich(&self, params: Value, _ctx: ToolContext) -> Result<ToolOutput> {
         let raw_path = params["path"]
             .as_str()
             .ok_or_else(|| RuntimeError::Tool("Missing path parameter".to_string()))?;
@@ -54,10 +67,14 @@ impl Tool for ReadTool {
             RuntimeError::Tool(format!("Failed to read file '{}': {}", path.display(), e))
         })?;
 
+        if let Some(mime) = sniff_image_mime(&bytes) {
+            return image_output(&path, mime, &bytes);
+        }
+
         let content = match String::from_utf8(bytes) {
             Ok(s) => s,
             Err(_) => return Err(RuntimeError::Tool(format!(
-                "File '{}' appears to be binary (not valid UTF-8). Use `bash` with `xxd` or `file` to inspect binary files.",
+                "File '{}' appears to be binary (not valid UTF-8). Use `bash` with `xxd` or `file` to inspect binary files. Image files (png/jpg/gif/webp) are returned as images automatically.",
                 path.display()
             ))),
         };
@@ -83,9 +100,144 @@ impl Tool for ReadTool {
             result.push_str(&format!("\n... ({} more lines)", total_lines - end));
         }
 
-        Ok(result)
+        Ok(ToolOutput::Text(result))
     }
 }
+
+/// Magic-byte sniff — content, never extension.
+pub(crate) fn sniff_image_mime(b: &[u8]) -> Option<&'static str> {
+    if b.len() >= 8 && b[..8] == [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A] {
+        return Some("image/png");
+    }
+    if b.len() >= 3 && b[..3] == [0xFF, 0xD8, 0xFF] {
+        return Some("image/jpeg");
+    }
+    if b.len() >= 6 && (&b[..6] == b"GIF87a" || &b[..6] == b"GIF89a") {
+        return Some("image/gif");
+    }
+    if b.len() >= 12 && &b[..4] == b"RIFF" && &b[8..12] == b"WEBP" {
+        return Some("image/webp");
+    }
+    None
+}
+
+/// Header-only dimension parse. Best effort: `None` → label shows `?x?`.
+/// Never a hard failure — dims are for the label and the 8000px guard only.
+pub(crate) fn image_dimensions(mime: &str, b: &[u8]) -> Option<(u32, u32)> {
+    match mime {
+        "image/png" if b.len() >= 24 => Some((be32(&b[16..20]), be32(&b[20..24]))),
+        "image/gif" if b.len() >= 10 => Some((le16(&b[6..8]) as u32, le16(&b[8..10]) as u32)),
+        "image/webp" if b.len() >= 30 => match &b[12..16] {
+            b"VP8 " => Some((
+                (le16(&b[26..28]) & 0x3FFF) as u32,
+                (le16(&b[28..30]) & 0x3FFF) as u32,
+            )),
+            b"VP8L" => {
+                let x = [b[21], b[22], b[23], b[24]];
+                Some((
+                    1 + (((x[1] & 0x3F) as u32) << 8 | x[0] as u32),
+                    1 + (((x[3] & 0x0F) as u32) << 10
+                        | (x[2] as u32) << 2
+                        | ((x[1] & 0xC0) as u32) >> 6),
+                ))
+            }
+            b"VP8X" => Some((1 + le24(&b[24..27]), 1 + le24(&b[27..30]))),
+            _ => None,
+        },
+        "image/jpeg" => jpeg_dimensions(b),
+        _ => None,
+    }
+}
+
+fn jpeg_dimensions(b: &[u8]) -> Option<(u32, u32)> {
+    // Walk segments from offset 2 until a SOFn marker (C0–CF except C4, C8, CC).
+    let mut i = 2usize;
+    while i + 4 <= b.len() {
+        if b[i] != 0xFF {
+            return None;
+        }
+        let m = b[i + 1];
+        if m == 0xFF {
+            i += 1; // fill byte
+            continue;
+        }
+        if m == 0xD8 || m == 0x01 || (0xD0..=0xD7).contains(&m) {
+            i += 2; // standalone marker
+            continue;
+        }
+        if m == 0xD9 || m == 0xDA {
+            return None; // EOI / SOS: no SOF found
+        }
+        let len = be16(&b[i + 2..i + 4]) as usize;
+        if matches!(m, 0xC0..=0xCF) && !matches!(m, 0xC4 | 0xC8 | 0xCC) {
+            if i + 9 > b.len() {
+                return None;
+            }
+            // SOFn payload: Lf(2) P(1) Y(2) X(2) — height then width.
+            return Some((be16(&b[i + 7..i + 9]) as u32, be16(&b[i + 5..i + 7]) as u32));
+        }
+        i += 2 + len;
+    }
+    None
+}
+
+fn be16(b: &[u8]) -> u16 {
+    u16::from_be_bytes([b[0], b[1]])
+}
+fn be32(b: &[u8]) -> u32 {
+    u32::from_be_bytes([b[0], b[1], b[2], b[3]])
+}
+fn le16(b: &[u8]) -> u16 {
+    u16::from_le_bytes([b[0], b[1]])
+}
+fn le24(b: &[u8]) -> u32 {
+    u32::from_le_bytes([b[0], b[1], b[2], 0])
+}
+
+fn image_output(path: &std::path::Path, mime: &'static str, bytes: &[u8]) -> Result<ToolOutput> {
+    use base64::Engine as _;
+    let kb = bytes.len().div_ceil(1024);
+    if bytes.len() > MAX_IMAGE_BYTES {
+        return Err(RuntimeError::Tool(format!(
+            "Image '{p}' is {kb} KB; the read tool accepts images up to {cap} KB. \
+             Shrink it with bash and read the new file, e.g.:\n  \
+             convert '{p}' -resize 1568x1568\\> -quality 85 /tmp/shrunk.jpg   (ImageMagick)\n  \
+             sips -Z 1568 '{p}' --out /tmp/shrunk.png                        (macOS)",
+            p = path.display(),
+            kb = kb,
+            cap = MAX_IMAGE_BYTES / 1024
+        )));
+    }
+    let dims = image_dimensions(mime, bytes);
+    if let Some((w, h)) = dims {
+        if w > MAX_IMAGE_SIDE_PX || h > MAX_IMAGE_SIDE_PX {
+            return Err(RuntimeError::Tool(format!(
+                "Image '{}' is {w}x{h}; the provider rejects images with any side over {MAX_IMAGE_SIDE_PX} px. \
+                 Downscale it with bash (e.g. `convert ... -resize 1568x1568\\>`) and read the new file.",
+                path.display()
+            )));
+        }
+    }
+    let dims_label = dims
+        .map(|(w, h)| format!("{w}x{h}"))
+        .unwrap_or_else(|| "?x?".into());
+    let mut summary = format!("Image: {} ({dims_label}, {mime}, {kb} KB)", path.display());
+    if let Some((w, h)) = dims {
+        if w.max(h) > PROVIDER_DOWNSCALE_LONG_EDGE {
+            summary.push_str("\nNote: long edge exceeds 1568 px; the provider downscales before viewing, so pixel coordinates read from the image are approximate.");
+        }
+    }
+    let data = base64::engine::general_purpose::STANDARD.encode(bytes);
+    Ok(ToolOutput::Blocks {
+        blocks: vec![
+            // FIRST — invariant: blocks[0] is text == summary.
+            json!({ "type": "text", "text": summary }),
+            json!({ "type": "image", "source": { "type": "base64", "media_type": mime, "data": data } }),
+        ],
+        summary,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::test_helpers::create_tool_context;
@@ -175,5 +327,302 @@ mod tests {
 
         // Cleanup
         let _ = std::fs::remove_file(&test_file);
+    }
+
+    // ── image support ───────────────────────────────────────────────────────
+
+    const PNG_SIG: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+
+    /// PNG signature + IHDR chunk header with the given dims (24 bytes total).
+    fn png_header(w: u32, h: u32) -> Vec<u8> {
+        let mut v = PNG_SIG.to_vec();
+        v.extend_from_slice(&13u32.to_be_bytes()); // IHDR length
+        v.extend_from_slice(b"IHDR");
+        v.extend_from_slice(&w.to_be_bytes());
+        v.extend_from_slice(&h.to_be_bytes());
+        v
+    }
+
+    /// Minimal 1×1 PNG: header + IHDR body tail + (fake) CRC.
+    fn tiny_png() -> Vec<u8> {
+        let mut v = png_header(1, 1);
+        v.extend_from_slice(&[8, 6, 0, 0, 0]); // depth, color, comp, filter, interlace
+        v.extend_from_slice(&[0, 0, 0, 0]); // crc (not validated)
+        v
+    }
+
+    fn tmp(name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!("read_img_{}_{name}", std::process::id()));
+        std::fs::write(&p, bytes).unwrap();
+        p
+    }
+
+    #[test]
+    fn sniff_png_jpeg_gif_webp() {
+        assert_eq!(sniff_image_mime(&PNG_SIG), Some("image/png"));
+        assert_eq!(
+            sniff_image_mime(&[0xFF, 0xD8, 0xFF, 0xE0]),
+            Some("image/jpeg")
+        );
+        assert_eq!(
+            sniff_image_mime(b"GIF89a\x01\x00\x01\x00"),
+            Some("image/gif")
+        );
+        assert_eq!(
+            sniff_image_mime(b"GIF87a\x01\x00\x01\x00"),
+            Some("image/gif")
+        );
+        assert_eq!(
+            sniff_image_mime(b"RIFF\x00\x00\x00\x00WEBPVP8 "),
+            Some("image/webp")
+        );
+        assert_eq!(sniff_image_mime(b"hello"), None);
+        assert_eq!(
+            sniff_image_mime(b"BM\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"),
+            None
+        );
+        assert_eq!(sniff_image_mime(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3"), None);
+        assert_eq!(sniff_image_mime(b"RIFF\x00\x00\x00\x00WAVEfmt "), None);
+        assert_eq!(sniff_image_mime(b""), None);
+    }
+
+    #[tokio::test]
+    async fn sniff_ignores_extension() {
+        let text_as_png = tmp("notes.png", b"just text\nline two");
+        let out = ReadTool
+            .execute_rich(
+                json!({"path": text_as_png.to_string_lossy()}),
+                create_tool_context(),
+            )
+            .await
+            .unwrap();
+        match out {
+            ToolOutput::Text(s) => assert!(s.contains("1\tjust text"), "{s}"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+
+        let png_as_txt = tmp("data.txt", &tiny_png());
+        let out = ReadTool
+            .execute_rich(
+                json!({"path": png_as_txt.to_string_lossy()}),
+                create_tool_context(),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(out, ToolOutput::Blocks { .. }), "{out:?}");
+        let _ = std::fs::remove_file(text_as_png);
+        let _ = std::fs::remove_file(png_as_txt);
+    }
+
+    #[test]
+    fn png_dimensions_from_ihdr() {
+        assert_eq!(image_dimensions("image/png", &tiny_png()), Some((1, 1)));
+        assert_eq!(
+            image_dimensions("image/png", &png_header(1024, 1536)),
+            Some((1024, 1536))
+        );
+        assert_eq!(image_dimensions("image/png", &PNG_SIG), None);
+    }
+
+    #[test]
+    fn jpeg_dimensions_from_sof0() {
+        let mut j = vec![0xFF, 0xD8]; // SOI
+        j.extend_from_slice(&[0xFF, 0xE0, 0x00, 0x10]); // APP0, len 16
+        j.extend_from_slice(b"JFIF\0");
+        j.extend_from_slice(&[1, 1, 0, 0, 1, 0, 1, 0, 0]); // 14 payload bytes total
+        j.extend_from_slice(&[0xFF, 0xC0, 0x00, 0x11, 0x08]); // SOF0, len 17, precision
+        j.extend_from_slice(&480u16.to_be_bytes()); // height
+        j.extend_from_slice(&640u16.to_be_bytes()); // width
+        j.extend_from_slice(&[3, 1, 0x22, 0, 2, 0x11, 1, 3, 0x11, 1]);
+        assert_eq!(image_dimensions("image/jpeg", &j), Some((640, 480)));
+
+        // SOI + SOS only → no SOF → None, no panic.
+        let sos_only = [0xFF, 0xD8, 0xFF, 0xDA, 0x00, 0x08, 0, 0, 0, 0, 0, 0];
+        assert_eq!(image_dimensions("image/jpeg", &sos_only), None);
+
+        // Truncated SOF header → None, no panic.
+        let trunc = [0xFF, 0xD8, 0xFF, 0xC0, 0x00, 0x11, 0x08, 0x01];
+        assert_eq!(image_dimensions("image/jpeg", &trunc), None);
+
+        // Garbage after SOI: deterministic pseudo-random bytes, must never panic.
+        let mut seed = 0x9E37_79B9u32;
+        for _ in 0..200 {
+            let mut buf = vec![0xFF, 0xD8, 0xFF];
+            for _ in 0..64 {
+                seed ^= seed << 13;
+                seed ^= seed >> 17;
+                seed ^= seed << 5;
+                buf.push((seed & 0xFF) as u8);
+            }
+            let _ = image_dimensions("image/jpeg", &buf);
+        }
+    }
+
+    #[test]
+    fn webp_dimensions_vp8_vp8l_vp8x() {
+        // VP8 (lossy): frame tag (3) + start code 9D 01 2A + w(2) + h(2)
+        let mut vp8 = b"RIFF\x00\x00\x00\x00WEBPVP8 \x00\x00\x00\x00".to_vec();
+        vp8.extend_from_slice(&[0x00, 0x00, 0x00, 0x9D, 0x01, 0x2A]);
+        vp8.extend_from_slice(&320u16.to_le_bytes());
+        vp8.extend_from_slice(&240u16.to_le_bytes());
+        assert_eq!(image_dimensions("image/webp", &vp8), Some((320, 240)));
+
+        // VP8L (lossless): signature 0x2F then 14-bit w-1, 14-bit h-1.
+        let (w, h) = (100u32, 50u32);
+        let bits: u32 = (w - 1) | ((h - 1) << 14);
+        let mut vp8l = b"RIFF\x00\x00\x00\x00WEBPVP8L\x00\x00\x00\x00\x2F".to_vec();
+        vp8l.extend_from_slice(&bits.to_le_bytes());
+        vp8l.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        assert_eq!(image_dimensions("image/webp", &vp8l), Some((100, 50)));
+
+        // VP8X (extended): flags(4) + 24-bit w-1 + 24-bit h-1.
+        let mut vp8x = b"RIFF\x00\x00\x00\x00WEBPVP8X\x0A\x00\x00\x00".to_vec();
+        vp8x.extend_from_slice(&[0, 0, 0, 0]);
+        vp8x.extend_from_slice(&(1999u32).to_le_bytes()[..3]);
+        vp8x.extend_from_slice(&(999u32).to_le_bytes()[..3]);
+        assert_eq!(image_dimensions("image/webp", &vp8x), Some((2000, 1000)));
+    }
+
+    #[tokio::test]
+    async fn image_read_block_ordering() {
+        use base64::Engine as _;
+        let bytes = tiny_png();
+        let p = tmp("order.png", &bytes);
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        let ToolOutput::Blocks { blocks, summary } = out else {
+            panic!("expected Blocks");
+        };
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0]["type"], "text");
+        assert_eq!(blocks[0]["text"], summary);
+        assert_eq!(blocks[1]["type"], "image");
+        assert_eq!(blocks[1]["source"]["type"], "base64");
+        assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(blocks[1]["source"]["data"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(decoded, bytes);
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn image_over_cap_rejected() {
+        let mut bytes = png_header(10, 10);
+        bytes.resize(MAX_IMAGE_BYTES + 1, 0);
+        let p = tmp("big.png", &bytes);
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err();
+        let RuntimeError::Tool(msg) = err else {
+            panic!("expected Tool error, got {err:?}");
+        };
+        assert!(msg.contains("convert"), "{msg}");
+        assert!(msg.contains("KB"), "{msg}");
+        assert!(msg.len() < 1024, "{}", msg.len());
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn image_over_8000px_rejected() {
+        let p = tmp("wide.png", &png_header(8001, 10));
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("8000"), "{err}");
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn legacy_execute_returns_summary_for_images() {
+        let p = tmp("legacy.png", &tiny_png());
+        let s = ReadTool
+            .execute(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        assert!(s.starts_with("Image: "), "{s}");
+        assert!(s.len() < 512);
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn label_format() {
+        let p = tmp("label.png", &tiny_png());
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        assert_eq!(
+            out.summary(),
+            format!("Image: {} (1x1, image/png, 1 KB)", p.display())
+        );
+        let _ = std::fs::remove_file(p);
+
+        let p = tmp("wide2.png", &png_header(2000, 100));
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        assert!(out.summary().starts_with(&format!(
+            "Image: {} (2000x100, image/png, 1 KB)",
+            p.display()
+        )));
+        assert!(out.summary().contains("1568 px"), "{}", out.summary());
+        let _ = std::fs::remove_file(p);
+    }
+
+    /// Spec §5.7 scripted integration check against the real test asset.
+    /// Skips (passes) if the asset is absent so CI without ~/Jawz stays green.
+    #[tokio::test]
+    async fn real_avatar_png_round_trips_as_image_blocks() {
+        let Some(home) = std::env::var_os("HOME") else {
+            return;
+        };
+        let p = std::path::PathBuf::from(home).join("Jawz/media/jawz-avatar-v1.png");
+        if !p.exists() {
+            eprintln!("skip: {} absent", p.display());
+            return;
+        }
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        let ToolOutput::Blocks { blocks, summary } = out else {
+            panic!("expected Blocks");
+        };
+        assert!(
+            summary.starts_with(&format!(
+                "Image: {} (1024x1536, image/png, 2292 KB)",
+                p.display()
+            )),
+            "{summary}"
+        );
+        assert_eq!(blocks[0]["text"], summary);
+        assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+        let data = blocks[1]["source"]["data"].as_str().unwrap();
+        assert!(data.starts_with("iVBORw0KGgo"));
+        assert!(serde_json::to_vec(&blocks[1]).unwrap().len() < 5_000_000);
+        eprintln!(
+            "INTEGRATION summary={summary:?} base64[..40]={}",
+            &data[..40]
+        );
+    }
+
+    #[tokio::test]
+    async fn non_image_binary_mentions_image_support() {
+        let p = tmp("blob.bin", &[0xFF, 0xFE, 0x00, 0x80, 0x81]);
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("returned as images automatically"),
+            "{err}"
+        );
+        let _ = std::fs::remove_file(p);
     }
 }


### PR DESCRIPTION
## What
`read` on an image file (png/jpg/gif/webp) now returns a `tool_result` with `[text label, Anthropic image block]` instead of failing with "appears to be binary". The runtime was the only blind part of the stack — the model is multimodal.

## How
- `tools/mod.rs` — `ToolOutput::{Text, Blocks}` + defaulted `Tool::execute_rich()`. Existing tools untouched.
- `tools/read.rs` — magic-byte sniff (never extension), header-only dims, integrity checks (PNG IHDR/IEND, JPEG EOI, GIF trailer, WebP RIFF), `fs::metadata` guard before read, 3.5 MiB raw cap with actionable shrink hint, 8000px guard, text block FIRST.
- `runtime/stream.rs` — both wrap sites use `execute_rich`; array content bypasses `truncate_tool_result`; byte budget charges serialized size; **history image byte cap** (20 MiB across history → oldest images become a `[image dropped …]` label at request assembly, durable history untouched).
- `runtime/context.rs` — flat `IMAGE_TOKEN_ESTIMATE=1600` per image block (was payload-length → ~550K tokens/PNG); short-circuit keeps non-image array messages charged identically.
- `openai/translate.rs`, `google_gemini/runtime.rs` — `[image omitted: <mime>]` note so non-vision transports never imply they saw it. v2: synthetic user-message fallback.

## Evidence
- Full `synaps-engine` suite: **1763 passed / 0 failed** (baseline 1726). Stream-loop tests drive a real axum mock and assert on the round-2 request body.
- Integration: release binary, `synaps chat` → `read /tmp/jawz-avatar-v1.png` (1024×1536 PNG, 2.3 MB) → model described the image from pixels (details absent from any prompt).
- `git merge-tree` vs `fix/catalog-gen-desync` (#100): 0 conflicts. No ExecutionGate/catalog/provenance files touched.
- Reviewed (static): SHIP-WITH-NITS 7/10 → all HIGH/MED findings fixed in round 2.

## Design notes
Recon of Codex, Goose, opencode, gemini-cli, aider informed this. Adopted: magic-byte sniff, text-first ordering, in-slot failure placeholder, never-log-base64, flat per-image token constant. Deferred to v2: actual downscale (image crate), synthetic user-message for OpenAI Chat/Gemini, LRU cache, `crop`, user-side `-i` attach, TUI inline render, strip-base64-on-save, runtime kill switch.

Refs #341.