### PR TITLE
fix: address Copilot review on #100/#102/#103 — server lock order everywhere, no-clone message_count, release-build block normalization, zero-dim reject, complete dropped report

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ tempfile = "3"
 clap_complete = "4.5.67"
 
 [dev-dependencies]
+# Unlocks `Runtime::new_headless()` for bin tests (feature-unified in test builds).
+agent-engine = { path = "crates/agent-engine", version = "0.9.0", package = "synaps-engine", features = ["testing"] }
 serial_test = "3.4.0"
 tempfile = "3"
 rcgen = { version = "0.14", default-features = true }

--- a/crates/agent-core/src/core/session_journal.rs
+++ b/crates/agent-core/src/core/session_journal.rs
@@ -825,10 +825,11 @@ mod tests {
         s.abort_context = Some("ctx".into());
         s.parent_session = Some("parent".into());
         s.compacted_into = Some("child".into());
-        s.api_messages
-            .push(std::sync::Arc::new(serde_json::json!({"role": "user", "content": "hi"})));
+        s.api_messages.push(std::sync::Arc::new(
+            serde_json::json!({"role": "user", "content": "hi"}),
+        ));
         s.message_count = 0; // stale in memory — snapshot must not trust it
-        // Expected = the old clone-and-refresh path, byte for byte.
+                             // Expected = the old clone-and-refresh path, byte for byte.
         let mut expected = s.clone();
         expected.message_count = expected.api_messages.len();
         let expected = serde_json::to_string(&expected).unwrap();
@@ -839,7 +840,10 @@ mod tests {
         let s = Session::new("model-x", "medium", None);
         let mut expected = s.clone();
         expected.message_count = 0;
-        assert_eq!(snapshot_json(&s).unwrap(), serde_json::to_string(&expected).unwrap());
+        assert_eq!(
+            snapshot_json(&s).unwrap(),
+            serde_json::to_string(&expected).unwrap()
+        );
     }
 
     #[test]

--- a/crates/agent-core/src/core/session_journal.rs
+++ b/crates/agent-core/src/core/session_journal.rs
@@ -19,6 +19,7 @@
 //! 0600 files, symlink-refusing, atomic snapshot replacement, synced appends.
 
 use crate::core::session::Session;
+use crate::core::stream_types::SharedMessage;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::io::Write;
@@ -508,15 +509,12 @@ pub fn save_session_in_dir(
     // ONE strict resolution per save (fix2); every artifact operation below
     // is relative to this handle.
     let handle = create_sessions_dir(dir)?;
-    // Refresh the persisted listing hint at the single save choke point so
-    // the header always carries the current count (messages are Arc-shared;
-    // the clone is cheap).
-    let mut session = session.clone();
-    session.message_count = session.api_messages.len();
-    let session = &session;
+    // The persisted listing hint (`message_count`) is refreshed at write
+    // time by `snapshot_json` / `SessionMeta::of` — no `Session` clone, so
+    // the journal delta path stays O(delta) rather than O(history).
     match mode {
         SessionPersistence::Json => {
-            let json = serde_json::to_string(session).map_err(std::io::Error::other)?;
+            let json = snapshot_json(session)?;
             handle.write_atomic(&format!("{}.json", session.id), json.as_bytes())?;
             // Rollback fold: the snapshot now holds everything; a stale
             // journal must not shadow future legacy-only readers.
@@ -607,11 +605,75 @@ fn save_journal_mode(
 /// Atomic full snapshot (unchanged legacy schema) followed by an atomic
 /// journal reset to a lone `open` record. Snapshot strictly first: a crash
 /// between the two leaves a stale-but-idempotent journal, never data loss.
+/// Borrowing mirror of [`Session`] used ONLY for snapshot serialization:
+/// identical field order and serde attributes, with `message_count`
+/// computed from `api_messages.len()` at write time instead of read from
+/// the (non-authoritative) in-memory field. Field order matters —
+/// `message_count` must precede `api_messages` for `read_session_header`.
+/// The `snapshot_json_matches_session_schema` test guards drift.
+#[derive(Serialize)]
+struct SessionSnapshotRef<'a> {
+    id: &'a str,
+    title: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: &'a Option<String>,
+    model: &'a str,
+    thinking_level: &'a str,
+    system_prompt: &'a Option<String>,
+    created_at: &'a DateTime<Utc>,
+    updated_at: &'a DateTime<Utc>,
+    total_input_tokens: u64,
+    total_output_tokens: u64,
+    session_cost: f64,
+    message_count: usize,
+    api_messages: &'a [SharedMessage],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    abort_context: &'a Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_session: &'a Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compacted_into: &'a Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_provenance: &'a Option<crate::prompt::PromptProvenance>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compaction: &'a Option<crate::core::compaction::CompactionRecord>,
+}
+
+impl<'a> SessionSnapshotRef<'a> {
+    fn of(s: &'a Session) -> Self {
+        Self {
+            id: &s.id,
+            title: &s.title,
+            name: &s.name,
+            model: &s.model,
+            thinking_level: &s.thinking_level,
+            system_prompt: &s.system_prompt,
+            created_at: &s.created_at,
+            updated_at: &s.updated_at,
+            total_input_tokens: s.total_input_tokens,
+            total_output_tokens: s.total_output_tokens,
+            session_cost: s.session_cost,
+            message_count: s.api_messages.len(),
+            api_messages: &s.api_messages,
+            abort_context: &s.abort_context,
+            parent_session: &s.parent_session,
+            compacted_into: &s.compacted_into,
+            prompt_provenance: &s.prompt_provenance,
+            compaction: &s.compaction,
+        }
+    }
+}
+
+/// Full-snapshot JSON with a fresh `message_count`, without cloning.
+fn snapshot_json(session: &Session) -> std::io::Result<String> {
+    serde_json::to_string(&SessionSnapshotRef::of(session)).map_err(std::io::Error::other)
+}
+
 fn full_snapshot_reset(
     handle: &SessionsDirHandle,
     session: &Session,
 ) -> std::io::Result<SaveReceipt> {
-    let json = serde_json::to_string(session).map_err(std::io::Error::other)?;
+    let json = snapshot_json(session)?;
     handle.write_atomic(&format!("{}.json", session.id), json.as_bytes())?;
 
     let open = JournalRecord::Open {
@@ -756,6 +818,30 @@ mod tests {
     /// field. Serializing a full `Session`, dropping `api_messages`, and
     /// parsing the rest as `SessionMeta` (deny_unknown_fields) fails the
     /// moment `Session` grows a field this module does not journal.
+    #[test]
+    fn snapshot_json_matches_session_schema() {
+        let mut s = Session::new("model-x", "medium", Some("prompt"));
+        s.name = Some("named".into());
+        s.abort_context = Some("ctx".into());
+        s.parent_session = Some("parent".into());
+        s.compacted_into = Some("child".into());
+        s.api_messages
+            .push(std::sync::Arc::new(serde_json::json!({"role": "user", "content": "hi"})));
+        s.message_count = 0; // stale in memory — snapshot must not trust it
+        // Expected = the old clone-and-refresh path, byte for byte.
+        let mut expected = s.clone();
+        expected.message_count = expected.api_messages.len();
+        let expected = serde_json::to_string(&expected).unwrap();
+        assert_eq!(snapshot_json(&s).unwrap(), expected);
+        let back: Session = serde_json::from_str(&snapshot_json(&s).unwrap()).unwrap();
+        assert_eq!(back.message_count, 1);
+        // Same check with every optional absent.
+        let s = Session::new("model-x", "medium", None);
+        let mut expected = s.clone();
+        expected.message_count = 0;
+        assert_eq!(snapshot_json(&s).unwrap(), serde_json::to_string(&expected).unwrap());
+    }
+
     #[test]
     fn session_meta_stays_in_sync_with_session_schema() {
         let mut s = Session::new("model-x", "medium", Some("prompt"));

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -204,15 +204,25 @@ impl ToolOutput {
     }
 
     /// `(summary, Some(blocks))` for rich output, `(text, None)` for plain.
-    /// Debug builds assert the `blocks[0]` text-first invariant here — this
-    /// is the one choke point every rich result passes through.
+    /// This is the one choke point every rich result passes through, so the
+    /// `blocks[0]` text-first invariant is ENFORCED here in every build: a
+    /// `Blocks` value whose first block is not `{"type":"text"}` gets a text
+    /// block built from `summary` prepended. Debug builds additionally
+    /// assert that an existing leading text block matches `summary`.
     pub fn into_parts(self) -> (String, Option<Vec<Value>>) {
         match self {
             Self::Text(s) => (s, None),
-            Self::Blocks { blocks, summary } => {
+            Self::Blocks {
+                mut blocks,
+                summary,
+            } => {
+                let text_first = blocks.first().is_some_and(|b| b["type"] == "text");
+                if !text_first {
+                    blocks.insert(0, serde_json::json!({"type": "text", "text": summary}));
+                }
                 debug_assert!(
-                    blocks.first().is_some_and(|b| b["type"] == "text" && b["text"] == summary),
-                    "ToolOutput::Blocks invariant: blocks[0] must be a text block equal to summary"
+                    blocks[0]["text"] == summary,
+                    "ToolOutput::Blocks invariant: blocks[0] text must equal summary"
                 );
                 (summary, Some(blocks))
             }
@@ -286,3 +296,45 @@ pub trait Tool: Send + Sync {
 
 #[cfg(test)]
 mod test_helpers;
+
+#[cfg(test)]
+mod tool_output_tests {
+    use super::ToolOutput;
+    use serde_json::json;
+
+    #[test]
+    fn into_parts_prepends_summary_text_when_blocks_not_text_first() {
+        let img = json!({"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AA=="}});
+        let out = ToolOutput::Blocks {
+            blocks: vec![img.clone()],
+            summary: "[image 1x1]".into(),
+        };
+        let (summary, blocks) = out.into_parts();
+        let blocks = blocks.unwrap();
+        assert_eq!(summary, "[image 1x1]");
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0], json!({"type": "text", "text": "[image 1x1]"}));
+        assert_eq!(blocks[1], img);
+    }
+
+    #[test]
+    fn into_parts_prepends_summary_text_when_blocks_empty() {
+        let out = ToolOutput::Blocks {
+            blocks: vec![],
+            summary: "s".into(),
+        };
+        let (_, blocks) = out.into_parts();
+        assert_eq!(blocks.unwrap(), vec![json!({"type": "text", "text": "s"})]);
+    }
+
+    #[test]
+    fn into_parts_leaves_well_formed_blocks_alone() {
+        let blocks = vec![json!({"type": "text", "text": "ok"}), json!({"type": "image"})];
+        let out = ToolOutput::Blocks {
+            blocks: blocks.clone(),
+            summary: "ok".into(),
+        };
+        let (_, got) = out.into_parts();
+        assert_eq!(got.unwrap(), blocks);
+    }
+}

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -329,7 +329,10 @@ mod tool_output_tests {
 
     #[test]
     fn into_parts_leaves_well_formed_blocks_alone() {
-        let blocks = vec![json!({"type": "text", "text": "ok"}), json!({"type": "image"})];
+        let blocks = vec![
+            json!({"type": "text", "text": "ok"}),
+            json!({"type": "image"}),
+        ];
         let out = ToolOutput::Blocks {
             blocks: blocks.clone(),
             summary: "ok".into(),

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -283,6 +283,14 @@ fn image_output(path: &std::path::Path, mime: &'static str, bytes: &[u8]) -> Res
             path.display()
         )));
     };
+    // Zero-sized images are invalid for every supported format and are
+    // rejected by providers — same poison-pill class as unknown dims.
+    if w == 0 || h == 0 {
+        return Err(RuntimeError::Tool(format!(
+            "Image '{}' ({mime}, {kb} KB) declares invalid dimensions {w}x{h} (zero-sized).              Not sent to the model. Re-export it and read the new file.",
+            path.display()
+        )));
+    }
     if w > MAX_IMAGE_SIDE_PX || h > MAX_IMAGE_SIDE_PX {
         return Err(RuntimeError::Tool(format!(
             "Image '{}' is {w}x{h}; the provider rejects images with any side over {MAX_IMAGE_SIDE_PX} px. \
@@ -803,6 +811,22 @@ mod tests {
         assert!(err.contains("could not parse dimensions"), "{err}");
         assert!(err.contains("Not sent to the model"), "{err}");
         let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn zero_dimension_images_rejected_not_shipped() {
+        for (name, w, h) in [("w0.png", 0u32, 7u32), ("h0.png", 7, 0), ("both0.png", 0, 0)] {
+            let p = tmp(name, &png_with_dims(w, h));
+            let err = ReadTool
+                .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+                .await
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("zero-sized"), "{name}: {err}");
+            assert!(err.contains(&format!("{w}x{h}")), "{name}: {err}");
+            assert!(err.contains("Not sent to the model"), "{name}: {err}");
+            let _ = std::fs::remove_file(p);
+        }
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -667,7 +667,10 @@ mod tests {
         };
         let p = std::path::PathBuf::from(home).join("Jawz/media/jawz-avatar-v1.png");
         if !p.exists() {
-            eprintln!("SKIPPED real_avatar_png_round_trips_as_image_blocks: {} absent", p.display());
+            eprintln!(
+                "SKIPPED real_avatar_png_round_trips_as_image_blocks: {} absent",
+                p.display()
+            );
             return;
         }
         let out = ReadTool
@@ -703,7 +706,9 @@ mod tests {
             )
             .await
             .unwrap();
-        let ToolOutput::Text(text) = out else { panic!("expected Text") };
+        let ToolOutput::Text(text) = out else {
+            panic!("expected Text")
+        };
         assert!(text.starts_with("1\tuse super::"), "{text}");
 
         let Ok(big) = std::env::var("SYNAPS_TEST_BIG_IMAGE") else {
@@ -732,10 +737,16 @@ mod tests {
         assert!(image_integrity_error("image/png", &bad_chunk).is_some());
         assert!(image_integrity_error("image/png", &PNG_SIG).is_some());
         // JPEG
-        assert_eq!(image_integrity_error("image/jpeg", &[0xFF, 0xD8, 0xFF, 0xD9]), None);
+        assert_eq!(
+            image_integrity_error("image/jpeg", &[0xFF, 0xD8, 0xFF, 0xD9]),
+            None
+        );
         assert!(image_integrity_error("image/jpeg", &[0xFF, 0xD8, 0xFF, 0xE0, 0, 0]).is_some());
         // GIF
-        assert_eq!(image_integrity_error("image/gif", b"GIF89a\x01\x00\x01\x00\x3B"), None);
+        assert_eq!(
+            image_integrity_error("image/gif", b"GIF89a\x01\x00\x01\x00\x3B"),
+            None
+        );
         assert!(image_integrity_error("image/gif", b"GIF89a\x01\x00\x01\x00").is_some());
         // WebP: RIFF size must equal len - 8.
         let mut webp = b"RIFF\x00\x00\x00\x00WEBPVP8 ".to_vec();
@@ -777,7 +788,10 @@ mod tests {
 
     #[tokio::test]
     async fn truncated_jpeg_and_gif_rejected() {
-        let jpeg = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, b'J', b'F', b'I', b'F', 0, 1, 1, 0, 0, 1, 0, 1, 0, 0];
+        let jpeg = [
+            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, b'J', b'F', b'I', b'F', 0, 1, 1, 0, 0, 1, 0, 1, 0,
+            0,
+        ];
         let p = tmp("trunc.jpg", &jpeg);
         let err = ReadTool
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
@@ -801,7 +815,9 @@ mod tests {
     async fn unparseable_dims_rejected_not_shipped() {
         // Structurally complete JPEG (SOI … EOI) but SOS before any SOF →
         // dims None → must NOT become an image block.
-        let jpeg = [0xFF, 0xD8, 0xFF, 0xDA, 0x00, 0x08, 0, 0, 0, 0, 0, 0, 0xFF, 0xD9];
+        let jpeg = [
+            0xFF, 0xD8, 0xFF, 0xDA, 0x00, 0x08, 0, 0, 0, 0, 0, 0, 0xFF, 0xD9,
+        ];
         let p = tmp("nodims.jpg", &jpeg);
         let err = ReadTool
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
@@ -815,7 +831,11 @@ mod tests {
 
     #[tokio::test]
     async fn zero_dimension_images_rejected_not_shipped() {
-        for (name, w, h) in [("w0.png", 0u32, 7u32), ("h0.png", 7, 0), ("both0.png", 0, 0)] {
+        for (name, w, h) in [
+            ("w0.png", 0u32, 7u32),
+            ("h0.png", 7, 0),
+            ("both0.png", 0, 0),
+        ] {
             let p = tmp(name, &png_with_dims(w, h));
             let err = ReadTool
                 .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
@@ -836,7 +856,11 @@ mod tests {
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
             .await
             .unwrap();
-        assert!(out.summary().contains("(2x3, image/gif, 1 KB)"), "{}", out.summary());
+        assert!(
+            out.summary().contains("(2x3, image/gif, 1 KB)"),
+            "{}",
+            out.summary()
+        );
         assert!(matches!(out, ToolOutput::Blocks { .. }));
         let _ = std::fs::remove_file(p);
 
@@ -849,7 +873,11 @@ mod tests {
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
             .await
             .unwrap();
-        assert!(out.summary().contains("(640x480, image/jpeg, 1 KB)"), "{}", out.summary());
+        assert!(
+            out.summary().contains("(640x480, image/jpeg, 1 KB)"),
+            "{}",
+            out.summary()
+        );
         let _ = std::fs::remove_file(p);
     }
 

--- a/crates/agent-engine/src/tools/registry.rs
+++ b/crates/agent-engine/src/tools/registry.rs
@@ -646,7 +646,8 @@ impl ToolRegistry {
         // `dropped` and the audit signal lost. Walk the session's own
         // core + activated pins and report any id the catalog no longer
         // knows and that the loop did not already account for.
-        let seen: HashSet<&crate::tools::catalog::ToolId> = dropped.iter().map(|(id, _)| id).collect();
+        let seen: HashSet<&crate::tools::catalog::ToolId> =
+            dropped.iter().map(|(id, _)| id).collect();
         let vanished: Vec<crate::tools::catalog::ToolId> = session
             .core_ids()
             .chain(session.activated().map(|a| a.grant().tool_id()))

--- a/crates/agent-engine/src/tools/registry.rs
+++ b/crates/agent-engine/src/tools/registry.rs
@@ -640,6 +640,26 @@ impl ToolRegistry {
             }
             projected.push(entry.clone());
         }
+        // Post-pass: a pinned member that vanished ENTIRELY (extension
+        // unload → `try_disable` rebuilds `cached_schema` without it) never
+        // appears in the loop above, so it would be silently omitted from
+        // `dropped` and the audit signal lost. Walk the session's own
+        // core + activated pins and report any id the catalog no longer
+        // knows and that the loop did not already account for.
+        let seen: HashSet<&crate::tools::catalog::ToolId> = dropped.iter().map(|(id, _)| id).collect();
+        let vanished: Vec<crate::tools::catalog::ToolId> = session
+            .core_ids()
+            .chain(session.activated().map(|a| a.grant().tool_id()))
+            .filter(|id| !seen.contains(id) && self.catalog.get(id).is_none())
+            .cloned()
+            .collect();
+        for id in vanished {
+            tracing::warn!(
+                tool = %id,
+                "session schema projection drops uncataloged session member                  (removed from the registry since the session pinned it)"
+            );
+            dropped.push((id, DroppedSessionMember::Uncataloged));
+        }
         SessionSchemaProjection {
             schema: projected,
             dropped,

--- a/crates/agent-engine/tests/session_schema_projection.rs
+++ b/crates/agent-engine/tests/session_schema_projection.rs
@@ -308,3 +308,46 @@ fn projection_reports_coherent_provenance_imposter_as_dropped() {
         vec![(id, DroppedSessionMember::ProvenanceMismatch)]
     );
 }
+
+/// A pinned member that vanishes ENTIRELY from the registry (extension
+/// unload → `try_disable` rebuilds the cached schema without it) has no
+/// `cached_schema` entry to iterate, so the primary loop never sees it.
+/// The post-pass over the session's own pins must still report it as
+/// `Uncataloged` — otherwise the round-level dropped-member log is blind
+/// to exactly the removal it exists to surface.
+#[test]
+fn projection_reports_vanished_pinned_member_as_uncataloged() {
+    let mut registry = collision_registry();
+    let mut set = SessionToolSet::new(
+        session_id(),
+        [ToolId::builtin("core_tool")],
+        registry.catalog(),
+    )
+    .expect("core resolves");
+    // Pin one exact activation on top of the core set so both pin kinds are covered.
+    activate_exact_for_user(&mut set, registry.catalog(), &ToolId::builtin("deferred_tool"))
+        .expect("activates");
+    assert!(registry.session_tools_schema(&set).dropped.is_empty());
+
+    registry
+        .try_disable(&["core_tool".to_string(), "deferred_tool".to_string()])
+        .expect("disable");
+    assert!(registry.catalog().get(&ToolId::builtin("core_tool")).is_none());
+
+    let report = registry.session_tools_schema(&set);
+    assert!(
+        !report.schema.iter().any(|s| {
+            matches!(s["name"].as_str(), Some("core_tool") | Some("deferred_tool"))
+        }),
+        "a vanished member's schema must never be served"
+    );
+    let mut dropped = report.dropped.clone();
+    dropped.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(
+        dropped,
+        vec![
+            (ToolId::builtin("core_tool"), DroppedSessionMember::Uncataloged),
+            (ToolId::builtin("deferred_tool"), DroppedSessionMember::Uncataloged),
+        ]
+    );
+}

--- a/crates/agent-engine/tests/session_schema_projection.rs
+++ b/crates/agent-engine/tests/session_schema_projection.rs
@@ -325,19 +325,29 @@ fn projection_reports_vanished_pinned_member_as_uncataloged() {
     )
     .expect("core resolves");
     // Pin one exact activation on top of the core set so both pin kinds are covered.
-    activate_exact_for_user(&mut set, registry.catalog(), &ToolId::builtin("deferred_tool"))
-        .expect("activates");
+    activate_exact_for_user(
+        &mut set,
+        registry.catalog(),
+        &ToolId::builtin("deferred_tool"),
+    )
+    .expect("activates");
     assert!(registry.session_tools_schema(&set).dropped.is_empty());
 
     registry
         .try_disable(&["core_tool".to_string(), "deferred_tool".to_string()])
         .expect("disable");
-    assert!(registry.catalog().get(&ToolId::builtin("core_tool")).is_none());
+    assert!(registry
+        .catalog()
+        .get(&ToolId::builtin("core_tool"))
+        .is_none());
 
     let report = registry.session_tools_schema(&set);
     assert!(
         !report.schema.iter().any(|s| {
-            matches!(s["name"].as_str(), Some("core_tool") | Some("deferred_tool"))
+            matches!(
+                s["name"].as_str(),
+                Some("core_tool") | Some("deferred_tool")
+            )
         }),
         "a vanished member's schema must never be served"
     );
@@ -346,8 +356,14 @@ fn projection_reports_vanished_pinned_member_as_uncataloged() {
     assert_eq!(
         dropped,
         vec![
-            (ToolId::builtin("core_tool"), DroppedSessionMember::Uncataloged),
-            (ToolId::builtin("deferred_tool"), DroppedSessionMember::Uncataloged),
+            (
+                ToolId::builtin("core_tool"),
+                DroppedSessionMember::Uncataloged
+            ),
+            (
+                ToolId::builtin("deferred_tool"),
+                DroppedSessionMember::Uncataloged
+            ),
         ]
     );
 }

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -1296,12 +1296,11 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
                 // T30 (spec §9.2): server compaction routes through the ONE
                 // engine transition with the in-place policy. Snapshot under
                 // brief locks; the LLM round-trip runs with no lock held.
+                // Lock order: `runtime` → `conv` (file-wide invariant).
                 let (msgs, session, rt) = {
+                    let rt = state.runtime.lock().await;
                     let conv = state.conv.read().await;
-                    (conv.api_messages.clone(), conv.session.clone(), {
-                        let rt = state.runtime.lock().await;
-                        rt.clone()
-                    })
+                    (conv.api_messages.clone(), conv.session.clone(), rt.clone())
                 };
                 if msgs.len() < 4 {
                     let _ = broadcast.send(ServerMessage::System {

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -1278,8 +1278,7 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
     // The engine result is applied to `conv` while `runtime` is still held
     // so concurrent clients can't interleave between the runtime mutation
     // and the conv mirror (runtime → conv is the legal order).
-    let engine_result =
-        run_engine_command_synced(name, args, &state.runtime, &state.conv).await;
+    let engine_result = run_engine_command_synced(name, args, &state.runtime, &state.conv).await;
 
     if let Some(result) = engine_result {
         match result {
@@ -1564,7 +1563,10 @@ mod tests {
             None,
         )));
         let res = run_engine_command_synced("thinking", "high", &runtime, &conv).await;
-        assert!(matches!(res, Some(CommandResult::ThinkingChanged { .. })), "{res:?}");
+        assert!(
+            matches!(res, Some(CommandResult::ThinkingChanged { .. })),
+            "{res:?}"
+        );
         assert_eq!(conv.read().await.session.thinking_level, "high");
         assert_eq!(runtime.lock().await.thinking_level(), "high");
     }

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -1210,6 +1210,37 @@ async fn run_injected_event_turn(state: &Arc<ServerState>) {
     *state.cancel_token.write().await = None;
 }
 
+/// Run an engine command and mirror any model/thinking change into `conv`
+/// atomically with respect to other commands.
+///
+/// Both locks are taken in the file-wide order `runtime` → `conv`, and the
+/// `runtime` guard is held across the `conv` write so a second client's
+/// command can't slip between "runtime mutated" and "conv mirrored" and
+/// leave `conv.session.{model,thinking_level}` stale.
+async fn run_engine_command_synced(
+    name: &str,
+    args: &str,
+    runtime: &Mutex<Runtime>,
+    conv: &RwLock<ConversationState>,
+) -> Option<CommandResult> {
+    let mut rt = runtime.lock().await;
+    let result = engine_commands::handle_engine_command(name, args, &mut rt)?;
+    match &result {
+        CommandResult::ModelChanged { .. } => {
+            let mut conv = conv.write().await;
+            conv.session.model = rt.model().to_string();
+            // Covers the reasoning-clamp case; a no-op otherwise.
+            conv.session.thinking_level = rt.thinking_level().to_string();
+        }
+        CommandResult::ThinkingChanged { spec } => {
+            // Custom budgets persist as the raw number (matches chat.rs).
+            conv.write().await.session.thinking_level = spec.config_value();
+        }
+        _ => {}
+    }
+    Some(result)
+}
+
 async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
     let broadcast = &state.broadcast_tx;
 
@@ -1244,17 +1275,11 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
     // levels, quit, compact).
     //
     // Lock order in this file is `runtime` → `conv` (see `/clear` below).
-    // Snapshot everything the ModelChanged arm needs while `rt` is held here
-    // so that arm only ever takes `conv` and never both.
-    let (engine_result, post_thinking, post_model) = {
-        let mut rt = state.runtime.lock().await;
-        let result = engine_commands::handle_engine_command(name, args, &mut rt);
-        (
-            result,
-            rt.thinking_level().to_string(),
-            rt.model().to_string(),
-        )
-    };
+    // The engine result is applied to `conv` while `runtime` is still held
+    // so concurrent clients can't interleave between the runtime mutation
+    // and the conv mirror (runtime → conv is the legal order).
+    let engine_result =
+        run_engine_command_synced(name, args, &state.runtime, &state.conv).await;
 
     if let Some(result) = engine_result {
         match result {
@@ -1263,23 +1288,17 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
                 reasoning_clamped,
             } => {
                 let mut message = format!("model set to: {model}");
-                {
-                    let mut conv = state.conv.write().await;
-                    conv.session.model = model.clone();
-                    if let Some(clamp) = reasoning_clamped {
-                        conv.session.thinking_level = post_thinking;
-                        message.push_str(&format!(
-                            "; thinking → {} (clamped from {}: not supported by {})",
-                            clamp.to.as_str(),
-                            clamp.from.as_str(),
-                            post_model
-                        ));
-                    }
+                if let Some(clamp) = reasoning_clamped {
+                    message.push_str(&format!(
+                        "; thinking → {} (clamped from {}: not supported by {})",
+                        clamp.to.as_str(),
+                        clamp.from.as_str(),
+                        model
+                    ));
                 }
                 let _ = broadcast.send(ServerMessage::System { message });
             }
             CommandResult::ThinkingChanged { spec } => {
-                state.conv.write().await.session.thinking_level = spec.config_value();
                 let _ = broadcast.send(ServerMessage::System {
                     message: format!("thinking set to: {}", spec.level()),
                 });
@@ -1484,4 +1503,69 @@ fn rebuild_history(api_messages: &[synaps_cli::SharedMessage]) -> Vec<HistoryEnt
         }
     }
     history
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synaps_cli::Session;
+
+    /// Two clients hammering `/model` and `/thinking` concurrently must never
+    /// leave `conv.session` out of sync with the live runtime — the mirror
+    /// write happens under the `runtime` lock (runtime → conv).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn interleaved_commands_keep_conv_in_sync_with_runtime() {
+        let runtime = Arc::new(Mutex::new(Runtime::new_headless()));
+        let conv = Arc::new(RwLock::new(ConversationState::new(Session::new(
+            "anthropic/claude-fable-5",
+            "medium",
+            None,
+        ))));
+
+        let models = [
+            "anthropic/claude-fable-5",
+            "openrouter/deepseek/deepseek-v4-pro",
+        ];
+        let mut tasks = Vec::new();
+        for i in 0..2 {
+            let runtime = Arc::clone(&runtime);
+            let conv = Arc::clone(&conv);
+            tasks.push(tokio::spawn(async move {
+                for n in 0..50 {
+                    let model = models[(i + n) % 2];
+                    let res = run_engine_command_synced("model", model, &runtime, &conv).await;
+                    assert!(matches!(res, Some(CommandResult::ModelChanged { .. })));
+                    // Check the invariant at an arbitrary point, not just at the end.
+                    let rt = runtime.lock().await;
+                    let c = conv.read().await;
+                    assert_eq!(c.session.model, rt.model());
+                    assert_eq!(c.session.thinking_level, rt.thinking_level());
+                    drop(c);
+                    drop(rt);
+                    tokio::task::yield_now().await;
+                }
+            }));
+        }
+        for t in tasks {
+            t.await.unwrap();
+        }
+        let rt = runtime.lock().await;
+        let c = conv.read().await;
+        assert_eq!(c.session.model, rt.model());
+        assert_eq!(c.session.thinking_level, rt.thinking_level());
+    }
+
+    #[tokio::test]
+    async fn thinking_custom_budget_persists_raw_number() {
+        let runtime = Mutex::new(Runtime::new_headless());
+        let conv = RwLock::new(ConversationState::new(Session::new(
+            "anthropic/claude-fable-5",
+            "medium",
+            None,
+        )));
+        let res = run_engine_command_synced("thinking", "high", &runtime, &conv).await;
+        assert!(matches!(res, Some(CommandResult::ThinkingChanged { .. })), "{res:?}");
+        assert_eq!(conv.read().await.session.thinking_level, "high");
+        assert_eq!(runtime.lock().await.thinking_level(), "high");
+    }
 }


### PR DESCRIPTION
Addresses the six Copilot review comments left on merged PRs #100 / #102 / #103. One commit per fix, plus a rustfmt pass over touched files.

## #103

### 1. `server.rs` — lock order is now `runtime → conv` everywhere (c9e49556)
[Comment](https://github.com/HaseebKhalid1507/SynapsCLI/pull/103#discussion_r3932417412)

**What:** the `/compact` snapshot block took `conv.read()` then `runtime.lock()` — the only inversion left in the file. It now takes `runtime` first.
**Why:** the file-wide comment claimed `runtime → conv`; with one path inverted that was a live AB/BA deadlock against `/clear` (and now the command-sync helper). Enumerated every site holding both locks (`grep conv.(read|write)` × `runtime.lock`): `/clear`, `/compact`, and the new helper below all go `runtime → conv`; every other site releases one before taking the other.

### 2. `server.rs` — engine command result mirrored into `conv` under the runtime lock (12ee8551)
[Comment](https://github.com/HaseebKhalid1507/SynapsCLI/pull/103#discussion_r3932417393)

**What:** new `run_engine_command_synced(name, args, &Mutex<Runtime>, &RwLock<ConversationState>)` runs `handle_engine_command` and writes `conv.session.{model,thinking_level}` while still holding `runtime` (legal now that the order is uniform). The `ModelChanged`/`ThinkingChanged` arms only broadcast. Custom `/thinking <budget>` still persists the raw number (`spec.config_value()`), matching `chat.rs`.
**Why:** the previous snapshot-then-write-after-release let a second client's command land between the runtime mutation and the conv mirror, leaving `conv.session` stale or overwriting a newer update.
**Test:** `cmd::server::tests::interleaved_commands_keep_conv_in_sync_with_runtime` — two tasks on a multi-thread runtime alternate `/model` 50× each and assert `conv.session.model == rt.model()` at every step; `thinking_custom_budget_persists_raw_number`. Needed `Runtime::new_headless()` in bin tests → `[dev-dependencies] agent-engine = { …, features = ["testing"] }`.

### 3. `session_journal.rs` — `message_count` refreshed without cloning `Session` (2c465775)
[Comment](https://github.com/HaseebKhalid1507/SynapsCLI/pull/103#discussion_r3932417341)

**What:** removed the `session.clone()` at the top of `save_session_in_dir`. Snapshot JSON now serializes through a borrowing `SessionSnapshotRef<'a>` (same field order + serde attrs as `Session`, `message_count = api_messages.len()` computed at write time). The journal delta path already gets its count from `SessionMeta::of`, so it's back to O(delta).
**Why:** cloning `Vec<Arc<_>>` is O(history) per save, defeating the delta-append design.
**Test:** `snapshot_json_matches_session_schema` asserts byte-for-byte equality with the old clone-and-refresh output (with and without optionals), and round-trips `message_count`. All #103 `header_message_count` tests still green.

## #102

### 4. `tools/mod.rs` — `ToolOutput::into_parts()` normalizes in all builds (90c48e26)
[Comment](https://github.com/HaseebKhalid1507/SynapsCLI/pull/102#discussion_r3932093921)

**What:** if `blocks[0]` isn't `{"type":"text"}` (or blocks is empty), a text block built from `summary` is prepended. `debug_assert!` retained only for the "leading text ≠ summary" case.
**Why:** compaction reads `blocks[0].text`; non-Anthropic translators join text sub-blocks. A release-build tool emitting image-first blocks would silently break both.
**Tests:** `into_parts_prepends_summary_text_when_blocks_not_text_first`, `…_when_blocks_empty`, `into_parts_leaves_well_formed_blocks_alone`.

### 5. `tools/read.rs` — zero-dimension images rejected (27f8e903)
[Comment](https://github.com/HaseebKhalid1507/SynapsCLI/pull/102#discussion_r3932093985)

**What:** `image_output` errors on `w == 0 || h == 0` ("declares invalid dimensions WxH (zero-sized). Not sent to the model.") — same fail-closed path as unparseable dims.
**Why:** 0×N is invalid for every supported format; shipping it is the same provider-400 poison pill the guards exist to prevent.
**Test:** `zero_dimension_images_rejected_not_shipped` — PNG headers 0×7, 7×0, 0×0.

## #100

### 6. `tools/registry.rs` — `dropped` reports members that vanished entirely (c2b89d2e)
[Comment](https://github.com/HaseebKhalid1507/SynapsCLI/pull/100#discussion_r3916572960)

**What:** post-pass in `session_tools_schema` walks the session's `core_ids()` + `activated()` pins and reports any id not in the catalog (and not already reported) as `DroppedSessionMember::Uncataloged`.
**Why:** the main loop iterates `cached_schema`; after `try_disable` (extension unload) rebuilds it without the tool, the pinned member was never visited and silently vanished from `dropped`, blinding the round-level logging in `runtime/stream.rs`.
**Test:** `projection_reports_vanished_pinned_member_as_uncataloged` — pins one core + one exact activation, `try_disable`s both, asserts both appear as `Uncataloged` and neither is served.

## Evidence

`cargo test --workspace --no-fail-fast` on bella at `b83af465`:

```
EXIT=0
118 suites ok — passed=3802 failed=0 ignored=20
```

(One earlier run hit a flake in `synaps-tui::tui::models::input::tests::e_opens_expanded_provider_browser` — untouched crate, passes 4/4 on rerun and in the final full run.)
