### PR TITLE
fix(dev): post-merge follow-ups — server lock order, resume clamp, session message_count

### DIFF
--- a/crates/agent-core/src/core/session.rs
+++ b/crates/agent-core/src/core/session.rs
@@ -17,6 +17,13 @@ pub struct Session {
     pub total_input_tokens: u64,
     pub total_output_tokens: u64,
     pub session_cost: f64,
+    /// Persisted listing hint: `api_messages.len()` at save time. Declared
+    /// BEFORE `api_messages` so it lands in the header that
+    /// `read_session_header` reads without touching the message array.
+    /// Not authoritative in memory — use `api_messages.len()`; refreshed by
+    /// `session_journal::save_session_in_dir`. Legacy files → 0.
+    #[serde(default)]
+    pub message_count: usize,
     pub api_messages: Vec<SharedMessage>,
     /// Saved abort context — injected into the next user message on /continue
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -69,6 +76,7 @@ impl Session {
             total_input_tokens: 0,
             total_output_tokens: 0,
             session_cost: 0.0,
+            message_count: 0,
             api_messages: Vec::new(),
             abort_context: None,
             parent_session: None,
@@ -117,6 +125,7 @@ impl Session {
             total_input_tokens: 0,
             total_output_tokens: 0,
             session_cost: 0.0,
+            message_count: 0,
             api_messages: crate::compaction::compaction_context_messages(summary_text),
             abort_context: None,
             parent_session: Some(parent.id.clone()),
@@ -390,8 +399,9 @@ pub fn list_recent_sessions(limit: usize) -> std::io::Result<Vec<SessionInfo>> {
 }
 
 /// Read + parse just the metadata header of one session file into a
-/// [`SessionInfo`] (no message history). `message_count` is left 0 — it isn't
-/// parsed in the header read; use [`Session::info`] when an exact count matters.
+/// [`SessionInfo`] (no message history). `message_count` comes from the
+/// persisted header field (written at save time); legacy files without it
+/// report 0.
 fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<SessionInfo> {
     #[derive(Deserialize)]
     struct SessionMetadata {
@@ -405,12 +415,11 @@ fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<Sessio
         updated_at: DateTime<Utc>,
         #[serde(default)]
         session_cost: f64,
+        #[serde(default)]
+        message_count: usize,
     }
     let header = read_session_header(dir, file_name)?;
     let meta: SessionMetadata = serde_json::from_str(&header).ok()?;
-    // Cheap message count: each api_message has exactly one "role" field.
-    // Count occurrences without deserializing the full array.
-    let message_count = header.matches("\"role\":").count();
     let mut info = SessionInfo {
         id: meta.id,
         title: meta.title,
@@ -419,7 +428,7 @@ fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<Sessio
         created_at: meta.created_at,
         updated_at: meta.updated_at,
         session_cost: meta.session_cost,
-        message_count,
+        message_count: meta.message_count,
     };
     // Journal freshness overlay (Task 35): when an opt-in journal exists,
     // its bounded meta tail is newer than the (possibly lagging) snapshot
@@ -428,6 +437,9 @@ fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<Sessio
         if tail.updated_at > info.updated_at {
             info.updated_at = tail.updated_at;
             info.session_cost = tail.session_cost;
+            if let Some(count) = tail.message_count {
+                info.message_count = count;
+            }
         }
     }
     Some(info)
@@ -1029,6 +1041,70 @@ mod tests {
                 "original",
                 "no bytes may be written through the planted symlink"
             );
+        }
+    }
+
+    mod header_message_count {
+        use super::*;
+        use crate::core::session_journal::{save_session_in_dir, SessionPersistence};
+        use std::sync::Arc;
+
+        fn session_with(n: usize) -> Session {
+            let mut s = Session::new("claude-sonnet-4-6", "medium", None);
+            for i in 0..n {
+                let role = if i % 2 == 0 { "user" } else { "assistant" };
+                s.api_messages
+                    .push(Arc::new(serde_json::json!({"role": role, "content": format!("m{i}")})));
+            }
+            s
+        }
+
+        /// save → header reader round-trip: the count is persisted in the
+        /// header (before `api_messages`), so the truncating reader sees it.
+        #[test]
+        fn json_save_persists_count_in_header() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let dir = tmp.path().join("sessions");
+            let s = session_with(7);
+            save_session_in_dir(&dir, &s, SessionPersistence::Json).unwrap();
+            let header = read_session_header(&dir, &format!("{}.json", s.id)).unwrap();
+            assert!(
+                !header.contains("\"api_messages\""),
+                "header must stop before the message array"
+            );
+            let info = parse_session_header(&dir, &format!("{}.json", s.id)).unwrap();
+            assert_eq!(info.message_count, 7);
+        }
+
+        /// Journal mode: appended messages update the count via the meta tail.
+        #[test]
+        fn journal_append_updates_count() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let dir = tmp.path().join("sessions");
+            let mut s = session_with(2);
+            save_session_in_dir(&dir, &s, SessionPersistence::Journal).unwrap();
+            s.api_messages
+                .push(Arc::new(serde_json::json!({"role": "user", "content": "more"})));
+            s.updated_at = Utc::now();
+            save_session_in_dir(&dir, &s, SessionPersistence::Journal).unwrap();
+            let info = parse_session_header(&dir, &format!("{}.json", s.id)).unwrap();
+            assert_eq!(info.message_count, 3);
+        }
+
+        /// Legacy files without the field report 0, never fail to parse.
+        #[test]
+        fn legacy_header_defaults_to_zero() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let dir = tmp.path().join("sessions");
+            let s = session_with(3);
+            // Strip the field textually to keep declaration order (a
+            // `to_value` round-trip would re-sort keys alphabetically).
+            let json = serde_json::to_string(&s).unwrap();
+            assert!(json.contains("\"message_count\":0,"));
+            let legacy = json.replace("\"message_count\":0,", "");
+            save_json_in_dir(&dir, &s.id, legacy.as_bytes()).unwrap();
+            let info = parse_session_header(&dir, &format!("{}.json", s.id)).unwrap();
+            assert_eq!(info.message_count, 0);
         }
     }
 }

--- a/crates/agent-core/src/core/session_journal.rs
+++ b/crates/agent-core/src/core/session_journal.rs
@@ -292,6 +292,8 @@ pub struct SaveReceipt {
 pub struct JournalMetaTail {
     pub updated_at: DateTime<Utc>,
     pub session_cost: f64,
+    /// `None` for meta records written before the count was journaled.
+    pub message_count: Option<usize>,
 }
 
 /// `sessions/<id>.journal` — single-extension name so the session id stays
@@ -344,6 +346,8 @@ struct SessionMeta {
     total_output_tokens: u64,
     session_cost: f64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    message_count: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     abort_context: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     parent_session: Option<String>,
@@ -369,6 +373,7 @@ impl SessionMeta {
             total_input_tokens: s.total_input_tokens,
             total_output_tokens: s.total_output_tokens,
             session_cost: s.session_cost,
+            message_count: Some(s.api_messages.len()),
             abort_context: s.abort_context.clone(),
             parent_session: s.parent_session.clone(),
             compacted_into: s.compacted_into.clone(),
@@ -503,6 +508,12 @@ pub fn save_session_in_dir(
     // ONE strict resolution per save (fix2); every artifact operation below
     // is relative to this handle.
     let handle = create_sessions_dir(dir)?;
+    // Refresh the persisted listing hint at the single save choke point so
+    // the header always carries the current count (messages are Arc-shared;
+    // the clone is cheap).
+    let mut session = session.clone();
+    session.message_count = session.api_messages.len();
+    let session = &session;
     match mode {
         SessionPersistence::Json => {
             let json = serde_json::to_string(session).map_err(std::io::Error::other)?;
@@ -699,6 +710,7 @@ pub fn journal_meta_tail(dir: &Path, id: &str) -> Option<JournalMetaTail> {
                 freshest = Some(JournalMetaTail {
                     updated_at: meta.updated_at,
                     session_cost: meta.session_cost,
+                    message_count: meta.message_count,
                 });
             }
         }

--- a/crates/agent-engine/src/engine/setup.rs
+++ b/crates/agent-engine/src/engine/setup.rs
@@ -353,7 +353,7 @@ fn resolve_or_create_session(
 ) -> Result<SessionBootResult> {
     match continue_session {
         Some(ref maybe_id) => {
-            let session = match maybe_id {
+            let mut session = match maybe_id {
                 Some(ref id) => resolve_session(id).map_err(|e| {
                     crate::error::RuntimeError::Tool(format!(
                         "Failed to load session '{}': {}",
@@ -366,15 +366,17 @@ fn resolve_or_create_session(
             };
             runtime.set_model(session.model.clone());
             // Restore the session's named reasoning level so max/ultra/off
-            // and custom budgets survive --continue.
-            if let Some(level) =
-                agent_core::reasoning::ReasoningLevel::parse(&session.thinking_level)
-            {
-                runtime.set_reasoning_level_explicit(level);
-            } else if let Some(budget) =
-                crate::models::budget_for_thinking_level(&session.thinking_level)
-            {
-                runtime.set_thinking_budget_explicit(budget);
+            // and custom budgets survive --continue — then clamp against the
+            // model so old grok+xhigh session files don't resume into a
+            // permanently failing state.
+            if let Some(clamp) = runtime.restore_session_reasoning(&session.thinking_level) {
+                tracing::warn!(
+                    from = %clamp.from,
+                    to = %clamp.to,
+                    model = %session.model,
+                    "saved session thinking level not supported by model; clamped"
+                );
+                session.thinking_level = runtime.thinking_level().to_string();
             }
             if let Some(ref sp) = session.system_prompt {
                 runtime.set_system_prompt(sp.clone());

--- a/crates/agent-engine/src/runtime/memory_history.rs
+++ b/crates/agent-engine/src/runtime/memory_history.rs
@@ -1274,6 +1274,7 @@ mod tests {
                 total_input_tokens: 0,
                 total_output_tokens: 0,
                 session_cost: 0.0,
+                message_count: 0,
                 api_messages: vec![
                     Arc::new(json!({"role": "user", "content": user})),
                     Arc::new(json!({"role": "assistant", "content": assistant})),

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -1305,6 +1305,22 @@ impl Runtime {
         self.explicit_reasoning = true;
     }
 
+    /// Restore a saved session's `thinking_level` string as an explicit user
+    /// choice, then clamp it against the current model. Call **after**
+    /// `set_model(session.model)`: re-applying the saved level would otherwise
+    /// undo the clamp `set_model` performed (old grok+xhigh session files).
+    /// Returns the clamp applied, if any, so callers can surface it.
+    pub fn restore_session_reasoning(&mut self, thinking_level: &str) -> Option<ReasoningClamp> {
+        if let Some(level) = agent_core::reasoning::ReasoningLevel::parse(thinking_level) {
+            self.set_reasoning_level_explicit(level);
+        } else if let Some(budget) = crate::models::budget_for_thinking_level(thinking_level) {
+            self.set_thinking_budget_explicit(budget);
+        } else {
+            return None;
+        }
+        self.clamp_reasoning_to_model()
+    }
+
     /// Set a custom numeric thinking budget as an **explicit user choice**
     /// (e.g. `/thinking 8192`). Retains the exact budget in `thinking_budget`
     /// while syncing `named_level` to the nearest named level for display.
@@ -4790,6 +4806,35 @@ mod set_reasoning_level_checked_tests {
         rt.set_reasoning_level_explicit(ReasoningLevel::XHigh);
         let clamp = rt.set_model("xai-auth/grok-4.6".to_string());
         assert_eq!(clamp.map(|c| c.to), Some(ReasoningLevel::High));
+    }
+
+    /// Resume path: a saved grok+xhigh session (written before clamping
+    /// existed) must not resume into a permanently failing state.
+    #[test]
+    fn restore_session_reasoning_clamps_after_reapply() {
+        let mut rt = Runtime::new_headless();
+        rt.set_model("xai-auth/grok-4.6".to_string());
+        let clamp = rt.restore_session_reasoning("xhigh");
+        assert_eq!(
+            clamp,
+            Some(ReasoningClamp {
+                from: ReasoningLevel::XHigh,
+                to: ReasoningLevel::High,
+            })
+        );
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(rt.is_reasoning_explicit());
+        assert!(rt.set_reasoning_level_checked(rt.reasoning_level()).is_ok());
+    }
+
+    /// Supported saved level restores verbatim with no clamp.
+    #[test]
+    fn restore_session_reasoning_keeps_supported_level() {
+        let mut rt = Runtime::new_headless();
+        rt.set_model("xai-auth/grok-4.6".to_string());
+        assert_eq!(rt.restore_session_reasoning("low"), None);
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::Low);
+        assert!(rt.is_reasoning_explicit());
     }
 
     /// Boot path: config `model` + unsupported explicit `thinking` no longer

--- a/crates/agent-engine/tests/memory_history_import.rs
+++ b/crates/agent-engine/tests/memory_history_import.rs
@@ -133,6 +133,7 @@ fn fixture_session(id: &str, system_prompt: Option<&str>, api_messages: Vec<Valu
         total_input_tokens: 0,
         total_output_tokens: 0,
         session_cost: 0.0,
+        message_count: 0,
         api_messages: api_messages.into_iter().map(Arc::new).collect(),
         abort_context: None,
         parent_session: None,

--- a/crates/agent-tui/src/tui/commands.rs
+++ b/crates/agent-tui/src/tui/commands.rs
@@ -600,7 +600,7 @@ pub(super) async fn handle_command(
                         .unwrap_or_default();
                     let age = {
                         let secs = chrono::Utc::now()
-                            .signed_duration_since(s.created_at)
+                            .signed_duration_since(s.updated_at)
                             .num_seconds();
                         if secs < 3600 {
                             format!("{}m ago", secs / 60)

--- a/crates/agent-tui/src/tui/commands.rs
+++ b/crates/agent-tui/src/tui/commands.rs
@@ -325,12 +325,19 @@ pub(super) fn resolve_prefix(raw: &str, commands: &[String]) -> String {
     raw.to_string()
 }
 
-fn restore_session_reasoning(runtime: &mut Runtime, thinking_level: &str) {
-    if let Some(level) = agent_core::reasoning::ReasoningLevel::parse(thinking_level) {
-        runtime.set_reasoning_level_explicit(level);
-    } else if let Some(budget) = synaps_cli::models::budget_for_thinking_level(thinking_level) {
-        runtime.set_thinking_budget_explicit(budget);
-    }
+/// Re-apply a saved session's reasoning level as explicit, clamped to the
+/// current model. Returns a notice when the saved level was clamped.
+fn restore_session_reasoning(runtime: &mut Runtime, thinking_level: &str) -> Option<String> {
+    runtime
+        .restore_session_reasoning(thinking_level)
+        .map(|clamp| {
+            format!(
+                "thinking → {} (clamped from {}: not supported by {})",
+                clamp.to.as_str(),
+                clamp.from.as_str(),
+                runtime.model()
+            )
+        })
 }
 
 /// Handle a slash command when NOT streaming.
@@ -648,7 +655,8 @@ pub(super) async fn handle_command(
                         runtime.set_model(session.model.clone());
                         // A resumed session owns its saved choice. Preserve that
                         // explicit provenance across later model switches.
-                        restore_session_reasoning(runtime, &session.thinking_level);
+                        let clamp_notice =
+                            restore_session_reasoning(runtime, &session.thinking_level);
                         if let Some(ref sp) = session.system_prompt {
                             runtime.set_system_prompt(sp.clone());
                         }
@@ -663,6 +671,11 @@ pub(super) async fn handle_command(
                         super::rebuild_display_messages(&session.api_messages, app);
                         let new_id = session.id.clone();
                         app.session = session;
+                        if let Some(notice) = clamp_notice {
+                            // Keep the session file in sync with the clamped runtime.
+                            app.session.thinking_level = runtime.thinking_level().to_string();
+                            app.push_msg(ChatMessage::System(notice));
+                        }
                         let via = if synaps_cli::chain::load_chain(arg).is_ok() {
                             format!(" (via chain '{}')", arg)
                         } else if synaps_cli::session::find_session_by_name(arg).is_ok() {
@@ -2176,5 +2189,20 @@ mod tests {
             agent_core::reasoning::ReasoningLevel::Ultra,
             "restored explicit Ultra must survive model switches"
         );
+    }
+
+    #[tokio::test]
+    async fn resume_clamps_unsupported_saved_level() {
+        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
+        runtime.set_model("xai-auth/grok-4.6".to_string());
+
+        let notice = restore_session_reasoning(&mut runtime, "xhigh");
+
+        assert!(notice.is_some(), "clamp must be surfaced");
+        assert_eq!(
+            runtime.reasoning_level(),
+            agent_core::reasoning::ReasoningLevel::High
+        );
+        assert!(runtime.is_reasoning_explicit());
     }
 }

--- a/docs/tools.json
+++ b/docs/tools.json
@@ -273,7 +273,7 @@
     }
   },
   {
-    "description": "Read the contents of a file. Returns lines with line numbers. Reads up to 500 lines by default. For large files, use offset and limit to read in sections.",
+    "description": "Read the contents of a file. Returns lines with line numbers. Reads up to 500 lines by default. For large files, use offset and limit to read in sections. Image files (PNG, JPEG, GIF, WebP) are returned as an image the model can see, up to 3.5 MB.",
     "name": "read",
     "parameters": {
       "properties": {

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -1242,9 +1242,18 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
 
     // Try engine-level command (model with args, thinking with engine-known
     // levels, quit, compact).
-    let engine_result = {
+    //
+    // Lock order in this file is `runtime` → `conv` (see `/clear` below).
+    // Snapshot everything the ModelChanged arm needs while `rt` is held here
+    // so that arm only ever takes `conv` and never both.
+    let (engine_result, post_thinking, post_model) = {
         let mut rt = state.runtime.lock().await;
-        engine_commands::handle_engine_command(name, args, &mut rt)
+        let result = engine_commands::handle_engine_command(name, args, &mut rt);
+        (
+            result,
+            rt.thinking_level().to_string(),
+            rt.model().to_string(),
+        )
     };
 
     if let Some(result) = engine_result {
@@ -1258,13 +1267,12 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
                     let mut conv = state.conv.write().await;
                     conv.session.model = model.clone();
                     if let Some(clamp) = reasoning_clamped {
-                        let rt = state.runtime.lock().await;
-                        conv.session.thinking_level = rt.thinking_level().to_string();
+                        conv.session.thinking_level = post_thinking;
                         message.push_str(&format!(
                             "; thinking → {} (clamped from {}: not supported by {})",
                             clamp.to.as_str(),
                             clamp.from.as_str(),
-                            rt.model()
+                            post_model
                         ));
                     }
                 }

--- a/tests/execution_gate_stream.rs
+++ b/tests/execution_gate_stream.rs
@@ -326,7 +326,8 @@ const SSE_LATE_TOOL_ROUND: &str = concat!(
 );
 
 /// Builtin-origin fixture registered mid-round by the `before_message`
-/// mutator: its registration bumps the catalog generation.
+/// mutator under a NEW name: its registration bumps the catalog generation
+/// without touching any tool the model is about to call.
 struct MidRoundRegisteredTool;
 
 #[async_trait]
@@ -348,10 +349,39 @@ impl Tool for MidRoundRegisteredTool {
     }
 }
 
-/// `before_message` handler that mutates the live registry exactly once —
-/// AFTER the round-top session-set rebuild, BEFORE tool authorization.
+/// Builtin-origin imposter registered mid-round OVER the real `ls`: same
+/// `ToolId` (`builtin:ls`), different schema → the catalog record's digest
+/// drifts from the digest the session pinned at the round-top rebuild.
+struct DriftedLsTool;
+
+#[async_trait]
+impl Tool for DriftedLsTool {
+    fn name(&self) -> &str {
+        "ls"
+    }
+    fn description(&self) -> &str {
+        "schema-drifted replacement for ls registered mid-round"
+    }
+    fn parameters(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {"drifted": {"type": "boolean"}}
+        })
+    }
+    fn origin(&self) -> ToolOrigin {
+        ToolOrigin::Builtin
+    }
+    async fn execute(&self, _params: Value, _ctx: ToolContext) -> Result<String> {
+        Ok("DRIFTED_OK".to_string())
+    }
+}
+
+/// `before_message` handler that registers `tool` into the live registry
+/// exactly once — AFTER the round-top session-set rebuild, BEFORE tool
+/// authorization.
 struct RegistryMutator {
     tools: Arc<tokio::sync::RwLock<synaps_cli::ToolRegistry>>,
+    tool: Arc<dyn Tool>,
     fired: Arc<AtomicBool>,
 }
 
@@ -365,11 +395,28 @@ impl ExtensionHandler for RegistryMutator {
             self.tools
                 .write()
                 .await
-                .register(Arc::new(MidRoundRegisteredTool));
+                .register(Arc::clone(&self.tool));
         }
         HookResult::Continue
     }
     async fn shutdown(&self) {}
+}
+
+async fn install_mid_round_mutator(rt: &Runtime, tool: Arc<dyn Tool>) {
+    rt.hook_bus()
+        .subscribe(
+            HookKind::BeforeMessage,
+            Arc::new(RegistryMutator {
+                tools: rt.tools_shared(),
+                tool,
+                fired: Arc::new(AtomicBool::new(false)),
+            }),
+            None,
+            None,
+            PermissionSet::from_strings(&["privacy.llm_content".to_string()]),
+        )
+        .await
+        .expect("mutator subscription");
 }
 
 /// Builtin-origin fixture that dynamically registers `gate_late_fixture`
@@ -421,14 +468,15 @@ impl Tool for LateFixtureTool {
     }
 }
 
-/// A catalog mutation AFTER the round-top rebuild makes the retained
-/// session set stale: BOTH sibling calls of the same response are denied
-/// with the IDENTICAL stale-generation message (one set snapshot, one
-/// generation — never per-call silent refresh), no `before_tool_call` hook
-/// fires for them, and the NEXT round's explicit rebuild recovers.
+/// #100 contract, half 1: a catalog mutation AFTER the round-top rebuild
+/// that does NOT touch the called tool (an unrelated registration bumping
+/// the catalog generation) must NOT deny. Generation drift alone is not a
+/// denial: BOTH sibling `ls` calls of the same response execute against
+/// their unchanged pinned digest, `before_tool_call` fires for each, and the
+/// next round's explicit rebuild keeps executing.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
-async fn mid_round_catalog_mutation_denies_stale_until_next_round_rebuild() {
+async fn mid_round_unrelated_catalog_mutation_does_not_deny_schema_identical_core_tool() {
     let _guard = HomeGuard::new();
     let (url, hits, _) = spawn_stub(Script::SeqSse(&[
         SSE_PARALLEL_LS_TOOL_USE,
@@ -441,21 +489,57 @@ async fn mid_round_catalog_mutation_denies_stale_until_next_round_rebuild() {
     let mut rt = Runtime::new().await.expect("runtime");
     rt.set_model("claude-sonnet-4-5".to_string());
     let seen_hooks = install_hook_spy(&rt).await;
-    rt.hook_bus()
-        .subscribe(
-            HookKind::BeforeMessage,
-            Arc::new(RegistryMutator {
-                tools: rt.tools_shared(),
-                fired: Arc::new(AtomicBool::new(false)),
-            }),
-            None,
-            None,
-            PermissionSet::from_strings(&["privacy.llm_content".to_string()]),
-        )
-        .await
-        .expect("mutator subscription");
+    install_mid_round_mutator(&rt, Arc::new(MidRoundRegisteredTool)).await;
 
-    let ev = drive_runtime_turn(&rt, "stale round fixture", false).await;
+    let ev = drive_runtime_turn(&rt, "unrelated drift fixture", false).await;
+    assert_eq!(hits.load(Ordering::SeqCst), 3, "three model rounds");
+
+    let results = tool_results(&final_history(&ev));
+    assert_eq!(results.len(), 3, "two round-1 runs plus one round-2 run");
+    assert_eq!(results[0].0, "toolu_s1");
+    assert_eq!(results[1].0, "toolu_s2");
+    assert_eq!(results[2].0, "toolu_ph2");
+    for (id, content) in &results {
+        assert!(
+            !content.contains("denied") && !content.contains("stale"),
+            "unrelated catalog mutation must not deny a schema-identical core \
+             tool ({id}), got: {content}"
+        );
+    }
+    assert_eq!(
+        seen_hooks.lock().unwrap().as_slice(),
+        ["ls", "ls", "ls"],
+        "every executed call emits before_tool_call: two round-1 siblings \
+         plus the round-2 call"
+    );
+}
+
+/// #100 contract, half 2: a catalog mutation AFTER the round-top rebuild
+/// that DOES change the called tool's record — `ls` replaced under the same
+/// `ToolId` with a different schema, so its digest drifts from the pinned
+/// core digest — denies THAT tool with the typed per-tool
+/// `SchemaDigestMismatch` message. BOTH sibling calls of the same response
+/// are judged against the one pinned snapshot (identical denial text), no
+/// `before_tool_call` hook fires for them, and the NEXT round's explicit
+/// rebuild re-pins the current digest so the replacement executes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn mid_round_schema_drift_of_called_tool_denies_per_tool_until_next_round_rebuild() {
+    let _guard = HomeGuard::new();
+    let (url, hits, _) = spawn_stub(Script::SeqSse(&[
+        SSE_PARALLEL_LS_TOOL_USE,
+        ANTHROPIC_SSE_TOOL_USE,
+        ANTHROPIC_SSE,
+    ]))
+    .await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+
+    let mut rt = Runtime::new().await.expect("runtime");
+    rt.set_model("claude-sonnet-4-5".to_string());
+    let seen_hooks = install_hook_spy(&rt).await;
+    install_mid_round_mutator(&rt, Arc::new(DriftedLsTool)).await;
+
+    let ev = drive_runtime_turn(&rt, "digest drift fixture", false).await;
     assert_eq!(hits.load(Ordering::SeqCst), 3, "denial continues the loop");
 
     let results = tool_results(&final_history(&ev));
@@ -463,25 +547,33 @@ async fn mid_round_catalog_mutation_denies_stale_until_next_round_rebuild() {
     assert_eq!(results[0].0, "toolu_s1");
     assert_eq!(results[1].0, "toolu_s2");
     assert!(
-        results[0].1.contains("stale"),
-        "post-rebuild catalog mutation must deny stale, got: {}",
+        results[0].1.contains("Tool call denied")
+            && results[0].1.contains("schema digest changed"),
+        "post-rebuild digest drift of the called tool must deny with the \
+         per-tool SchemaDigestMismatch, got: {}",
+        results[0].1
+    );
+    assert!(
+        !results[0].1.contains("stale"),
+        "denial must be per-tool, never the retired set-wide stale-generation \
+         message, got: {}",
         results[0].1
     );
     assert_eq!(
         results[0].1, results[1].1,
-        "sibling calls of one response must be judged against ONE set \
-         snapshot at ONE generation"
+        "sibling calls of one response must be judged against ONE pinned \
+         set snapshot"
     );
     assert_eq!(results[2].0, "toolu_ph2");
-    assert!(
-        !results[2].1.contains("denied") && !results[2].1.contains("stale"),
-        "next-round explicit rebuild must recover, got: {}",
-        results[2].1
+    assert_eq!(
+        results[2].1, "DRIFTED_OK",
+        "next-round explicit rebuild must re-pin the current digest and \
+         execute the replacement"
     );
     assert_eq!(
         seen_hooks.lock().unwrap().as_slice(),
         ["ls"],
-        "stale denials must not emit before_tool_call; only the recovered \
+        "digest denials must not emit before_tool_call; only the recovered \
          round-2 call may"
     );
 }

--- a/tests/phase3_activation.rs
+++ b/tests/phase3_activation.rs
@@ -388,7 +388,7 @@ fn a01_first_request_core_only_within_budget() {
     const DOCUMENTED_FIRST_REQUEST_BUDGET_BYTES: usize = 8 * 1024;
 
     let set = SessionToolSet::progressive_core_for_catalog(sid("a01"), registry.catalog());
-    let schemas = registry.session_tools_schema(&set).unwrap();
+    let schemas = registry.session_tools_schema(&set).schema;
     let names: BTreeSet<String> = schemas
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
@@ -421,7 +421,7 @@ fn a02_dormant_bodies_absent_from_first_request() {
     let registry = acceptance_registry(&mcp, &ext);
     // Progressive (flag ON): dormant builtin/MCP/extension schemas absent.
     let set = progressive_set(&registry, &sid("a02"));
-    let serialized = serde_json::to_string(&*registry.session_tools_schema(&set).unwrap()).unwrap();
+    let serialized = serde_json::to_string(&registry.session_tools_schema(&set).schema).unwrap();
     assert!(
         !serialized.contains(SCHEMA_MARKER),
         "dormant builtin schema leaked"
@@ -437,7 +437,7 @@ fn a02_dormant_bodies_absent_from_first_request() {
     // Legacy (flag OFF): full catalog exposed — documented compatibility.
     let legacy = legacy_set(&registry, &sid("a02"));
     let legacy_serialized =
-        serde_json::to_string(&*registry.session_tools_schema(&legacy).unwrap()).unwrap();
+        serde_json::to_string(&registry.session_tools_schema(&legacy).schema).unwrap();
     assert!(
         legacy_serialized.contains("ext__srv__echo_tool"),
         "flag-off keeps the legacy full exposure"
@@ -515,7 +515,7 @@ fn a04_activation_adds_exactly_one_schema() {
     let mut set = progressive_set(&registry, &sid("a04"));
     let before: BTreeSet<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();
@@ -527,7 +527,7 @@ fn a04_activation_adds_exactly_one_schema() {
     .unwrap();
     let after: BTreeSet<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();
@@ -619,7 +619,7 @@ fn a06_alias_spellings_cannot_bypass_activation() {
         .unwrap();
         registry
             .session_tools_schema(&probe)
-            .unwrap()
+            .schema
             .iter()
             .filter_map(|s| s["name"].as_str().map(String::from))
             .find(|n| registry.runtime_name_for_api(n) == "fixture-plugin:search")
@@ -796,20 +796,19 @@ fn a10_revocation_digest_generation_invalidate() {
         Err(ToolAuthorizationError::NotActivated(ref id)) if *id == echo
     ));
 
-    // 2. Catalog generation change (registry mutation) invalidates the
-    // whole stale session set at the gate.
+    // 2. Catalog generation change (unrelated registry mutation) marks the
+    // set stale but does NOT deny per-tool: the gate validates each pinned
+    // record's digest + provenance individually (6b668835), so an unchanged
+    // activated tool keeps authorizing while fresh grants are blocked.
     let mut set2 =
         SessionToolSet::progressive_core_for_catalog(session.clone(), registry.catalog());
     activate_exact_for_user(&mut set2, registry.catalog(), &echo).unwrap();
     registry
         .try_disable(&["dormant_07".to_string()])
         .expect("disable advances the catalog generation");
-    let err = ExecutionGate::authorize_wire_call(&registry, &set2, "ext__srv__echo_tool")
-        .expect_err("stale generation must deny");
-    assert!(matches!(
-        err,
-        ToolAuthorizationError::StaleSessionSet { .. }
-    ));
+    assert!(set2.is_stale(registry.catalog()));
+    ExecutionGate::authorize_wire_call(&registry, &set2, "ext__srv__echo_tool")
+        .expect("schema-identical activated tool survives unrelated drift");
 
     // 3. Schema digest drift: a session set whose grant was pinned under
     // the ORIGINAL schema must be denied against a registry whose live
@@ -892,7 +891,7 @@ fn a11_cross_provider_logical_set_equivalence() {
     modes.push(("flag-off/legacy", legacy_set(&registry, &sid("a11-legacy"))));
     for (mode, set) in modes {
         // Anthropic-side: the session projection (api-safe names).
-        let schemas = registry.session_tools_schema(&set).unwrap();
+        let schemas = registry.session_tools_schema(&set).schema;
         let anthropic_logical: BTreeSet<String> = schemas
             .iter()
             .filter_map(|s| s["name"].as_str())
@@ -1012,7 +1011,7 @@ async fn a12_skill_bodies_lazy_and_exact() {
     tools.register(Arc::new(LoadSkillTool::new(registry.clone())));
     tools.register(Arc::new(SearchSkillsTool::new(registry.clone())));
     let set = SessionToolSet::progressive_core_for_catalog(sid("a12"), tools.catalog());
-    let projection = serde_json::to_string(&*tools.session_tools_schema(&set).unwrap()).unwrap();
+    let projection = serde_json::to_string(&tools.session_tools_schema(&set).schema).unwrap();
     assert!(
         projection.contains("load_skill"),
         "projection includes the skill tools"
@@ -1064,13 +1063,13 @@ fn a13_activate_many_single_generation_update() {
     // Stable order: projection order deterministic across runs.
     let names: Vec<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();
     let again: Vec<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();


### PR DESCRIPTION
Post-merge follow-ups on dev (53cd3b83) from the #101 and #97 reviews, plus two pre-existing breakages that made merged dev's `cargo test --workspace` red.

## 1. server.rs lock inversion (#101 review M2)
**What:** `/model` ModelChanged arm took `conv.write()` → `runtime.lock()`; `/clear` takes `runtime.lock()` → `conv.write()`. ABBA deadlock window under concurrent commands.
**Fix:** snapshot `thinking_level`/`model` while `rt` is already held in `handle_engine_command`; the arm now only touches `conv`. Comment documents the `runtime → conv` lock order.

## 2. Resume re-applied thinking level after clamp (#101 review M1)
**What:** `setup.rs` (`--continue`) and TUI `/resume` called `set_model` (clamps) then re-applied `session.thinking_level` verbatim — old `grok + xhigh` session files resumed straight into a permanently failing state.
**Fix:** new `Runtime::restore_session_reasoning(&str) -> Option<ReasoningClamp>` (explicit re-apply, then `clamp_reasoning_to_model`). Both resume paths route through it; `setup.rs` logs the clamp and syncs `session.thinking_level`, TUI surfaces a System notice and syncs the session file.
**Tests:** `restore_session_reasoning_clamps_after_reapply` (grok-4.6 + "xhigh" → High, explicit, validates), `restore_session_reasoning_keeps_supported_level`, TUI `resume_clamps_unsupported_saved_level`.

## 3. `message_count` was dead code (#97 review)
**What:** `read_session_header()` truncates before `"api_messages"`, so the `"role":` count was always 0 (UI hid zeros, so it looked fixed).
**Fix:** `Session.message_count` (`#[serde(default)]`, declared before `api_messages` so it lands in the header), refreshed at the single save choke point `save_session_in_dir`; journaled in the meta record (`Option<usize>`) so journal-mode listings stay exact; header parser reads it, legacy files → 0. `/sessions` age now uses `updated_at` (the list sort key).
**Tests:** `json_save_persists_count_in_header` (save 7 → header reader returns 7, header stops before `api_messages`), `journal_append_updates_count`, `legacy_header_defaults_to_zero`.

## Pre-existing on merged dev (not from these fixes)
- `tests/phase3_activation.rs` didn't compile: #100 changed `session_tools_schema` to return typed `SessionSchemaProjection` and dropped `StaleSessionSet`. Mechanical `.unwrap()` → `.schema`; a10 step 2 now asserts the per-tool semantics (stale set, unchanged tool still authorizes).
- `docs/tools.json` drift from #102's `read` description → regenerated.
- **Still failing, NOT fixed here:** `tests/execution_gate_stream.rs::mid_round_catalog_mutation_denies_stale_until_next_round_rebuild` asserts the pre-#100 "wholesale stale denial" semantics that #100 intentionally reversed. Needs a fixture rewrite by the #100 author.

## Test evidence (bella)
```
synaps-core   : 448 passed; 0 failed  (lib) + all integration bins ok
synaps-engine : 1787 passed; 0 failed (lib) + all integration bins ok
synaps-tui    : 557 passed; 0 failed  (lib) + all integration bins ok
synaps (root) : all green except execution_gate_stream (1 failed, pre-existing #100 semantic change, see above)
```

Refs #97 #101 #100 #102