### PR TITLE
feat(daemon): experimental daemon mode — SessionActor, LocalTransport/SocketTransport, synaps daemon/attach, shared extension host (phase 2, default off)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ rust-version = "1.80"
 
 [features]
 testing = ["agent-tui/testing", "agent-engine/testing"]
+# Pre-actor inline `synaps chat` loop (A2 kill-switch, with SYNAPS_CHAT_INLINE=1). Deleted on day 3.
+legacy_inline = []
 
 [dependencies]
 # Non-musl only: jemalloc + background purge to stop glibc RSS ratchet on

--- a/crates/agent-engine/src/daemon/conn.rs
+++ b/crates/agent-engine/src/daemon/conn.rs
@@ -265,14 +265,10 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     let sid = handle.id.clone();
     let fwd_tx = tx.clone();
     let fwd_handle = handle.clone();
-    let fwd_shutdown = shutdown.clone();
-    let forward = tokio::spawn(async move {
+    // Not tied to `shutdown`: on daemon stop the client must still see `Ended`.
+    let mut forward = tokio::spawn(async move {
         loop {
-            let recv = tokio::select! {
-                _ = fwd_shutdown.cancelled() => break,
-                r = rx.recv() => r,
-            };
-            match recv {
+            match rx.recv().await {
                 Ok(env) => {
                     // Attached is addressed to one client; ours already went out as a frame.
                     if matches!(env.event, SessionEventWire::Attached { .. }) {
@@ -304,9 +300,10 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     });
 
     let mut ended = false;
+    let mut stopping = false;
     loop {
         let frame = tokio::select! {
-            _ = shutdown.cancelled() => break,
+            _ = shutdown.cancelled() => { stopping = true; break; }
             _ = handle.closed() => { ended = true; break; }
             r = read_frame(&mut reader, &mut line) => r,
         };
@@ -361,8 +358,19 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     }
 
     // Socket gone / Bye = Detach. The turn keeps running (§8).
-    forward.abort();
-    let _ = forward.await;
+    if stopping {
+        // Daemon stop: let the forwarder deliver Ended inside the lifecycle budget.
+        match tokio::time::timeout(super::lifecycle::SESSION_END_BUDGET + Duration::from_secs(1), &mut forward).await {
+            Ok(_) => {}
+            Err(_) => {
+                forward.abort();
+                let _ = forward.await;
+            }
+        }
+    } else {
+        forward.abort();
+        let _ = forward.await;
+    }
     if !ended && handle.is_alive() {
         let _ = handle.send(SessionCommand::Detach { client }).await;
     }

--- a/crates/agent-engine/src/daemon/conn.rs
+++ b/crates/agent-engine/src/daemon/conn.rs
@@ -65,7 +65,17 @@ fn spawn_writer(mut w: OwnedWriteHalf) -> (mpsc::Sender<DaemonFrame>, tokio::tas
                         break;
                     }
                 }
-                Err(e) => tracing::warn!("daemon: encode failed: {e}"),
+                Err(e) => {
+                    // Symmetric cap: an outbound frame we cannot legally send
+                    // becomes an Error frame and the connection closes.
+                    tracing::warn!("daemon: encode failed: {e}");
+                    let err = DaemonFrame::Error { session_id: None, message: format!("daemon could not encode a frame: {e}") };
+                    if let Ok(line) = encode_line(&err) {
+                        let _ = w.write_all(line.as_bytes()).await;
+                    }
+                    let _ = w.shutdown().await;
+                    break;
+                }
             }
             if bye {
                 let _ = w.shutdown().await;
@@ -93,7 +103,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
             return;
         }
         Ok(Ok(Read::Oversize)) => {
-            let _ = tx.send(DaemonFrame::Error { session_id: None, message: "frame exceeds 1 MiB limit".into() }).await;
+            let _ = tx.send(DaemonFrame::Error { session_id: None, message: frame_limit_msg() }).await;
             drop(tx);
             let _ = writer.await;
             return;
@@ -172,7 +182,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
                 return;
             }
             Ok(Read::Oversize) => {
-                let _ = tx.send(DaemonFrame::Error { session_id: None, message: "frame exceeds 1 MiB limit".into() }).await;
+                let _ = tx.send(DaemonFrame::Error { session_id: None, message: frame_limit_msg() }).await;
                 drop(tx);
                 let _ = writer.await;
                 return;
@@ -348,7 +358,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
             }
             Ok(Read::Frame(ClientFrame::Bye)) | Ok(Read::Eof) | Err(_) => break,
             Ok(Read::Oversize) => {
-                let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: "frame exceeds 1 MiB limit".into() }).await;
+                let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: frame_limit_msg() }).await;
                 break;
             }
             Ok(Read::Bad(e)) => {

--- a/crates/agent-engine/src/daemon/conn.rs
+++ b/crates/agent-engine/src/daemon/conn.rs
@@ -1,0 +1,376 @@
+//! Per-connection pump: handshake → control loop → attach → pump.
+//!
+//! Tracing here never logs frame bodies (`ClientFrame`'s `Debug` redacts
+//! `Answer`/`Submit`/`Steer`); `Answer` values are forwarded to the actor
+//! and nowhere else.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::UnixStream;
+use tokio::sync::{broadcast, mpsc};
+use tokio_util::sync::CancellationToken;
+
+use super::DaemonState;
+use crate::session::handle::CMD_CHAN_CAP;
+use crate::session::transport::{TransportError, ATTACH_TIMEOUT};
+use crate::session::wire::*;
+use crate::session::*;
+
+const HELLO_TIMEOUT: Duration = Duration::from_secs(2);
+
+type Reader = BufReader<OwnedReadHalf>;
+
+enum Read {
+    Frame(ClientFrame),
+    Eof,
+    Oversize,
+    Bad(String),
+}
+
+async fn read_frame(reader: &mut Reader, line: &mut String) -> std::io::Result<Read> {
+    loop {
+        line.clear();
+        let n = tokio::io::AsyncReadExt::take(&mut *reader, MAX_FRAME_BYTES as u64 + 1)
+            .read_line(line)
+            .await?;
+        if n == 0 {
+            return Ok(Read::Eof);
+        }
+        if n > MAX_FRAME_BYTES {
+            return Ok(Read::Oversize);
+        }
+        let t = line.trim_end();
+        if t.is_empty() {
+            continue;
+        }
+        return Ok(match decode_line::<ClientFrame>(t) {
+            Ok(f) => Read::Frame(f),
+            Err(e) => Read::Bad(e),
+        });
+    }
+}
+
+/// Writer task: owns the write half; bounded queue = per-client backpressure.
+fn spawn_writer(mut w: OwnedWriteHalf) -> (mpsc::Sender<DaemonFrame>, tokio::task::JoinHandle<()>) {
+    let (tx, mut rx) = mpsc::channel::<DaemonFrame>(CMD_CHAN_CAP);
+    let task = tokio::spawn(async move {
+        while let Some(frame) = rx.recv().await {
+            let bye = matches!(frame, DaemonFrame::Bye | DaemonFrame::Refused { .. });
+            match encode_line(&frame) {
+                Ok(line) => {
+                    if w.write_all(line.as_bytes()).await.is_err() {
+                        break;
+                    }
+                }
+                Err(e) => tracing::warn!("daemon: encode failed: {e}"),
+            }
+            if bye {
+                let _ = w.shutdown().await;
+                break;
+            }
+        }
+    });
+    (tx, task)
+}
+
+pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: CancellationToken) {
+    let (r, w) = stream.into_split();
+    let mut reader = BufReader::new(r);
+    let (tx, writer) = spawn_writer(w);
+    let mut line = String::new();
+
+    // ── handshake: first frame MUST be Hello ──
+    let hello = match tokio::time::timeout(HELLO_TIMEOUT, read_frame(&mut reader, &mut line)).await {
+        Ok(Ok(Read::Frame(ClientFrame::Hello(h)))) => h,
+        Ok(Ok(Read::Frame(_))) | Ok(Ok(Read::Bad(_))) => {
+            let _ = tx
+                .send(DaemonFrame::Refused { reason: RefuseReason::Protocol, message: "first frame must be hello".into() })
+                .await;
+            let _ = writer.await;
+            return;
+        }
+        Ok(Ok(Read::Oversize)) => {
+            let _ = tx.send(DaemonFrame::Error { session_id: None, message: "frame exceeds 1 MiB limit".into() }).await;
+            drop(tx);
+            let _ = writer.await;
+            return;
+        }
+        _ => {
+            drop(tx);
+            let _ = writer.await;
+            return;
+        }
+    };
+    if hello.protocol_version < PROTOCOL_MIN || hello.protocol_version > PROTOCOL_MAX {
+        tracing::warn!(client = hello.protocol_version, daemon = PROTOCOL_VERSION, "daemon: refusing protocol version");
+        let _ = tx
+            .send(DaemonFrame::Refused {
+                reason: RefuseReason::Version { daemon_version: PROTOCOL_VERSION, min: PROTOCOL_MIN, max: PROTOCOL_MAX },
+                message: format!(
+                    "protocol version {} not supported (daemon speaks {}; daemon binary {})",
+                    hello.protocol_version,
+                    PROTOCOL_VERSION,
+                    binary_version()
+                ),
+            })
+            .await;
+        let _ = writer.await;
+        return;
+    }
+    let daemon_version = binary_version();
+    if hello.client_version != daemon_version {
+        tracing::info!(client = %hello.client_version, daemon = %daemon_version, "daemon: client binary version differs (same protocol; allowed)");
+    }
+    let welcome = Welcome {
+        protocol_version: PROTOCOL_VERSION,
+        daemon_version,
+        pid: std::process::id(),
+        profile: state.profile.clone(),
+        sessions: state.session_metas(),
+        progressive_tool_disclosure: state.host.parts().progressive_tool_disclosure,
+    };
+    if tx.send(DaemonFrame::Welcome(welcome)).await.is_err() {
+        return;
+    }
+    tracing::debug!(kind = ?hello.client.kind, "daemon: client connected");
+
+    // ── control loop (no session allocated) ──
+    let attach = loop {
+        let frame = tokio::select! {
+            _ = shutdown.cancelled() => { let _ = tx.send(DaemonFrame::Bye).await; let _ = writer.await; return; }
+            r = read_frame(&mut reader, &mut line) => r,
+        };
+        match frame {
+            Ok(Read::Frame(ClientFrame::Ping)) => {
+                let _ = tx
+                    .send(DaemonFrame::Pong { pid: std::process::id(), uptime_s: state.uptime_s(), sessions: state.live_sessions().len() })
+                    .await;
+            }
+            Ok(Read::Frame(ClientFrame::Sessions)) => {
+                let _ = tx.send(DaemonFrame::SessionList { sessions: state.session_metas() }).await;
+            }
+            Ok(Read::Frame(ClientFrame::Shutdown { force })) => {
+                tracing::info!(force, "daemon: shutdown requested over the socket");
+                let _ = tx.send(DaemonFrame::Bye).await;
+                let _ = writer.await;
+                state.request_shutdown(force);
+                return;
+            }
+            Ok(Read::Frame(ClientFrame::Attach(a))) => break a,
+            Ok(Read::Frame(ClientFrame::Cmd { session_id, .. })) => {
+                let _ = tx.send(DaemonFrame::Error { session_id: Some(session_id), message: "not attached".into() }).await;
+            }
+            Ok(Read::Frame(ClientFrame::Hello(_))) => {
+                let _ = tx.send(DaemonFrame::Error { session_id: None, message: "duplicate hello".into() }).await;
+            }
+            Ok(Read::Frame(ClientFrame::Bye)) | Ok(Read::Eof) | Err(_) => {
+                let _ = tx.send(DaemonFrame::Bye).await;
+                let _ = writer.await;
+                return;
+            }
+            Ok(Read::Oversize) => {
+                let _ = tx.send(DaemonFrame::Error { session_id: None, message: "frame exceeds 1 MiB limit".into() }).await;
+                drop(tx);
+                let _ = writer.await;
+                return;
+            }
+            Ok(Read::Bad(e)) => {
+                let _ = tx.send(DaemonFrame::Error { session_id: None, message: format!("malformed frame: {e}") }).await;
+            }
+        }
+    };
+
+    // ── attach ──
+    let (handle, mode) = match attach {
+        Attach::Existing { session_id, mode } => match state.attach(&session_id) {
+            Some(h) => (h, mode),
+            None => {
+                let _ = tx
+                    .send(DaemonFrame::Error { session_id: Some(session_id), message: "unknown session".into() })
+                    .await;
+                let _ = tx.send(DaemonFrame::Bye).await;
+                let _ = writer.await;
+                return;
+            }
+        },
+        Attach::Create { mut config, mode } => {
+            if config.cwd.is_none() {
+                config.cwd = Some(hello.cwd.clone());
+            }
+            if let Some(cwd) = &config.cwd {
+                if !cwd.is_absolute() || !cwd.is_dir() {
+                    let _ = tx
+                        .send(DaemonFrame::Error {
+                            session_id: None,
+                            message: format!("cwd must be an absolute existing directory: {}", cwd.display()),
+                        })
+                        .await;
+                    let _ = tx.send(DaemonFrame::Bye).await;
+                    let _ = writer.await;
+                    return;
+                }
+            }
+            match state.create(config).await {
+                Ok(h) => (h, mode),
+                Err(e) => {
+                    let _ = tx.send(DaemonFrame::Error { session_id: None, message: format!("create session: {e}") }).await;
+                    let _ = tx.send(DaemonFrame::Bye).await;
+                    let _ = writer.await;
+                    return;
+                }
+            }
+        }
+    };
+
+    let mut rx = handle.subscribe();
+    if let Err(e) = handle.send(SessionCommand::Attach { client: hello.client.clone(), mode }).await {
+        let _ = tx.send(DaemonFrame::Error { session_id: Some(handle.id.clone()), message: format!("attach: {e}") }).await;
+        let _ = tx.send(DaemonFrame::Bye).await;
+        let _ = writer.await;
+        return;
+    }
+    let attached = tokio::time::timeout(ATTACH_TIMEOUT, async {
+        loop {
+            match rx.recv().await {
+                Ok(env) => {
+                    if let SessionEventWire::Attached { client, snapshot } = env.event {
+                        return Some((client, snapshot));
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    })
+    .await;
+    let (client, snapshot) = match attached {
+        Ok(Some(x)) => x,
+        _ => {
+            let _ = tx.send(DaemonFrame::Error { session_id: Some(handle.id.clone()), message: "attach timed out".into() }).await;
+            let _ = tx.send(DaemonFrame::Bye).await;
+            let _ = writer.await;
+            return;
+        }
+    };
+    if tx.send(DaemonFrame::Attached(AttachedWire::new(client, snapshot))).await.is_err() {
+        let _ = handle.send(SessionCommand::Detach { client }).await;
+        return;
+    }
+    tracing::debug!(session = %handle.id, client = client.0, "daemon: client attached");
+
+    // ── pump ──
+    let sid = handle.id.clone();
+    let fwd_tx = tx.clone();
+    let fwd_handle = handle.clone();
+    let fwd_shutdown = shutdown.clone();
+    let forward = tokio::spawn(async move {
+        loop {
+            let recv = tokio::select! {
+                _ = fwd_shutdown.cancelled() => break,
+                r = rx.recv() => r,
+            };
+            match recv {
+                Ok(env) => {
+                    // Attached is addressed to one client; ours already went out as a frame.
+                    if matches!(env.event, SessionEventWire::Attached { .. }) {
+                        continue;
+                    }
+                    let ended = matches!(env.event, SessionEventWire::Ended { .. });
+                    if fwd_tx.send(DaemonFrame::Event(env.into())).await.is_err() {
+                        break;
+                    }
+                    if ended {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(session = %fwd_handle.id, dropped = n, "daemon: client lagged");
+                    let env = Envelope {
+                        session_id: fwd_handle.id.clone(),
+                        seq: u64::MAX,
+                        ts: chrono::Utc::now(),
+                        event: SessionEventWire::SystemNotice(format!("event stream lagged; {n} dropped")),
+                    };
+                    if fwd_tx.send(DaemonFrame::Event(env.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+
+    let mut ended = false;
+    loop {
+        let frame = tokio::select! {
+            _ = shutdown.cancelled() => break,
+            _ = handle.closed() => { ended = true; break; }
+            r = read_frame(&mut reader, &mut line) => r,
+        };
+        match frame {
+            Ok(Read::Frame(ClientFrame::Cmd { session_id, cmd })) => {
+                if session_id != sid {
+                    let _ = tx.send(DaemonFrame::Error { session_id: Some(session_id), message: "not attached to that session".into() }).await;
+                    continue;
+                }
+                if matches!(cmd, SessionCommand::HostEvent(_)) {
+                    continue;
+                }
+                match handle.send(cmd).await {
+                    Ok(()) => {}
+                    Err(TransportError::Backpressure) => {
+                        let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: "backpressure: command queue full".into() }).await;
+                    }
+                    Err(TransportError::Closed) => {
+                        ended = true;
+                        break;
+                    }
+                    Err(e) => {
+                        let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: e.to_string() }).await;
+                    }
+                }
+            }
+            Ok(Read::Frame(ClientFrame::Ping)) => {
+                let _ = tx
+                    .send(DaemonFrame::Pong { pid: std::process::id(), uptime_s: state.uptime_s(), sessions: state.live_sessions().len() })
+                    .await;
+            }
+            Ok(Read::Frame(ClientFrame::Sessions)) => {
+                let _ = tx.send(DaemonFrame::SessionList { sessions: state.session_metas() }).await;
+            }
+            Ok(Read::Frame(ClientFrame::Shutdown { force })) => {
+                let _ = tx.send(DaemonFrame::Bye).await;
+                state.request_shutdown(force);
+                break;
+            }
+            Ok(Read::Frame(ClientFrame::Attach(_))) | Ok(Read::Frame(ClientFrame::Hello(_))) => {
+                let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: "already attached".into() }).await;
+            }
+            Ok(Read::Frame(ClientFrame::Bye)) | Ok(Read::Eof) | Err(_) => break,
+            Ok(Read::Oversize) => {
+                let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: "frame exceeds 1 MiB limit".into() }).await;
+                break;
+            }
+            Ok(Read::Bad(e)) => {
+                let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: format!("malformed frame: {e}") }).await;
+            }
+        }
+    }
+
+    // Socket gone / Bye = Detach. The turn keeps running (§8).
+    forward.abort();
+    let _ = forward.await;
+    if !ended && handle.is_alive() {
+        let _ = handle.send(SessionCommand::Detach { client }).await;
+    }
+    if !handle.is_alive() {
+        state.remove(&sid);
+    }
+    let _ = tx.send(DaemonFrame::Bye).await;
+    drop(tx);
+    let _ = tokio::time::timeout(Duration::from_millis(500), writer).await;
+    tracing::debug!(session = %sid, client = client.0, "daemon: client detached");
+}

--- a/crates/agent-engine/src/daemon/conn.rs
+++ b/crates/agent-engine/src/daemon/conn.rs
@@ -23,6 +23,34 @@ const HELLO_TIMEOUT: Duration = Duration::from_secs(2);
 
 type Reader = BufReader<OwnedReadHalf>;
 
+/// Which `SessionCommand`s a socket client may originate (§4 MED). The UDS
+/// is 0600 same-uid, so this is a footgun guard, not an auth boundary:
+/// anything that drives the actor's *own* bookkeeping (`Attach`, `Detach`
+/// for another client, `Resync`, `HostEvent`) or ends the session for every
+/// other client (`End`) is refused with an `Error` frame. Ending a session
+/// is `daemon stop`'s job today.
+fn client_may_send(cmd: &SessionCommand, own: ClientId) -> Result<(), &'static str> {
+    use SessionCommand as C;
+    match cmd {
+        C::Submit { .. }
+        | C::Steer { .. }
+        | C::Cancel
+        | C::Answer { .. }
+        | C::Set(_)
+        | C::Compact { .. }
+        | C::NewSession
+        | C::Save
+        | C::Query { .. }
+        | C::EngineCommand { .. } => Ok(()),
+        C::Detach { client } if *client == own => Ok(()),
+        C::Detach { .. } => Err("detach: not your client id"),
+        C::Attach { .. } => Err("attach: already attached (one session per connection)"),
+        C::End { .. } => Err("end: sessions are ended by `synaps daemon stop`, not by clients"),
+        C::Resync { .. } => Err("resync: not a client command"),
+        C::HostEvent(_) => Err("host_event: not a client command"),
+    }
+}
+
 enum Read {
     Frame(ClientFrame),
     Eof,
@@ -323,7 +351,8 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
                     let _ = tx.send(DaemonFrame::Error { session_id: Some(session_id), message: "not attached to that session".into() }).await;
                     continue;
                 }
-                if matches!(cmd, SessionCommand::HostEvent(_)) {
+                if let Err(why) = client_may_send(&cmd, client) {
+                    let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: format!("refused: {why}") }).await;
                     continue;
                 }
                 match handle.send(cmd).await {

--- a/crates/agent-engine/src/daemon/lifecycle.rs
+++ b/crates/agent-engine/src/daemon/lifecycle.rs
@@ -7,9 +7,9 @@ use std::time::Duration;
 use super::DaemonState;
 use crate::session::{EndReason, SessionCommand};
 
-/// `SAVE_TIMEOUT_SECS + HOOKS_TIMEOUT_SECS` (tui/signals.rs: 2 + 5); shared
-/// across all sessions, not ×N.
-pub const SESSION_END_BUDGET: Duration = Duration::from_secs(7);
+/// `session::budgets::TEARDOWN_TIMEOUT_SECS` (SAVE + HOOKS); shared across
+/// all sessions, not ×N.
+pub const SESSION_END_BUDGET: Duration = Duration::from_secs(crate::session::budgets::TEARDOWN_TIMEOUT_SECS);
 /// `--force`: give the actors this long, then drop them.
 pub const FORCE_BUDGET: Duration = Duration::from_millis(500);
 

--- a/crates/agent-engine/src/daemon/lifecycle.rs
+++ b/crates/agent-engine/src/daemon/lifecycle.rs
@@ -1,0 +1,36 @@
+//! Daemon shutdown: end every session concurrently inside ONE wall budget,
+//! then shut the shared extension host down.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::DaemonState;
+use crate::session::{EndReason, SessionCommand};
+
+/// `SAVE_TIMEOUT_SECS + HOOKS_TIMEOUT_SECS` (tui/signals.rs: 2 + 5); shared
+/// across all sessions, not ×N.
+pub const SESSION_END_BUDGET: Duration = Duration::from_secs(7);
+/// `--force`: give the actors this long, then drop them.
+pub const FORCE_BUDGET: Duration = Duration::from_millis(500);
+
+pub async fn shutdown_all(state: &Arc<DaemonState>, force: bool) {
+    let sessions = state.live_sessions();
+    let n = sessions.len();
+    tracing::info!(sessions = n, force, "daemon: ending sessions");
+    let budget = if force { FORCE_BUDGET } else { SESSION_END_BUDGET };
+    let ends = sessions.iter().map(|h| async move {
+        let _ = h.send(SessionCommand::End { reason: EndReason::HostShutdown }).await;
+        h.closed().await;
+    });
+    if tokio::time::timeout(budget, futures::future::join_all(ends)).await.is_err() {
+        tracing::warn!(budget = ?budget, "daemon: session shutdown budget exceeded; continuing");
+    }
+    state.sessions.lock().unwrap_or_else(|e| e.into_inner()).clear();
+
+    let ext = Arc::clone(state.host.ext_manager());
+    let ext_shutdown = async move { ext.write().await.shutdown_all().await };
+    if tokio::time::timeout(Duration::from_secs(5), ext_shutdown).await.is_err() {
+        tracing::warn!("daemon: extension shutdown budget exceeded");
+    }
+    state.host.flush_logs();
+}

--- a/crates/agent-engine/src/daemon/listener.rs
+++ b/crates/agent-engine/src/daemon/listener.rs
@@ -1,0 +1,47 @@
+//! UDS listener: bind with 0600, accept until shutdown, one task per
+//! connection.
+
+use std::path::Path;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use tokio::net::UnixListener;
+use tokio_util::sync::CancellationToken;
+
+use super::DaemonState;
+
+/// Bind `path` (refusing to replace a symlink), then chmod 0600.
+pub fn bind(path: &Path) -> std::io::Result<UnixListener> {
+    crate::events::socket::cleanup_socket(&path.to_string_lossy());
+    let listener = UnixListener::bind(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(listener)
+}
+
+pub async fn accept_loop(state: Arc<DaemonState>, listener: UnixListener, shutdown: CancellationToken) {
+    loop {
+        let accepted = tokio::select! {
+            _ = shutdown.cancelled() => break,
+            r = listener.accept() => r,
+        };
+        match accepted {
+            Ok((stream, _)) => {
+                let state = Arc::clone(&state);
+                let shutdown = shutdown.clone();
+                state.connections.fetch_add(1, Ordering::SeqCst);
+                tokio::spawn(async move {
+                    super::conn::serve(Arc::clone(&state), stream, shutdown).await;
+                    state.connections.fetch_sub(1, Ordering::SeqCst);
+                });
+            }
+            Err(e) => {
+                tracing::warn!("daemon: accept error: {e}");
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+        }
+    }
+}

--- a/crates/agent-engine/src/daemon/mod.rs
+++ b/crates/agent-engine/src/daemon/mod.rs
@@ -1,0 +1,3 @@
+//! Daemon front-end (`synaps daemon`): UDS listener, per-connection pump,
+//! registry file, lifecycle. Declared in P2-0 so package B can add files
+//! without touching `lib.rs`; empty until B3 lands.

--- a/crates/agent-engine/src/daemon/mod.rs
+++ b/crates/agent-engine/src/daemon/mod.rs
@@ -1,3 +1,461 @@
 //! Daemon front-end (`synaps daemon`): UDS listener, per-connection pump,
-//! registry file, lifecycle. Declared in P2-0 so package B can add files
-//! without touching `lib.rs`; empty until B3 lands.
+//! registry file, lifecycle (PLAN-phase2 §2.11). Lives in `agent-engine`
+//! (S289 D-1 amended) — `agent-tui` must never appear in this graph.
+//!
+//! Gated: `SYNAPS_DAEMON=1` is required for `run_foreground` (exit 3 with a
+//! one-line reason otherwise). Safety properties that are NEVER stubbed:
+//! the flock liveness oracle, the ready-fd pipe, socket perms 0700/0600.
+
+pub mod conn;
+pub mod lifecycle;
+pub mod listener;
+pub mod registry;
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio_util::sync::CancellationToken;
+
+use crate::session::{SessionConfig, SessionHandle, SessionId, SessionMeta};
+use crate::EngineHost;
+use registry::{DaemonInfo, DaemonLock, DaemonPaths};
+
+/// Exit code when the daemon refuses to start (flag off / legacy MCP).
+pub const EXIT_REFUSED: i32 = 3;
+/// Exit code for a protocol/version refusal on the client side.
+pub const EXIT_VERSION: i32 = 2;
+/// Env var carrying the write end of the ready pipe to a spawned daemon.
+pub const READY_FD_ENV: &str = "SYNAPS_DAEMON_READY_FD";
+/// How long `spawn_detached` waits for the child's ready byte.
+pub const SPAWN_READY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// `SYNAPS_DAEMON=1` feature flag (§4.4).
+pub fn enabled() -> bool {
+    matches!(std::env::var("SYNAPS_DAEMON").as_deref(), Ok("1") | Ok("true"))
+}
+
+/// `SYNAPS_DAEMON_ALLOW_LEGACY_MCP=1` (§4.4).
+pub fn allow_legacy_mcp_env() -> bool {
+    matches!(std::env::var("SYNAPS_DAEMON_ALLOW_LEGACY_MCP").as_deref(), Ok("1") | Ok("true"))
+}
+
+/// Builds a session for `Attach::Create`. Today: `EngineHost::create_session`
+/// once A1 lands; `echo_factory` under `testing`.
+pub type SessionFactory = Arc<
+    dyn Fn(SessionConfig) -> Pin<Box<dyn Future<Output = Result<SessionHandle, String>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// EchoActor-backed factory (B's socket tests before A1).
+#[cfg(any(test, feature = "testing"))]
+pub fn echo_factory() -> SessionFactory {
+    Arc::new(|cfg: SessionConfig| {
+        Box::pin(async move {
+            let id = SessionId(format!(
+                "echo-{}-{}",
+                chrono::Utc::now().format("%Y%m%d-%H%M%S%3f"),
+                uuid::Uuid::new_v4().simple()
+            ));
+            let (handle, _task) = SessionHandle::echo_for_test(id);
+            let _ = cfg;
+            Ok(handle)
+        })
+    })
+}
+
+/// The default factory for a booted host. Until A1 (`EngineHost::create_session`)
+/// is merged this refuses with a clear message so nothing is silently stubbed.
+pub fn host_factory(_host: &Arc<EngineHost>) -> SessionFactory {
+    Arc::new(|_cfg: SessionConfig| {
+        Box::pin(async move { Err("real sessions need SessionActor (A1); not merged into this build".to_string()) })
+    })
+}
+
+#[derive(Clone, Default)]
+pub struct DaemonOpts {
+    /// Override the socket path (the lock/json/pid stay under `registry_dir()`).
+    pub socket: Option<PathBuf>,
+    pub profile: Option<String>,
+    /// Exit after this long with zero connections and zero live sessions.
+    pub idle_exit: Option<Duration>,
+    pub allow_legacy_mcp: bool,
+    /// Test seam: `registry_dir()` replacement.
+    pub runtime_dir: Option<PathBuf>,
+    /// Test seam / A1 hook: how `Attach::Create` builds a session.
+    pub factory: Option<SessionFactory>,
+}
+
+impl DaemonOpts {
+    pub fn paths(&self) -> DaemonPaths {
+        let mut p = match &self.runtime_dir {
+            Some(d) => registry::daemon_paths_in(d, self.profile.as_deref()),
+            None => registry::daemon_paths(self.profile.as_deref()),
+        };
+        if let Some(s) = &self.socket {
+            p.sock = s.clone();
+        }
+        p
+    }
+}
+
+/// Shared by the accept loop and every connection.
+pub struct DaemonState {
+    pub host: Arc<EngineHost>,
+    pub profile: Option<String>,
+    pub started: Instant,
+    pub sessions: Mutex<HashMap<SessionId, SessionHandle>>,
+    pub factory: SessionFactory,
+    pub connections: AtomicUsize,
+    pub shutdown: CancellationToken,
+    pub force_shutdown: AtomicBool,
+}
+
+impl DaemonState {
+    pub fn uptime_s(&self) -> u64 {
+        self.started.elapsed().as_secs()
+    }
+
+    /// Live handles only (dead actors are dropped on read).
+    pub fn live_sessions(&self) -> Vec<SessionHandle> {
+        let mut map = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
+        map.retain(|_, h| h.is_alive());
+        map.values().cloned().collect()
+    }
+
+    pub fn session_metas(&self) -> Vec<SessionMeta> {
+        self.live_sessions().iter().map(|h| h.meta().clone()).collect()
+    }
+
+    pub fn attach(&self, id: &SessionId) -> Option<SessionHandle> {
+        self.live_sessions().into_iter().find(|h| &h.id == id)
+    }
+
+    pub fn insert(&self, handle: SessionHandle) {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(handle.id.clone(), handle);
+    }
+
+    pub fn remove(&self, id: &SessionId) {
+        self.sessions.lock().unwrap_or_else(|e| e.into_inner()).remove(id);
+    }
+
+    pub async fn create(&self, cfg: SessionConfig) -> Result<SessionHandle, String> {
+        let handle = (self.factory)(cfg).await?;
+        self.insert(handle.clone());
+        Ok(handle)
+    }
+
+    pub fn request_shutdown(&self, force: bool) {
+        if force {
+            self.force_shutdown.store(true, Ordering::SeqCst);
+        }
+        self.shutdown.cancel();
+    }
+}
+
+/// A running daemon (bound socket, lock held, accept loop spawned).
+pub struct Daemon {
+    pub paths: DaemonPaths,
+    pub state: Arc<DaemonState>,
+    accept: tokio::task::JoinHandle<()>,
+    _lock: DaemonLock,
+}
+
+/// Refuse-to-start check (§2.11): legacy `McpTool` connections would be
+/// shared across sessions.
+pub fn legacy_mcp_conflict(host: &EngineHost, allow: bool) -> Option<String> {
+    if allow || allow_legacy_mcp_env() {
+        return None;
+    }
+    let cfg = host.config();
+    if !cfg.progressive_tool_disclosure && host.mcp_server_count() > 0 {
+        return Some(format!(
+            "progressive_tool_disclosure=false with {} MCP server(s) configured: legacy McpTool connections would be shared across sessions. Set progressive_tool_disclosure=true, or pass --allow-legacy-mcp / SYNAPS_DAEMON_ALLOW_LEGACY_MCP=1",
+            host.mcp_server_count()
+        ));
+    }
+    None
+}
+
+impl Daemon {
+    /// Reap stale files, take the flock, bind (dir 0700 / sock 0600), write
+    /// `daemon.json`, spawn the accept loop, signal the ready fd if any.
+    pub async fn start(host: Arc<EngineHost>, opts: DaemonOpts) -> anyhow::Result<Self> {
+        let paths = opts.paths();
+        std::fs::create_dir_all(&paths.dir)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&paths.dir, std::fs::Permissions::from_mode(0o700))?;
+        }
+        if let Some(msg) = legacy_mcp_conflict(&host, opts.allow_legacy_mcp) {
+            anyhow::bail!("refusing to start: {msg}");
+        }
+        registry::reap_stale(&paths);
+        let lock = match DaemonLock::try_acquire(&paths)? {
+            Some(l) => l,
+            None => {
+                let who = registry::read_daemon_json(&paths).map(|i| i.pid);
+                anyhow::bail!(
+                    "another daemon holds {} (pid {})",
+                    paths.lock.display(),
+                    who.map_or("unknown".to_string(), |p| p.to_string())
+                );
+            }
+        };
+        let listener = listener::bind(&paths.sock)?;
+
+        let factory = opts.factory.clone().unwrap_or_else(|| host_factory(&host));
+        let state = Arc::new(DaemonState {
+            host,
+            profile: opts.profile.clone(),
+            started: Instant::now(),
+            sessions: Mutex::new(HashMap::new()),
+            factory,
+            connections: AtomicUsize::new(0),
+            shutdown: CancellationToken::new(),
+            force_shutdown: AtomicBool::new(false),
+        });
+
+        let info = DaemonInfo {
+            pid: std::process::id(),
+            protocol_version: crate::session::wire::PROTOCOL_VERSION,
+            daemon_version: crate::session::wire::binary_version(),
+            profile: opts.profile.clone(),
+            started_at: chrono::Utc::now(),
+            socket: paths.sock.to_string_lossy().into_owned(),
+        };
+        registry::write_daemon_json(&paths, &info)?;
+
+        let accept = tokio::spawn(listener::accept_loop(Arc::clone(&state), listener, state.shutdown.clone()));
+        if let Some(idle) = opts.idle_exit {
+            tokio::spawn(idle_monitor(Arc::clone(&state), idle));
+        }
+        signal_ready();
+        tracing::info!(sock = %paths.sock.display(), pid = info.pid, "daemon: listening");
+        Ok(Self { paths, state, accept, _lock: lock })
+    }
+
+    pub fn shutdown_token(&self) -> CancellationToken {
+        self.state.shutdown.clone()
+    }
+
+    /// Block until shutdown is requested (frame, signal, idle), then end
+    /// every session inside one budget and unlink the files.
+    pub async fn wait(self) {
+        self.state.shutdown.cancelled().await;
+        let force = self.state.force_shutdown.load(Ordering::SeqCst);
+        lifecycle::shutdown_all(&self.state, force).await;
+        self.accept.abort();
+        let _ = self.accept.await;
+        for p in [&self.paths.sock, &self.paths.json, &self.paths.pid] {
+            crate::events::socket::cleanup_socket(&p.to_string_lossy());
+        }
+        tracing::info!("daemon: stopped");
+        // `_lock` drops here → flock released.
+    }
+}
+
+async fn idle_monitor(state: Arc<DaemonState>, idle: Duration) {
+    let mut idle_since: Option<Instant> = None;
+    let tick = Duration::from_secs(5).min(idle.max(Duration::from_millis(100)));
+    loop {
+        tokio::select! {
+            _ = state.shutdown.cancelled() => return,
+            _ = tokio::time::sleep(tick) => {}
+        }
+        let busy = state.connections.load(Ordering::SeqCst) > 0 || !state.live_sessions().is_empty();
+        if busy {
+            idle_since = None;
+            continue;
+        }
+        let since = *idle_since.get_or_insert_with(Instant::now);
+        if since.elapsed() >= idle {
+            tracing::info!("daemon: idle for {:?}, exiting", idle);
+            state.request_shutdown(false);
+            return;
+        }
+    }
+}
+
+/// Child side of the ready pipe: write `R` to `SYNAPS_DAEMON_READY_FD` (if
+/// set), close it, and scrub the env so tool subprocesses do not inherit it.
+pub fn signal_ready() {
+    #[cfg(unix)]
+    {
+        let Some(fd) = std::env::var(READY_FD_ENV).ok().and_then(|s| s.parse::<i32>().ok()) else {
+            return;
+        };
+        std::env::remove_var(READY_FD_ENV);
+        // SAFETY: fd is the write end handed to us by the parent; we own it.
+        unsafe {
+            let _ = libc::write(fd, b"R".as_ptr() as *const libc::c_void, 1);
+            libc::close(fd);
+        }
+    }
+}
+
+/// Parent side: `current_exe daemon --foreground …` in its own session
+/// (`setsid`), stdout → null, stderr → pipe; waits ≤ 5 s for `R` on the
+/// ready pipe. EOF before `R` = child died → error with its stderr tail.
+#[cfg(unix)]
+pub fn spawn_detached(opts: &DaemonOpts) -> anyhow::Result<u32> {
+    use std::io::Read;
+    use std::os::unix::process::CommandExt;
+
+    let exe = std::env::current_exe()?;
+    let mut fds = [0i32; 2];
+    // SAFETY: plain pipe(2) on a valid 2-slot array.
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let (read_fd, write_fd) = (fds[0], fds[1]);
+
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("daemon").arg("--foreground");
+    if let Some(p) = &opts.profile {
+        cmd.arg("--profile").arg(p);
+    }
+    if let Some(s) = &opts.socket {
+        cmd.arg("--socket").arg(s);
+    }
+    if let Some(i) = opts.idle_exit {
+        cmd.arg("--idle-exit").arg(i.as_secs().to_string());
+    }
+    if opts.allow_legacy_mcp {
+        cmd.arg("--allow-legacy-mcp");
+    }
+    cmd.env("SYNAPS_DAEMON", "1")
+        .env(READY_FD_ENV, write_fd.to_string())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped());
+    // SAFETY: pre_exec runs in the forked child before exec; only async-signal-safe calls.
+    unsafe {
+        cmd.pre_exec(move || {
+            libc::close(read_fd);
+            // Clear CLOEXEC on the write end so it survives exec.
+            let flags = libc::fcntl(write_fd, libc::F_GETFD);
+            if flags >= 0 {
+                libc::fcntl(write_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC);
+            }
+            libc::setsid();
+            Ok(())
+        });
+    }
+    let mut child = cmd.spawn()?;
+    // SAFETY: parent no longer needs the write end; closing it makes EOF mean "child died".
+    unsafe { libc::close(write_fd) };
+    let pid = child.id();
+
+    // Wait for 'R' with a deadline (poll(2) on the read end).
+    let mut pfd = libc::pollfd { fd: read_fd, events: libc::POLLIN, revents: 0 };
+    let deadline = Instant::now() + SPAWN_READY_TIMEOUT;
+    let ready = loop {
+        let left = deadline.saturating_duration_since(Instant::now());
+        if left.is_zero() {
+            break false;
+        }
+        // SAFETY: one valid pollfd.
+        let n = unsafe { libc::poll(&mut pfd, 1, left.as_millis() as i32) };
+        if n < 0 {
+            let e = std::io::Error::last_os_error();
+            if e.kind() == std::io::ErrorKind::Interrupted {
+                continue;
+            }
+            break false;
+        }
+        if n == 0 {
+            break false;
+        }
+        let mut byte = [0u8; 1];
+        // SAFETY: reading one byte into a 1-byte buffer.
+        let r = unsafe { libc::read(read_fd, byte.as_mut_ptr() as *mut libc::c_void, 1) };
+        break r == 1 && byte[0] == b'R';
+    };
+    // SAFETY: done with the read end.
+    unsafe { libc::close(read_fd) };
+
+    if ready {
+        // Keep draining stderr so the child never blocks on a full pipe.
+        if let Some(mut err) = child.stderr.take() {
+            std::thread::spawn(move || {
+                let mut sink = Vec::new();
+                let _ = err.read_to_end(&mut sink);
+            });
+        }
+        drop(child);
+        return Ok(pid);
+    }
+    let mut tail = String::new();
+    if let Some(mut err) = child.stderr.take() {
+        let _ = err.read_to_string(&mut tail);
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    let tail: String = tail.lines().rev().take(20).collect::<Vec<_>>().into_iter().rev().collect::<Vec<_>>().join("\n");
+    anyhow::bail!("daemon did not become ready within {SPAWN_READY_TIMEOUT:?}\n{tail}")
+}
+
+/// `synaps daemon --foreground` body: gate → boot host → extension discovery
+/// once → start → wait for SIGTERM/SIGINT/Shutdown frame/idle.
+pub async fn run_foreground(opts: DaemonOpts) -> anyhow::Result<()> {
+    if !enabled() {
+        anyhow::bail!("synaps daemon is experimental; set SYNAPS_DAEMON=1 to enable (exit {EXIT_REFUSED})");
+    }
+    let host = EngineHost::boot_and_install(crate::HostOpts { profile: opts.profile.clone(), no_extensions: false }).await?;
+    if let Some(msg) = legacy_mcp_conflict(&host, opts.allow_legacy_mcp) {
+        anyhow::bail!("refusing to start: {msg} (exit {EXIT_REFUSED})");
+    }
+    // Sidecars spawn once per daemon: discover before accepting (bounded 10 s).
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let _loader = crate::extensions::loader::spawn_discover_and_load(Arc::clone(host.ext_manager()), tx, None);
+    let wait = async {
+        while let Some(ev) = rx.recv().await {
+            if let crate::extensions::loader::ExtensionLoaderEvent::Finished { loaded, failed } = ev {
+                tracing::info!(loaded = loaded.len(), failed = failed.len(), "daemon: extensions discovered");
+                break;
+            }
+        }
+    };
+    if tokio::time::timeout(Duration::from_secs(10), wait).await.is_err() {
+        tracing::warn!("daemon: extension discovery still running after 10 s; accepting anyway");
+    }
+
+    let mut opts = opts;
+    if opts.factory.is_none() {
+        opts.factory = Some(host_factory(&host));
+    }
+    let daemon = Daemon::start(host, opts).await?;
+    let state = Arc::clone(&daemon.state);
+    tokio::spawn(async move {
+        #[cfg(unix)]
+        {
+            let mut term = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).ok();
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = async { match term.as_mut() { Some(t) => { t.recv().await; } None => std::future::pending::<()>().await } } => {}
+                _ = state.shutdown.cancelled() => return,
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {}
+                _ = state.shutdown.cancelled() => return,
+            }
+        }
+        tracing::info!("daemon: signal received, shutting down");
+        state.request_shutdown(false);
+    });
+    daemon.wait().await;
+    Ok(())
+}

--- a/crates/agent-engine/src/daemon/mod.rs
+++ b/crates/agent-engine/src/daemon/mod.rs
@@ -44,8 +44,8 @@ pub fn allow_legacy_mcp_env() -> bool {
     matches!(std::env::var("SYNAPS_DAEMON_ALLOW_LEGACY_MCP").as_deref(), Ok("1") | Ok("true"))
 }
 
-/// Builds a session for `Attach::Create`. Today: `EngineHost::create_session`
-/// once A1 lands; `echo_factory` under `testing`.
+/// Builds a session for `Attach::Create`: `host_factory` (real actor) or
+/// `echo_factory` (tests).
 pub type SessionFactory = Arc<
     dyn Fn(SessionConfig) -> Pin<Box<dyn Future<Output = Result<SessionHandle, String>> + Send>>
         + Send
@@ -69,11 +69,13 @@ pub fn echo_factory() -> SessionFactory {
     })
 }
 
-/// The default factory for a booted host. Until A1 (`EngineHost::create_session`)
-/// is merged this refuses with a clear message so nothing is silently stubbed.
-pub fn host_factory(_host: &Arc<EngineHost>) -> SessionFactory {
-    Arc::new(|_cfg: SessionConfig| {
-        Box::pin(async move { Err("real sessions need SessionActor (A1); not merged into this build".to_string()) })
+/// The default factory for a booted host: `EngineHost::create_session` (A1) —
+/// the real `SessionActor` owning one `Runtime` + `ConversationState`.
+pub fn host_factory(host: &Arc<EngineHost>) -> SessionFactory {
+    let host = Arc::clone(host);
+    Arc::new(move |cfg: SessionConfig| {
+        let host = Arc::clone(&host);
+        Box::pin(async move { host.create_session(cfg).await.map_err(|e| e.to_string()) })
     })
 }
 

--- a/crates/agent-engine/src/daemon/mod.rs
+++ b/crates/agent-engine/src/daemon/mod.rs
@@ -84,7 +84,9 @@ pub struct DaemonOpts {
     /// Override the socket path (the lock/json/pid stay under `registry_dir()`).
     pub socket: Option<PathBuf>,
     pub profile: Option<String>,
-    /// Exit after this long with zero connections and zero live sessions.
+    /// Exit after this long with zero connections and no session running a
+    /// turn (idle, client-less sessions are saved on exit; `--continue`
+    /// brings them back). A turn in flight always blocks the exit.
     pub idle_exit: Option<Duration>,
     pub allow_legacy_mcp: bool,
     /// Test seam: `registry_dir()` replacement.
@@ -266,6 +268,58 @@ impl Daemon {
     }
 }
 
+/// How long a `Status` probe may take before the session counts as busy.
+const IDLE_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Whether `handle`'s actor is between turns. Asks `Query{Status}` under the
+/// reserved [`crate::session::wire::IDLE_PROBE_QUERY_ID`] (transports swallow
+/// it) and reads `streaming`. A no-answer inside [`IDLE_PROBE_TIMEOUT`] —
+/// the actor is inside `compact()`/preflight, or its queue is full — counts
+/// as busy: the daemon never exits under a running turn (jcode mistake #1).
+pub async fn session_is_idle(handle: &SessionHandle) -> bool {
+    use crate::session::wire::IDLE_PROBE_QUERY_ID;
+    use crate::session::{SessionCommand, SessionEventWire, SessionQuery};
+    let mut rx = handle.subscribe();
+    if handle.send(SessionCommand::Query { id: IDLE_PROBE_QUERY_ID, query: SessionQuery::Status }).await.is_err() {
+        return false;
+    }
+    let probe = async {
+        loop {
+            match rx.recv().await {
+                Ok(env) => {
+                    if let SessionEventWire::QueryResult { id, value } = env.event {
+                        if id == IDLE_PROBE_QUERY_ID {
+                            // Real actor: {"streaming": bool, "pending_prompts": n}. A backend that
+                            // does not implement Status (echo) has no turns to protect.
+                            let streaming = value.get("streaming").and_then(|v| v.as_bool()).unwrap_or(false);
+                            let prompts = value.get("pending_prompts").and_then(|v| v.as_u64()).unwrap_or(0);
+                            return !streaming && prompts == 0;
+                        }
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return true,
+            }
+        }
+    };
+    tokio::time::timeout(IDLE_PROBE_TIMEOUT, probe).await.unwrap_or(false)
+}
+
+/// Idle = zero connections AND every live session between turns, held for
+/// `idle` continuously. Clients count first so a probe is never sent while
+/// someone is attached.
+pub async fn daemon_is_idle(state: &DaemonState) -> bool {
+    if state.connections.load(Ordering::SeqCst) > 0 {
+        return false;
+    }
+    for h in state.live_sessions() {
+        if !session_is_idle(&h).await {
+            return false;
+        }
+    }
+    true
+}
+
 async fn idle_monitor(state: Arc<DaemonState>, idle: Duration) {
     let mut idle_since: Option<Instant> = None;
     let tick = Duration::from_secs(5).min(idle.max(Duration::from_millis(100)));
@@ -274,8 +328,7 @@ async fn idle_monitor(state: Arc<DaemonState>, idle: Duration) {
             _ = state.shutdown.cancelled() => return,
             _ = tokio::time::sleep(tick) => {}
         }
-        let busy = state.connections.load(Ordering::SeqCst) > 0 || !state.live_sessions().is_empty();
-        if busy {
+        if !daemon_is_idle(&state).await {
             idle_since = None;
             continue;
         }
@@ -431,6 +484,9 @@ pub async fn run_foreground(opts: DaemonOpts) -> anyhow::Result<()> {
     if tokio::time::timeout(Duration::from_secs(10), wait).await.is_err() {
         tracing::warn!("daemon: extension discovery still running after 10 s; accepting anyway");
     }
+    // C3 router: widget.* frames from every sidecar fan out to every live
+    // session (daemon-global widgets today — frames carry no session id).
+    let _router = crate::extensions::notify_router::spawn_notification_router(Arc::clone(&host));
 
     let mut opts = opts;
     if opts.factory.is_none() {

--- a/crates/agent-engine/src/daemon/registry.rs
+++ b/crates/agent-engine/src/daemon/registry.rs
@@ -1,0 +1,160 @@
+//! `daemon.json` / `daemon.lock` / `daemon.pid` under `registry_dir()`
+//! (PLAN-phase2 §2.11). The flock on `daemon.lock` is THE liveness oracle
+//! (jcode `socket.rs:89-139`): a daemon is alive iff someone holds the lock.
+//! A socket file with no lock holder is stale and gets unlinked. Nobody
+//! unlinks on ECONNREFUSED alone.
+
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::path::Path;
+
+use fs4::fs_std::FileExt;
+use serde::{Deserialize, Serialize};
+
+pub use crate::events::registry::{daemon_paths, daemon_paths_in, DaemonPaths};
+
+/// `daemon.json` — pid + profile + paths only. Never credentials.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DaemonInfo {
+    pub pid: u32,
+    pub protocol_version: u32,
+    pub daemon_version: String,
+    pub profile: Option<String>,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub socket: String,
+}
+
+#[cfg(unix)]
+fn chmod_600(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+}
+#[cfg(not(unix))]
+fn chmod_600(_path: &Path) {}
+
+/// Write `daemon.json` + `daemon.pid` atomically (tmp + rename), 0600.
+pub fn write_daemon_json(paths: &DaemonPaths, info: &DaemonInfo) -> io::Result<()> {
+    let body = serde_json::to_vec_pretty(info).map_err(io::Error::other)?;
+    write_atomic(&paths.json, &body)?;
+    write_atomic(&paths.pid, format!("{}\n", info.pid).as_bytes())
+}
+
+fn write_atomic(path: &Path, body: &[u8]) -> io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, body)?;
+    chmod_600(&tmp);
+    std::fs::rename(&tmp, path)
+}
+
+pub fn read_daemon_json(paths: &DaemonPaths) -> Option<DaemonInfo> {
+    let s = std::fs::read_to_string(&paths.json).ok()?;
+    serde_json::from_str(&s).ok()
+}
+
+/// Held for the daemon's lifetime; dropping releases the flock.
+pub struct DaemonLock {
+    file: File,
+}
+
+impl DaemonLock {
+    /// `flock(LOCK_EX|LOCK_NB)` on `daemon.lock` (0600). `None` if another
+    /// daemon holds it.
+    pub fn try_acquire(paths: &DaemonPaths) -> io::Result<Option<Self>> {
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&paths.lock)?;
+        chmod_600(&paths.lock);
+        if FileExt::try_lock_exclusive(&file)? {
+            Ok(Some(Self { file }))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl Drop for DaemonLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+/// Liveness probe: try to take the lock; success means nobody holds it
+/// (dead or never started) — release immediately. Never unlinks anything.
+pub fn is_alive(paths: &DaemonPaths) -> bool {
+    if !paths.lock.exists() {
+        return false;
+    }
+    match DaemonLock::try_acquire(paths) {
+        Ok(Some(_guard)) => false,
+        Ok(None) => true,
+        Err(_) => false,
+    }
+}
+
+/// Unlink `sock`/`json`/`pid` if — and only if — no daemon holds the lock.
+/// Returns `true` when something stale was removed.
+pub fn reap_stale(paths: &DaemonPaths) -> bool {
+    if is_alive(paths) {
+        return false;
+    }
+    let mut reaped = false;
+    for p in [&paths.sock, &paths.json, &paths.pid] {
+        if p.exists() {
+            crate::events::socket::cleanup_socket(&p.to_string_lossy());
+            reaped |= !p.exists();
+        }
+    }
+    reaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths() -> (tempfile::TempDir, DaemonPaths) {
+        let d = tempfile::tempdir().unwrap();
+        let p = daemon_paths_in(d.path(), None);
+        (d, p)
+    }
+
+    #[test]
+    fn lock_is_the_liveness_oracle() {
+        let (_d, p) = paths();
+        assert!(!is_alive(&p));
+        let guard = DaemonLock::try_acquire(&p).unwrap().expect("first holder");
+        assert!(is_alive(&p));
+        assert!(DaemonLock::try_acquire(&p).unwrap().is_none(), "second holder refused");
+        drop(guard);
+        assert!(!is_alive(&p));
+    }
+
+    #[test]
+    fn stale_files_reaped_only_without_holder() {
+        let (_d, p) = paths();
+        std::fs::write(&p.sock, b"").unwrap();
+        let info = DaemonInfo {
+            pid: 4_000_000,
+            protocol_version: 1,
+            daemon_version: "t".into(),
+            profile: None,
+            started_at: chrono::Utc::now(),
+            socket: p.sock.to_string_lossy().into_owned(),
+        };
+        write_daemon_json(&p, &info).unwrap();
+        assert_eq!(read_daemon_json(&p).unwrap(), info);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(std::fs::metadata(&p.json).unwrap().permissions().mode() & 0o777, 0o600);
+        }
+        let guard = DaemonLock::try_acquire(&p).unwrap().unwrap();
+        assert!(!reap_stale(&p), "live holder: nothing reaped");
+        assert!(p.sock.exists());
+        drop(guard);
+        assert!(reap_stale(&p));
+        assert!(!p.sock.exists() && !p.json.exists() && !p.pid.exists());
+    }
+}

--- a/crates/agent-engine/src/engine/session.rs
+++ b/crates/agent-engine/src/engine/session.rs
@@ -8,6 +8,7 @@ use crate::SharedMessage;
 use crate::{Runtime, Session};
 
 /// Conversation state tracked by the engine.
+#[derive(Clone)]
 pub struct ConversationState {
     pub session: Session,
     pub api_messages: Vec<SharedMessage>,
@@ -90,6 +91,29 @@ impl ConversationState {
             runtime.thinking_level(),
             runtime.system_prompt(),
         );
+    }
+
+    /// Serializable mirror for clients (`SessionEventWire::Conversation`).
+    /// `consecutive_auto_turns` is actor/App-side state, not conversation
+    /// state, so the caller supplies it.
+    pub fn snapshot(
+        &self,
+        consecutive_auto_turns: u32,
+    ) -> crate::session::ConversationSnapshot {
+        crate::session::ConversationSnapshot {
+            api_messages: self.api_messages.clone(),
+            tokens: crate::session::ConversationTokens {
+                input: self.total_input_tokens,
+                output: self.total_output_tokens,
+                cache_read: self.total_cache_read_tokens,
+                cache_creation: self.total_cache_creation_tokens,
+            },
+            cost: self.session_cost,
+            abort_context: self.abort_context.clone(),
+            queued_message: self.queued_message.clone(),
+            pending_events_len: self.pending_events.len(),
+            consecutive_auto_turns,
+        }
     }
 
     /// Add usage from a model turn.

--- a/crates/agent-engine/src/engine/setup.rs
+++ b/crates/agent-engine/src/engine/setup.rs
@@ -124,14 +124,75 @@ pub async fn boot(opts: EngineOpts) -> Result<EngineBoot> {
     let mut runtime = host.foreground_runtime().await?;
     let config: crate::SynapsConfig = (**host.config()).clone();
 
+    let sb = resolve_session_and_prompt(
+        &mut runtime,
+        &opts.continue_session,
+        opts.system.as_deref(),
+        opts.prompt_manifest.as_deref(),
+    )?;
+
+    // Skills, command registry, MCP setup and the MCP lease manager are
+    // host-owned (see `EngineHost::boot`); the runtime already holds them.
+    let registry = Arc::clone(host.command_registry());
+    let keybind_registry = Arc::clone(host.keybind_registry());
+    let mcp_server_count = host.mcp_server_count();
+
+    let system_prompt_path = crate::config::resolve_read_path("system.md");
+
+    // Session was resolved before policy compilation so its model is the immutable
+    // foreground identity used by worker inheritance and authorization.
+
+    let background = spawn_session_background(&runtime, &sb.session)?;
+
+    finish_session_setup(&mut runtime, &config, &sb.session, None);
+
+    // Extension manager: host-owned.
+    let ext_manager = Arc::clone(host.ext_manager());
+
+    if mcp_server_count > 0 {
+        tracing::info!(
+            "{} MCP servers available (use connect_mcp_server to activate)",
+            mcp_server_count
+        );
+    }
+
+    Ok(EngineBoot {
+        runtime,
+        config,
+        no_extensions: opts.no_extensions,
+        session: sb.session,
+        api_messages: sb.api_messages,
+        total_input_tokens: sb.total_input_tokens,
+        total_output_tokens: sb.total_output_tokens,
+        session_cost: sb.session_cost,
+        abort_context: sb.abort_context,
+        continued: sb.continued,
+        continue_info: sb.continue_info,
+        registry,
+        keybind_registry,
+        mcp_server_count,
+        system_prompt_path,
+        ext_manager,
+        background,
+    })
+}
+
+/// Session resolution + prompt/orchestration install (code motion from
+/// `boot()`; called per session by `SessionActor::create` too).
+pub(crate) fn resolve_session_and_prompt(
+    runtime: &mut Runtime,
+    continue_session: &Option<Option<String>>,
+    system: Option<&str>,
+    prompt_manifest: Option<&std::path::Path>,
+) -> Result<SessionBootResult> {
     // Resolve the final foreground route before compiling immutable delegation
     // policy. Continuing a session may replace the configured model.
-    let sb = resolve_or_create_session(&mut runtime, &opts.continue_session)?;
+    let sb = resolve_or_create_session(runtime, continue_session)?;
     runtime.set_session_id(Some(sb.session.id.clone()));
 
     // Validate and compile an opted-in manifest before any session/network work.
-    let legacy_prompt = crate::config::resolve_system_prompt(opts.system.as_deref());
-    if let Some(path) = &opts.prompt_manifest {
+    let legacy_prompt = crate::config::resolve_system_prompt(system);
+    if let Some(path) = prompt_manifest {
         let raw = std::fs::read_to_string(path)
             .map_err(|_| crate::RuntimeError::Config("prompt manifest is unavailable".into()))?;
         let manifest = agent_core::prompt::PromptManifest::parse(&raw)
@@ -162,9 +223,7 @@ pub async fn boot(opts: EngineOpts) -> Result<EngineBoot> {
                     .map_err(|error| crate::RuntimeError::Config(error.into()))?,
             ));
         }
-        let user = opts
-            .system
-            .as_ref()
+        let user = system
             .map(|_| {
                 agent_core::prompt::resolved_system_prompt_as_user_module(legacy_prompt.clone())
             })
@@ -178,7 +237,12 @@ pub async fn boot(opts: EngineOpts) -> Result<EngineBoot> {
         runtime
             .apply_prompt_stack(stack)
             .map_err(|e| crate::RuntimeError::Config(format!("invalid prompt manifest: {e}")))?;
-        runtime.retain_prompt_reload_source(path.clone(), context, user, delegation_policy_digest);
+        runtime.retain_prompt_reload_source(
+            path.to_path_buf(),
+            context,
+            user,
+            delegation_policy_digest,
+        );
     } else {
         let foreground = crate::orchestration::canonical_foreground_identity(runtime.model())
             .map_err(|e| crate::RuntimeError::Config(format!("invalid foreground model: {e}")))?;
@@ -189,17 +253,15 @@ pub async fn boot(opts: EngineOpts) -> Result<EngineBoot> {
         runtime.set_system_prompt(legacy_prompt);
     }
 
-    // Skills, command registry, MCP setup and the MCP lease manager are
-    // host-owned (see `EngineHost::boot`); the runtime already holds them.
-    let registry = Arc::clone(host.command_registry());
-    let keybind_registry = Arc::clone(host.keybind_registry());
-    let mcp_server_count = host.mcp_server_count();
+    Ok(sb)
+}
 
-    let system_prompt_path = crate::config::resolve_read_path("system.md");
-
-    // Session was resolved before policy compilation so its model is the immutable
-    // foreground identity used by worker inheritance and authorization.
-
+/// Inbox watcher + per-session UDS listener + registry registration (code
+/// motion from `boot()`). Fails loudly when registration fails.
+pub(crate) fn spawn_session_background(
+    runtime: &Runtime,
+    session: &Session,
+) -> Result<BackgroundTasks> {
     // Start inbox watcher
     let watcher_shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let watcher_task = {
@@ -220,15 +282,15 @@ pub async fn boot(opts: EngineOpts) -> Result<EngineBoot> {
 
     // Start per-session Unix socket listener + register in session registry
     let socket_shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let session_socket_path = crate::events::registry::socket_path_for_session(&sb.session.id);
+    let session_socket_path = crate::events::registry::socket_path_for_session(&session.id);
     let socket_task = crate::events::socket::listen_session_socket(
         session_socket_path.clone(),
         runtime.event_queue().clone(),
         socket_shutdown.clone(),
     );
     let session_registration = crate::events::registry::SessionRegistration {
-        session_id: sb.session.id.clone(),
-        name: sb.session.name.clone(),
+        session_id: session.id.clone(),
+        name: session.name.clone(),
         socket_path: session_socket_path.clone(),
         pid: std::process::id(),
         started_at: chrono::Utc::now(),
@@ -247,17 +309,33 @@ pub async fn boot(opts: EngineOpts) -> Result<EngineBoot> {
         )));
     }
 
+    Ok(BackgroundTasks {
+        watcher_shutdown,
+        watcher_task,
+        socket_shutdown,
+        socket_task,
+        session_socket_path,
+        session_id: session.id.clone(),
+        hook_bus: Arc::clone(runtime.hook_bus()),
+        // The appender guard lives on the `EngineHost` now.
+        log_guard: None,
+    })
+}
+
+/// Foreground turn budget + session start index record (code motion from
+/// `boot()`). `cwd` = the session's configured cwd (`None` → process cwd).
+pub(crate) fn finish_session_setup(
+    runtime: &mut Runtime,
+    config: &crate::SynapsConfig,
+    session: &Session,
+    cwd: Option<std::path::PathBuf>,
+) {
     // Task 23: the engine's interactive session runs under the FOREGROUND
     // turn budget with typed per-role config overrides applied.
     runtime.set_turn_budget(crate::runtime::budget::TurnBudget::from_config(
         crate::runtime::budget::TurnRole::Foreground,
         &config.turn_budgets,
     ));
-
-    // Extension manager: host-owned (progressive deferral + the shared
-    // extension lease manager were wired in `EngineHost::boot` /
-    // `foreground_runtime`).
-    let ext_manager = Arc::clone(host.ext_manager());
 
     // Session start index record.
     //
@@ -269,67 +347,27 @@ pub async fn boot(opts: EngineOpts) -> Result<EngineBoot> {
     // subscribers exist.
     {
         let mut index_record =
-            crate::core::session_index::SessionIndexRecord::start(&sb.session.id);
-        index_record.model = Some(sb.session.model.clone());
+            crate::core::session_index::SessionIndexRecord::start(&session.id);
+        index_record.model = Some(session.model.clone());
         index_record.profile = crate::core::config::get_profile();
-        index_record.cwd = std::env::current_dir().ok();
+        index_record.cwd = cwd.or_else(|| std::env::current_dir().ok());
         if let Err(err) = crate::core::session_index::append_record(&index_record) {
             tracing::warn!("failed to append session start index record: {}", err);
         }
     }
 
-    if mcp_server_count > 0 {
-        tracing::info!(
-            "{} MCP servers available (use connect_mcp_server to activate)",
-            mcp_server_count
-        );
-    }
-
-    let session_id = sb.session.id.clone();
-    let hook_bus = Arc::clone(runtime.hook_bus());
-
-    Ok(EngineBoot {
-        runtime,
-        config,
-        no_extensions: opts.no_extensions,
-        session: sb.session,
-        api_messages: sb.api_messages,
-        total_input_tokens: sb.total_input_tokens,
-        total_output_tokens: sb.total_output_tokens,
-        session_cost: sb.session_cost,
-        abort_context: sb.abort_context,
-        continued: sb.continued,
-        continue_info: sb.continue_info,
-        registry,
-        keybind_registry,
-        mcp_server_count,
-        system_prompt_path,
-        ext_manager,
-        background: BackgroundTasks {
-            watcher_shutdown,
-            watcher_task,
-            socket_shutdown,
-            socket_task,
-            session_socket_path,
-            session_id,
-            hook_bus,
-            // The appender guard lives on the `EngineHost` now.
-            log_guard: None,
-        },
-    })
 }
 
-/// Resolve a session to continue, or create a new one.
 /// Result of session resolution.
-struct SessionBootResult {
-    session: Session,
-    api_messages: Vec<crate::SharedMessage>,
-    total_input_tokens: u64,
-    total_output_tokens: u64,
-    session_cost: f64,
-    abort_context: Option<String>,
-    continued: bool,
-    continue_info: Option<ContinueInfo>,
+pub(crate) struct SessionBootResult {
+    pub(crate) session: Session,
+    pub(crate) api_messages: Vec<crate::SharedMessage>,
+    pub(crate) total_input_tokens: u64,
+    pub(crate) total_output_tokens: u64,
+    pub(crate) session_cost: f64,
+    pub(crate) abort_context: Option<String>,
+    pub(crate) continued: bool,
+    pub(crate) continue_info: Option<ContinueInfo>,
 }
 
 fn resolve_or_create_session(

--- a/crates/agent-engine/src/engine/setup.rs
+++ b/crates/agent-engine/src/engine/setup.rs
@@ -371,7 +371,7 @@ fn resolve_or_create_session(
                 let resolved_via = if *q != session.id {
                     if crate::chain::load_chain(q).is_ok() {
                         Some("chain".to_string())
-                    } else if crate::session::find_session_by_name(q).is_ok() {
+                    } else if agent_core::session::find_session_by_name(q).is_ok() {
                         Some("name".to_string())
                     } else {
                         None

--- a/crates/agent-engine/src/events/registry.rs
+++ b/crates/agent-engine/src/events/registry.rs
@@ -449,6 +449,6 @@ mod daemon_paths_tests {
         assert_eq!(p.json, d.join("daemon.json"));
         assert_eq!(p.pid, d.join("daemon.pid"));
         let p = daemon_paths_in(d, Some("work/../evil"));
-        assert_eq!(p.sock, d.join("daemon-work_____evil.sock"));
+        assert_eq!(p.sock, d.join("daemon-work____evil.sock"));
     }
 }

--- a/crates/agent-engine/src/events/registry.rs
+++ b/crates/agent-engine/src/events/registry.rs
@@ -402,3 +402,53 @@ mod tests {
         assert_eq!(perms.mode() & 0o777, 0o600, "registry file should be 0600");
     }
 }
+
+// ── daemon paths (Phase 2 B) ──────────────────────────────────────────────────
+
+/// Files the `synaps daemon` keeps under `registry_dir()` (0700). One daemon
+/// per profile: `daemon.{sock,lock,json,pid}` or `daemon-<P>.{…}`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonPaths {
+    pub dir: PathBuf,
+    pub sock: PathBuf,
+    pub lock: PathBuf,
+    pub json: PathBuf,
+    pub pid: PathBuf,
+}
+
+/// Daemon file paths for a profile, under `registry_dir()`.
+pub fn daemon_paths(profile: Option<&str>) -> DaemonPaths {
+    daemon_paths_in(&registry_dir(), profile)
+}
+
+/// Same, rooted at an explicit dir (tests; `--socket` overrides only `.sock`).
+pub fn daemon_paths_in(dir: &std::path::Path, profile: Option<&str>) -> DaemonPaths {
+    let stem = match profile.map(sanitize_session_id).filter(|p| !p.is_empty()) {
+        Some(p) => format!("daemon-{p}"),
+        None => "daemon".to_string(),
+    };
+    DaemonPaths {
+        dir: dir.to_path_buf(),
+        sock: dir.join(format!("{stem}.sock")),
+        lock: dir.join(format!("{stem}.lock")),
+        json: dir.join(format!("{stem}.json")),
+        pid: dir.join(format!("{stem}.pid")),
+    }
+}
+
+#[cfg(test)]
+mod daemon_paths_tests {
+    use super::*;
+
+    #[test]
+    fn daemon_paths_are_profile_scoped_and_sanitised() {
+        let d = std::path::Path::new("/run/x");
+        let p = daemon_paths_in(d, None);
+        assert_eq!(p.sock, d.join("daemon.sock"));
+        assert_eq!(p.lock, d.join("daemon.lock"));
+        assert_eq!(p.json, d.join("daemon.json"));
+        assert_eq!(p.pid, d.join("daemon.pid"));
+        let p = daemon_paths_in(d, Some("work/../evil"));
+        assert_eq!(p.sock, d.join("daemon-work_____evil.sock"));
+    }
+}

--- a/crates/agent-engine/src/extensions/hooks/events.rs
+++ b/crates/agent-engine/src/extensions/hooks/events.rs
@@ -147,19 +147,31 @@ impl HookKind {
 
 // ── HookEvent ─────────────────────────────────────────────────────────────────
 
+/// `SYNAPS_HOOK_SESSION_ID=0` disables the `session_id` field on tool/message
+/// hook events (they emit `null`, as before daemon-mode phase 2).
+pub fn hook_session_id_enabled() -> bool {
+    !matches!(
+        std::env::var("SYNAPS_HOOK_SESSION_ID").as_deref(),
+        Ok("0") | Ok("false") | Ok("off")
+    )
+}
+
 /// A hook event payload dispatched to extension handlers.
 ///
 /// Fields are optional and populated only when relevant to the hook kind:
 ///
 /// | Kind                  | tool_name | tool_input | tool_output | message | session_id |
 /// |-----------------------|-----------|------------|-------------|---------|------------|
-/// | `before_tool_call`    | ✓         | ✓          |             |         |            |
-/// | `after_tool_call`     | ✓         | ✓          | ✓           |         |            |
-/// | `before_message`      |           |            |             | ✓       |            |
-/// | `on_message_complete` |           |            |             | ✓       |            |
+/// | `before_tool_call`    | ✓         | ✓          |             |         | ✓*         |
+/// | `after_tool_call`     | ✓         | ✓          | ✓           |         | ✓*         |
+/// | `before_message`      |           |            |             | ✓       | ✓*         |
+/// | `on_message_complete` |           |            |             | ✓       | ✓*         |
 /// | `on_compaction`       |           |            |             | ✓       | ✓          |
 /// | `on_session_start`    |           |            |             |         | ✓          |
 /// | `on_session_end`      |           |            |             |         | ✓          |
+///
+/// `✓*` — set via [`HookEvent::with_session`] for foreground sessions; `null`
+/// for workers (no conversation id) and when `SYNAPS_HOOK_SESSION_ID=0`.
 ///
 /// The `data` field is available on all events for extensions that need to
 /// attach arbitrary structured context when constructing synthetic events.
@@ -192,6 +204,21 @@ pub struct HookEvent {
 }
 
 impl HookEvent {
+    /// Attach the owning conversation id to a tool/message event (builder).
+    ///
+    /// Additive: the JSON field already exists (`session_id`), so extensions
+    /// that ignore it are unaffected. Workers pass `None` and keep emitting
+    /// `null`. Kill-switch `SYNAPS_HOOK_SESSION_ID=0` forces `null` for a
+    /// misbehaving plugin.
+    pub fn with_session(mut self, id: Option<&str>) -> Self {
+        self.session_id = if hook_session_id_enabled() {
+            id.map(str::to_string)
+        } else {
+            None
+        };
+        self
+    }
+
     /// Construct a `before_tool_call` event.
     pub fn before_tool_call(tool_name: &str, input: Value) -> Self {
         Self {

--- a/crates/agent-engine/src/extensions/hooks/mod.rs
+++ b/crates/agent-engine/src/extensions/hooks/mod.rs
@@ -580,6 +580,7 @@ mod tests {
             serde_json::json!({"command": "cat huge.log"}),
             "RAW 10k lines".to_string(),
             30_000,
+            None,
         )
         .await;
 
@@ -597,6 +598,7 @@ mod tests {
             serde_json::json!({}),
             "RAW".to_string(),
             30_000,
+            None,
         )
         .await;
 
@@ -679,6 +681,7 @@ mod tests {
             serde_json::json!({}),
             "ORIGINAL".to_string(),
             30_000,
+            None,
         )
         .await;
 
@@ -1137,6 +1140,7 @@ mod tests {
             serde_json::json!({"command": "yes hello | head -c 150000"}),
             output,
             30_000,
+            None,
         )
         .await;
 
@@ -1173,6 +1177,7 @@ mod tests {
             serde_json::json!({}),
             "tiny original".to_string(),
             30_000,
+            None,
         )
         .await;
 
@@ -1197,6 +1202,7 @@ mod tests {
             serde_json::json!({}),
             huge.clone(),
             30_000,
+            None,
         )
         .await;
 
@@ -1223,6 +1229,7 @@ mod tests {
             serde_json::json!({}),
             multibyte,
             30_000,
+            None,
         )
         .await;
         assert!(result.is_char_boundary(result.len()));
@@ -1249,6 +1256,7 @@ mod tests {
             serde_json::json!({}),
             "orig".to_string(),
             30_000,
+            None,
         )
         .await;
         assert!(result2.is_char_boundary(result2.len()));

--- a/crates/agent-engine/src/extensions/loader.rs
+++ b/crates/agent-engine/src/extensions/loader.rs
@@ -117,6 +117,15 @@ pub fn spawn_discover_and_load(
     tx: mpsc::UnboundedSender<ExtensionLoaderEvent>,
     session_id: Option<String>,
 ) -> tokio::task::JoinHandle<()> {
+    // Host seam (C2): when this is the process host's manager, tell the host
+    // a walk is in flight BEFORE the task runs, and flip `extensions_ready`
+    // at Finished so `SessionActor::create` fires `on_session_start` only
+    // once extensions are subscribed.
+    let host = crate::host::EngineHost::current()
+        .filter(|host| Arc::ptr_eq(host.ext_manager(), &manager));
+    if let Some(host) = &host {
+        host.note_extensions_loading();
+    }
     tokio::spawn(async move {
         let _ = tx.send(ExtensionLoaderEvent::Started);
         let (loaded, failed) = manager
@@ -133,6 +142,9 @@ pub fn spawn_discover_and_load(
             emit_session_start(&hook_bus, &session_id).await;
         }
 
+        if let Some(host) = &host {
+            host.mark_extensions_ready();
+        }
         let _ = tx.send(ExtensionLoaderEvent::Finished { loaded, failed });
     })
 }

--- a/crates/agent-engine/src/extensions/loader.rs
+++ b/crates/agent-engine/src/extensions/loader.rs
@@ -41,7 +41,66 @@ impl ExtensionLoaderEvent {
     }
 }
 
+/// Session-level: fire `on_session_start` for one session and store any
+/// `inject` as that session's keyed injection (`stream.rs` reads it when
+/// composing the system prompt). Call AFTER discovery is known-finished —
+/// in-process hosts get that from [`spawn_discover_and_load`] itself; the
+/// daemon's `SessionActor` awaits `EngineHost::extensions_ready()` first.
+/// Never re-runs discovery. Returns `true` when something was injected.
+pub async fn emit_session_start(hook_bus: &Arc<super::hooks::HookBus>, session_id: &str) -> bool {
+    let event = HookEvent::on_session_start(session_id);
+    if let HookResult::Inject { content } = hook_bus.emit(&event).await {
+        tracing::debug!(
+            len = content.len(),
+            "on_session_start injected session-scoped context"
+        );
+        hook_bus
+            .set_session_injection_for(session_id, content)
+            .await;
+        return true;
+    }
+    false
+}
+
+/// Session-level: fire `on_session_end` for one session — concurrent
+/// dispatch (the hook only allows `continue`, so ordering cannot matter),
+/// fail-open under `budget`. Clears the session's keyed injection
+/// afterwards. Returns `false` if the budget elapsed (handlers may not have
+/// flushed; the transcript is already saved by the caller, so nothing is
+/// lost). Per session, not per process: every session in a daemon gets its
+/// own end event.
+pub async fn emit_session_end(
+    hook_bus: &Arc<super::hooks::HookBus>,
+    session_id: &str,
+    transcript: Option<Vec<crate::SharedMessage>>,
+    budget: std::time::Duration,
+) -> bool {
+    let event = HookEvent::on_session_end(session_id, transcript);
+    let completed = match tokio::time::timeout(budget, hook_bus.emit_concurrent(&event)).await {
+        Ok(_) => {
+            tracing::debug!(session = %session_id, "on_session_end hooks completed");
+            true
+        }
+        Err(_elapsed) => {
+            tracing::warn!(
+                session = %session_id,
+                budget_secs = budget.as_secs(),
+                "on_session_end hooks timed out — extensions may not have flushed"
+            );
+            false
+        }
+    };
+    hook_bus.clear_session_injection(session_id).await;
+    completed
+}
+
 /// Discover and load extensions in the background, then fire `on_session_start`.
+///
+/// Process-level and IDEMPOTENT (daemon-mode C2): the manager records its
+/// discovery result, so a second call on the same manager (second host in
+/// one process, or a second session in a daemon) replays `Finished` from
+/// that record and spawns nothing. `on_session_start` still fires for
+/// `session_id` on every call — that part is per session.
 ///
 /// The hook is emitted HERE, not at engine boot, and that placement is the
 /// whole point. `engine::setup::boot()` used to emit it while constructing an
@@ -71,16 +130,7 @@ pub fn spawn_discover_and_load(
         // Extensions are now subscribed; the event has somewhere to land.
         if let Some(session_id) = session_id {
             let hook_bus = manager.read().await.hook_bus().clone();
-            let event = HookEvent::on_session_start(&session_id);
-            if let HookResult::Inject { content } = hook_bus.emit(&event).await {
-                tracing::debug!(
-                    len = content.len(),
-                    "on_session_start injected session-scoped context"
-                );
-                hook_bus
-                    .set_session_injection_for(&session_id, content)
-                    .await;
-            }
+            emit_session_start(&hook_bus, &session_id).await;
         }
 
         let _ = tx.send(ExtensionLoaderEvent::Finished { loaded, failed });

--- a/crates/agent-engine/src/extensions/loader.rs
+++ b/crates/agent-engine/src/extensions/loader.rs
@@ -121,11 +121,11 @@ pub fn spawn_discover_and_load(
     // a walk is in flight BEFORE the task runs, and flip `extensions_ready`
     // at Finished so `SessionActor::create` fires `on_session_start` only
     // once extensions are subscribed.
-    let host = crate::host::EngineHost::current()
-        .filter(|host| Arc::ptr_eq(host.ext_manager(), &manager));
-    if let Some(host) = &host {
-        host.note_extensions_loading();
-    }
+    // The guard marks ready on ANY task exit (incl. panic) so
+    // `extensions_ready()` waiters are never stranded.
+    let ready_guard = crate::host::EngineHost::current()
+        .filter(|host| Arc::ptr_eq(host.ext_manager(), &manager))
+        .map(|host| host.extensions_loading_guard());
     tokio::spawn(async move {
         let _ = tx.send(ExtensionLoaderEvent::Started);
         let (loaded, failed) = manager
@@ -142,9 +142,8 @@ pub fn spawn_discover_and_load(
             emit_session_start(&hook_bus, &session_id).await;
         }
 
-        if let Some(host) = &host {
-            host.mark_extensions_ready();
-        }
+        // Ready BEFORE Finished, as before.
+        drop(ready_guard);
         let _ = tx.send(ExtensionLoaderEvent::Finished { loaded, failed });
     })
 }

--- a/crates/agent-engine/src/extensions/manager.rs
+++ b/crates/agent-engine/src/extensions/manager.rs
@@ -154,8 +154,26 @@ pub fn compute_extension_load_hint(
     }
 }
 
+/// Process-level discovery state (daemon-mode phase 2, C2). Discovery walks
+/// the plugin roots and spawns sidecars ONCE per manager; a second
+/// `discover_and_load` call replays the recorded result instead of
+/// re-walking (which would report every extension as "already loaded" —
+/// N false failures on the second host in one process).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum DiscoveryState {
+    #[default]
+    NotStarted,
+    Running,
+    Done {
+        loaded: Vec<String>,
+        failed: Vec<ExtensionLoadFailure>,
+    },
+}
+
 /// Manages the lifecycle of all loaded extensions.
 pub struct ExtensionManager {
+    /// Once-per-process discovery record; see [`DiscoveryState`].
+    discovery: DiscoveryState,
     /// The shared hook bus.
     hook_bus: Arc<HookBus>,
     /// Optional shared tool registry for extension-provided tools.
@@ -241,6 +259,7 @@ impl ExtensionManager {
     /// Create a new manager with a shared hook bus.
     pub fn new(hook_bus: Arc<HookBus>) -> Self {
         Self {
+            discovery: DiscoveryState::NotStarted,
             hook_bus,
             tools: None,
             providers: ProviderRegistry::new(),
@@ -264,6 +283,7 @@ impl ExtensionManager {
         tools: Arc<tokio::sync::RwLock<crate::ToolRegistry>>,
     ) -> Self {
         Self {
+            discovery: DiscoveryState::NotStarted,
             hook_bus,
             tools: Some(tools),
             providers: ProviderRegistry::new(),
@@ -1120,8 +1140,25 @@ impl ExtensionManager {
         self.load_with_cwd(id, manifest, cwd).await
     }
 
-    /// Shut down all extensions gracefully.
+    /// Current process-level discovery state.
+    pub fn discovery_state(&self) -> &DiscoveryState {
+        &self.discovery
+    }
+
+    /// `Some((loaded, failed))` once discovery has completed on this
+    /// manager; `None` while not started / running. Idempotence seam for
+    /// [`crate::extensions::loader::spawn_discover_and_load`].
+    pub fn discovery_done(&self) -> Option<(Vec<String>, Vec<ExtensionLoadFailure>)> {
+        match &self.discovery {
+            DiscoveryState::Done { loaded, failed } => Some((loaded.clone(), failed.clone())),
+            _ => None,
+        }
+    }
+
+    /// Shut down all extensions gracefully. Resets discovery so a later
+    /// `discover_and_load` on this manager walks the roots again.
     pub async fn shutdown_all(&mut self) {
+        self.discovery = DiscoveryState::NotStarted;
         let ids: Vec<String> = self.extensions.keys().cloned().collect();
         for id in ids {
             let _ = self.unload(&id).await;
@@ -1618,6 +1655,32 @@ impl ExtensionManager {
     pub async fn discover_and_load_with_progress<F>(
         &mut self,
         mut progress: F,
+    ) -> (Vec<String>, Vec<ExtensionLoadFailure>)
+    where
+        F: FnMut(crate::extensions::loader::ExtensionLoaderEvent),
+    {
+        // Idempotent (daemon-mode C2): discovery runs once per manager.
+        // A second call replays the recorded result and spawns nothing.
+        if let Some(done) = self.discovery_done() {
+            tracing::debug!(
+                loaded = done.0.len(),
+                failed = done.1.len(),
+                "Extension discovery already done; replaying recorded result"
+            );
+            return done;
+        }
+        self.discovery = DiscoveryState::Running;
+        let (loaded, failed) = self.discover_and_load_uncached(&mut progress).await;
+        self.discovery = DiscoveryState::Done {
+            loaded: loaded.clone(),
+            failed: failed.clone(),
+        };
+        (loaded, failed)
+    }
+
+    async fn discover_and_load_uncached<F>(
+        &mut self,
+        progress: &mut F,
     ) -> (Vec<String>, Vec<ExtensionLoadFailure>)
     where
         F: FnMut(crate::extensions::loader::ExtensionLoaderEvent),

--- a/crates/agent-engine/src/extensions/mod.rs
+++ b/crates/agent-engine/src/extensions/mod.rs
@@ -29,6 +29,7 @@ pub mod lifecycle;
 pub mod loader;
 pub mod manager;
 pub mod manifest;
+pub mod notify_router;
 pub mod permissions;
 pub mod providers;
 pub mod runtime;

--- a/crates/agent-engine/src/extensions/notify_router.rs
+++ b/crates/agent-engine/src/extensions/notify_router.rs
@@ -1,0 +1,87 @@
+//! Daemon-mode phase 2 (C3): extension notification router.
+//!
+//! One subscriber per loaded extension (`ProcessExtension::subscribe_notifications`),
+//! started ONCE by the host after discovery; forwards `widget.*` frames
+//! ([`super::widgets::is_widget_method`]) to every live session as
+//! `SessionEventWire::ExtensionNotification` via
+//! [`crate::host::EngineHost::broadcast_extension_notification`].
+//!
+//! Frames carry no session id today, so every session receives every frame
+//! (documented; per-session routing arrives when the extension contract adds
+//! `params.session_id`, day 2). Delivery is non-blocking: a session whose
+//! command queue is full drops the frame with a `warn!` — widget upserts are
+//! idempotent last-writer-wins UI state (`loop_arms.rs` semantics), and
+//! blocking would backpressure the extension's lossless fan-out and stall
+//! `command.invoke` / `provider.stream` subscribers on the same queue.
+//!
+//! The inline TUI keeps its own watcher (`loop_arms.rs`) today; this router
+//! serves actor-hosted sessions (daemon, `synaps chat` on the actor).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::host::EngineHost;
+
+/// Resubscribe delay after an extension's notification channel closes
+/// (EOF / restart) — mirrors the TUI watcher.
+const RESUBSCRIBE_DELAY: Duration = Duration::from_millis(500);
+
+/// Start one forwarding task per loaded extension. Idempotent per call
+/// site by construction — the host calls it once after
+/// `extensions_ready()`; call it again only after a genuine re-discovery.
+/// The returned handle completes once every per-extension task has been
+/// spawned (the tasks themselves run for the host's lifetime and end when
+/// their extension is gone and stays gone).
+pub fn spawn_notification_router(host: Arc<EngineHost>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let handlers = host.ext_manager().read().await.handlers();
+        for (ext_id, handler) in handlers {
+            let host = Arc::clone(&host);
+            tokio::spawn(async move {
+                forward_extension_notifications(host, ext_id, handler).await;
+            });
+        }
+    })
+}
+
+/// Forward loop for ONE extension. Exits when the extension has been
+/// unloaded from the manager (its channel closed and it is no longer
+/// listed); otherwise resubscribes after [`RESUBSCRIBE_DELAY`].
+pub async fn forward_extension_notifications(
+    host: Arc<EngineHost>,
+    ext_id: String,
+    handler: Arc<dyn super::runtime::ExtensionHandler>,
+) {
+    loop {
+        let (_sub_id, mut rx) = handler.subscribe_notifications().await;
+        while let Some(frame) = rx.recv().await {
+            if !super::widgets::is_widget_method(&frame.method) {
+                continue;
+            }
+            if super::widgets::parse_widget_event(&frame.method, &frame.params).is_err() {
+                tracing::debug!(extension = %ext_id, method = %frame.method,
+                    "ignoring malformed widget frame");
+                continue;
+            }
+            let delivered = host
+                .broadcast_extension_notification(&ext_id, &frame.method, frame.params)
+                .await;
+            tracing::trace!(extension = %ext_id, method = %frame.method, sessions = delivered,
+                "extension notification broadcast");
+        }
+        // Channel closed (EOF/restart). Stop if the extension is gone for
+        // good; otherwise wait and resubscribe.
+        tokio::time::sleep(RESUBSCRIBE_DELAY).await;
+        let still_loaded = host
+            .ext_manager()
+            .read()
+            .await
+            .handlers()
+            .iter()
+            .any(|(id, h)| id == &ext_id && Arc::ptr_eq(h, &handler));
+        if !still_loaded {
+            tracing::debug!(extension = %ext_id, "notification router: extension unloaded; stopping");
+            return;
+        }
+    }
+}

--- a/crates/agent-engine/src/extensions/runtime/process.rs
+++ b/crates/agent-engine/src/extensions/runtime/process.rs
@@ -262,6 +262,9 @@ pub async fn execute_provider_tool_use(
             &tool_name,
             Some(&runtime_name),
             input.clone(),
+            // Extension-originated tool.invoke: no owning conversation on this
+            // path (ToolContext carries none) → `null`, as before.
+            None,
         )
         .await,
         ctx.capabilities.secret_prompt.as_ref(),
@@ -293,6 +296,7 @@ pub async fn execute_provider_tool_use(
         input_for_hook,
         result,
         max_tool_output,
+        None,
     )
     .await;
 

--- a/crates/agent-engine/src/host.rs
+++ b/crates/agent-engine/src/host.rs
@@ -11,6 +11,7 @@ use tokio::sync::RwLock;
 
 use crate::extensions::hooks::HookBus;
 use crate::runtime::RuntimeParts;
+use crate::session::{SessionActor, SessionConfig, SessionHandle, SessionId, SessionMeta};
 use crate::tools::catalog::CatalogGeneration;
 use crate::{Result, Runtime, ToolRegistry};
 
@@ -60,6 +61,11 @@ pub struct EngineHost {
     /// process exit — otherwise the tail of the log dies with the writer
     /// thread.
     log_guard: std::sync::Mutex<Option<tracing_appender::non_blocking::WorkerGuard>>,
+    /// Live sessions (Phase 2): id → handle. The map holds one handle per
+    /// actor so the actor outlives any single client; the actor task removes
+    /// itself here when it finishes.
+    sessions: std::sync::Mutex<std::collections::HashMap<SessionId, SessionHandle>>,
+    // C: extensions_ready goes here
 }
 
 static HOST: OnceLock<Arc<EngineHost>> = OnceLock::new();
@@ -140,6 +146,7 @@ impl EngineHost {
             mcp_server_count,
             worker_registry: std::sync::Mutex::new(None),
             log_guard: std::sync::Mutex::new(log_guard),
+            sessions: std::sync::Mutex::new(std::collections::HashMap::new()),
         }))
     }
 
@@ -284,5 +291,53 @@ impl EngineHost {
     pub fn reload_config(&self) {
         self.config
             .store(Arc::new(crate::config::load_config()));
+    }
+
+    // ── sessions (Phase 2) ────────────────────────────────────────────────
+
+    /// Create a session on this host: builds the `SessionActor` (the one
+    /// `Runtime` + `ConversationState`), spawns its task, registers the
+    /// handle. The task removes itself from the map when it ends.
+    pub async fn create_session(self: &Arc<Self>, cfg: SessionConfig) -> Result<SessionHandle> {
+        let (handle, task) = SessionActor::create(self, cfg).await?;
+        let id = handle.id.clone();
+        self.sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(id.clone(), handle.clone());
+        let host = Arc::clone(self);
+        tokio::spawn(async move {
+            task.run().await;
+            host.remove_session(&id);
+        });
+        Ok(handle)
+    }
+
+    /// Handle for a live session, if any.
+    pub fn attach(&self, id: &SessionId) -> Option<SessionHandle> {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(id)
+            .cloned()
+    }
+
+    /// Metadata of every live session.
+    pub fn sessions(&self) -> Vec<SessionMeta> {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .map(|h| h.meta().clone())
+            .collect()
+    }
+
+    /// Drop the host's handle for a session (the actor keeps running until
+    /// its command queue closes or it receives `End`).
+    pub fn remove_session(&self, id: &SessionId) -> Option<SessionHandle> {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(id)
     }
 }

--- a/crates/agent-engine/src/host.rs
+++ b/crates/agent-engine/src/host.rs
@@ -65,7 +65,13 @@ pub struct EngineHost {
     /// actor so the actor outlives any single client; the actor task removes
     /// itself here when it finishes.
     sessions: std::sync::Mutex<std::collections::HashMap<SessionId, SessionHandle>>,
-    // C: extensions_ready goes here
+    /// C2: flips to `true` when extension discovery on `ext_manager` has
+    /// finished (the loader sets it; `extensions_ready()` awaits it). The
+    /// paired flag records that a loader was DISPATCHED, so a session
+    /// created between `spawn_discover_and_load` and its first lock
+    /// acquisition still waits instead of racing the walk.
+    extensions_ready: tokio::sync::watch::Sender<bool>,
+    extensions_loading: std::sync::atomic::AtomicBool,
 }
 
 static HOST: OnceLock<Arc<EngineHost>> = OnceLock::new();
@@ -147,6 +153,8 @@ impl EngineHost {
             worker_registry: std::sync::Mutex::new(None),
             log_guard: std::sync::Mutex::new(log_guard),
             sessions: std::sync::Mutex::new(std::collections::HashMap::new()),
+            extensions_ready: tokio::sync::watch::channel(false).0,
+            extensions_loading: std::sync::atomic::AtomicBool::new(false),
         }))
     }
 
@@ -339,5 +347,91 @@ impl EngineHost {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(id)
+    }
+
+    // ── shared extension host (Phase 2, C) ────────────────────────────────
+
+    /// Loader seam (C2): a discovery pass for this host's manager has been
+    /// dispatched. Called synchronously by `spawn_discover_and_load` before
+    /// its task runs, so `extensions_ready()` cannot slip through the gap.
+    pub fn note_extensions_loading(&self) {
+        self.extensions_loading
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Loader seam (C2): discovery finished — every `extensions_ready()`
+    /// waiter proceeds. Idempotent.
+    pub fn mark_extensions_ready(&self) {
+        self.extensions_ready.send_replace(true);
+    }
+
+    /// Resolve once extension discovery on this host is known-finished, so a
+    /// session's `on_session_start` lands on subscribed extensions. Resolves
+    /// IMMEDIATELY when no loader was dispatched (hosts that never load
+    /// extensions, `--no-extensions`, tests) or discovery already completed
+    /// on the manager (in-process `discover_and_load()` callers such as
+    /// `synaps chat`); otherwise awaits the loader's `Finished`. Never
+    /// blocks forever: a loader that dies drops the sender and we return.
+    pub async fn extensions_ready(&self) {
+        let mut rx = self.extensions_ready.subscribe();
+        if *rx.borrow() {
+            return;
+        }
+        // A running walk holds the manager write lock; this read waits it out.
+        if self.ext_manager.read().await.discovery_done().is_some() {
+            return;
+        }
+        if !self
+            .extensions_loading
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return;
+        }
+        while !*rx.borrow_and_update() {
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+
+    /// C3: push one extension notification frame to every live session
+    /// (non-blocking; a session whose command queue is full drops it with a
+    /// warning — widget upserts are idempotent last-writer-wins). Frames
+    /// carry no session id today, hence broadcast. Returns how many
+    /// sessions accepted it.
+    pub async fn broadcast_extension_notification(
+        &self,
+        ext_id: &str,
+        method: &str,
+        params: serde_json::Value,
+    ) -> usize {
+        let handles: Vec<SessionHandle> = self
+            .sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .cloned()
+            .collect();
+        let mut delivered = 0;
+        for handle in handles {
+            let cmd = crate::session::SessionCommand::HostEvent(
+                crate::session::HostEvent::ExtensionNotification {
+                    extension_id: ext_id.to_string(),
+                    method: method.to_string(),
+                    params: params.clone(),
+                },
+            );
+            match handle.send(cmd).await {
+                Ok(()) => delivered += 1,
+                Err(err) => tracing::warn!(
+                    session = %handle.id,
+                    extension = %ext_id,
+                    method = %method,
+                    error = %err,
+                    "dropping extension notification for session"
+                ),
+            }
+        }
+        delivered
     }
 }

--- a/crates/agent-engine/src/host.rs
+++ b/crates/agent-engine/src/host.rs
@@ -65,6 +65,10 @@ pub struct EngineHost {
     /// actor so the actor outlives any single client; the actor task removes
     /// itself here when it finishes.
     sessions: std::sync::Mutex<std::collections::HashMap<SessionId, SessionHandle>>,
+    /// Serialises `create_session`'s resolve-then-insert so two concurrent
+    /// `--continue X` cannot both miss the live check and build two actors
+    /// on one session id.
+    create_lock: tokio::sync::Mutex<()>,
     /// C2: flips to `true` when extension discovery on `ext_manager` has
     /// finished (the loader sets it; `extensions_ready()` awaits it). The
     /// paired flag records that a loader was DISPATCHED, so a session
@@ -153,6 +157,7 @@ impl EngineHost {
             worker_registry: std::sync::Mutex::new(None),
             log_guard: std::sync::Mutex::new(log_guard),
             sessions: std::sync::Mutex::new(std::collections::HashMap::new()),
+            create_lock: tokio::sync::Mutex::new(()),
             extensions_ready: tokio::sync::watch::channel(false).0,
             extensions_loading: std::sync::atomic::AtomicBool::new(false),
         }))
@@ -306,7 +311,21 @@ impl EngineHost {
     /// Create a session on this host: builds the `SessionActor` (the one
     /// `Runtime` + `ConversationState`), spawns its task, registers the
     /// handle. The task removes itself from the map when it ends.
+    ///
+    /// **Attach-if-live:** when `cfg.continue_session` resolves to a session
+    /// that is already running on this host (`--continue X` twice,
+    /// `Attach::Create` twice, `--continue` latest while latest is live),
+    /// the existing handle is returned and NO second actor is built. Two
+    /// actors on one id would share the session file, and the second's
+    /// `spawn_session_background` would unlink the first's per-session UDS
+    /// and overwrite its registry entry. `cfg`'s other fields (cwd, model
+    /// override, …) are ignored in that case — the live session wins.
     pub async fn create_session(self: &Arc<Self>, cfg: SessionConfig) -> Result<SessionHandle> {
+        let _serial = self.create_lock.lock().await;
+        if let Some(live) = self.live_continue_target(&cfg.continue_session) {
+            tracing::info!(session = %live.id, "create_session: target is live — attaching");
+            return Ok(live);
+        }
         let (handle, task) = SessionActor::create(self, cfg).await?;
         let id = handle.id.clone();
         self.sessions
@@ -319,6 +338,35 @@ impl EngineHost {
             host.remove_session(&id);
         });
         Ok(handle)
+    }
+
+    /// Resolve a `continue_session` request the same way
+    /// `setup::resolve_or_create_session` will (chain → name → partial id;
+    /// `Some(None)` = latest by mtime) and return the live handle if that
+    /// session is already running here. Resolution failures return `None`
+    /// so the real boot path reports the error.
+    fn live_continue_target(
+        &self,
+        continue_session: &Option<Option<String>>,
+    ) -> Option<SessionHandle> {
+        let query = continue_session.as_ref()?;
+        let sessions = self
+            .sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if sessions.is_empty() {
+            return None;
+        }
+        let id = match query {
+            Some(q) => {
+                if let Some(h) = sessions.get(&SessionId::from(q.clone())) {
+                    return Some(h.clone());
+                }
+                crate::core::session::resolve_session(q).ok()?.id
+            }
+            None => crate::core::session::latest_session().ok()?.id,
+        };
+        sessions.get(&SessionId::from(id)).cloned()
     }
 
     /// Handle for a live session, if any.

--- a/crates/agent-engine/src/host.rs
+++ b/crates/agent-engine/src/host.rs
@@ -80,6 +80,17 @@ pub struct EngineHost {
 
 static HOST: OnceLock<Arc<EngineHost>> = OnceLock::new();
 
+/// See [`EngineHost::extensions_loading_guard`].
+pub struct ExtensionsLoadingGuard {
+    host: Arc<EngineHost>,
+}
+
+impl Drop for ExtensionsLoadingGuard {
+    fn drop(&mut self) {
+        self.host.mark_extensions_ready();
+    }
+}
+
 impl EngineHost {
     /// Every step of the old `setup::boot()` that does NOT mention a session:
     /// profile, logging, HTTP client, registry, config, skills, MCP, extension
@@ -413,13 +424,30 @@ impl EngineHost {
         self.extensions_ready.send_replace(true);
     }
 
+    /// Loader seam (C2): `note_extensions_loading()` now, and
+    /// `mark_extensions_ready()` when the guard drops — however the loader
+    /// task ends (return, cancel, panic). Hold it inside the task so a
+    /// panicking walk cannot strand `extensions_ready()` waiters.
+    pub fn extensions_loading_guard(self: &Arc<Self>) -> ExtensionsLoadingGuard {
+        self.note_extensions_loading();
+        ExtensionsLoadingGuard {
+            host: Arc::clone(self),
+        }
+    }
+
     /// Resolve once extension discovery on this host is known-finished, so a
     /// session's `on_session_start` lands on subscribed extensions. Resolves
     /// IMMEDIATELY when no loader was dispatched (hosts that never load
     /// extensions, `--no-extensions`, tests) or discovery already completed
     /// on the manager (in-process `discover_and_load()` callers such as
-    /// `synaps chat`); otherwise awaits the loader's `Finished`. Never
-    /// blocks forever: a loader that dies drops the sender and we return.
+    /// `synaps chat`); otherwise awaits `mark_extensions_ready()`.
+    ///
+    /// The watch sender is a field of the host, so "sender dropped" is NOT a
+    /// wake-up path while the host lives. Liveness comes from
+    /// [`ExtensionsLoadingGuard`] (the loader task marks ready on any exit,
+    /// including panic); callers that must not trust the loader at all
+    /// (`SessionActor::create`) additionally bound the await with
+    /// `budgets::EXTENSIONS_READY_TIMEOUT`.
     pub async fn extensions_ready(&self) {
         let mut rx = self.extensions_ready.subscribe();
         if *rx.borrow() {

--- a/crates/agent-engine/src/lib.rs
+++ b/crates/agent-engine/src/lib.rs
@@ -4,10 +4,12 @@
 pub mod engine;
 pub mod events;
 pub mod extensions;
+pub mod daemon;
 pub mod help;
 pub mod host;
 pub mod mcp;
 pub mod runtime;
+pub mod session;
 pub mod sidecar;
 pub mod skills;
 #[cfg(test)]
@@ -18,7 +20,7 @@ pub mod tools;
 // Re-export core so that internal `crate::core::X`, `crate::config`, etc.
 // resolve inside agent-engine (mirrors root lib.rs approach).
 pub use agent_core::{
-    auth, chain, config, error, logging, models, protocol, session, watcher_types,
+    auth, chain, config, error, logging, models, protocol, watcher_types,
 };
 pub use agent_core::{core, memory, pricing};
 pub use agent_core::{epoch_millis, truncate_str, BoundedText};
@@ -32,8 +34,12 @@ pub use config::{load_config, resolve_system_prompt, SynapsConfig};
 pub use error::{Result, RuntimeError};
 pub use host::{EngineHost, HostOpts, HostParts};
 pub use runtime::{AgentEvent, LlmEvent, Runtime, SessionEvent, StreamEvent};
-pub use serde_json::Value;
 pub use session::{
+    ClientTransport, Envelope, LocalTransport, SessionCommand, SessionConfig, SessionEventWire,
+    SessionHandle, SessionId,
+};
+pub use serde_json::Value;
+pub use agent_core::session::{
     find_session, find_session_by_name, latest_session, list_recent_sessions, list_sessions,
     resolve_session, validate_name, Session, SessionInfo,
 };

--- a/crates/agent-engine/src/mcp/descriptors.rs
+++ b/crates/agent-engine/src/mcp/descriptors.rs
@@ -55,6 +55,9 @@ const ERROR_ECHO_MAX_BYTES: usize = 160;
 /// (command, args, env). Cached descriptors are only trusted while the
 /// current config still fingerprints identically; any drift invalidates
 /// them. Pure local computation — no process, no network.
+///
+/// `shared` is deliberately EXCLUDED: it changes the lease key, not the
+/// launched process, so flipping it must not discard a valid listing.
 pub fn server_config_fingerprint(config: &McpServerConfig) -> String {
     let env: BTreeMap<&str, &str> = config
         .env
@@ -324,6 +327,93 @@ pub fn store_cache_at(path: &Path, cache: &McpDescriptorCache) -> Result<(), Des
         }
     }
     write_atomic_private(path, &bytes).map_err(map_fs)
+}
+
+/// `SYNAPS_MCP_CACHE_WRITEBACK=0` disables [`record_server_listing`].
+pub fn cache_writeback_enabled() -> bool {
+    !matches!(
+        std::env::var("SYNAPS_MCP_CACHE_WRITEBACK").as_deref(),
+        Ok("0") | Ok("false") | Ok("off")
+    )
+}
+
+/// Write-back after a successful, lease-authorized `tools/list` (daemon-mode
+/// phase 2, C4): merge `tools` into the cache at `path` under `server`,
+/// keyed by the launch `fingerprint`, so the NEXT boot's `setup_lazy_mcp`
+/// registers the same dormant descriptors without spawning anything (stable
+/// prompt-cache prefix across daemon restarts).
+///
+/// Only the exact-lease path calls this — the listing it records comes from
+/// a server the operator configured, started for an already gate-authorized
+/// call. The legacy server-wide gateway never writes here (cache-poisoning
+/// bridge, see module docs).
+///
+/// Concurrency: exclusive `fs4` lock on `<path>.lock` for the whole
+/// read-merge-write, then [`store_cache_at`] (0600, atomic rename). A cache
+/// that fails to load (corrupt/oversize/version) is REPLACED by a fresh one
+/// carrying only this server — the reader refuses such a file anyway.
+/// Entries are sanitized through the same bounds as a load, so a hostile
+/// listing cannot write what a load would reject. Returns the number of
+/// descriptors recorded for `server`.
+pub fn record_server_listing(
+    path: &Path,
+    server: &str,
+    fingerprint: &str,
+    tools: &[CachedToolDescriptor],
+) -> Result<usize, DescriptorCacheError> {
+    use fs4::fs_std::FileExt;
+
+    if !valid_server_name(server) {
+        return Err(DescriptorCacheError::Parse("invalid server name".to_string()));
+    }
+    let map_io = |err: std::io::Error| {
+        DescriptorCacheError::Io(BoundedText::new(&err.to_string(), ERROR_ECHO_MAX_BYTES).text)
+    };
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            agent_core::core::private_fs::ensure_private_dir(parent).map_err(|err| match err {
+                agent_core::core::private_fs::PrivateFsError::SymlinkRefused(_) => {
+                    DescriptorCacheError::NotRegularFile
+                }
+                agent_core::core::private_fs::PrivateFsError::Io(io) => map_io(io),
+            })?;
+        }
+    }
+    let lock_path = {
+        let mut name = path
+            .file_name()
+            .map(|n| n.to_os_string())
+            .unwrap_or_else(|| std::ffi::OsString::from(DESCRIPTOR_CACHE_FILE));
+        name.push(".lock");
+        path.with_file_name(name)
+    };
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)
+        .map_err(map_io)?;
+    FileExt::lock_exclusive(&lock_file).map_err(map_io)?;
+
+    let mut cache = match load_cache_from(path) {
+        Ok(cache) => cache,
+        Err(DescriptorCacheError::NotFound) => McpDescriptorCache::empty(),
+        Err(err) => {
+            tracing::warn!(error = %err,
+                "MCP descriptor cache unreadable; replacing with a fresh cache on write-back");
+            McpDescriptorCache::empty()
+        }
+    };
+    let entry = CachedServerDescriptors {
+        fingerprint: fingerprint.to_string(),
+        tools: tools.to_vec(),
+    };
+    cache.servers.insert(server.to_string(), entry);
+    let cache = sanitize_cache(cache)?;
+    let recorded = cache.servers.get(server).map_or(0, |e| e.tools.len());
+    store_cache_at(path, &cache)?;
+    let _ = FileExt::unlock(&lock_file);
+    Ok(recorded)
 }
 
 /// A dormant, descriptor-backed MCP tool. Registered like any live tool

--- a/crates/agent-engine/src/mcp/lease.rs
+++ b/crates/agent-engine/src/mcp/lease.rs
@@ -28,7 +28,12 @@
 //!   scan cap; session end is the drop of the LAST owner of the shared
 //!   durable [`McpSessionEndGuard`] scope (runtime clones + in-flight
 //!   streams hold it; no per-turn guard exists). No PID signalling, no
-//!   long-lived task, no unbounded channel.
+//!   long-lived task, no unbounded channel;
+//! - a server configured `shared: true` (daemon mode, opt-in) is keyed
+//!   under [`SHARED_SESSION_KEY`] instead of the session: one child serves
+//!   every session, `terminate_session` spares it, `reap_idle` and
+//!   `terminate_all` still reap it. Every call still validates exact
+//!   name + digest; sharing widens the CHILD, never the grant.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -38,7 +43,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 use super::connection::McpConnection;
-use super::descriptors::server_config_fingerprint;
+use super::descriptors::{self, server_config_fingerprint};
 use super::McpServerConfig;
 use crate::tools::activation::SessionId;
 use crate::tools::catalog::SchemaDigest;
@@ -52,6 +57,20 @@ pub fn config_source_from_disk() -> ConfigSource {
     Arc::new(|server: &str| {
         super::load_mcp_config().and_then(|c| c.mcp_servers.get(server).cloned())
     })
+}
+
+/// Lease-map session key for `shared: true` servers (one child per
+/// process, not per session). Never a real session's key: `terminate_session`
+/// skips it explicitly.
+pub const SHARED_SESSION_KEY: &str = "*";
+
+/// Session component of the lease key for `server` under `config`.
+pub fn lease_session_key(config: &McpServerConfig, session: &SessionId) -> String {
+    if config.shared {
+        SHARED_SESSION_KEY.to_string()
+    } else {
+        session.as_str().to_string()
+    }
 }
 
 /// Default idle bound for opportunistic reaping.
@@ -139,6 +158,9 @@ pub struct McpRuntimeManager {
     config_source: ConfigSource,
     idle_max: Duration,
     next_token: std::sync::atomic::AtomicU64,
+    /// Descriptor-cache path for write-back after `tools/list`
+    /// (production: profile-resolved default; tests inject a temp path).
+    cache_path: Arc<dyn Fn() -> std::path::PathBuf + Send + Sync>,
 }
 
 impl McpRuntimeManager {
@@ -148,7 +170,26 @@ impl McpRuntimeManager {
             config_source,
             idle_max,
             next_token: std::sync::atomic::AtomicU64::new(1),
+            cache_path: Arc::new(descriptors::default_cache_path),
         }
+    }
+
+    /// Override the descriptor-cache write-back location (tests, or a
+    /// host that keeps its cache elsewhere).
+    pub fn with_cache_path(mut self, path: std::path::PathBuf) -> Self {
+        self.cache_path = Arc::new(move || path.clone());
+        self
+    }
+
+    /// Lease-map key for (session, server), honouring `shared: true`.
+    /// Reads the config source (bounded local read); an unconfigured
+    /// server keys per session (it has no lease to find anyway).
+    fn lease_key(&self, session: &SessionId, server: &str) -> (String, String) {
+        let session_key = match (self.config_source)(server) {
+            Some(config) => lease_session_key(&config, session),
+            None => session.as_str().to_string(),
+        };
+        (session_key, server.to_string())
     }
 
     /// Sync RAII-safe termination: mark cancelled, then — when the
@@ -220,12 +261,13 @@ impl McpRuntimeManager {
     /// one child process shared by that session's exact tools of that
     /// server).
     pub fn revoke_server_lease(&self, session: &SessionId, server: &str) {
+        let key = self.lease_key(session, server);
         let removed = {
             let mut map = self
                 .leases
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            map.remove(&(session.as_str().to_string(), server.to_string()))
+            map.remove(&key)
         };
         if let Some(state) = removed {
             Self::cancel_state(state);
@@ -243,6 +285,7 @@ impl McpRuntimeManager {
     }
 
     /// Terminate every lease held by one session. Returns how many.
+    /// Shared (`"*"`) leases are never a session's to terminate.
     pub fn terminate_session(&self, session: &SessionId) -> usize {
         let removed: Vec<LeaseState> = {
             let mut map = self
@@ -251,7 +294,7 @@ impl McpRuntimeManager {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             let keys: Vec<(String, String)> = map
                 .keys()
-                .filter(|(s, _)| s == session.as_str())
+                .filter(|(s, _)| s != SHARED_SESSION_KEY && s == session.as_str())
                 .cloned()
                 .collect();
             keys.into_iter().filter_map(|k| map.remove(&k)).collect()
@@ -330,7 +373,7 @@ impl McpRuntimeManager {
         }
         self.reap_idle();
 
-        let key = (session.as_str().to_string(), server.to_string());
+        let key = (lease_session_key(&config, session), server.to_string());
         let inner: Arc<LeaseInner> = loop {
             // 2. Single-flight acquisition. The guard-scoped decision below
             // returns an owned action, so the map lock is NEVER held across
@@ -413,7 +456,7 @@ impl McpRuntimeManager {
                 }
                 Acquire::Start { token, done_tx } => {
                     let started = self
-                        .start_lease(expected_fingerprint, &config)
+                        .start_lease(server, expected_fingerprint, &config)
                         .await
                         .map_err(|e| McpLeaseError::Transport(server.to_string(), e));
                     let ours = {
@@ -504,8 +547,12 @@ impl McpRuntimeManager {
 
     /// Spawn + initialize + single bounded tools/list for one server. No
     /// manager lock is held. Any failure kills the child before returning.
+    /// On success the listing is written back to the descriptor cache
+    /// (`SYNAPS_MCP_CACHE_WRITEBACK=0` disables) so the next boot advertises
+    /// the same dormant tools without spawning.
     async fn start_lease(
         &self,
+        server: &str,
         fingerprint: &str,
         config: &McpServerConfig,
     ) -> Result<Arc<LeaseInner>, String> {
@@ -518,8 +565,37 @@ impl McpRuntimeManager {
             }
         };
         let mut listing = HashMap::new();
-        for def in defs {
+        for def in &defs {
             listing.insert(def.name.clone(), SchemaDigest::of_schema(&def.input_schema));
+        }
+        if descriptors::cache_writeback_enabled() {
+            let descriptors: Vec<descriptors::CachedToolDescriptor> = defs
+                .into_iter()
+                .map(|def| descriptors::CachedToolDescriptor {
+                    name: def.name,
+                    description: def.description,
+                    input_schema: def.input_schema,
+                })
+                .collect();
+            let path = (self.cache_path)();
+            let server_owned = server.to_string();
+            let fingerprint_owned = fingerprint.to_string();
+            // Blocking file I/O (flock + atomic rename) off the reactor;
+            // failure is logged, never surfaced — the lease is already good.
+            let _ = tokio::task::spawn_blocking(move || {
+                match descriptors::record_server_listing(
+                    &path,
+                    &server_owned,
+                    &fingerprint_owned,
+                    &descriptors,
+                ) {
+                    Ok(count) => tracing::debug!(server = %server_owned, tools = count,
+                        "MCP descriptor cache written back after tools/list"),
+                    Err(err) => tracing::warn!(server = %server_owned, error = %err,
+                        "MCP descriptor cache write-back failed"),
+                }
+            })
+            .await;
         }
         Ok(Arc::new(LeaseInner {
             fingerprint: fingerprint.to_string(),
@@ -531,6 +607,19 @@ impl McpRuntimeManager {
         }))
     }
 
+    /// Test seam: the live lease keys `(session_key, server)`; shared
+    /// servers show [`SHARED_SESSION_KEY`].
+    #[doc(hidden)]
+    pub fn lease_keys_for_tests(&self) -> Vec<(String, String)> {
+        let map = self
+            .leases
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut keys: Vec<_> = map.keys().cloned().collect();
+        keys.sort();
+        keys
+    }
+
     /// Test seam: `Weak` ownership token of one lease. `upgrade() == None`
     /// proves the manager (and any bounded shutdown task) released it.
     #[doc(hidden)]
@@ -539,11 +628,12 @@ impl McpRuntimeManager {
         session: &SessionId,
         server: &str,
     ) -> Option<std::sync::Weak<()>> {
+        let key = self.lease_key(session, server);
         let map = self
             .leases
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        match map.get(&(session.as_str().to_string(), server.to_string())) {
+        match map.get(&key) {
             Some(LeaseState::Ready(inner)) => Some(Arc::downgrade(&inner.liveness)),
             _ => None,
         }

--- a/crates/agent-engine/src/mcp/mod.rs
+++ b/crates/agent-engine/src/mcp/mod.rs
@@ -22,6 +22,14 @@ pub struct McpServerConfig {
     pub args: Vec<String>,
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// Daemon-mode opt-in: ONE child serves every session in the process
+    /// (lease key `"*"`) instead of one child per session. The server then
+    /// sees every session's calls and holds cross-session state
+    /// (roots/cwd) — never the default. Excluded from the config
+    /// fingerprint (launch identity only); flipping it starts a fresh
+    /// lease key. See `docs/mcp.md`.
+    #[serde(default)]
+    pub shared: bool,
 }
 
 /// MCP config file format: { "mcpServers": { "name": { command, args, env } } }
@@ -364,6 +372,7 @@ mod tests {
             command: "/bin/true".to_string(),
             args: vec!["--flag".to_string()],
             env: HashMap::from([("KEY".to_string(), "value".to_string())]),
+            shared: false,
         }
     }
 

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -708,6 +708,7 @@ impl RuntimeParts {
     }
 
     /// Fresh shell session manager, no reaper (offline / headless).
+    #[cfg_attr(not(any(test, feature = "testing")), allow(dead_code))]
     pub(crate) fn without_reaper(host: crate::host::HostParts) -> Self {
         Self {
             host,

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -3252,6 +3252,7 @@ impl Runtime {
                             let event_queue_inner = cfg_event_queue.clone();
                             let hook_bus_inner = cfg_hook_bus.clone();
                             let orchestration_inner = cfg_orchestration.clone();
+                            let cwd_inner = cfg_cwd.clone();
                             let tool_name_for_hook = tool_name.clone();
                             let runtime_name_for_hook = runtime_name.clone();
 
@@ -3302,7 +3303,7 @@ impl Runtime {
                                                     mcp_leases: None,
                                                     extension_leases: None,
                                                     memory_context: None,
-                                                    cwd: cfg_cwd.clone(),
+                                                    cwd: cwd_inner,
                                                 },
                                                 limits: crate::tools::ToolLimits {
                                                     max_tool_output: cfg_max_tool_output,

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -2,7 +2,7 @@ use crate::{Result, RuntimeError, ToolRegistry};
 use futures::stream::Stream;
 use reqwest::Client;
 use serde_json::{json, Value};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -433,6 +433,10 @@ pub struct Runtime {
     /// `on_session_start` hook injection (Phase 2 keys everything).
     /// `None` = unkeyed (workers, tests) — reads no injection.
     session_id: Option<String>,
+    /// Per-session working directory (Phase 2 daemon mode). `None` = process
+    /// cwd — every in-process host leaves it `None`, so `ToolCapabilities.cwd`
+    /// stays `None` exactly as before. The daemon sets it per session.
+    cwd: Option<PathBuf>,
 }
 
 /// Mint a fresh runtime-scoped tool-session identity. Process id + UUIDv4
@@ -859,6 +863,7 @@ impl Runtime {
             ),
             host_tool_session: fresh_host_tool_session(),
             session_id: None,
+            cwd: None,
         };
         // Lease managers are installed through the same seams boot used, so
         // the per-runtime durable session-scope guards are minted exactly as
@@ -1291,6 +1296,16 @@ impl Runtime {
 
     pub fn session_id(&self) -> Option<&str> {
         self.session_id.as_deref()
+    }
+
+    /// Per-session working directory handed to tools via
+    /// `ToolCapabilities.cwd`. `None` = process cwd.
+    pub fn set_cwd(&mut self, cwd: Option<PathBuf>) {
+        self.cwd = cwd;
+    }
+
+    pub fn cwd(&self) -> Option<&Path> {
+        self.cwd.as_deref()
     }
 
     /// Get a shared reference to the tool registry (for MCP lazy loading).
@@ -3147,7 +3162,7 @@ impl Runtime {
                                         mcp_leases: None,
                                         extension_leases: None,
                                         memory_context: None,
-                                        cwd: None,
+                                        cwd: self.cwd.clone(),
                                     },
                                     limits: crate::tools::ToolLimits {
                                         max_tool_output: self.max_tool_output,
@@ -3216,6 +3231,7 @@ impl Runtime {
                     let cfg_event_queue = self.event_queue.clone();
                     let cfg_hook_bus = self.hook_bus.clone();
                     let cfg_orchestration = self.orchestration.clone();
+                    let cfg_cwd = self.cwd.clone();
 
                     for tool_use in &tool_uses {
                         if let (Some(tool_name), Some(tool_id)) = (
@@ -3286,7 +3302,7 @@ impl Runtime {
                                                     mcp_leases: None,
                                                     extension_leases: None,
                                                     memory_context: None,
-                                                    cwd: None,
+                                                    cwd: cfg_cwd.clone(),
                                                 },
                                                 limits: crate::tools::ToolLimits {
                                                     max_tool_output: cfg_max_tool_output,
@@ -3534,6 +3550,7 @@ impl Runtime {
             secret_prompt,
             hook_bus: self.hook_bus.clone(),
             session_id: self.session_id.clone(),
+            cwd: self.cwd.clone(),
             auto_approve_confirms,
             telemetry_level: self.telemetry_level,
             orchestration: self.orchestration.clone(),
@@ -3696,6 +3713,7 @@ impl Clone for Runtime {
             host_tool_session: self.host_tool_session.clone(),
             // Clones serve the same conversation (see memory_context_state).
             session_id: self.session_id.clone(),
+            cwd: self.cwd.clone(),
         }
     }
 }

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -52,14 +52,17 @@ pub enum BeforeToolCallDecision {
 }
 
 /// Emit a `before_tool_call` event and include the runtime tool name when it
-/// differs from the API-safe name.
+/// differs from the API-safe name. `session_id` is the owning conversation
+/// (`None` for workers → JSON `null`, unchanged).
 pub async fn emit_before_tool_call(
     hook_bus: &Arc<crate::extensions::hooks::HookBus>,
     tool_name: &str,
     runtime_tool_name: Option<&str>,
     input: Value,
+    session_id: Option<&str>,
 ) -> crate::extensions::hooks::events::HookResult {
-    let mut event = crate::extensions::hooks::events::HookEvent::before_tool_call(tool_name, input);
+    let mut event = crate::extensions::hooks::events::HookEvent::before_tool_call(tool_name, input)
+        .with_session(session_id);
     if let Some(runtime_tool_name) = runtime_tool_name {
         event.tool_runtime_name = Some(runtime_tool_name.to_string());
     }
@@ -164,12 +167,14 @@ pub async fn emit_after_tool_call(
     input: Value,
     output: String,
     max_tool_output: usize,
+    session_id: Option<&str>,
 ) -> String {
     use crate::extensions::hooks::events::HookResult;
     // Keep the original to return verbatim if no transform fires.
     let original = output.clone();
     let mut event =
-        crate::extensions::hooks::events::HookEvent::after_tool_call(tool_name, input, output);
+        crate::extensions::hooks::events::HookEvent::after_tool_call(tool_name, input, output)
+            .with_session(session_id);
     if let Some(runtime_tool_name) = runtime_tool_name {
         event.tool_runtime_name = Some(runtime_tool_name.to_string());
     }
@@ -3180,6 +3185,7 @@ impl Runtime {
                                         tool_name,
                                         Some(&runtime_name),
                                         input.clone(),
+                                        self.session_id.as_deref(),
                                     )
                                     .await,
                                     None,
@@ -3205,6 +3211,7 @@ impl Runtime {
                                         input_for_hook,
                                         output,
                                         self.max_tool_output,
+                                        self.session_id.as_deref(),
                                     )
                                     .await;
                                     output
@@ -3233,6 +3240,7 @@ impl Runtime {
                     let cfg_hook_bus = self.hook_bus.clone();
                     let cfg_orchestration = self.orchestration.clone();
                     let cfg_cwd = self.cwd.clone();
+                    let cfg_session_id = self.session_id.clone();
 
                     for tool_use in &tool_uses {
                         if let (Some(tool_name), Some(tool_id)) = (
@@ -3254,6 +3262,7 @@ impl Runtime {
                             let hook_bus_inner = cfg_hook_bus.clone();
                             let orchestration_inner = cfg_orchestration.clone();
                             let cwd_inner = cfg_cwd.clone();
+                            let session_id_inner = cfg_session_id.clone();
                             let tool_name_for_hook = tool_name.clone();
                             let runtime_name_for_hook = runtime_name.clone();
 
@@ -3268,6 +3277,7 @@ impl Runtime {
                                                     &tool_name_for_hook,
                                                     Some(&runtime_name_for_hook),
                                                     input.clone(),
+                                                    session_id_inner.as_deref(),
                                                 )
                                                 .await,
                                                 None,
@@ -3326,6 +3336,7 @@ impl Runtime {
                                                 input_for_hook,
                                                 output,
                                                 cfg_max_tool_output,
+                                                session_id_inner.as_deref(),
                                             )
                                             .await;
                                             output

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -54,6 +54,9 @@ pub(super) struct StreamSession {
     /// Conversation id keying the `on_session_start` injection. `None`
     /// (workers) reads nothing.
     pub(super) session_id: Option<String>,
+    /// Per-session working directory forwarded as `ToolCapabilities.cwd`.
+    /// `None` = process cwd (every in-process host today).
+    pub(super) cwd: Option<PathBuf>,
     pub(super) secret_prompt: Option<crate::tools::SecretPromptHandle>,
     pub(super) auto_approve_confirms: bool,
     pub(super) telemetry_level: crate::runtime::telemetry::TelemetryLevel,
@@ -260,6 +263,7 @@ impl StreamMethods {
             event_queue,
             hook_bus,
             session_id,
+            cwd,
             secret_prompt,
             auto_approve_confirms,
             telemetry_level,
@@ -938,7 +942,7 @@ impl StreamMethods {
                                     tokio::select! {
                                         res = tool.execute_rich(input, crate::ToolContext {
                                             channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx.clone()) },
-                                            capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()), delegation_parent: delegation_parent.clone(), secret_prompt: secret_prompt.clone(), orchestration: orchestration.clone(), tool_activation: Some(crate::tools::discovery::ActivationCapability::new(catalog_snapshot.clone(), std::sync::Arc::clone(&session_tool_set), activation_authority)), mcp_leases: mcp_lease_capability.clone(), extension_leases: extension_lease_capability.clone(), memory_context: None /* TODO(task A5): host wiring of MemoryContextCapability */, cwd: None },
+                                            capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()), delegation_parent: delegation_parent.clone(), secret_prompt: secret_prompt.clone(), orchestration: orchestration.clone(), tool_activation: Some(crate::tools::discovery::ActivationCapability::new(catalog_snapshot.clone(), std::sync::Arc::clone(&session_tool_set), activation_authority)), mcp_leases: mcp_lease_capability.clone(), extension_leases: extension_lease_capability.clone(), memory_context: None /* TODO(task A5): host wiring of MemoryContextCapability */, cwd: cwd.clone() },
                                             limits: crate::tools::ToolLimits { max_tool_output, max_tool_buffer: 256 * 1024, bash_timeout, bash_max_timeout, subagent_timeout },
                                         }) => {
                                             let (output, rich_blocks) = match res {
@@ -1182,6 +1186,7 @@ impl StreamMethods {
                         let eq_inner = event_queue.clone();
                         let hook_bus_inner = hook_bus.clone();
                         let prompt_inner = secret_prompt.clone();
+                        let cwd_inner = cwd.clone();
                         let auto_approve_inner = auto_approve_confirms;
                         let orchestration_inner = orchestration.clone();
                         let mcp_leases_inner = mcp_lease_capability.clone();
@@ -1259,7 +1264,7 @@ impl StreamMethods {
                                     tokio::select! {
                                         res = t.execute_rich(input, crate::ToolContext {
                                             channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx_stream.clone()) },
-                                            capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()), delegation_parent: delegation_parent_inner.clone(), secret_prompt: prompt_inner.clone(), orchestration: orchestration_inner.clone(), tool_activation: Some(activation_inner.clone()), mcp_leases: mcp_leases_inner.clone(), extension_leases: extension_leases_inner.clone(), memory_context: None /* TODO(task A5): host wiring of MemoryContextCapability */, cwd: None },
+                                            capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()), delegation_parent: delegation_parent_inner.clone(), secret_prompt: prompt_inner.clone(), orchestration: orchestration_inner.clone(), tool_activation: Some(activation_inner.clone()), mcp_leases: mcp_leases_inner.clone(), extension_leases: extension_leases_inner.clone(), memory_context: None /* TODO(task A5): host wiring of MemoryContextCapability */, cwd: cwd_inner.clone() },
                                             limits: crate::tools::ToolLimits { max_tool_output, max_tool_buffer: 256 * 1024, bash_timeout, bash_max_timeout, subagent_timeout },
                                         }) => {
                                             let (output, rich_blocks) = match res {

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -2155,6 +2155,7 @@ mod rich_output_tests {
             event_queue: Arc::new(crate::events::EventQueue::new(100)),
             hook_bus,
             session_id: None,
+            cwd: None,
             secret_prompt: None,
             auto_approve_confirms: true,
             telemetry_level: crate::runtime::telemetry::TelemetryLevel::Off,

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -548,7 +548,8 @@ impl StreamMethods {
                 });
             let turn_injected_context: Option<String> = if let Some(ref msg_text) = last_user_msg {
                 let hook_event =
-                    crate::extensions::hooks::events::HookEvent::before_message(msg_text);
+                    crate::extensions::hooks::events::HookEvent::before_message(msg_text)
+                        .with_session(session_id.as_deref());
                 if let crate::extensions::hooks::events::HookResult::Inject { content } =
                     hook_bus.emit(&hook_event).await
                 {
@@ -726,7 +727,8 @@ impl StreamMethods {
                         "content_block_count": content.len(),
                         "has_tool_use": !tool_uses.is_empty(),
                     }),
-                );
+                )
+                .with_session(session_id.as_deref());
                 let _ = hook_bus.emit(&hook_event).await;
 
                 // If no tool uses, check for steering messages before finishing.
@@ -925,6 +927,7 @@ impl StreamMethods {
                                         &tool_name,
                                         Some(&runtime_name),
                                         input.clone(),
+                                        session_id.as_deref(),
                                     )
                                     .await,
                                     secret_prompt.as_ref(),
@@ -956,6 +959,7 @@ impl StreamMethods {
                                                 input_for_hook,
                                                 output.clone(),
                                                 max_tool_output,
+                                                session_id.as_deref(),
                                             ).await;
                                             // Hook policy: a Replace transform wins over the rich
                                             // blocks — the hook saw only the summary, so keeping
@@ -1187,6 +1191,7 @@ impl StreamMethods {
                         let hook_bus_inner = hook_bus.clone();
                         let prompt_inner = secret_prompt.clone();
                         let cwd_inner = cwd.clone();
+                        let session_id_inner = session_id.clone();
                         let auto_approve_inner = auto_approve_confirms;
                         let orchestration_inner = orchestration.clone();
                         let mcp_leases_inner = mcp_lease_capability.clone();
@@ -1228,6 +1233,7 @@ impl StreamMethods {
                                             &tool_name_for_hook,
                                             Some(&runtime_name_for_hook),
                                             input.clone(),
+                                            session_id_inner.as_deref(),
                                         ).await,
                                         prompt_inner.as_ref(),
                                         auto_approve_inner,
@@ -1278,6 +1284,7 @@ impl StreamMethods {
                                                 input_for_hook,
                                                 output.clone(),
                                                 max_tool_output,
+                                                session_id_inner.as_deref(),
                                             ).await;
                                             // Hook Replace wins over rich blocks (see single-tool site).
                                             let rich_blocks = drop_rich_if_rewritten(rich_blocks, &hooked_output, &output);

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -51,7 +51,17 @@ const TURN_REPLAY_CAP: usize = 4096;
 /// what `App::capture_abort_context` walks in the TUI transcript
 /// (`ChatMessage::{Thinking,Text,ToolUse,ToolResult}` since the last user
 /// message). Consecutive text/thinking deltas coalesce like
-/// `append_or_update_*` does.
+/// `append_or_update_*` does; tool-result deltas accumulate per `tool_id`
+/// at the position of the first delta and the final `ToolResult` replaces
+/// them in place (`Transcript::on_tool_result_delta`/`on_tool_result`), so
+/// an abort mid-tool captures the partial output exactly as the TUI does.
+///
+/// Known divergence from the TUI (documented, not closed): the TUI walks
+/// its transcript back to the last `ChatMessage::User` card. During an
+/// event-triggered auto-turn there is no User card, so the TUI's context
+/// also includes the PREVIOUS turn's output; `TurnLog` is cleared at every
+/// `start_turn` and holds the current turn only. The actor's content is
+/// the narrower, arguably correct one.
 #[derive(Default)]
 struct TurnLog {
     parts: Vec<TurnPart>,
@@ -61,12 +71,43 @@ enum TurnPart {
     Thinking(String),
     Text(String),
     ToolUse { name: String, input: String },
-    ToolResult(String),
+    ToolResult { tool_id: String, content: String },
 }
 
 impl TurnLog {
     fn clear(&mut self) {
         self.parts.clear();
+    }
+
+    fn tool_result_mut(&mut self, tool_id: &str) -> Option<&mut String> {
+        self.parts.iter_mut().rev().find_map(|p| match p {
+            TurnPart::ToolResult { tool_id: id, content } if id == tool_id => Some(content),
+            _ => None,
+        })
+    }
+
+    /// `Transcript::on_tool_result_delta`: append to the in-flight result
+    /// for this tool, or open one.
+    fn tool_result_delta(&mut self, tool_id: String, delta: String) {
+        match self.tool_result_mut(&tool_id) {
+            Some(c) => c.push_str(&delta),
+            None => self.parts.push(TurnPart::ToolResult {
+                tool_id,
+                content: delta,
+            }),
+        }
+    }
+
+    /// `Transcript::on_tool_result`: the final result replaces any
+    /// delta-buffered content in place.
+    fn tool_result(&mut self, tool_id: String, result: String) {
+        match self.tool_result_mut(&tool_id) {
+            Some(c) => *c = result,
+            None => self.parts.push(TurnPart::ToolResult {
+                tool_id,
+                content: result,
+            }),
+        }
     }
 
     fn text(&mut self, t: &str) {
@@ -101,7 +142,7 @@ impl TurnLog {
                     let input_preview: String = input.chars().take(200).collect();
                     parts.push(format!("[tool_use]: {} — {}", name, input_preview));
                 }
-                TurnPart::ToolResult(content) if !content.is_empty() => {
+                TurnPart::ToolResult { content, .. } if !content.is_empty() => {
                     let preview: String = content.chars().take(300).collect();
                     parts.push(format!("[tool_result]: {}", preview));
                 }
@@ -524,8 +565,11 @@ impl SessionActor {
                     input: input_str,
                 });
             }
-            StreamEvent::Llm(LlmEvent::ToolResult { result, .. }) => {
-                self.turn_log.parts.push(TurnPart::ToolResult(result));
+            StreamEvent::Llm(LlmEvent::ToolResultDelta { tool_id, delta }) => {
+                self.turn_log.tool_result_delta(tool_id, delta);
+            }
+            StreamEvent::Llm(LlmEvent::ToolResult { tool_id, result }) => {
+                self.turn_log.tool_result(tool_id, result);
             }
             StreamEvent::Llm(_) => {}
             StreamEvent::Session(SessionEvent::MessageHistory(history)) => {

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -332,11 +332,15 @@ impl SessionActor {
         self.steer_tx = Some(s_tx);
     }
 
+    /// Every turn-end path (Done/Error/Cancel/stream EOF). Clears `turn_log`
+    /// too: a `Cancel` racing a `Done` must not scrape the finished turn into
+    /// `abort_context`.
     fn clear_stream(&mut self) {
         self.stream = None;
         self.cancel = None;
         self.steer_tx = None;
         self.streaming = false;
+        self.turn_log.clear();
         self.update_attach_state();
     }
 
@@ -377,8 +381,15 @@ impl SessionActor {
         self.conv.queued_message = Some(text);
     }
 
-    /// dispatch.rs Abort (:134-192) verbatim minus presentation.
+    /// dispatch.rs Abort (:134-192) verbatim minus presentation, behind the
+    /// TUI's `if streaming` guard (input.rs:350): a `Cancel` while idle is a
+    /// no-op that only re-announces `Idle` — it must never touch
+    /// `abort_context`, save, or emit "aborted".
     async fn cancel_turn(&mut self) {
+        if !self.streaming {
+            self.emit(SessionEventWire::Idle);
+            return;
+        }
         if let Some(ref ct) = self.cancel {
             ct.cancel();
         }

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -186,7 +186,15 @@ impl SessionActor {
 
         // C2: per-session on_session_start (keyed injection) once the
         // process-level discovery is known-finished. Never re-runs discovery.
-        host.extensions_ready().await;
+        if tokio::time::timeout(budgets::EXTENSIONS_READY_TIMEOUT, host.extensions_ready())
+            .await
+            .is_err()
+        {
+            tracing::warn!(
+                budget_secs = budgets::EXTENSIONS_READY_TIMEOUT_SECS,
+                "extensions_ready timed out — on_session_start may miss late extensions"
+            );
+        }
         crate::extensions::loader::emit_session_start(runtime.hook_bus(), &sb.session.id).await;
 
         let id = SessionId::from(sb.session.id.clone());

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -26,7 +26,6 @@ use crate::engine::reactor::{
 };
 use crate::engine::session::ConversationState;
 use crate::engine::setup::BackgroundTasks;
-use crate::extensions::hooks::events::{HookEvent, HookResult};
 use crate::runtime::compaction::{
     apply_compaction, compact_conversation, preview_compaction_disclosure, CompactionPolicy,
     CompactionTransition,
@@ -185,22 +184,10 @@ impl SessionActor {
             cfg.cwd.clone(),
         );
 
-        // C2 replaces — keyed on_session_start injection, inlined from
-        // extensions/loader.rs (spawn_discover_and_load's post-discovery block).
-        {
-            let hook_bus = Arc::clone(runtime.hook_bus());
-            let event = HookEvent::on_session_start(&sb.session.id);
-            if let HookResult::Inject { content } = hook_bus.emit(&event).await {
-                tracing::debug!(
-                    len = content.len(),
-                    "on_session_start injected session-scoped context"
-                );
-                hook_bus
-                    .set_session_injection_for(&sb.session.id, content)
-                    .await;
-            }
-        }
-        // C2 replaces — end
+        // C2: per-session on_session_start (keyed injection) once the
+        // process-level discovery is known-finished. Never re-runs discovery.
+        host.extensions_ready().await;
+        crate::extensions::loader::emit_session_start(runtime.hook_bus(), &sb.session.id).await;
 
         let id = SessionId::from(sb.session.id.clone());
         let meta = SessionMeta {
@@ -1050,20 +1037,15 @@ impl SessionActor {
             );
         }
 
-        // STEP 2: on_session_end — concurrent, fail-open, own budget.
-        let hook_event = HookEvent::on_session_end(&session_id, Some(api_messages));
-        if tokio::time::timeout(
+        // STEP 2 (C2): on_session_end — per session, concurrent, fail-open,
+        // own budget; clears this session's keyed injection.
+        crate::extensions::loader::emit_session_end(
+            self.runtime.hook_bus(),
+            &session_id,
+            Some(api_messages),
             budgets::HOOKS_TIMEOUT,
-            self.runtime.hook_bus().emit_concurrent(&hook_event),
         )
-        .await
-        .is_err()
-        {
-            tracing::warn!(
-                budget_secs = budgets::HOOKS_TIMEOUT_SECS,
-                "on_session_end hooks timed out — extensions may not have flushed"
-            );
-        }
+        .await;
 
         // STEP 3: bounded observability flush.
         if let Some(outcome) = self

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -1,0 +1,1137 @@
+//! `SessionActor` — owns THE `Runtime` + `ConversationState` for one
+//! conversation and runs its turn machine (PLAN-phase2 §2.5).
+//!
+//! Every method body is moved from an existing reactor site (TUI
+//! `dispatch.rs` Abort/Submit/StreamingInput, `stream_handler.rs`
+//! event-queue + stream arms, `tui/mod.rs` teardown, `cmd/chat.rs`
+//! post-turn); the presentation halves stay client-side and are fed by
+//! the envelopes this actor emits. Each `StreamEvent` is forwarded to
+//! clients BEFORE the actor acts on it, so a client sees the same order it
+//! sees today.
+//!
+//! Invariants:
+//! - `Runtime::clone()` resets TTL latches — the actor never clones it.
+//! - `emit` is the ONLY `seq` increment site.
+//! - `Detach` never touches `stream`/`cancel`; only `End` (and `Cancel`)
+//!   stop a turn.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+
+use futures::StreamExt;
+use tokio::sync::{broadcast, mpsc, oneshot};
+
+use crate::engine::reactor::{
+    claim_auto_turn, drain_event_queue, wake_action, EventDisposition, WakeAction, AUTO_TURN_CAP,
+};
+use crate::engine::session::ConversationState;
+use crate::engine::setup::BackgroundTasks;
+use crate::extensions::hooks::events::{HookEvent, HookResult};
+use crate::runtime::compaction::{
+    apply_compaction, compact_conversation, preview_compaction_disclosure, CompactionPolicy,
+    CompactionTransition,
+};
+use crate::tools::{SecretPromptHandle, SecretPromptRequest};
+use crate::{
+    AgentEvent, CancellationToken, EngineHost, LlmEvent, Result, Runtime, SessionEvent,
+    StreamEvent,
+};
+
+use super::budgets;
+use super::handle::{SessionEndpoints, SessionHandle};
+use super::types::*;
+use super::view::RuntimeView;
+
+/// The in-flight response stream (tui/stream_handler.rs `ActiveStream`).
+pub type ActiveStream = std::pin::Pin<Box<dyn futures::Stream<Item = StreamEvent> + Send>>;
+
+/// `turn_replay` cap (envelopes). §6 #9: the 2 MiB text bound is day 3.
+const TURN_REPLAY_CAP: usize = 4096;
+
+/// Chronological record of the current turn's assistant output, mirroring
+/// what `App::capture_abort_context` walks in the TUI transcript
+/// (`ChatMessage::{Thinking,Text,ToolUse,ToolResult}` since the last user
+/// message). Consecutive text/thinking deltas coalesce like
+/// `append_or_update_*` does.
+#[derive(Default)]
+struct TurnLog {
+    parts: Vec<TurnPart>,
+}
+
+enum TurnPart {
+    Thinking(String),
+    Text(String),
+    ToolUse { name: String, input: String },
+    ToolResult(String),
+}
+
+impl TurnLog {
+    fn clear(&mut self) {
+        self.parts.clear();
+    }
+
+    fn text(&mut self, t: &str) {
+        if let Some(TurnPart::Text(s)) = self.parts.last_mut() {
+            s.push_str(t);
+        } else {
+            self.parts.push(TurnPart::Text(t.to_string()));
+        }
+    }
+
+    fn thinking(&mut self, t: &str) {
+        if let Some(TurnPart::Thinking(s)) = self.parts.last_mut() {
+            s.push_str(t);
+        } else {
+            self.parts.push(TurnPart::Thinking(t.to_string()));
+        }
+    }
+
+    /// `App::capture_abort_context` verbatim (app.rs:644-683).
+    fn abort_context(&self) -> Option<String> {
+        let mut parts: Vec<String> = Vec::new();
+        for p in &self.parts {
+            match p {
+                TurnPart::Thinking(t) if !t.is_empty() => {
+                    let preview: String = t.chars().take(500).collect();
+                    parts.push(format!("[thinking]: {}", preview));
+                }
+                TurnPart::Text(t) if !t.is_empty() => {
+                    parts.push(format!("[response]: {}", t));
+                }
+                TurnPart::ToolUse { name, input } => {
+                    let input_preview: String = input.chars().take(200).collect();
+                    parts.push(format!("[tool_use]: {} — {}", name, input_preview));
+                }
+                TurnPart::ToolResult(content) if !content.is_empty() => {
+                    let preview: String = content.chars().take(300).collect();
+                    parts.push(format!("[tool_result]: {}", preview));
+                }
+                _ => {}
+            }
+        }
+        if parts.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "[ABORT CONTEXT — your previous response was interrupted. Here's what you completed before the abort:]\n\n{}\n\n[END ABORT CONTEXT — continue from where you left off or adjust based on the user's new message]",
+            parts.join("\n")
+        ))
+    }
+}
+
+pub struct SessionActor {
+    id: SessionId,
+    meta: SessionMeta,
+    config: SessionConfig,
+    /// THE runtime; `session_id` + `cwd` set by `create`.
+    runtime: Runtime,
+    conv: ConversationState,
+    // ── turn machine: the run() loop locals + App fields ──
+    stream: Option<ActiveStream>,
+    cancel: Option<CancellationToken>,
+    steer_tx: Option<mpsc::UnboundedSender<String>>,
+    streaming: bool,
+    turn_baseline: usize,
+    consecutive_auto_turns: u32,
+    turn_log: TurnLog,
+    // ── prompts ──
+    secret_prompt_handle: SecretPromptHandle,
+    secret_prompt_rx: mpsc::UnboundedReceiver<SecretPromptRequest>,
+    /// Held across detach; replayed in `AttachSnapshot.pending_prompts`.
+    pending_prompts: VecDeque<(PromptRequest, oneshot::Sender<Option<String>>)>,
+    next_prompt_id: u64,
+    // ── clients ──
+    cmd_rx: mpsc::Receiver<SessionCommand>,
+    events: broadcast::Sender<Envelope>,
+    view: Arc<arc_swap::ArcSwap<RuntimeView>>,
+    attached: HashMap<ClientId, ClientMeta>,
+    next_client_id: u64,
+    seq: u64,
+    turn_replay: VecDeque<Envelope>,
+    state: AttachState,
+    background: BackgroundTasks,
+}
+
+impl SessionActor {
+    /// = today's `setup::boot()` per session (foreground_runtime →
+    /// resolve_session_and_prompt → set_cwd → model override →
+    /// spawn_session_background → finish_session_setup) then
+    /// `on_session_start` (keyed injection).
+    pub(crate) async fn create(
+        host: &Arc<EngineHost>,
+        cfg: SessionConfig,
+    ) -> Result<(SessionHandle, SessionTask)> {
+        let mut runtime = host.foreground_runtime().await?;
+        let config: crate::SynapsConfig = (**host.config()).clone();
+
+        let sb = crate::engine::setup::resolve_session_and_prompt(
+            &mut runtime,
+            &cfg.continue_session,
+            cfg.system.as_deref(),
+            cfg.prompt_manifest.as_deref(),
+        )?;
+        runtime.set_cwd(cfg.cwd.clone());
+        // CLI `--model` overrides whatever was persisted (rpc.rs precedent).
+        if let Some(ref m) = cfg.model_override {
+            runtime.set_model(m.clone());
+        }
+
+        let background =
+            crate::engine::setup::spawn_session_background(&runtime, &sb.session)?;
+        crate::engine::setup::finish_session_setup(
+            &mut runtime,
+            &config,
+            &sb.session,
+            cfg.cwd.clone(),
+        );
+
+        // C2 replaces — keyed on_session_start injection, inlined from
+        // extensions/loader.rs (spawn_discover_and_load's post-discovery block).
+        {
+            let hook_bus = Arc::clone(runtime.hook_bus());
+            let event = HookEvent::on_session_start(&sb.session.id);
+            if let HookResult::Inject { content } = hook_bus.emit(&event).await {
+                tracing::debug!(
+                    len = content.len(),
+                    "on_session_start injected session-scoped context"
+                );
+                hook_bus
+                    .set_session_injection_for(&sb.session.id, content)
+                    .await;
+            }
+        }
+        // C2 replaces — end
+
+        let id = SessionId::from(sb.session.id.clone());
+        let meta = SessionMeta {
+            id: id.clone(),
+            name: sb.session.name.clone(),
+            model: runtime.model().to_string(),
+            cwd: cfg.cwd.clone(),
+            created_at: sb.session.created_at,
+            continued: sb.continued,
+            continue_info: sb.continue_info.as_ref().map(ContinueInfoWire::from),
+            host_pid: std::process::id(),
+        };
+        let mut conv = if sb.continued {
+            ConversationState::from_resumed(sb.session)
+        } else {
+            ConversationState::new(sb.session)
+        };
+        conv.api_messages = sb.api_messages;
+        conv.total_input_tokens = sb.total_input_tokens;
+        conv.total_output_tokens = sb.total_output_tokens;
+        conv.session_cost = sb.session_cost;
+        conv.abort_context = sb.abort_context;
+
+        let view = RuntimeView::from_runtime(&runtime).await;
+        let (handle, SessionEndpoints { cmd_rx, events, view }) =
+            SessionHandle::new(meta.clone(), view);
+        let (sp_tx, secret_prompt_rx) = mpsc::unbounded_channel();
+
+        let actor = SessionActor {
+            id,
+            meta,
+            config: cfg,
+            runtime,
+            conv,
+            stream: None,
+            cancel: None,
+            steer_tx: None,
+            streaming: false,
+            turn_baseline: 0,
+            consecutive_auto_turns: 0,
+            turn_log: TurnLog::default(),
+            secret_prompt_handle: SecretPromptHandle::new(sp_tx),
+            secret_prompt_rx,
+            pending_prompts: VecDeque::new(),
+            next_prompt_id: 1,
+            cmd_rx,
+            events,
+            view,
+            attached: HashMap::new(),
+            next_client_id: 1,
+            seq: 0,
+            turn_replay: VecDeque::new(),
+            state: AttachState::Detached { running: false },
+            background,
+        };
+        Ok((handle, SessionTask(actor)))
+    }
+
+    // ── emit ─────────────────────────────────────────────────────────────
+
+    /// The ONLY seq++ site. Pushes to `turn_replay` while streaming, except
+    /// prompt traffic (never replayed) and per-client replies.
+    fn emit(&mut self, event: SessionEventWire) {
+        let replay = self.streaming
+            && !matches!(
+                event,
+                SessionEventWire::Prompt(_)
+                    | SessionEventWire::PromptResolved { .. }
+                    | SessionEventWire::Attached { .. }
+                    | SessionEventWire::QueryResult { .. }
+            );
+        let env = Envelope {
+            session_id: self.id.clone(),
+            seq: self.seq,
+            ts: chrono::Utc::now(),
+            event,
+        };
+        self.seq += 1;
+        if replay {
+            if self.turn_replay.len() >= TURN_REPLAY_CAP {
+                self.turn_replay.pop_front();
+            }
+            self.turn_replay.push_back(env.clone());
+        }
+        // No receivers is not an error: streams are not tied to clients.
+        let _ = self.events.send(env);
+    }
+
+    fn emit_conversation(&mut self) {
+        let snap = self.conv.snapshot(self.consecutive_auto_turns);
+        self.emit(SessionEventWire::Conversation(snap));
+    }
+
+    async fn publish_view(&mut self) {
+        let v = RuntimeView::from_runtime(&self.runtime).await;
+        self.view.store(Arc::new(v));
+    }
+
+    async fn save(&mut self) {
+        if self.config.persist {
+            self.conv.save().await;
+        }
+    }
+
+    fn update_attach_state(&mut self) {
+        self.state = if self.attached.is_empty() {
+            AttachState::Detached {
+                running: self.streaming,
+            }
+        } else {
+            AttachState::Attached(self.attached.len())
+        };
+    }
+
+    // ── turn start (dispatch.rs Submit tail / stream_handler.rs RunTurn) ──
+
+    async fn start_turn(&mut self, trigger: TurnTrigger) {
+        let ct = CancellationToken::new();
+        let (s_tx, s_rx) = mpsc::unbounded_channel::<String>();
+        self.streaming = true;
+        self.turn_baseline = self.conv.api_messages.len();
+        self.turn_log.clear();
+        self.turn_replay.clear();
+        self.update_attach_state();
+        self.emit(SessionEventWire::TurnStarted {
+            turn_baseline: self.turn_baseline,
+            trigger,
+        });
+        // Blocks command processing during setup exactly like the TUI loop.
+        let stream = self
+            .runtime
+            .run_stream_with_messages(
+                self.conv.api_messages.clone(),
+                ct.clone(),
+                Some(s_rx),
+                Some(self.secret_prompt_handle.clone()),
+                self.config.auto_approve_confirms,
+            )
+            .await;
+        self.stream = Some(stream);
+        self.cancel = Some(ct);
+        self.steer_tx = Some(s_tx);
+    }
+
+    fn clear_stream(&mut self) {
+        self.stream = None;
+        self.cancel = None;
+        self.steer_tx = None;
+        self.streaming = false;
+        self.update_attach_state();
+    }
+
+    /// dispatch.rs Submit (:1231-1288) minus presentation.
+    async fn submit(&mut self, text: String) {
+        if self.streaming {
+            // A Submit while streaming is what the TUI calls StreamingInput.
+            self.steer(text);
+            return;
+        }
+        // Real user send — reset auto-turn counter.
+        self.consecutive_auto_turns = 0;
+        // Inject abort context if previous response was interrupted
+        let api_content = if let Some(ref ctx) = self.conv.abort_context {
+            let combined = format!("{}\n\n{}", ctx, text);
+            self.conv.abort_context = None;
+            combined
+        } else {
+            text
+        };
+        self.conv.api_messages.push(std::sync::Arc::new(
+            serde_json::json!({"role": "user", "content": api_content}),
+        ));
+        self.start_turn(TurnTrigger::User).await;
+    }
+
+    /// dispatch.rs StreamingInput plain-text branch (:1369-1378).
+    fn steer(&mut self, text: String) {
+        let delivered = self
+            .steer_tx
+            .as_ref()
+            .map(|tx| tx.send(text.clone()).is_ok())
+            .unwrap_or(false);
+        self.emit(SessionEventWire::Steered {
+            text: text.clone(),
+            delivered,
+        });
+        self.conv.queued_message = Some(text);
+    }
+
+    /// dispatch.rs Abort (:134-192) verbatim minus presentation.
+    async fn cancel_turn(&mut self) {
+        if let Some(ref ct) = self.cancel {
+            ct.cancel();
+        }
+        self.conv.abort_context = self.turn_log.abort_context();
+        if let Some(q) = self.conv.queued_message.take() {
+            self.emit(SessionEventWire::Dequeued { text: q });
+        }
+        // Flush any events that arrived during streaming
+        for formatted in self.conv.pending_events.drain(..) {
+            self.conv
+                .api_messages
+                .push(std::sync::Arc::new(serde_json::json!({
+                    "role": "user",
+                    "content": formatted
+                })));
+        }
+        self.clear_stream();
+        // Cancel all running reactive subagents; recover a poisoned guard
+        // rather than skip cancellation.
+        {
+            let mut registry = match self.runtime.subagent_registry().lock() {
+                Ok(g) => g,
+                Err(poisoned) => {
+                    tracing::warn!(
+                        "subagent registry mutex poisoned during abort; recovering to cancel running handles"
+                    );
+                    poisoned.into_inner()
+                }
+            };
+            for handle in registry.iter_mut_handles() {
+                if handle.status() == crate::runtime::subagent::SubagentStatus::Running {
+                    handle.cancel();
+                }
+            }
+        }
+        let abort_msg = if self.conv.abort_context.is_some() {
+            "aborted — context saved for next message"
+        } else {
+            "aborted"
+        };
+        self.emit(SessionEventWire::SystemNotice(abort_msg.to_string()));
+        self.save().await;
+        self.emit_conversation();
+        self.emit(SessionEventWire::Idle);
+    }
+
+    // ── event-queue wake (stream_handler.rs handle_event_queue_arm) ──────
+
+    async fn on_queue_wake(&mut self) {
+        let busy = self.streaming;
+        let drained = drain_event_queue(
+            self.runtime.event_queue(),
+            &mut self.conv.api_messages,
+            &mut self.conv.pending_events,
+            busy,
+            self.steer_tx.as_ref(),
+        );
+        if drained.is_empty() {
+            return;
+        }
+        for de in &drained {
+            self.emit(SessionEventWire::External(de.event.clone()));
+        }
+        let injected = drained
+            .iter()
+            .any(|d| d.disposition == EventDisposition::Injected);
+        if injected || busy {
+            self.emit_conversation();
+        }
+
+        let auto_turn_enabled = true;
+        let action = wake_action(
+            &drained,
+            &self.conv.api_messages,
+            busy,
+            auto_turn_enabled,
+            self.consecutive_auto_turns,
+        );
+        match action {
+            WakeAction::RunTurn => {
+                if self.stream.is_some() {
+                    tracing::warn!("handle_event_arm: RunTurn with active stream — skipping");
+                } else {
+                    self.consecutive_auto_turns += 1;
+                    self.start_turn(TurnTrigger::EventAuto).await;
+                }
+            }
+            WakeAction::Forward => {
+                let hit_cap = injected
+                    && !busy
+                    && auto_turn_enabled
+                    && self.consecutive_auto_turns >= AUTO_TURN_CAP;
+                if hit_cap {
+                    self.emit(SessionEventWire::AutoTurnCapReached { cap: AUTO_TURN_CAP });
+                }
+            }
+            WakeAction::Nothing => {}
+        }
+    }
+
+    // ── stream events (stream_handler.rs handle_stream_event + arm tail) ──
+
+    async fn on_stream_event(&mut self, event: StreamEvent) {
+        // Forward first: clients see the same order they see today.
+        self.emit(SessionEventWire::Stream(event.clone()));
+
+        enum After {
+            Continue,
+            AutoSendQueued(String),
+            AutoTriggerEvents,
+            Failed,
+        }
+        let mut after = After::Continue;
+
+        match event {
+            StreamEvent::Llm(LlmEvent::Thinking(text)) => self.turn_log.thinking(&text),
+            StreamEvent::Llm(LlmEvent::Text(text)) => self.turn_log.text(&text),
+            StreamEvent::Llm(LlmEvent::ToolUse {
+                tool_name, input, ..
+            }) => {
+                let input_str = serde_json::to_string(&input).unwrap_or_default();
+                self.turn_log.parts.push(TurnPart::ToolUse {
+                    name: tool_name,
+                    input: input_str,
+                });
+            }
+            StreamEvent::Llm(LlmEvent::ToolResult { result, .. }) => {
+                self.turn_log.parts.push(TurnPart::ToolResult(result));
+            }
+            StreamEvent::Llm(_) => {}
+            StreamEvent::Session(SessionEvent::MessageHistory(history)) => {
+                self.conv.api_messages = history;
+                self.save().await;
+                self.emit_conversation();
+            }
+            StreamEvent::Agent(AgentEvent::SteeringDelivered { message }) => {
+                if self.conv.queued_message.as_ref() == Some(&message) {
+                    self.conv.queued_message = None;
+                    self.emit_conversation();
+                }
+            }
+            StreamEvent::Agent(_) => {}
+            StreamEvent::Session(SessionEvent::Usage {
+                input_tokens,
+                output_tokens,
+                cache_read_input_tokens,
+                cache_creation_input_tokens,
+                cache_creation_5m,
+                cache_creation_1h,
+                model: usage_model,
+            }) => {
+                let model_for_pricing = usage_model
+                    .as_deref()
+                    .unwrap_or(self.runtime.model())
+                    .to_string();
+                self.conv.add_usage(
+                    input_tokens,
+                    output_tokens,
+                    cache_read_input_tokens,
+                    cache_creation_input_tokens,
+                    cache_creation_5m,
+                    cache_creation_1h,
+                    &model_for_pricing,
+                );
+            }
+            StreamEvent::Session(SessionEvent::Notice(_)) => {}
+            StreamEvent::Session(SessionEvent::Done) => {
+                self.clear_stream();
+                // Flush events that arrived during streaming into api_messages
+                let had_pending = !self.conv.pending_events.is_empty();
+                for formatted in self.conv.pending_events.drain(..) {
+                    self.conv
+                        .api_messages
+                        .push(std::sync::Arc::new(serde_json::json!({
+                            "role": "user",
+                            "content": formatted
+                        })));
+                }
+                if let Some(queued) = self.conv.queued_message.take() {
+                    after = After::AutoSendQueued(queued);
+                } else if had_pending {
+                    self.save().await;
+                    after = After::AutoTriggerEvents;
+                }
+                self.emit_conversation();
+                if matches!(after, After::Continue) {
+                    if self.config.auto_compact {
+                        self.post_turn_chat().await;
+                    }
+                    self.emit(SessionEventWire::Idle);
+                }
+            }
+            StreamEvent::Session(SessionEvent::Error(_)) => {
+                self.clear_stream();
+                // Remove only invalid messages appended by the ACTIVE turn.
+                crate::engine::stream::repair_history_after_failure(
+                    &mut self.conv.api_messages,
+                    self.turn_baseline,
+                );
+                self.emit_conversation();
+                after = After::Failed;
+            }
+        }
+
+        match after {
+            After::Continue => {}
+            After::Failed => {
+                if self.config.auto_compact {
+                    self.post_turn_chat().await;
+                }
+                self.emit(SessionEventWire::Idle);
+            }
+            After::AutoSendQueued(queued) => {
+                if self.config.auto_compact {
+                    self.post_turn_chat().await;
+                }
+                // Auto-send the queued message (user-authored — reset counter)
+                self.consecutive_auto_turns = 0;
+                let api_content = if let Some(ref ctx) = self.conv.abort_context {
+                    let combined = format!("{}\n\n{}", ctx, queued);
+                    self.conv.abort_context = None;
+                    combined
+                } else {
+                    queued
+                };
+                self.conv.api_messages.push(std::sync::Arc::new(
+                    serde_json::json!({"role": "user", "content": api_content}),
+                ));
+                self.start_turn(TurnTrigger::QueuedAuto).await;
+            }
+            After::AutoTriggerEvents => {
+                if self.config.auto_compact {
+                    self.post_turn_chat().await;
+                }
+                // Central claim gate: allows turns 1-5, denies the 6th.
+                if claim_auto_turn(&mut self.consecutive_auto_turns) {
+                    self.start_turn(TurnTrigger::EventAuto).await;
+                } else {
+                    self.emit(SessionEventWire::AutoTurnCapReached { cap: AUTO_TURN_CAP });
+                    self.emit(SessionEventWire::Idle);
+                }
+            }
+        }
+    }
+
+    /// chat.rs post-turn block: save + engine-budget auto-compaction.
+    async fn post_turn_chat(&mut self) {
+        self.save().await;
+        let assessment = self.runtime.assess_context(&self.conv.api_messages).await;
+        if assessment.should_compact() {
+            self.emit(SessionEventWire::SystemNotice(format!(
+                "[auto-compacting ~{} tokens...]",
+                assessment.used_tokens()
+            )));
+            self.compact(None, "auto").await;
+        }
+    }
+
+    /// chat.rs `/compact` + auto-compaction body (inline; the TUI's spawned
+    /// compaction task is day 2).
+    async fn compact(&mut self, instructions: Option<String>, source: &str) {
+        self.emit(SessionEventWire::SystemNotice(format!(
+            "[{}]",
+            preview_compaction_disclosure(&self.runtime, &self.conv.api_messages).render_line()
+        )));
+        let outcome =
+            compact_conversation(&self.conv.api_messages, &self.runtime, instructions.as_deref())
+                .await;
+        let applied = match outcome {
+            Ok(outcome) => {
+                apply_compaction(
+                    &self.runtime,
+                    &self.conv.session,
+                    &self.conv.api_messages,
+                    &outcome,
+                    CompactionTransition {
+                        policy: CompactionPolicy::InPlace,
+                        pending_events: Vec::new(),
+                        queued_message: None,
+                        hook_source: source.to_string(),
+                    },
+                )
+                .await
+            }
+            Err(e) => Err(e),
+        };
+        match applied {
+            Ok(applied) => {
+                self.conv.session = applied.session;
+                self.conv.api_messages = applied.api_messages;
+                let after = self.runtime.assess_context(&self.conv.api_messages).await;
+                self.emit(SessionEventWire::SystemNotice(format!(
+                    "[compacted → ~{} tokens]",
+                    after.used_tokens()
+                )));
+            }
+            Err(e) => self.emit(SessionEventWire::SystemNotice(format!(
+                "[compaction failed: {}]",
+                e
+            ))),
+        }
+        self.emit_conversation();
+    }
+
+    // ── prompts ──────────────────────────────────────────────────────────
+
+    fn on_prompt_request(&mut self, req: SecretPromptRequest) {
+        let id = self.next_prompt_id;
+        self.next_prompt_id += 1;
+        let pr = PromptRequest {
+            id,
+            kind: PromptKind::from_title(&req.title),
+            title: req.title,
+            prompt: req.prompt,
+            raised_at: chrono::Utc::now(),
+        };
+        self.pending_prompts.push_back((pr.clone(), req.response_tx));
+        self.emit(SessionEventWire::Prompt(pr));
+    }
+
+    fn answer(&mut self, prompt_id: u64, value: Option<String>) {
+        let Some(pos) = self.pending_prompts.iter().position(|(p, _)| p.id == prompt_id) else {
+            return; // unknown or already answered — dedup on id
+        };
+        let (_, tx) = self.pending_prompts.remove(pos).expect("position");
+        let _ = tx.send(value);
+        self.emit(SessionEventWire::PromptResolved { prompt_id });
+    }
+
+    // ── settings / queries / engine commands ─────────────────────────────
+
+    async fn apply_setting(&mut self, setting: SessionSetting) {
+        let name = match &setting {
+            SessionSetting::Model { .. } => "model",
+            SessionSetting::ReasoningLevel { .. } => "reasoning_level",
+            SessionSetting::ContextWindow { .. } => "context_window",
+            SessionSetting::CompactionModel { .. } => "compaction_model",
+            SessionSetting::ApiRetries { .. } => "api_retries",
+            SessionSetting::SubagentTimeout { .. } => "subagent_timeout",
+            SessionSetting::MaxToolOutput { .. } => "max_tool_output",
+            SessionSetting::BashTimeout { .. } => "bash_timeout",
+            SessionSetting::BashMaxTimeout { .. } => "bash_max_timeout",
+            SessionSetting::SystemPrompt { .. } => "system_prompt",
+            SessionSetting::ReloadPrompt => "reload_prompt",
+            SessionSetting::GrantWorkerModel { .. } => "grant_worker_model",
+        };
+        let rt = &mut self.runtime;
+        let result: std::result::Result<Option<String>, String> = match setting {
+            SessionSetting::Model { model } => rt.try_set_model(model).map(|clamp| {
+                self.conv.session.model = rt.model().to_string();
+                clamp.map(|c| {
+                    self.conv.session.thinking_level = rt.thinking_level().to_string();
+                    format!(
+                        "thinking → {} (clamped from {}: not supported by {})",
+                        c.to.as_str(),
+                        c.from.as_str(),
+                        rt.model()
+                    )
+                })
+            }),
+            SessionSetting::ReasoningLevel { level } => {
+                rt.set_reasoning_level_checked(level).map(|_| {
+                    self.conv.session.thinking_level = rt.thinking_level().to_string();
+                    None
+                })
+            }
+            SessionSetting::ContextWindow { tokens } => {
+                rt.set_context_window(tokens);
+                Ok(None)
+            }
+            SessionSetting::CompactionModel { model } => {
+                rt.set_compaction_model(model);
+                Ok(None)
+            }
+            SessionSetting::ApiRetries { n } => {
+                rt.set_api_retries(n);
+                Ok(None)
+            }
+            SessionSetting::SubagentTimeout { secs } => {
+                rt.set_subagent_timeout(secs);
+                Ok(None)
+            }
+            SessionSetting::MaxToolOutput { bytes } => {
+                rt.set_max_tool_output(bytes);
+                Ok(None)
+            }
+            SessionSetting::BashTimeout { secs } => {
+                rt.set_bash_timeout(secs);
+                Ok(None)
+            }
+            SessionSetting::BashMaxTimeout { secs } => {
+                rt.set_bash_max_timeout(secs);
+                Ok(None)
+            }
+            SessionSetting::SystemPrompt { text } => {
+                rt.set_system_prompt(text);
+                Ok(None)
+            }
+            SessionSetting::ReloadPrompt => rt
+                .reload_prompt()
+                .map(|generation| Some(format!("prompt reloaded (generation {generation})")))
+                .map_err(|e| e.to_string()),
+            SessionSetting::GrantWorkerModel { model } => {
+                rt.grant_worker_model(&model).map(|_| None)
+            }
+        };
+        self.publish_view().await;
+        let view = (**self.view.load()).clone();
+        let (ok, message) = match result {
+            Ok(m) => (true, m),
+            Err(e) => (false, Some(e)),
+        };
+        self.emit(SessionEventWire::SettingChanged(SettingApplied {
+            setting: name.to_string(),
+            ok,
+            message,
+            view,
+        }));
+    }
+
+    async fn query(&mut self, id: u64, query: SessionQuery) {
+        let value = match query {
+            SessionQuery::Status => serde_json::json!({
+                "session": self.conv.session.id,
+                "model": self.runtime.model(),
+                "tokens": { "input": self.conv.total_input_tokens, "output": self.conv.total_output_tokens },
+                "cost": self.conv.session_cost,
+                "messages": self.conv.api_messages.len(),
+                "streaming": self.streaming,
+                "auto_turns": self.consecutive_auto_turns,
+                "attached": self.attached.len(),
+                "pending_prompts": self.pending_prompts.len(),
+            }),
+            SessionQuery::Messages => {
+                serde_json::to_value(&self.conv.api_messages).unwrap_or_default()
+            }
+            SessionQuery::SubagentRows => {
+                let rows = self
+                    .runtime
+                    .subagent_registry()
+                    .lock()
+                    .unwrap_or_else(|p| p.into_inner())
+                    .display_rows();
+                serde_json::Value::Array(
+                    rows.iter()
+                        .map(|r| {
+                            serde_json::json!({
+                                "subagent_id": r.subagent_id,
+                                "agent_name": r.agent_name,
+                                "status": format!("{:?}", r.status),
+                                "cancel_requested": r.cancel_requested,
+                                "elapsed_secs": r.elapsed_secs,
+                            })
+                        })
+                        .collect(),
+                )
+            }
+            SessionQuery::PromptInspection => {
+                serde_json::to_value(self.runtime.prompt_inspection_json()).unwrap_or_default()
+            }
+            SessionQuery::ToolsSchema => serde_json::json!({ "unsupported": "tools_schema" }),
+            SessionQuery::View => serde_json::to_value(&**self.view.load()).unwrap_or_default(),
+            SessionQuery::ContextAssessment => {
+                let a = self.runtime.assess_context(&self.conv.api_messages).await;
+                serde_json::json!({
+                    "used_tokens": a.used_tokens(),
+                    "budget_tokens": a.budget_tokens(),
+                    "provider_window": a.provider_window,
+                    "should_compact": a.should_compact(),
+                })
+            }
+        };
+        self.emit(SessionEventWire::QueryResult { id, value });
+    }
+
+    /// `engine::commands::handle_engine_command` on THE runtime; reply as a
+    /// `QueryResult` the client renders (chat.rs slash-command branch).
+    async fn engine_command(&mut self, id: u64, cmd: String, arg: String) {
+        use crate::engine::commands::{handle_engine_command, CommandResult};
+        let value = match handle_engine_command(&cmd, &arg, &mut self.runtime) {
+            None => serde_json::json!({ "kind": "unhandled" }),
+            Some(CommandResult::Quit) => serde_json::json!({ "kind": "quit" }),
+            Some(CommandResult::ModelChanged {
+                model,
+                reasoning_clamped,
+            }) => {
+                self.conv.session.model = self.runtime.model().to_string();
+                let mut text = format!("model → {}", model);
+                if let Some(clamp) = reasoning_clamped {
+                    self.conv.session.thinking_level = self.runtime.thinking_level().to_string();
+                    text.push_str(&format!(
+                        "\nthinking → {} (clamped from {}: not supported by {})",
+                        clamp.to.as_str(),
+                        clamp.from.as_str(),
+                        self.runtime.model()
+                    ));
+                }
+                self.publish_view().await;
+                serde_json::json!({ "kind": "notice", "text": text })
+            }
+            Some(CommandResult::ThinkingChanged { spec }) => {
+                self.conv.session.thinking_level = spec.config_value();
+                self.publish_view().await;
+                serde_json::json!({ "kind": "notice", "text": format!("thinking → {}", spec.level()) })
+            }
+            Some(CommandResult::Compact {
+                custom_instructions,
+            }) => {
+                self.emit(SessionEventWire::SystemNotice("compacting...".into()));
+                self.compact(custom_instructions, "manual").await;
+                serde_json::json!({ "kind": "none" })
+            }
+            Some(CommandResult::Error(e)) => serde_json::json!({ "kind": "error", "text": e }),
+            Some(CommandResult::Output(text)) => {
+                serde_json::json!({ "kind": "output", "text": text })
+            }
+            Some(_) => serde_json::json!({ "kind": "none" }),
+        };
+        self.emit(SessionEventWire::QueryResult { id, value });
+    }
+
+    // ── attach / detach ──────────────────────────────────────────────────
+
+    fn snapshot(&self) -> AttachSnapshot {
+        AttachSnapshot {
+            meta: self.meta.clone(),
+            view: (**self.view.load()).clone(),
+            conversation: self.conv.snapshot(self.consecutive_auto_turns),
+            streaming: self.streaming,
+            replay: self.turn_replay.iter().cloned().collect(),
+            pending_prompts: self.pending_prompts.iter().map(|(p, _)| p.clone()).collect(),
+            clients: self.attached.iter().map(|(c, m)| (*c, m.kind)).collect(),
+        }
+    }
+
+    fn attach(&mut self, client: ClientMeta, mode: AttachMode) {
+        let cid = ClientId(self.next_client_id);
+        self.next_client_id += 1;
+        let kind = client.kind;
+        self.attached.insert(cid, client);
+        self.update_attach_state();
+        if mode != AttachMode::Mirror {
+            self.emit(SessionEventWire::SystemNotice(format!(
+                "attach mode {mode:?} not supported yet; using mirror"
+            )));
+        }
+        let snapshot = self.snapshot();
+        self.emit(SessionEventWire::Attached {
+            client: cid,
+            snapshot,
+        });
+        self.emit(SessionEventWire::ClientJoined { client: cid, kind });
+    }
+
+    /// Never touches `stream`/`cancel`: the turn keeps running and its
+    /// events buffer in the broadcast (§8 detach-without-abort).
+    fn detach(&mut self, client: ClientId) {
+        if self.attached.remove(&client).is_some() {
+            self.update_attach_state();
+            self.emit(SessionEventWire::ClientLeft { client });
+        }
+    }
+
+    // ── command dispatch ─────────────────────────────────────────────────
+
+    async fn handle(&mut self, cmd: SessionCommand) -> std::ops::ControlFlow<EndReason> {
+        use std::ops::ControlFlow;
+        match cmd {
+            SessionCommand::Submit { text, .. } => self.submit(text).await,
+            SessionCommand::Steer { text } => {
+                if self.streaming {
+                    self.steer(text)
+                } else {
+                    self.submit(text).await
+                }
+            }
+            SessionCommand::Cancel => self.cancel_turn().await,
+            SessionCommand::Answer { prompt_id, value } => self.answer(prompt_id, value),
+            SessionCommand::Set(setting) => self.apply_setting(setting).await,
+            SessionCommand::Compact { instructions } => {
+                self.emit(SessionEventWire::SystemNotice("compacting...".into()));
+                self.compact(instructions, "manual").await;
+            }
+            SessionCommand::NewSession => {
+                self.conv.clear(&self.runtime).await;
+                self.runtime
+                    .set_session_id(Some(self.conv.session.id.clone()));
+                self.emit(SessionEventWire::SystemNotice(format!(
+                    "session cleared → {}",
+                    &self.conv.session.id[..8.min(self.conv.session.id.len())]
+                )));
+                self.emit_conversation();
+            }
+            SessionCommand::Save => self.save().await,
+            SessionCommand::Query { id, query } => self.query(id, query).await,
+            SessionCommand::EngineCommand { id, name, arg } => {
+                self.engine_command(id, name, arg).await
+            }
+            SessionCommand::Attach { client, mode } => self.attach(client, mode),
+            SessionCommand::Detach { client } => self.detach(client),
+            SessionCommand::End { reason } => return ControlFlow::Break(reason),
+            SessionCommand::Resync { .. } => self.emit(SessionEventWire::SystemNotice(
+                "resync not supported yet".into(),
+            )),
+            SessionCommand::HostEvent(ev) => match ev {
+                HostEvent::ExtensionNotification {
+                    extension_id,
+                    method,
+                    params,
+                } => self.emit(SessionEventWire::ExtensionNotification {
+                    extension_id,
+                    method,
+                    params,
+                }),
+                HostEvent::LoaderProgress(ev) => self.emit(SessionEventWire::LoaderProgress(ev)),
+            },
+        }
+        ControlFlow::Continue(())
+    }
+
+    // ── teardown (tui/mod.rs:352-432 + chat.rs shutdown) ─────────────────
+
+    async fn finish(&mut self, reason: EndReason) {
+        if self.streaming {
+            self.cancel_turn().await;
+        }
+        // Outstanding prompts are cancelled (tool sees `None`).
+        while let Some((pr, tx)) = self.pending_prompts.pop_front() {
+            let _ = tx.send(None);
+            self.emit(SessionEventWire::PromptResolved { prompt_id: pr.id });
+        }
+
+        let session_id = self.conv.session.id.clone();
+        let api_messages = self.conv.api_messages.clone();
+
+        // STEP 1: save — own bounded budget, highest priority.
+        let persist = self.config.persist;
+        let save_fut = async {
+            if persist {
+                self.conv.save().await;
+                let mut index_record =
+                    crate::core::session_index::SessionIndexRecord::end(&session_id);
+                index_record.turns = Some(api_messages.len());
+                if let Err(err) = crate::core::session_index::append_record(&index_record) {
+                    tracing::warn!("failed to append session end index record: {}", err);
+                }
+            }
+        };
+        if tokio::time::timeout(budgets::SAVE_TIMEOUT, save_fut)
+            .await
+            .is_err()
+        {
+            tracing::warn!(
+                budget_secs = budgets::SAVE_TIMEOUT_SECS,
+                "session save timed out — data may be incomplete"
+            );
+        }
+
+        // STEP 2: on_session_end — concurrent, fail-open, own budget.
+        let hook_event = HookEvent::on_session_end(&session_id, Some(api_messages));
+        if tokio::time::timeout(
+            budgets::HOOKS_TIMEOUT,
+            self.runtime.hook_bus().emit_concurrent(&hook_event),
+        )
+        .await
+        .is_err()
+        {
+            tracing::warn!(
+                budget_secs = budgets::HOOKS_TIMEOUT_SECS,
+                "on_session_end hooks timed out — extensions may not have flushed"
+            );
+        }
+
+        // STEP 3: bounded observability flush.
+        if let Some(outcome) = self
+            .runtime
+            .shutdown_observability_async(crate::runtime::telemetry::DEFAULT_SHUTDOWN_FLUSH_TIMEOUT)
+            .await
+        {
+            if !outcome.is_flushed() {
+                tracing::warn!(
+                    stats = ?outcome.stats(),
+                    "observability flush timed out — detached worker keeps draining"
+                );
+            }
+        }
+
+        // Inbox watcher, per-session UDS, registry entry, keyed injection.
+        self.background.shutdown();
+        self.emit(SessionEventWire::Ended { reason });
+    }
+
+    pub fn id(&self) -> &SessionId {
+        &self.id
+    }
+}
+
+/// The tokio task. `SessionTask::run` is the reactor loop.
+pub struct SessionTask(SessionActor);
+
+async fn next_stream_event(stream: &mut Option<ActiveStream>) -> Option<StreamEvent> {
+    match stream {
+        Some(s) => s.next().await,
+        None => std::future::pending().await,
+    }
+}
+
+impl SessionTask {
+    pub fn id(&self) -> &SessionId {
+        self.0.id()
+    }
+
+    /// Unbiased select (the TUI loop is unbiased too).
+    pub async fn run(mut self) {
+        let queue = Arc::clone(self.0.runtime.event_queue());
+        let reason = loop {
+            let actor = &mut self.0;
+            tokio::select! {
+                cmd = actor.cmd_rx.recv() => match cmd {
+                    Some(cmd) => {
+                        if let std::ops::ControlFlow::Break(reason) = actor.handle(cmd).await {
+                            break reason;
+                        }
+                    }
+                    // Every handle dropped: nobody can ever reach us again.
+                    None => break EndReason::HostShutdown,
+                },
+                Some(req) = actor.secret_prompt_rx.recv() => actor.on_prompt_request(req),
+                _ = queue.notified() => actor.on_queue_wake().await,
+                ev = next_stream_event(&mut actor.stream) => match ev {
+                    Some(ev) => actor.on_stream_event(ev).await,
+                    None => {
+                        // Stream ended without a terminal event: defensive reset.
+                        actor.clear_stream();
+                        actor.emit_conversation();
+                        actor.emit(SessionEventWire::Idle);
+                    }
+                },
+            }
+        };
+        self.0.finish(reason).await;
+    }
+}

--- a/crates/agent-engine/src/session/budgets.rs
+++ b/crates/agent-engine/src/session/budgets.rs
@@ -11,3 +11,10 @@ pub const TEARDOWN_TIMEOUT_SECS: u64 = SAVE_TIMEOUT_SECS + HOOKS_TIMEOUT_SECS;
 
 pub const SAVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(SAVE_TIMEOUT_SECS);
 pub const HOOKS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(HOOKS_TIMEOUT_SECS);
+
+/// `SessionActor::create` bound on `EngineHost::extensions_ready()`: the
+/// loader guard should make this unreachable; it exists so a session can
+/// never hang on a loader that never reports (warns, then proceeds).
+pub const EXTENSIONS_READY_TIMEOUT_SECS: u64 = 30;
+pub const EXTENSIONS_READY_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(EXTENSIONS_READY_TIMEOUT_SECS);

--- a/crates/agent-engine/src/session/budgets.rs
+++ b/crates/agent-engine/src/session/budgets.rs
@@ -1,0 +1,13 @@
+//! Teardown budgets shared by every session host (values copied from
+//! `agent-tui/src/tui/signals.rs`; `signals.rs` re-exports these on day 2).
+//!
+//! - `SAVE_TIMEOUT_SECS`  — session save + index end record (data safety first)
+//! - `HOOKS_TIMEOUT_SECS` — `on_session_end` hook emit (concurrent, fail-open)
+//! - `TEARDOWN_TIMEOUT_SECS` = their sum.
+
+pub const SAVE_TIMEOUT_SECS: u64 = 2;
+pub const HOOKS_TIMEOUT_SECS: u64 = 5;
+pub const TEARDOWN_TIMEOUT_SECS: u64 = SAVE_TIMEOUT_SECS + HOOKS_TIMEOUT_SECS;
+
+pub const SAVE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(SAVE_TIMEOUT_SECS);
+pub const HOOKS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(HOOKS_TIMEOUT_SECS);

--- a/crates/agent-engine/src/session/handle.rs
+++ b/crates/agent-engine/src/session/handle.rs
@@ -103,6 +103,11 @@ impl SessionHandle {
         !self.cmd_tx.is_closed()
     }
 
+    /// Resolves once the actor is gone (command receiver dropped).
+    pub async fn closed(&self) {
+        self.cmd_tx.closed().await
+    }
+
     /// EchoActor: `Submit{text}` → `TurnStarted`, `Stream(Text(text))`,
     /// `Stream(Done)`, `Conversation` — for B's socket tests before A1 lands.
     #[cfg(any(test, feature = "testing"))]

--- a/crates/agent-engine/src/session/handle.rs
+++ b/crates/agent-engine/src/session/handle.rs
@@ -1,0 +1,415 @@
+//! `SessionHandle` — the in-process address of a session (PLAN-phase2 §2.6).
+//!
+//! `EngineHost::create_session` (A1) hands one out per session; every
+//! `ClientTransport` is built on it. `echo_for_test` ships a stand-in actor
+//! so package B can build the wire before the real `SessionActor` exists.
+
+use std::sync::Arc;
+
+use tokio::sync::{broadcast, mpsc};
+
+use super::transport::TransportError;
+use super::types::{Envelope, SessionCommand, SessionId, SessionMeta};
+use super::view::RuntimeView;
+
+/// Bounded command queue depth (rpc `WRITER_CHAN_CAP` precedent).
+pub const CMD_CHAN_CAP: usize = 256;
+/// Default broadcast capacity; `SYNAPS_SESSION_EVENTS_CAP` overrides.
+pub const DEFAULT_EVENTS_CAP: usize = 1024;
+
+/// Broadcast capacity from `SYNAPS_SESSION_EVENTS_CAP` (min 16) or the default.
+pub fn events_cap() -> usize {
+    std::env::var("SYNAPS_SESSION_EVENTS_CAP")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .map(|n| n.max(16))
+        .unwrap_or(DEFAULT_EVENTS_CAP)
+}
+
+#[derive(Clone)]
+pub struct SessionHandle {
+    pub id: SessionId,
+    cmd_tx: mpsc::Sender<SessionCommand>,
+    events: broadcast::Sender<Envelope>,
+    meta: Arc<SessionMeta>,
+    /// Sync, lock-free read of the last published RuntimeView (§2.7).
+    view: Arc<arc_swap::ArcSwap<RuntimeView>>,
+}
+
+impl std::fmt::Debug for SessionHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionHandle")
+            .field("id", &self.id)
+            .field("model", &self.meta.model)
+            .finish()
+    }
+}
+
+/// Actor-side ends of a session's channels, minted with the handle.
+pub struct SessionEndpoints {
+    pub cmd_rx: mpsc::Receiver<SessionCommand>,
+    pub events: broadcast::Sender<Envelope>,
+    pub view: Arc<arc_swap::ArcSwap<RuntimeView>>,
+}
+
+impl SessionHandle {
+    /// Mint a handle + the actor's ends. Used by `SessionActor` (A1) and the
+    /// test `EchoActor`.
+    pub fn new(meta: SessionMeta, view: RuntimeView) -> (Self, SessionEndpoints) {
+        let (cmd_tx, cmd_rx) = mpsc::channel(CMD_CHAN_CAP);
+        let (events, _) = broadcast::channel(events_cap());
+        let view = Arc::new(arc_swap::ArcSwap::from_pointee(view));
+        let handle = Self {
+            id: meta.id.clone(),
+            cmd_tx,
+            events: events.clone(),
+            meta: Arc::new(meta),
+            view: Arc::clone(&view),
+        };
+        (
+            handle,
+            SessionEndpoints {
+                cmd_rx,
+                events,
+                view,
+            },
+        )
+    }
+
+    /// Send a command. `Backpressure` when the queue is full (never drop
+    /// silently); `Closed` once the actor is gone.
+    pub async fn send(&self, cmd: SessionCommand) -> Result<(), TransportError> {
+        match self.cmd_tx.try_send(cmd) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(TransportError::Backpressure),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(TransportError::Closed),
+        }
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<Envelope> {
+        self.events.subscribe()
+    }
+
+    pub fn meta(&self) -> &SessionMeta {
+        &self.meta
+    }
+
+    pub fn view(&self) -> arc_swap::Guard<Arc<RuntimeView>> {
+        self.view.load()
+    }
+
+    /// Whether the actor is still alive (its command receiver exists).
+    pub fn is_alive(&self) -> bool {
+        !self.cmd_tx.is_closed()
+    }
+
+    /// EchoActor: `Submit{text}` → `TurnStarted`, `Stream(Text(text))`,
+    /// `Stream(Done)`, `Conversation` — for B's socket tests before A1 lands.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn echo_for_test(id: SessionId) -> (Self, tokio::task::JoinHandle<()>) {
+        echo::spawn(id)
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+pub mod echo {
+    //! Minimal stand-in actor. Honours the envelope/seq contract, `Attach`,
+    //! `Detach`, `Submit`, `Steer`, `Cancel`, `Query{View}`, `End`;
+    //! everything else is acknowledged with a `SystemNotice`.
+
+    use std::collections::HashMap;
+
+    use agent_core::reasoning::ReasoningLevel;
+
+    use super::*;
+    use crate::session::types::*;
+    use crate::{LlmEvent, SessionEvent, StreamEvent};
+
+    pub fn meta_for(id: &SessionId) -> SessionMeta {
+        SessionMeta {
+            id: id.clone(),
+            name: None,
+            model: "echo".into(),
+            cwd: None,
+            created_at: chrono::Utc::now(),
+            continued: false,
+            continue_info: None,
+            host_pid: std::process::id(),
+        }
+    }
+
+    pub fn view_for() -> RuntimeView {
+        RuntimeView {
+            model: "echo".into(),
+            thinking_level: "off".into(),
+            reasoning_level: ReasoningLevel::Off,
+            is_reasoning_explicit: false,
+            thinking_budget: 0,
+            context_window: 200_000,
+            system_prompt: None,
+            compaction_model: "echo".into(),
+            api_retries: 0,
+            subagent_timeout: 0,
+            max_tool_output: 4096,
+            bash_timeout: 30,
+            bash_max_timeout: 300,
+            prompt_generation: 0,
+            hook_handler_count: 0,
+            prompt_inspection: None,
+        }
+    }
+
+    pub fn spawn(id: SessionId) -> (SessionHandle, tokio::task::JoinHandle<()>) {
+        let (handle, ep) = SessionHandle::new(meta_for(&id), view_for());
+        let task = tokio::spawn(run(id, ep));
+        (handle, task)
+    }
+
+    struct Echo {
+        id: SessionId,
+        events: broadcast::Sender<Envelope>,
+        view: Arc<arc_swap::ArcSwap<RuntimeView>>,
+        seq: u64,
+        next_client: u64,
+        clients: HashMap<ClientId, ClientMeta>,
+        conv: ConversationSnapshot,
+    }
+
+    impl Echo {
+        fn emit(&mut self, event: SessionEventWire) {
+            let env = Envelope {
+                session_id: self.id.clone(),
+                seq: self.seq,
+                ts: chrono::Utc::now(),
+                event,
+            };
+            self.seq += 1;
+            // No receivers is not an error: streams are not tied to clients.
+            let _ = self.events.send(env);
+        }
+
+        fn snapshot(&self) -> AttachSnapshot {
+            AttachSnapshot {
+                meta: meta_for(&self.id),
+                view: (**self.view.load()).clone(),
+                conversation: self.conv.clone(),
+                streaming: false,
+                replay: Vec::new(),
+                pending_prompts: Vec::new(),
+                clients: self.clients.iter().map(|(c, m)| (*c, m.kind)).collect(),
+            }
+        }
+
+        fn handle(&mut self, cmd: SessionCommand) -> bool {
+            match cmd {
+                SessionCommand::Attach { client, mode } => {
+                    let cid = ClientId(self.next_client);
+                    self.next_client += 1;
+                    let kind = client.kind;
+                    self.clients.insert(cid, client);
+                    if mode != AttachMode::Mirror {
+                        self.emit(SessionEventWire::SystemNotice(format!(
+                            "attach mode {mode:?} not supported yet; using mirror"
+                        )));
+                    }
+                    let snapshot = self.snapshot();
+                    self.emit(SessionEventWire::Attached {
+                        client: cid,
+                        snapshot,
+                    });
+                    self.emit(SessionEventWire::ClientJoined { client: cid, kind });
+                }
+                SessionCommand::Detach { client } => {
+                    if self.clients.remove(&client).is_some() {
+                        self.emit(SessionEventWire::ClientLeft { client });
+                    }
+                }
+                SessionCommand::Submit { text, .. } => {
+                    let baseline = self.conv.api_messages.len();
+                    self.conv.api_messages.push(Arc::new(serde_json::json!({
+                        "role": "user", "content": text
+                    })));
+                    self.emit(SessionEventWire::TurnStarted {
+                        turn_baseline: baseline,
+                        trigger: TurnTrigger::User,
+                    });
+                    self.emit(SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(
+                        text.clone(),
+                    ))));
+                    self.conv.api_messages.push(Arc::new(serde_json::json!({
+                        "role": "assistant", "content": text
+                    })));
+                    self.emit(SessionEventWire::Stream(StreamEvent::Session(
+                        SessionEvent::MessageHistory(self.conv.api_messages.clone()),
+                    )));
+                    self.emit(SessionEventWire::Stream(StreamEvent::Session(
+                        SessionEvent::Done,
+                    )));
+                    let snap = self.conv.clone();
+                    self.emit(SessionEventWire::Conversation(snap));
+                }
+                SessionCommand::Steer { text } => {
+                    self.conv.queued_message = Some(text.clone());
+                    self.emit(SessionEventWire::Steered {
+                        text,
+                        delivered: false,
+                    });
+                }
+                SessionCommand::Cancel => {
+                    let snap = self.conv.clone();
+                    self.emit(SessionEventWire::Conversation(snap));
+                }
+                SessionCommand::Query { id, query } => {
+                    let value = match query {
+                        SessionQuery::View => {
+                            serde_json::to_value(&**self.view.load()).unwrap_or_default()
+                        }
+                        SessionQuery::Messages => {
+                            serde_json::to_value(&self.conv.api_messages).unwrap_or_default()
+                        }
+                        other => serde_json::json!({ "unsupported": format!("{other:?}") }),
+                    };
+                    self.emit(SessionEventWire::QueryResult { id, value });
+                }
+                SessionCommand::Set(setting) => {
+                    let mut view = (**self.view.load()).clone();
+                    if let SessionSetting::Model { model } = &setting {
+                        view.model = model.clone();
+                    }
+                    self.view.store(Arc::new(view.clone()));
+                    self.emit(SessionEventWire::SettingChanged(SettingApplied {
+                        setting: "echo".into(),
+                        ok: true,
+                        message: None,
+                        view,
+                    }));
+                }
+                SessionCommand::End { reason } => {
+                    self.emit(SessionEventWire::Ended { reason });
+                    return false;
+                }
+                other => {
+                    self.emit(SessionEventWire::SystemNotice(format!("echo: {other:?}")));
+                }
+            }
+            true
+        }
+    }
+
+    async fn run(id: SessionId, mut ep: SessionEndpoints) {
+        let mut echo = Echo {
+            id,
+            events: ep.events,
+            view: ep.view,
+            seq: 0,
+            next_client: 1,
+            clients: HashMap::new(),
+            conv: ConversationSnapshot::default(),
+        };
+        while let Some(cmd) = ep.cmd_rx.recv().await {
+            if !echo.handle(cmd) {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::types::*;
+    use crate::{LlmEvent, SessionEvent, StreamEvent};
+
+    async fn next(rx: &mut broadcast::Receiver<Envelope>) -> Envelope {
+        tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+            .await
+            .expect("timely")
+            .expect("open")
+    }
+
+    #[tokio::test]
+    async fn echo_actor_submit_emits_turn_in_order() {
+        let (handle, task) = SessionHandle::echo_for_test(SessionId::from("echo-1"));
+        let mut rx = handle.subscribe();
+        handle
+            .send(SessionCommand::Submit {
+                text: "hello".into(),
+                attachments: vec![],
+            })
+            .await
+            .unwrap();
+
+        let e0 = next(&mut rx).await;
+        assert!(matches!(
+            e0.event,
+            SessionEventWire::TurnStarted {
+                turn_baseline: 0,
+                trigger: TurnTrigger::User
+            }
+        ));
+        let e1 = next(&mut rx).await;
+        match e1.event {
+            SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(t))) => assert_eq!(t, "hello"),
+            other => panic!("unexpected {other:?}"),
+        }
+        let e2 = next(&mut rx).await;
+        assert!(matches!(
+            e2.event,
+            SessionEventWire::Stream(StreamEvent::Session(SessionEvent::MessageHistory(_)))
+        ));
+        let e3 = next(&mut rx).await;
+        assert!(matches!(
+            e3.event,
+            SessionEventWire::Stream(StreamEvent::Session(SessionEvent::Done))
+        ));
+        let e4 = next(&mut rx).await;
+        match e4.event {
+            SessionEventWire::Conversation(c) => assert_eq!(c.api_messages.len(), 2),
+            other => panic!("unexpected {other:?}"),
+        }
+        // gapless seq, same session id on every envelope
+        assert_eq!(
+            [e0.seq, e1.seq, e2.seq, e3.seq, e4.seq],
+            [0, 1, 2, 3, 4]
+        );
+        assert!(e4.session_id == SessionId::from("echo-1"));
+
+        handle
+            .send(SessionCommand::End {
+                reason: EndReason::ClientQuit,
+            })
+            .await
+            .unwrap();
+        let e5 = next(&mut rx).await;
+        assert!(matches!(
+            e5.event,
+            SessionEventWire::Ended {
+                reason: EndReason::ClientQuit
+            }
+        ));
+        task.await.unwrap();
+        assert!(!handle.is_alive());
+        assert!(matches!(
+            handle.send(SessionCommand::Save).await,
+            Err(TransportError::Closed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_view_swaps_on_set() {
+        let (handle, task) = SessionHandle::echo_for_test(SessionId::from("echo-2"));
+        let mut rx = handle.subscribe();
+        assert_eq!(handle.view().model, "echo");
+        handle
+            .send(SessionCommand::Set(SessionSetting::Model {
+                model: "other".into(),
+            }))
+            .await
+            .unwrap();
+        let e = next(&mut rx).await;
+        assert!(matches!(e.event, SessionEventWire::SettingChanged(_)));
+        assert_eq!(handle.view().model, "other");
+        drop(handle);
+        task.await.unwrap();
+    }
+}

--- a/crates/agent-engine/src/session/mod.rs
+++ b/crates/agent-engine/src/session/mod.rs
@@ -7,12 +7,14 @@
 //! the daemon UDS. `agent-tui` must never be a dependency of anything here.
 
 pub mod handle;
+pub mod socket_transport;
 pub mod transport;
 pub mod types;
 pub mod view;
 pub mod wire;
 
 pub use handle::SessionHandle;
+pub use socket_transport::SocketTransport;
 pub use transport::{ClientTransport, LocalTransport, TransportError};
 pub use types::*;
 pub use view::{RuntimeRead, RuntimeView};

--- a/crates/agent-engine/src/session/mod.rs
+++ b/crates/agent-engine/src/session/mod.rs
@@ -1,0 +1,17 @@
+//! Session actor surface (Phase 2 daemon mode).
+//!
+//! One `SessionActor` (A1) owns THE `Runtime` + `ConversationState` for a
+//! conversation and runs its turn machine; clients talk to it through a
+//! `ClientTransport` — `LocalTransport` in-process (same `StreamEvent`
+//! values, never serialised = byte-identical), `SocketTransport` (B2) over
+//! the daemon UDS. `agent-tui` must never be a dependency of anything here.
+
+pub mod handle;
+pub mod transport;
+pub mod types;
+pub mod view;
+
+pub use handle::SessionHandle;
+pub use transport::{ClientTransport, LocalTransport, TransportError};
+pub use types::*;
+pub use view::{RuntimeRead, RuntimeView};

--- a/crates/agent-engine/src/session/mod.rs
+++ b/crates/agent-engine/src/session/mod.rs
@@ -10,6 +10,7 @@ pub mod handle;
 pub mod transport;
 pub mod types;
 pub mod view;
+pub mod wire;
 
 pub use handle::SessionHandle;
 pub use transport::{ClientTransport, LocalTransport, TransportError};

--- a/crates/agent-engine/src/session/mod.rs
+++ b/crates/agent-engine/src/session/mod.rs
@@ -6,11 +6,14 @@
 //! values, never serialised = byte-identical), `SocketTransport` (B2) over
 //! the daemon UDS. `agent-tui` must never be a dependency of anything here.
 
+pub mod actor;
+pub mod budgets;
 pub mod handle;
 pub mod transport;
 pub mod types;
 pub mod view;
 
+pub use actor::{SessionActor, SessionTask};
 pub use handle::SessionHandle;
 pub use transport::{ClientTransport, LocalTransport, TransportError};
 pub use types::*;

--- a/crates/agent-engine/src/session/socket_transport.rs
+++ b/crates/agent-engine/src/session/socket_transport.rs
@@ -1,0 +1,455 @@
+//! `SocketTransport` — the client side of the daemon UDS (PLAN-phase2 §2.10).
+//!
+//! Line-JSON frames (`wire.rs`). A writer task owns the write half; the
+//! reader lives on the transport. Backpressure mirrors `LocalTransport`:
+//! `send` fails with `Backpressure` when the bounded writer queue is full and
+//! `Closed` once the socket is gone — never a silent drop.
+//!
+//! Tracing here logs frame *types* only (`ClientFrame`'s redacting `Debug`).
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::UnixStream;
+use tokio::sync::mpsc;
+
+use super::handle::CMD_CHAN_CAP;
+use super::transport::{ClientTransport, TransportError, ATTACH_TIMEOUT};
+use super::types::*;
+use super::view::RuntimeView;
+use super::wire::*;
+
+pub const CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// A connection past `Hello`/`Welcome`, before `Attach`.
+pub struct Connected {
+    reader: BufReader<OwnedReadHalf>,
+    writer: mpsc::Sender<ClientFrame>,
+    writer_task: tokio::task::JoinHandle<()>,
+    pub welcome: Welcome,
+}
+
+pub struct Pong {
+    pub pid: u32,
+    pub uptime_s: u64,
+    pub sessions: usize,
+}
+
+async fn read_frame(reader: &mut BufReader<OwnedReadHalf>) -> Result<Option<DaemonFrame>, TransportError> {
+    let mut line = String::new();
+    loop {
+        line.clear();
+        // `take` bounds the read so an oversize frame cannot grow memory.
+        let n = (&mut *reader)
+            .take(MAX_FRAME_BYTES as u64 + 1)
+            .read_line(&mut line)
+            .await?;
+        if n == 0 {
+            return Ok(None);
+        }
+        if n > MAX_FRAME_BYTES {
+            return Err(TransportError::Protocol("frame exceeds 1 MiB limit".into()));
+        }
+        let t = line.trim_end();
+        if t.is_empty() {
+            continue;
+        }
+        return decode_line::<DaemonFrame>(t)
+            .map(Some)
+            .map_err(TransportError::Protocol);
+    }
+}
+
+fn spawn_writer(mut w: OwnedWriteHalf) -> (mpsc::Sender<ClientFrame>, tokio::task::JoinHandle<()>) {
+    let (tx, mut rx) = mpsc::channel::<ClientFrame>(CMD_CHAN_CAP);
+    let task = tokio::spawn(async move {
+        while let Some(frame) = rx.recv().await {
+            let line = match encode_line(&frame) {
+                Ok(l) => l,
+                Err(e) => {
+                    tracing::warn!(frame = ?frame, "socket_transport: encode failed: {e}");
+                    continue;
+                }
+            };
+            if let Err(e) = w.write_all(line.as_bytes()).await {
+                tracing::debug!("socket_transport: write failed: {e}");
+                break;
+            }
+            if matches!(frame, ClientFrame::Bye) {
+                let _ = w.shutdown().await;
+                break;
+            }
+        }
+    });
+    (tx, task)
+}
+
+impl Connected {
+    /// Hello/Welcome only. `Refused{Version}` → `TransportError::Version`;
+    /// any other refusal → `Protocol`.
+    pub async fn connect(path: &Path, hello: Hello) -> Result<Self, TransportError> {
+        let stream = tokio::time::timeout(CONNECT_TIMEOUT, UnixStream::connect(path))
+            .await
+            .map_err(|_| TransportError::Protocol("connect timed out".into()))??;
+        let (r, w) = stream.into_split();
+        let mut reader = BufReader::new(r);
+        let (writer, writer_task) = spawn_writer(w);
+        let client_version = hello.protocol_version;
+        writer
+            .send(ClientFrame::Hello(hello))
+            .await
+            .map_err(|_| TransportError::Closed)?;
+        let frame = tokio::time::timeout(HANDSHAKE_TIMEOUT, read_frame(&mut reader))
+            .await
+            .map_err(|_| TransportError::Protocol("handshake timed out".into()))??;
+        match frame {
+            Some(DaemonFrame::Welcome(welcome)) => {
+                if welcome.protocol_version != client_version {
+                    return Err(TransportError::Version { client: client_version, daemon: welcome.protocol_version });
+                }
+                Ok(Self { reader, writer, writer_task, welcome })
+            }
+            Some(DaemonFrame::Refused { reason: RefuseReason::Version { daemon_version, .. }, .. }) => {
+                Err(TransportError::Version { client: client_version, daemon: daemon_version })
+            }
+            Some(DaemonFrame::Refused { reason, message }) => {
+                Err(TransportError::Protocol(format!("refused ({reason:?}): {message}")))
+            }
+            Some(other) => Err(TransportError::Protocol(format!("expected welcome, got {other:?}"))),
+            None => Err(TransportError::Closed),
+        }
+    }
+
+    async fn request(&mut self, frame: ClientFrame) -> Result<DaemonFrame, TransportError> {
+        self.writer.send(frame).await.map_err(|_| TransportError::Closed)?;
+        tokio::time::timeout(HANDSHAKE_TIMEOUT, read_frame(&mut self.reader))
+            .await
+            .map_err(|_| TransportError::Protocol("reply timed out".into()))??
+            .ok_or(TransportError::Closed)
+    }
+
+    pub async fn ping(&mut self) -> Result<Pong, TransportError> {
+        match self.request(ClientFrame::Ping).await? {
+            DaemonFrame::Pong { pid, uptime_s, sessions } => Ok(Pong { pid, uptime_s, sessions }),
+            other => Err(TransportError::Protocol(format!("expected pong, got {other:?}"))),
+        }
+    }
+
+    pub async fn sessions(&mut self) -> Result<Vec<SessionMeta>, TransportError> {
+        match self.request(ClientFrame::Sessions).await? {
+            DaemonFrame::SessionList { sessions } => Ok(sessions),
+            other => Err(TransportError::Protocol(format!("expected session list, got {other:?}"))),
+        }
+    }
+
+    pub async fn shutdown(&mut self, force: bool) -> Result<(), TransportError> {
+        match self.request(ClientFrame::Shutdown { force }).await? {
+            DaemonFrame::Bye => Ok(()),
+            DaemonFrame::Error { message, .. } => Err(TransportError::Protocol(message)),
+            other => Err(TransportError::Protocol(format!("expected bye, got {other:?}"))),
+        }
+    }
+
+    /// Say goodbye and drop the connection.
+    pub async fn bye(self) {
+        let _ = self.writer.send(ClientFrame::Bye).await;
+        let _ = tokio::time::timeout(Duration::from_millis(200), self.writer_task).await;
+    }
+}
+
+pub struct SocketTransport {
+    reader: BufReader<OwnedReadHalf>,
+    writer: mpsc::Sender<ClientFrame>,
+    _writer_task: tokio::task::JoinHandle<()>,
+    session: SessionId,
+    meta: SessionMeta,
+    client: ClientId,
+    view: Arc<arc_swap::ArcSwap<RuntimeView>>,
+    pub welcome: Welcome,
+    ended: bool,
+}
+
+impl SocketTransport {
+    /// Hello/Welcome only (50 ms connect + 2 s handshake budgets).
+    pub async fn connect(path: &Path, hello: Hello) -> Result<Connected, TransportError> {
+        Connected::connect(path, hello).await
+    }
+
+    /// Attach (existing or create) on a handshaken connection.
+    pub async fn attach(mut conn: Connected, attach: Attach) -> Result<(Self, AttachSnapshot), TransportError> {
+        conn.writer
+            .send(ClientFrame::Attach(attach))
+            .await
+            .map_err(|_| TransportError::Closed)?;
+        let frame = tokio::time::timeout(ATTACH_TIMEOUT, read_frame(&mut conn.reader))
+            .await
+            .map_err(|_| TransportError::Protocol("attach timed out".into()))??;
+        let attached = match frame {
+            Some(DaemonFrame::Attached(a)) => a,
+            Some(DaemonFrame::Error { message, .. }) => return Err(TransportError::Protocol(message)),
+            Some(other) => return Err(TransportError::Protocol(format!("expected attached, got {other:?}"))),
+            None => return Err(TransportError::Closed),
+        };
+        let (client, snapshot) = attached.into_snapshot();
+        let meta = snapshot.meta.clone();
+        let view = Arc::new(arc_swap::ArcSwap::from_pointee(snapshot.view.clone()));
+        Ok((
+            Self {
+                reader: conn.reader,
+                writer: conn.writer,
+                _writer_task: conn.writer_task,
+                session: meta.id.clone(),
+                meta,
+                client,
+                view,
+                welcome: conn.welcome,
+                ended: false,
+            },
+            snapshot,
+        ))
+    }
+
+    // ── control fast path helpers (fresh connection each) ──
+
+    pub async fn ping(path: &Path) -> Result<Pong, TransportError> {
+        let mut c = Connected::connect(path, Hello::new(ClientKind::Attach)).await?;
+        let p = c.ping().await;
+        c.bye().await;
+        p
+    }
+
+    pub async fn sessions(path: &Path) -> Result<Vec<SessionMeta>, TransportError> {
+        let mut c = Connected::connect(path, Hello::new(ClientKind::Attach)).await?;
+        let s = c.sessions().await;
+        c.bye().await;
+        s
+    }
+
+    pub async fn shutdown(path: &Path, force: bool) -> Result<(), TransportError> {
+        let mut c = Connected::connect(path, Hello::new(ClientKind::Attach)).await?;
+        c.shutdown(force).await
+    }
+
+    /// Detach cleanly: `Detach` + `Bye`. The turn keeps running in the daemon.
+    pub async fn detach(&self) {
+        let _ = self
+            .writer
+            .send(ClientFrame::Cmd { session_id: self.session.clone(), cmd: SessionCommand::Detach { client: self.client } })
+            .await;
+        let _ = self.writer.send(ClientFrame::Bye).await;
+    }
+
+    fn notice(&self, text: String) -> Envelope {
+        Envelope { session_id: self.session.clone(), seq: u64::MAX, ts: chrono::Utc::now(), event: SessionEventWire::SystemNotice(text) }
+    }
+}
+
+#[async_trait::async_trait]
+impl ClientTransport for SocketTransport {
+    fn session_id(&self) -> &SessionId {
+        &self.session
+    }
+
+    fn meta(&self) -> &SessionMeta {
+        &self.meta
+    }
+
+    async fn send(&self, cmd: SessionCommand) -> Result<(), TransportError> {
+        match self.writer.try_send(ClientFrame::Cmd { session_id: self.session.clone(), cmd }) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => Err(TransportError::Backpressure),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(TransportError::Closed),
+        }
+    }
+
+    async fn next_event(&mut self) -> Option<Envelope> {
+        if self.ended {
+            return None;
+        }
+        loop {
+            match read_frame(&mut self.reader).await {
+                Ok(Some(DaemonFrame::Event(w))) => {
+                    let env: Envelope = w.into();
+                    match &env.event {
+                        SessionEventWire::SettingChanged(applied) => {
+                            self.view.store(Arc::new(applied.view.clone()));
+                        }
+                        SessionEventWire::Ended { .. } => self.ended = true,
+                        _ => {}
+                    }
+                    return Some(env);
+                }
+                Ok(Some(DaemonFrame::Error { message, .. })) => return Some(self.notice(message)),
+                Ok(Some(DaemonFrame::Bye)) | Ok(None) => {
+                    self.ended = true;
+                    return None;
+                }
+                Ok(Some(other)) => {
+                    tracing::debug!("socket_transport: unexpected frame after attach: {other:?}");
+                    continue;
+                }
+                Err(e) => {
+                    tracing::debug!("socket_transport: read error: {e}");
+                    self.ended = true;
+                    return None;
+                }
+            }
+        }
+    }
+
+    fn view(&self) -> Arc<RuntimeView> {
+        Arc::clone(&self.view.load())
+    }
+
+    fn client_id(&self) -> ClientId {
+        self.client
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LlmEvent, StreamEvent};
+    use tokio::net::UnixListener;
+
+    /// A hand-rolled daemon: Welcome, answer Ping, Attach → Attached, then
+    /// echo every Cmd::Submit as an Event stream.
+    async fn fake_daemon(listener: UnixListener, protocol_version: u32) {
+        let (stream, _) = listener.accept().await.unwrap();
+        let (r, mut w) = stream.into_split();
+        let mut reader = BufReader::new(r);
+        let mut line = String::new();
+        let mut seq = 0u64;
+        let sid = SessionId::from("fake-1");
+        loop {
+            line.clear();
+            if reader.read_line(&mut line).await.unwrap() == 0 {
+                break;
+            }
+            let frame: ClientFrame = decode_line(line.trim_end()).unwrap();
+            let reply = match frame {
+                ClientFrame::Hello(h) => {
+                    if h.protocol_version != protocol_version {
+                        let f = DaemonFrame::Refused {
+                            reason: RefuseReason::Version { daemon_version: protocol_version, min: protocol_version, max: protocol_version },
+                            message: "version".into(),
+                        };
+                        w.write_all(encode_line(&f).unwrap().as_bytes()).await.unwrap();
+                        break;
+                    }
+                    DaemonFrame::Welcome(Welcome {
+                        protocol_version,
+                        daemon_version: "t".into(),
+                        pid: 1,
+                        profile: None,
+                        sessions: vec![],
+                        progressive_tool_disclosure: true,
+                    })
+                }
+                ClientFrame::Ping => DaemonFrame::Pong { pid: 1, uptime_s: 0, sessions: 0 },
+                ClientFrame::Attach(_) => DaemonFrame::Attached(AttachedWire::new(
+                    ClientId(7),
+                    AttachSnapshot {
+                        meta: crate::session::handle::echo::meta_for(&sid),
+                        view: crate::session::handle::echo::view_for(),
+                        conversation: ConversationSnapshot::default(),
+                        streaming: false,
+                        replay: vec![],
+                        pending_prompts: vec![],
+                        clients: vec![],
+                    },
+                )),
+                ClientFrame::Cmd { cmd: SessionCommand::Submit { text, .. }, .. } => {
+                    seq += 1;
+                    DaemonFrame::Event(WireEnvelope {
+                        session_id: sid.clone(),
+                        seq,
+                        ts: chrono::Utc::now(),
+                        event: SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(text))).into(),
+                    })
+                }
+                ClientFrame::Cmd { cmd: SessionCommand::Set(_), .. } => {
+                    seq += 1;
+                    let mut view = crate::session::handle::echo::view_for();
+                    view.model = "changed".into();
+                    DaemonFrame::Event(WireEnvelope {
+                        session_id: sid.clone(),
+                        seq,
+                        ts: chrono::Utc::now(),
+                        event: SessionEventWire::SettingChanged(SettingApplied { setting: "model".into(), ok: true, message: None, view }).into(),
+                    })
+                }
+                ClientFrame::Bye => {
+                    let _ = w.write_all(encode_line(&DaemonFrame::Bye).unwrap().as_bytes()).await;
+                    break;
+                }
+                _ => DaemonFrame::Error { session_id: None, message: "nope".into() },
+            };
+            w.write_all(encode_line(&reply).unwrap().as_bytes()).await.unwrap();
+        }
+    }
+
+    fn sock() -> (tempfile::TempDir, std::path::PathBuf) {
+        let d = tempfile::tempdir().unwrap();
+        let p = d.path().join("d.sock");
+        (d, p)
+    }
+
+    #[tokio::test]
+    async fn socket_transport_handshake_attach_pump() {
+        let (_d, path) = sock();
+        let l = UnixListener::bind(&path).unwrap();
+        let srv = tokio::spawn(fake_daemon(l, PROTOCOL_VERSION));
+
+        let mut conn = SocketTransport::connect(&path, Hello::new(ClientKind::Test)).await.unwrap();
+        assert_eq!(conn.welcome.protocol_version, PROTOCOL_VERSION);
+        assert_eq!(conn.ping().await.unwrap().pid, 1);
+        let (mut t, snap) = SocketTransport::attach(conn, Attach::Existing { session_id: "fake-1".into(), mode: AttachMode::Mirror })
+            .await
+            .unwrap();
+        assert_eq!(t.client_id(), ClientId(7));
+        assert_eq!(snap.meta.id.as_str(), "fake-1");
+        assert_eq!(t.session_id().as_str(), "fake-1");
+        assert_eq!(t.view().model, "echo");
+
+        t.send(SessionCommand::Submit { text: "hello".into(), attachments: vec![] }).await.unwrap();
+        let e = t.next_event().await.unwrap();
+        match e.event {
+            SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(s))) => assert_eq!(s, "hello"),
+            other => panic!("{other:?}"),
+        }
+        t.send(SessionCommand::Set(SessionSetting::Model { model: "changed".into() })).await.unwrap();
+        let e = t.next_event().await.unwrap();
+        assert!(matches!(e.event, SessionEventWire::SettingChanged(_)));
+        assert_eq!(t.view().model, "changed");
+
+        // Error → SystemNotice; Bye → None.
+        t.send(SessionCommand::Save).await.unwrap();
+        assert!(matches!(t.next_event().await.unwrap().event, SessionEventWire::SystemNotice(_)));
+        t.detach().await;
+        assert!(t.next_event().await.is_none());
+        assert!(t.next_event().await.is_none());
+        srv.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn socket_transport_refuses_version_mismatch() {
+        let (_d, path) = sock();
+        let l = UnixListener::bind(&path).unwrap();
+        let srv = tokio::spawn(fake_daemon(l, 99));
+        let err = SocketTransport::connect(&path, Hello::new(ClientKind::Test)).await.err().unwrap();
+        assert!(matches!(err, TransportError::Version { client: 1, daemon: 99 }), "{err}");
+        srv.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn socket_transport_connect_refused_when_nobody_listens() {
+        let (_d, path) = sock();
+        let err = SocketTransport::connect(&path, Hello::new(ClientKind::Test)).await.err().unwrap();
+        assert!(matches!(err, TransportError::Io(_)));
+    }
+}

--- a/crates/agent-engine/src/session/socket_transport.rs
+++ b/crates/agent-engine/src/session/socket_transport.rs
@@ -51,7 +51,7 @@ async fn read_frame(reader: &mut BufReader<OwnedReadHalf>) -> Result<Option<Daem
             return Ok(None);
         }
         if n > MAX_FRAME_BYTES {
-            return Err(TransportError::Protocol("frame exceeds 1 MiB limit".into()));
+            return Err(TransportError::Protocol(frame_limit_msg()));
         }
         let t = line.trim_end();
         if t.is_empty() {
@@ -170,6 +170,12 @@ pub struct SocketTransport {
     view: Arc<arc_swap::ArcSwap<RuntimeView>>,
     pub welcome: Welcome,
     ended: bool,
+    /// Local `api_messages` mirror: seeded by `Attached`, updated by
+    /// `Stream(MessageHistory)` and `QueryResult{DIGEST_RESYNC_QUERY_ID}`.
+    /// `Conversation` arrives as a digest; the mirror fills it in.
+    messages: Vec<crate::SharedMessage>,
+    /// Digest awaiting a `Messages` re-query (hash miss).
+    pending_digest: Option<ConversationDigest>,
 }
 
 impl SocketTransport {
@@ -207,6 +213,8 @@ impl SocketTransport {
                 view,
                 welcome: conn.welcome,
                 ended: false,
+                messages: snapshot.conversation.api_messages.clone(),
+                pending_digest: None,
             },
             snapshot,
         ))
@@ -245,6 +253,66 @@ impl SocketTransport {
     fn notice(&self, text: String) -> Envelope {
         Envelope { session_id: self.session.clone(), seq: u64::MAX, ts: chrono::Utc::now(), event: SessionEventWire::SystemNotice(text) }
     }
+
+    /// The client's view of `api_messages` (kept current by the digest protocol).
+    pub fn messages(&self) -> &[crate::SharedMessage] {
+        &self.messages
+    }
+
+    /// Turn a wire envelope into the in-process one, keeping the message
+    /// mirror honest. `None` = swallowed (reserved query id, or a digest that
+    /// needs a re-query first — the `Conversation` is re-emitted once the
+    /// `Messages` result lands).
+    fn absorb(&mut self, w: WireEnvelope) -> Option<Envelope> {
+        match w.event {
+            WireSessionEvent::Conversation { digest } => {
+                if digest.matches(&self.messages) {
+                    let event = SessionEventWire::Conversation(digest.into_snapshot(self.messages.clone()));
+                    return Some(Envelope { session_id: w.session_id, seq: w.seq, ts: w.ts, event });
+                }
+                if digest.messages_len == 0 {
+                    self.messages.clear();
+                    let event = SessionEventWire::Conversation(digest.into_snapshot(Vec::new()));
+                    return Some(Envelope { session_id: w.session_id, seq: w.seq, ts: w.ts, event });
+                }
+                // Mirror drifted (compaction, abort repair, flushed events): re-fetch.
+                let first = self.pending_digest.is_none();
+                self.pending_digest = Some(digest);
+                if first {
+                    let _ = self.writer.try_send(ClientFrame::Cmd {
+                        session_id: self.session.clone(),
+                        cmd: SessionCommand::Query { id: DIGEST_RESYNC_QUERY_ID, query: SessionQuery::Messages },
+                    });
+                }
+                None
+            }
+            WireSessionEvent::QueryResult { id, value } if id == DIGEST_RESYNC_QUERY_ID => {
+                if let Ok(msgs) = serde_json::from_value::<Vec<serde_json::Value>>(value) {
+                    self.messages = msgs.into_iter().map(Arc::new).collect();
+                }
+                let digest = self.pending_digest.take()?;
+                if !digest.matches(&self.messages) {
+                    tracing::debug!("socket_transport: messages re-query still disagrees with digest; using fetched history");
+                }
+                let event = SessionEventWire::Conversation(digest.into_snapshot(self.messages.clone()));
+                Some(Envelope { session_id: w.session_id, seq: w.seq, ts: w.ts, event })
+            }
+            WireSessionEvent::QueryResult { id, .. } if id >= RESERVED_QUERY_ID_BASE => None,
+            event => {
+                let env = Envelope { session_id: w.session_id, seq: w.seq, ts: w.ts, event: event.into() };
+                match &env.event {
+                    SessionEventWire::Stream(crate::StreamEvent::Session(crate::SessionEvent::MessageHistory(m))) => {
+                        self.messages = m.clone();
+                    }
+                    SessionEventWire::Attached { snapshot, .. } => {
+                        self.messages = snapshot.conversation.api_messages.clone();
+                    }
+                    _ => {}
+                }
+                Some(env)
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -272,7 +340,7 @@ impl ClientTransport for SocketTransport {
         loop {
             match read_frame(&mut self.reader).await {
                 Ok(Some(DaemonFrame::Event(w))) => {
-                    let env: Envelope = w.into();
+                    let Some(env) = self.absorb(w) else { continue };
                     match &env.event {
                         SessionEventWire::SettingChanged(applied) => {
                             self.view.store(Arc::new(applied.view.clone()));
@@ -382,6 +450,33 @@ mod tests {
                         event: SessionEventWire::SettingChanged(SettingApplied { setting: "model".into(), ok: true, message: None, view }).into(),
                     })
                 }
+                // Steer = "the daemon's history drifted": digest for [user:text] without a MessageHistory.
+                ClientFrame::Cmd { cmd: SessionCommand::Steer { text }, .. } => {
+                    seq += 1;
+                    let snap = ConversationSnapshot {
+                        api_messages: vec![Arc::new(serde_json::json!({"role":"user","content":text}))],
+                        cost: 1.5,
+                        ..Default::default()
+                    };
+                    DaemonFrame::Event(WireEnvelope {
+                        session_id: sid.clone(),
+                        seq,
+                        ts: chrono::Utc::now(),
+                        event: SessionEventWire::Conversation(snap).into(),
+                    })
+                }
+                ClientFrame::Cmd { cmd: SessionCommand::Query { id, query: SessionQuery::Messages }, .. } => {
+                    seq += 1;
+                    DaemonFrame::Event(WireEnvelope {
+                        session_id: sid.clone(),
+                        seq,
+                        ts: chrono::Utc::now(),
+                        event: WireSessionEvent::QueryResult {
+                            id,
+                            value: serde_json::json!([{"role":"user","content":"drifted"}]),
+                        },
+                    })
+                }
                 ClientFrame::Bye => {
                     let _ = w.write_all(encode_line(&DaemonFrame::Bye).unwrap().as_bytes()).await;
                     break;
@@ -432,6 +527,38 @@ mod tests {
         assert!(matches!(t.next_event().await.unwrap().event, SessionEventWire::SystemNotice(_)));
         t.detach().await;
         assert!(t.next_event().await.is_none());
+        assert!(t.next_event().await.is_none());
+        srv.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn conversation_digest_miss_requeries_messages() {
+        let (_d, path) = sock();
+        let l = UnixListener::bind(&path).unwrap();
+        let srv = tokio::spawn(fake_daemon(l, PROTOCOL_VERSION));
+        let conn = SocketTransport::connect(&path, Hello::new(ClientKind::Test)).await.unwrap();
+        let (mut t, _) = SocketTransport::attach(conn, Attach::Existing { session_id: "fake-1".into(), mode: AttachMode::Mirror })
+            .await
+            .unwrap();
+        assert!(t.messages().is_empty());
+        t.send(SessionCommand::Steer { text: "drifted".into() }).await.unwrap();
+        // The digest misses the (empty) mirror → transport re-queries → one
+        // Conversation with the fetched history and the digest's cost.
+        let e = t.next_event().await.unwrap();
+        match e.event {
+            SessionEventWire::Conversation(c) => {
+                assert_eq!(c.api_messages.len(), 1);
+                assert_eq!(c.api_messages[0]["content"], "drifted");
+                assert_eq!(c.cost, 1.5);
+            }
+            other => panic!("{other:?}"),
+        }
+        assert_eq!(t.messages().len(), 1);
+        // Same digest again now matches the mirror: no re-query, served locally.
+        t.send(SessionCommand::Steer { text: "drifted".into() }).await.unwrap();
+        let e = t.next_event().await.unwrap();
+        assert!(matches!(e.event, SessionEventWire::Conversation(ref c) if c.api_messages.len() == 1));
+        t.detach().await;
         assert!(t.next_event().await.is_none());
         srv.await.unwrap();
     }

--- a/crates/agent-engine/src/session/socket_transport.rs
+++ b/crates/agent-engine/src/session/socket_transport.rs
@@ -44,8 +44,7 @@ async fn read_frame(reader: &mut BufReader<OwnedReadHalf>) -> Result<Option<Daem
     loop {
         line.clear();
         // `take` bounds the read so an oversize frame cannot grow memory.
-        let n = (&mut *reader)
-            .take(MAX_FRAME_BYTES as u64 + 1)
+        let n = tokio::io::AsyncReadExt::take(&mut *reader, MAX_FRAME_BYTES as u64 + 1)
             .read_line(&mut line)
             .await?;
         if n == 0 {

--- a/crates/agent-engine/src/session/socket_transport.rs
+++ b/crates/agent-engine/src/session/socket_transport.rs
@@ -386,6 +386,7 @@ mod tests {
                     let _ = w.write_all(encode_line(&DaemonFrame::Bye).unwrap().as_bytes()).await;
                     break;
                 }
+                ClientFrame::Cmd { cmd: SessionCommand::Detach { .. }, .. } => continue,
                 _ => DaemonFrame::Error { session_id: None, message: "nope".into() },
             };
             w.write_all(encode_line(&reply).unwrap().as_bytes()).await.unwrap();

--- a/crates/agent-engine/src/session/transport.rs
+++ b/crates/agent-engine/src/session/transport.rs
@@ -1,0 +1,297 @@
+//! `ClientTransport` + `LocalTransport` (PLAN-phase2 §2.7).
+//!
+//! `LocalTransport` is the in-process client: same `Runtime`, same
+//! `StreamEvent` values moved through a channel, never serialised. The
+//! socket flavour (`SocketTransport`, B2) implements the same trait.
+
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+
+use super::handle::SessionHandle;
+use super::types::{
+    AttachMode, AttachSnapshot, ClientId, ClientMeta, Envelope, SessionCommand, SessionEventWire,
+    SessionId, SessionMeta,
+};
+use super::view::RuntimeView;
+
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    #[error("session closed")]
+    Closed,
+    #[error("backpressure")]
+    Backpressure,
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("protocol: {0}")]
+    Protocol(String),
+    #[error("version: client {client} daemon {daemon}")]
+    Version { client: u32, daemon: u32 },
+}
+
+#[async_trait::async_trait]
+pub trait ClientTransport: Send {
+    fn session_id(&self) -> &SessionId;
+    fn meta(&self) -> &SessionMeta;
+    async fn send(&self, cmd: SessionCommand) -> Result<(), TransportError>;
+    /// Next envelope, or `None` when the session ended / socket closed.
+    async fn next_event(&mut self) -> Option<Envelope>;
+    /// Sync, cheap, never stale by more than one `SettingChanged`: what the
+    /// TUI's getters read on day 2.
+    fn view(&self) -> Arc<RuntimeView>;
+    /// Client id assigned at Attach (needed for Detach/Resync).
+    fn client_id(&self) -> ClientId;
+}
+
+/// Attach handshake budget.
+pub const ATTACH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+pub struct LocalTransport {
+    handle: SessionHandle,
+    rx: broadcast::Receiver<Envelope>,
+    client: ClientId,
+    meta: SessionMeta,
+}
+
+impl LocalTransport {
+    /// Attach in-process: sends Attach, awaits the Attached envelope
+    /// (bounded 5 s), returns the transport + snapshot.
+    pub async fn attach(
+        handle: SessionHandle,
+        meta: ClientMeta,
+    ) -> Result<(Self, AttachSnapshot), TransportError> {
+        // Subscribe BEFORE sending so the Attached reply cannot be missed.
+        // `Attached` is broadcast; with one attach in flight per handle at a
+        // time (every host today) the first one seen is ours.
+        let mut rx = handle.subscribe();
+        handle
+            .send(SessionCommand::Attach {
+                client: meta,
+                mode: AttachMode::Mirror,
+            })
+            .await?;
+
+        let wait = async {
+            loop {
+                match rx.recv().await {
+                    Ok(env) => {
+                        if let SessionEventWire::Attached { client, snapshot } = env.event {
+                            return Ok((client, snapshot));
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => {
+                        return Err(TransportError::Closed)
+                    }
+                }
+            }
+        };
+        let (client, snapshot) = match tokio::time::timeout(ATTACH_TIMEOUT, wait).await {
+            Ok(r) => r?,
+            Err(_) => return Err(TransportError::Protocol("attach timed out".into())),
+        };
+        let meta = snapshot.meta.clone();
+        Ok((
+            Self {
+                handle,
+                rx,
+                client,
+                meta,
+            },
+            snapshot,
+        ))
+    }
+
+    pub fn handle(&self) -> &SessionHandle {
+        &self.handle
+    }
+}
+
+#[async_trait::async_trait]
+impl ClientTransport for LocalTransport {
+    fn session_id(&self) -> &SessionId {
+        &self.handle.id
+    }
+
+    fn meta(&self) -> &SessionMeta {
+        &self.meta
+    }
+
+    async fn send(&self, cmd: SessionCommand) -> Result<(), TransportError> {
+        self.handle.send(cmd).await
+    }
+
+    async fn next_event(&mut self) -> Option<Envelope> {
+        match self.rx.recv().await {
+            Ok(env) => Some(env),
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                // server.rs Lagged pattern: warn, tell the client once, keep going.
+                tracing::warn!(session = %self.handle.id, dropped = n, "session event stream lagged");
+                Some(Envelope {
+                    session_id: self.handle.id.clone(),
+                    seq: u64::MAX,
+                    ts: chrono::Utc::now(),
+                    event: SessionEventWire::SystemNotice(format!(
+                        "event stream lagged; {n} dropped"
+                    )),
+                })
+            }
+            Err(broadcast::error::RecvError::Closed) => None,
+        }
+    }
+
+    fn view(&self) -> Arc<RuntimeView> {
+        Arc::clone(&self.handle.view())
+    }
+
+    fn client_id(&self) -> ClientId {
+        self.client
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::types::*;
+    use crate::{LlmEvent, SessionEvent, StreamEvent};
+
+    async fn next(t: &mut LocalTransport) -> Envelope {
+        tokio::time::timeout(std::time::Duration::from_secs(2), t.next_event())
+            .await
+            .expect("timely")
+            .expect("open")
+    }
+
+    /// Debug strings of every `Stream(_)` up to and including the next `Conversation`.
+    async fn collect(t: &mut LocalTransport) -> Vec<String> {
+        let mut out = Vec::new();
+        loop {
+            let env = next(t).await;
+            let done = matches!(env.event, SessionEventWire::Conversation(_));
+            if matches!(env.event, SessionEventWire::Stream(_)) {
+                out.push(format!("{:?}", env.event));
+            }
+            if done {
+                break;
+            }
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn local_transport_round_trip_over_echo() {
+        let (handle, task) = SessionHandle::echo_for_test(SessionId::from("lt-1"));
+        let (mut t, snap) = LocalTransport::attach(handle, ClientMeta::new(ClientKind::Test))
+            .await
+            .unwrap();
+        assert_eq!(t.session_id().as_str(), "lt-1");
+        assert_eq!(t.client_id(), ClientId(1));
+        assert_eq!(snap.meta.model, "echo");
+        assert_eq!(t.view().model, "echo");
+        assert!(snap.conversation.api_messages.is_empty());
+
+        // ClientJoined follows Attached on the shared channel.
+        let joined = next(&mut t).await;
+        assert!(matches!(
+            joined.event,
+            SessionEventWire::ClientJoined {
+                client: ClientId(1),
+                kind: ClientKind::Test
+            }
+        ));
+
+        t.send(SessionCommand::Submit {
+            text: "ping".into(),
+            attachments: vec![],
+        })
+        .await
+        .unwrap();
+
+        let mut seen = Vec::new();
+        loop {
+            let env = next(&mut t).await;
+            let done = matches!(env.event, SessionEventWire::Conversation(_));
+            seen.push(env);
+            if done {
+                break;
+            }
+        }
+        assert!(matches!(seen[0].event, SessionEventWire::TurnStarted { .. }));
+        match &seen[1].event {
+            SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(t))) => assert_eq!(t, "ping"),
+            other => panic!("unexpected {other:?}"),
+        }
+        assert!(matches!(
+            seen[3].event,
+            SessionEventWire::Stream(StreamEvent::Session(SessionEvent::Done))
+        ));
+        let seqs: Vec<u64> = seen.iter().map(|e| e.seq).collect();
+        assert!(seqs.windows(2).all(|w| w[1] == w[0] + 1), "gapless: {seqs:?}");
+
+        // Query{View} answered with the published view.
+        t.send(SessionCommand::Query {
+            id: 7,
+            query: SessionQuery::View,
+        })
+        .await
+        .unwrap();
+        let q = next(&mut t).await;
+        match q.event {
+            SessionEventWire::QueryResult { id, value } => {
+                assert_eq!(id, 7);
+                assert_eq!(value["model"], "echo");
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+
+        // Detach does not end the session; End does.
+        t.send(SessionCommand::Detach { client: t.client_id() })
+            .await
+            .unwrap();
+        let left = next(&mut t).await;
+        assert!(matches!(left.event, SessionEventWire::ClientLeft { client: ClientId(1) }));
+        assert!(t.handle().is_alive());
+
+        t.send(SessionCommand::End {
+            reason: EndReason::HostShutdown,
+        })
+        .await
+        .unwrap();
+        let ended = next(&mut t).await;
+        assert!(matches!(ended.event, SessionEventWire::Ended { .. }));
+        task.await.unwrap();
+        assert!(t.next_event().await.is_none());
+        assert!(matches!(
+            t.send(SessionCommand::Save).await,
+            Err(TransportError::Closed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn two_local_clients_see_the_same_stream() {
+        let (handle, task) = SessionHandle::echo_for_test(SessionId::from("lt-2"));
+        let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+            .await
+            .unwrap();
+        let (mut b, snap_b) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
+            .await
+            .unwrap();
+        assert_ne!(a.client_id(), b.client_id());
+        assert_eq!(snap_b.clients.len(), 2);
+
+        a.send(SessionCommand::Submit {
+            text: "x".into(),
+            attachments: vec![],
+        })
+        .await
+        .unwrap();
+
+        let sa = collect(&mut a).await;
+        let sb = collect(&mut b).await;
+        assert_eq!(sa, sb);
+        assert_eq!(sa.len(), 3);
+
+        drop((a, b, handle));
+        task.await.unwrap();
+    }
+}

--- a/crates/agent-engine/src/session/transport.rs
+++ b/crates/agent-engine/src/session/transport.rs
@@ -51,6 +51,8 @@ pub struct LocalTransport {
     rx: broadcast::Receiver<Envelope>,
     client: ClientId,
     meta: SessionMeta,
+    /// Set after `Ended` (or actor gone): `next_event` returns `None` from then on.
+    ended: bool,
 }
 
 impl LocalTransport {
@@ -97,6 +99,7 @@ impl LocalTransport {
                 rx,
                 client,
                 meta,
+                ended: false,
             },
             snapshot,
         ))
@@ -122,8 +125,30 @@ impl ClientTransport for LocalTransport {
     }
 
     async fn next_event(&mut self) -> Option<Envelope> {
-        match self.rx.recv().await {
-            Ok(env) => Some(env),
+        if self.ended {
+            return None;
+        }
+        // The handle itself holds a broadcast sender, so `Closed` never
+        // fires on its own: end-of-stream is `Ended` or the actor going away
+        // (drain what it left behind first).
+        let recv = tokio::select! {
+            biased;
+            r = self.rx.recv() => r,
+            _ = self.handle.closed() => match self.rx.try_recv() {
+                Ok(env) => Ok(env),
+                Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                    Err(broadcast::error::RecvError::Lagged(n))
+                }
+                Err(_) => Err(broadcast::error::RecvError::Closed),
+            },
+        };
+        match recv {
+            Ok(env) => {
+                if matches!(env.event, SessionEventWire::Ended { .. }) {
+                    self.ended = true;
+                }
+                Some(env)
+            }
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 // server.rs Lagged pattern: warn, tell the client once, keep going.
                 tracing::warn!(session = %self.handle.id, dropped = n, "session event stream lagged");
@@ -136,7 +161,10 @@ impl ClientTransport for LocalTransport {
                     )),
                 })
             }
-            Err(broadcast::error::RecvError::Closed) => None,
+            Err(broadcast::error::RecvError::Closed) => {
+                self.ended = true;
+                None
+            }
         }
     }
 

--- a/crates/agent-engine/src/session/types.rs
+++ b/crates/agent-engine/src/session/types.rs
@@ -1,0 +1,502 @@
+//! Identity, configuration, commands, events and the envelope — the entire
+//! client↔session contract (PLAN-phase2 §2.1–§2.4). Everything a client can
+//! send is serde-able from day one; `SessionEventWire::Stream` deliberately
+//! is not (it carries the un-serialised `StreamEvent` in-process).
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::view::RuntimeView;
+
+// ── identity + configuration ──────────────────────────────────────────────────
+
+/// Conversation session id — the `Session.id` string (`{name}-{ts}-{pid}`; see
+/// events/registry.rs sanitize rules). NOT the tools::activation::SessionId
+/// (that is the per-runtime gate identity minted at Runtime::from_parts).
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SessionId(pub String);
+
+impl SessionId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for SessionId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for SessionId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for SessionId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Everything `EngineHost::create_session` needs. Serializable: it is the
+/// payload of the wire `Attach::Create`. Mirrors `EngineOpts` minus the
+/// host-level fields (profile, no_extensions), plus the per-session facts a
+/// daemon cannot inherit from its own process (cwd, env overlay).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SessionConfig {
+    /// `EngineOpts.continue_session`.
+    #[serde(default)]
+    pub continue_session: Option<Option<String>>,
+    /// `EngineOpts.system`.
+    #[serde(default)]
+    pub system: Option<String>,
+    /// `EngineOpts.prompt_manifest`.
+    #[serde(default)]
+    pub prompt_manifest: Option<PathBuf>,
+    /// Per-session working directory. `None` = process cwd (in-process hosts
+    /// pass `None` today → byte-identical). The daemon ALWAYS fills it from
+    /// `Hello.cwd`.
+    #[serde(default)]
+    pub cwd: Option<PathBuf>,
+    /// `Confirm` hook results auto-approved (server `--auto-approve-confirms`).
+    /// Interactive hosts: false.
+    #[serde(default)]
+    pub auto_approve_confirms: bool,
+    /// CLI `--model` override applied after session resolution.
+    #[serde(default)]
+    pub model_override: Option<String>,
+    /// Save policy: only "save at all" — the TUI/chat/rpc always save; tests
+    /// may disable. Default `true`.
+    #[serde(default = "default_true")]
+    pub persist: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            continue_session: None,
+            system: None,
+            prompt_manifest: None,
+            cwd: None,
+            auto_approve_confirms: false,
+            model_override: None,
+            persist: true,
+        }
+    }
+}
+
+/// Serializable copy of `engine::setup::ContinueInfo`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContinueInfoWire {
+    pub session_id: String,
+    /// "chain", "name", or None.
+    pub resolved_via: Option<String>,
+    pub query: String,
+}
+
+impl From<&crate::engine::setup::ContinueInfo> for ContinueInfoWire {
+    fn from(c: &crate::engine::setup::ContinueInfo) -> Self {
+        Self {
+            session_id: c.session_id.clone(),
+            resolved_via: c.resolved_via.clone(),
+            query: c.query.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SessionMeta {
+    pub id: SessionId,
+    pub name: Option<String>,
+    pub model: String,
+    pub cwd: Option<PathBuf>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub continued: bool,
+    pub continue_info: Option<ContinueInfoWire>,
+    /// Daemon pid (in-process: this process).
+    pub host_pid: u32,
+}
+
+/// Minted by the actor per Attach.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ClientId(pub u64);
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClientMeta {
+    pub kind: ClientKind,
+    /// `$TERM`, informational.
+    pub terminal: Option<String>,
+    /// Client-generated uuid; reattach dedup (day 3).
+    pub instance: String,
+}
+
+impl ClientMeta {
+    /// Fresh meta with a random instance id and no terminal.
+    pub fn new(kind: ClientKind) -> Self {
+        Self {
+            kind,
+            terminal: None,
+            instance: uuid::Uuid::new_v4().to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientKind {
+    Tui,
+    Chat,
+    Attach,
+    Rpc,
+    Server,
+    Test,
+}
+
+/// Today: Mirror only is honoured; Takeover/Observe parse and map to Mirror
+/// with a Notice.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachMode {
+    Mirror,
+    Takeover,
+    Observe,
+}
+
+/// Actor-side client accounting (§8): `Detached` never cancels a stream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AttachState {
+    Attached(usize),
+    Detached { running: bool },
+}
+
+// ── prompts ───────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptKind {
+    Secret,
+    Confirm,
+}
+
+/// Fixed title `resolve_before_tool_call_result` uses for Confirm prompts
+/// (runtime/mod.rs). Everything else is `Secret`.
+pub const CONFIRM_PROMPT_TITLE: &str = "Confirm tool call";
+
+impl PromptKind {
+    /// Derive the kind from the prompt title (the actor classifies at receipt).
+    pub fn from_title(title: &str) -> Self {
+        if title == CONFIRM_PROMPT_TITLE {
+            Self::Confirm
+        } else {
+            Self::Secret
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PromptRequest {
+    /// Per-session monotonic; actor dedups answers on it.
+    pub id: u64,
+    pub kind: PromptKind,
+    pub title: String,
+    pub prompt: String,
+    pub raised_at: chrono::DateTime<chrono::Utc>,
+}
+
+// ── commands, settings, queries ───────────────────────────────────────────────
+
+/// The entire client→session control surface (SEAMS §5.2/§5.3).
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "cmd", rename_all = "snake_case")]
+pub enum SessionCommand {
+    /// User-authored prompt. Actor: reset auto-turn counter, fold
+    /// abort_context, push user msg, start turn.
+    Submit {
+        text: String,
+        #[serde(default)]
+        attachments: Vec<agent_core::core::rpc_protocol::RpcAttachment>,
+    },
+    /// Text typed while streaming. Actor: steer if a steer_tx is live else
+    /// queue; ALWAYS also sets queued_message.
+    Steer { text: String },
+    /// Esc. Cancel, capture abort context, dequeue, flush pending events,
+    /// cancel subagents, save.
+    Cancel,
+    /// Answer to a PromptRequest. `None` = cancelled.
+    /// NEVER journaled, NEVER replayed, NEVER traced.
+    Answer { prompt_id: u64, value: Option<String> },
+    Set(SessionSetting),
+    Compact { instructions: Option<String> },
+    /// `/new`: ConversationState::clear.
+    NewSession,
+    Save,
+    /// Reply = `SessionEventWire::QueryResult { id, value }`.
+    Query { id: u64, query: SessionQuery },
+    /// Reply = `Attached { client_id, … }` on THIS client's channel only.
+    Attach { client: ClientMeta, mode: AttachMode },
+    Detach { client: ClientId },
+    /// Host shutdown of this session: save → on_session_end → leases → Ended.
+    End { reason: EndReason },
+    /// Resync after Lagged (B, day 3): actor re-sends history + turn_replay.
+    Resync { client: ClientId, since_seq: u64 },
+    /// Host→session (never wire): the actor re-emits as `SessionEventWire`.
+    #[serde(skip)]
+    HostEvent(HostEvent),
+}
+
+/// Host-originated events pushed into a session (C3 router, loader).
+#[derive(Debug, Clone)]
+pub enum HostEvent {
+    ExtensionNotification {
+        extension_id: String,
+        method: String,
+        params: serde_json::Value,
+    },
+    LoaderProgress(crate::extensions::loader::ExtensionLoaderEvent),
+}
+
+/// The `&mut Runtime` setters the TUI/rpc/server call (SEAMS §5.3).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "setting", rename_all = "snake_case")]
+pub enum SessionSetting {
+    /// try_set_model → SettingApplied::Model{applied, thinking_level}
+    Model { model: String },
+    /// set_reasoning_level_checked
+    ReasoningLevel {
+        #[serde(with = "reasoning_level_serde")]
+        level: agent_core::reasoning::ReasoningLevel,
+    },
+    /// set_context_window
+    ContextWindow { tokens: Option<u64> },
+    CompactionModel { model: Option<String> },
+    ApiRetries { n: u32 },
+    SubagentTimeout { secs: u64 },
+    MaxToolOutput { bytes: usize },
+    BashTimeout { secs: u64 },
+    BashMaxTimeout { secs: u64 },
+    /// set_system_prompt
+    SystemPrompt { text: String },
+    /// reload_prompt() → SettingApplied::PromptReloaded{generation, source}
+    ReloadPrompt,
+    /// grant_worker_model
+    GrantWorkerModel { model: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SettingApplied {
+    pub setting: String,
+    pub ok: bool,
+    pub message: Option<String>,
+    pub view: RuntimeView,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "query", rename_all = "snake_case")]
+pub enum SessionQuery {
+    /// {session, model, tokens, cost, streaming, auto_turns, attached, pending_prompts}
+    Status,
+    /// Vec<SharedMessage> (api_messages)
+    Messages,
+    /// Vec<SubagentDisplayRow>
+    SubagentRows,
+    /// runtime.prompt_inspection_json()
+    PromptInspection,
+    /// rpc_dispatch::build_tools_list_body input
+    ToolsSchema,
+    /// RuntimeView (cheap; LocalTransport answers without a hop)
+    View,
+    /// assess_context
+    ContextAssessment,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EndReason {
+    ClientQuit,
+    HostShutdown,
+    Evicted,
+    Error,
+}
+
+// ── events + envelope ─────────────────────────────────────────────────────────
+
+/// What a session tells its clients. `Stream` carries the un-serialised
+/// StreamEvent in-process (LocalTransport) — that IS the byte-identical
+/// contract. The socket boundary converts to `wire::WireSessionEvent`.
+#[derive(Debug, Clone)]
+pub enum SessionEventWire {
+    Stream(crate::StreamEvent),
+    /// Actor bookkeeping the client needs to mirror `App` fields exactly.
+    TurnStarted {
+        turn_baseline: usize,
+        trigger: TurnTrigger,
+    },
+    /// Emitted after every MessageHistory / Done / Error / Cancel / Compact so
+    /// mirrors never diverge: the actor's api_messages IS the truth.
+    Conversation(ConversationSnapshot),
+    Prompt(PromptRequest),
+    /// So mirrors dismiss the modal.
+    PromptResolved { prompt_id: u64 },
+    /// Drained event card — presentation only.
+    External(crate::events::types::Event),
+    AutoTurnCapReached { cap: u32 },
+    /// "→ steering:" vs "queued:".
+    Steered { text: String, delivered: bool },
+    Dequeued { text: String },
+    /// Any ChatMessage::System the actor would have pushed.
+    SystemNotice(String),
+    LoaderProgress(crate::extensions::loader::ExtensionLoaderEvent),
+    ExtensionNotification {
+        extension_id: String,
+        method: String,
+        params: serde_json::Value,
+    },
+    SettingChanged(SettingApplied),
+    QueryResult { id: u64, value: serde_json::Value },
+    /// Only to the attaching client.
+    Attached {
+        client: ClientId,
+        snapshot: AttachSnapshot,
+    },
+    ClientJoined { client: ClientId, kind: ClientKind },
+    ClientLeft { client: ClientId },
+    Ended { reason: EndReason },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnTrigger {
+    User,
+    QueuedAuto,
+    EventAuto,
+    PluginCommand,
+    Compaction,
+}
+
+/// Per-session, gapless `seq` assigned at the single emit site
+/// (`SessionActor::emit`); `ts` from the host clock.
+#[derive(Debug, Clone)]
+pub struct Envelope {
+    pub session_id: SessionId,
+    pub seq: u64,
+    pub ts: chrono::DateTime<chrono::Utc>,
+    pub event: SessionEventWire,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConversationTokens {
+    pub input: u64,
+    pub output: u64,
+    pub cache_read: u64,
+    pub cache_creation: u64,
+}
+
+/// Serializable mirror of `ConversationState` (+ the actor's auto-turn
+/// counter). Clients MUST replace, never merge, on `Conversation(_)`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ConversationSnapshot {
+    pub api_messages: Vec<crate::SharedMessage>,
+    pub tokens: ConversationTokens,
+    pub cost: f64,
+    pub abort_context: Option<String>,
+    pub queued_message: Option<String>,
+    pub pending_events_len: usize,
+    pub consecutive_auto_turns: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct AttachSnapshot {
+    pub meta: SessionMeta,
+    pub view: RuntimeView,
+    pub conversation: ConversationSnapshot,
+    pub streaming: bool,
+    /// Current-turn events since TurnStarted (bounded ring) so a mid-turn
+    /// attach can rebuild partial text/tool cards.
+    pub replay: Vec<Envelope>,
+    pub pending_prompts: Vec<PromptRequest>,
+    pub clients: Vec<(ClientId, ClientKind)>,
+}
+
+/// `ReasoningLevel` has no serde impls in agent-core; go through its
+/// canonical string form.
+pub mod reasoning_level_serde {
+    use agent_core::reasoning::ReasoningLevel;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(level: &ReasoningLevel, s: S) -> Result<S::Ok, S::Error> {
+        level.as_str().serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<ReasoningLevel, D::Error> {
+        let s = String::deserialize(d)?;
+        ReasoningLevel::parse(&s)
+            .ok_or_else(|| serde::de::Error::custom(format!("unknown reasoning level `{s}`")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_kind_from_title() {
+        assert_eq!(PromptKind::from_title("Confirm tool call"), PromptKind::Confirm);
+        assert_eq!(PromptKind::from_title("API key"), PromptKind::Secret);
+    }
+
+    #[test]
+    fn session_config_default_persists() {
+        let cfg: SessionConfig = serde_json::from_str("{}").unwrap();
+        assert!(cfg.persist);
+        assert!(cfg.cwd.is_none());
+        assert_eq!(
+            serde_json::to_value(SessionConfig::default()).unwrap()["persist"],
+            serde_json::Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn command_json_round_trip() {
+        let cmd = SessionCommand::Set(SessionSetting::ReasoningLevel {
+            level: agent_core::reasoning::ReasoningLevel::Ultra,
+        });
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert_eq!(
+            json,
+            r#"{"cmd":"set","setting":"reasoning_level","level":"ultra"}"#
+        );
+        let back: SessionCommand = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            back,
+            SessionCommand::Set(SessionSetting::ReasoningLevel {
+                level: agent_core::reasoning::ReasoningLevel::Ultra
+            })
+        ));
+
+        let submit: SessionCommand = serde_json::from_str(r#"{"cmd":"submit","text":"hi"}"#).unwrap();
+        match submit {
+            SessionCommand::Submit { text, attachments } => {
+                assert_eq!(text, "hi");
+                assert!(attachments.is_empty());
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn host_event_is_never_serialised() {
+        let cmd = SessionCommand::HostEvent(HostEvent::LoaderProgress(
+            crate::extensions::loader::ExtensionLoaderEvent::Started,
+        ));
+        assert!(serde_json::to_string(&cmd).is_err());
+    }
+}

--- a/crates/agent-engine/src/session/types.rs
+++ b/crates/agent-engine/src/session/types.rs
@@ -333,6 +333,7 @@ pub enum EndReason {
 /// StreamEvent in-process (LocalTransport) — that IS the byte-identical
 /// contract. The socket boundary converts to `wire::WireSessionEvent`.
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)] // Attached carries the full snapshot by design (§2.4)
 pub enum SessionEventWire {
     Stream(crate::StreamEvent),
     /// Actor bookkeeping the client needs to mirror `App` fields exactly.

--- a/crates/agent-engine/src/session/types.rs
+++ b/crates/agent-engine/src/session/types.rs
@@ -73,6 +73,11 @@ pub struct SessionConfig {
     /// may disable. Default `true`.
     #[serde(default = "default_true")]
     pub persist: bool,
+    /// Headless-chat policy: after every turn, save + `assess_context` and
+    /// auto-compact when the engine budget says so (chat.rs post-turn block).
+    /// The TUI does its own compaction; default `false`.
+    #[serde(default)]
+    pub auto_compact: bool,
 }
 
 fn default_true() -> bool {
@@ -89,6 +94,7 @@ impl Default for SessionConfig {
             auto_approve_confirms: false,
             model_override: None,
             persist: true,
+            auto_compact: false,
         }
     }
 }
@@ -248,6 +254,10 @@ pub enum SessionCommand {
     End { reason: EndReason },
     /// Resync after Lagged (B, day 3): actor re-sends history + turn_replay.
     Resync { client: ClientId, since_seq: u64 },
+    /// Runtime-backed slash command (`engine::commands::handle_engine_command`:
+    /// /model /thinking /context /trace /memory /compact …). Reply =
+    /// `QueryResult { id, value: {"kind": .., "text": ..} }`.
+    EngineCommand { id: u64, name: String, arg: String },
     /// Host→session (never wire): the actor re-emits as `SessionEventWire`.
     #[serde(skip)]
     HostEvent(HostEvent),
@@ -350,6 +360,10 @@ pub enum SessionEventWire {
     /// Drained event card — presentation only.
     External(crate::events::types::Event),
     AutoTurnCapReached { cap: u32 },
+    /// The turn machine is idle: a stream ended (Done/Error/Cancel) and NO
+    /// auto-turn followed. Headless hosts gate stdin on this so a queued
+    /// auto-turn is never raced by the next line.
+    Idle,
     /// "→ steering:" vs "queued:".
     Steered { text: String, delivered: bool },
     Dequeued { text: String },

--- a/crates/agent-engine/src/session/view.rs
+++ b/crates/agent-engine/src/session/view.rs
@@ -1,0 +1,232 @@
+//! `RuntimeView` + `RuntimeRead` (PLAN-phase2 §2.8).
+//!
+//! The TUI's synchronous getters (`runtime.model()` …) compile against
+//! either a live `Runtime` (today) or a published `RuntimeView` snapshot
+//! (day 2, over a transport). Trait signatures are copied EXACTLY from
+//! `Runtime` so call sites do not change.
+
+use agent_core::reasoning::ReasoningLevel;
+use serde::{Deserialize, Serialize};
+
+use super::types::reasoning_level_serde;
+
+/// Snapshot of the read-mostly Runtime getters the clients render from.
+/// Refreshed by the actor after every Set, after prompt reload, at turn start.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeView {
+    pub model: String,
+    pub thinking_level: String,
+    #[serde(with = "reasoning_level_serde")]
+    pub reasoning_level: ReasoningLevel,
+    pub is_reasoning_explicit: bool,
+    pub thinking_budget: u32,
+    pub context_window: u64,
+    pub system_prompt: Option<String>,
+    pub compaction_model: String,
+    pub api_retries: u32,
+    pub subagent_timeout: u64,
+    pub max_tool_output: usize,
+    pub bash_timeout: u64,
+    pub bash_max_timeout: u64,
+    pub prompt_generation: u64,
+    pub hook_handler_count: usize,
+    /// `Runtime::prompt_inspection_json()` cached at snapshot time
+    /// (read once per `/prompt`).
+    pub prompt_inspection: Option<String>,
+}
+
+impl RuntimeView {
+    /// Synchronous snapshot. `hook_handler_count` is supplied by the caller
+    /// because `HookBus::handler_count` is async.
+    pub fn snapshot(runtime: &crate::Runtime, hook_handler_count: usize) -> Self {
+        Self {
+            model: runtime.model().to_string(),
+            thinking_level: runtime.thinking_level().to_string(),
+            reasoning_level: runtime.reasoning_level(),
+            is_reasoning_explicit: runtime.is_reasoning_explicit(),
+            thinking_budget: runtime.thinking_budget(),
+            context_window: runtime.context_window(),
+            system_prompt: runtime.system_prompt().map(str::to_string),
+            compaction_model: runtime.compaction_model().to_string(),
+            api_retries: runtime.api_retries(),
+            subagent_timeout: runtime.subagent_timeout(),
+            max_tool_output: runtime.max_tool_output(),
+            bash_timeout: runtime.bash_timeout(),
+            bash_max_timeout: runtime.bash_max_timeout(),
+            prompt_generation: runtime.prompt_generation(),
+            hook_handler_count,
+            prompt_inspection: runtime.prompt_inspection_json(),
+        }
+    }
+
+    /// Snapshot including the live hook handler count.
+    pub async fn from_runtime(runtime: &crate::Runtime) -> Self {
+        let n = runtime.hook_bus().handler_count().await;
+        Self::snapshot(runtime, n)
+    }
+}
+
+/// The 14 getters, with the EXACT signatures `Runtime` has today, so TUI
+/// call sites compile against either. Implemented for `Runtime` by
+/// delegation and for `RuntimeView` by field access.
+pub trait RuntimeRead {
+    fn model(&self) -> &str;
+    fn thinking_level(&self) -> &str;
+    fn reasoning_level(&self) -> ReasoningLevel;
+    fn is_reasoning_explicit(&self) -> bool;
+    fn thinking_budget(&self) -> u32;
+    fn context_window(&self) -> u64;
+    fn system_prompt(&self) -> Option<&str>;
+    fn compaction_model(&self) -> &str;
+    fn api_retries(&self) -> u32;
+    fn subagent_timeout(&self) -> u64;
+    fn max_tool_output(&self) -> usize;
+    fn bash_timeout(&self) -> u64;
+    fn bash_max_timeout(&self) -> u64;
+    /// `RuntimeView`: cached at snapshot time.
+    fn prompt_inspection_json(&self) -> Option<String>;
+}
+
+impl RuntimeRead for crate::Runtime {
+    fn model(&self) -> &str {
+        crate::Runtime::model(self)
+    }
+    fn thinking_level(&self) -> &str {
+        crate::Runtime::thinking_level(self)
+    }
+    fn reasoning_level(&self) -> ReasoningLevel {
+        crate::Runtime::reasoning_level(self)
+    }
+    fn is_reasoning_explicit(&self) -> bool {
+        crate::Runtime::is_reasoning_explicit(self)
+    }
+    fn thinking_budget(&self) -> u32 {
+        crate::Runtime::thinking_budget(self)
+    }
+    fn context_window(&self) -> u64 {
+        crate::Runtime::context_window(self)
+    }
+    fn system_prompt(&self) -> Option<&str> {
+        crate::Runtime::system_prompt(self)
+    }
+    fn compaction_model(&self) -> &str {
+        crate::Runtime::compaction_model(self)
+    }
+    fn api_retries(&self) -> u32 {
+        crate::Runtime::api_retries(self)
+    }
+    fn subagent_timeout(&self) -> u64 {
+        crate::Runtime::subagent_timeout(self)
+    }
+    fn max_tool_output(&self) -> usize {
+        crate::Runtime::max_tool_output(self)
+    }
+    fn bash_timeout(&self) -> u64 {
+        crate::Runtime::bash_timeout(self)
+    }
+    fn bash_max_timeout(&self) -> u64 {
+        crate::Runtime::bash_max_timeout(self)
+    }
+    fn prompt_inspection_json(&self) -> Option<String> {
+        crate::Runtime::prompt_inspection_json(self)
+    }
+}
+
+impl RuntimeRead for RuntimeView {
+    fn model(&self) -> &str {
+        &self.model
+    }
+    fn thinking_level(&self) -> &str {
+        &self.thinking_level
+    }
+    fn reasoning_level(&self) -> ReasoningLevel {
+        self.reasoning_level
+    }
+    fn is_reasoning_explicit(&self) -> bool {
+        self.is_reasoning_explicit
+    }
+    fn thinking_budget(&self) -> u32 {
+        self.thinking_budget
+    }
+    fn context_window(&self) -> u64 {
+        self.context_window
+    }
+    fn system_prompt(&self) -> Option<&str> {
+        self.system_prompt.as_deref()
+    }
+    fn compaction_model(&self) -> &str {
+        &self.compaction_model
+    }
+    fn api_retries(&self) -> u32 {
+        self.api_retries
+    }
+    fn subagent_timeout(&self) -> u64 {
+        self.subagent_timeout
+    }
+    fn max_tool_output(&self) -> usize {
+        self.max_tool_output
+    }
+    fn bash_timeout(&self) -> u64 {
+        self.bash_timeout
+    }
+    fn bash_max_timeout(&self) -> u64 {
+        self.bash_max_timeout
+    }
+    fn prompt_inspection_json(&self) -> Option<String> {
+        self.prompt_inspection.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn view() -> RuntimeView {
+        RuntimeView {
+            model: "m".into(),
+            thinking_level: "high".into(),
+            reasoning_level: ReasoningLevel::High,
+            is_reasoning_explicit: false,
+            thinking_budget: 1024,
+            context_window: 200_000,
+            system_prompt: Some("sys".into()),
+            compaction_model: "c".into(),
+            api_retries: 3,
+            subagent_timeout: 60,
+            max_tool_output: 4096,
+            bash_timeout: 30,
+            bash_max_timeout: 300,
+            prompt_generation: 1,
+            hook_handler_count: 0,
+            prompt_inspection: None,
+        }
+    }
+
+    #[test]
+    fn view_json_round_trip() {
+        let v = view();
+        let json = serde_json::to_string(&v).unwrap();
+        let back: RuntimeView = serde_json::from_str(&json).unwrap();
+        assert_eq!(v, back);
+        assert!(json.contains(r#""reasoning_level":"high""#));
+    }
+
+    #[test]
+    fn view_reads_through_trait() {
+        fn read(r: &impl RuntimeRead) -> (String, u64) {
+            (r.model().to_string(), r.context_window())
+        }
+        assert_eq!(read(&view()), ("m".to_string(), 200_000));
+    }
+
+    #[test]
+    fn headless_runtime_snapshot_matches_getters() {
+        let rt = crate::Runtime::new_headless();
+        let v = RuntimeView::snapshot(&rt, 0);
+        assert_eq!(v.model, crate::Runtime::model(&rt));
+        assert_eq!(v.thinking_level, crate::Runtime::thinking_level(&rt));
+        assert_eq!(v.context_window, crate::Runtime::context_window(&rt));
+        assert_eq!(v.bash_timeout, crate::Runtime::bash_timeout(&rt));
+        assert_eq!(RuntimeRead::model(&v), RuntimeRead::model(&rt));
+    }
+}

--- a/crates/agent-engine/src/session/wire.rs
+++ b/crates/agent-engine/src/session/wire.rs
@@ -268,6 +268,7 @@ impl AttachedWire {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "ev", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)] // mirrors SessionEventWire by design
 pub enum WireSessionEvent {
     Stream { event: WireStreamEvent },
     TurnStarted { turn_baseline: usize, trigger: TurnTrigger },

--- a/crates/agent-engine/src/session/wire.rs
+++ b/crates/agent-engine/src/session/wire.rs
@@ -710,8 +710,9 @@ mod tests {
         // Every SessionEventWire variant (18) + every StreamEvent leaf (18; Stream counted once).
         assert_eq!(all.len(), 17 + 18);
         for ev in all {
-            let before = format!("{:?}", env(ev.clone()));
-            let wire: WireEnvelope = env(ev).into();
+            let e = env(ev);
+            let before = format!("{e:?}");
+            let wire: WireEnvelope = e.into();
             let line = encode_line(&wire).unwrap();
             assert_eq!(line.matches('\n').count(), 1, "one line per frame");
             let back: WireEnvelope = decode_line(line.trim_end()).unwrap();

--- a/crates/agent-engine/src/session/wire.rs
+++ b/crates/agent-engine/src/session/wire.rs
@@ -154,7 +154,9 @@ pub enum DaemonFrame {
         uptime_s: u64,
         sessions: usize,
     },
-    SessionList(Vec<SessionMeta>),
+    SessionList {
+        sessions: Vec<SessionMeta>,
+    },
     Attached(AttachedWire),
     Event(WireEnvelope),
     Error {
@@ -705,8 +707,8 @@ mod tests {
     #[test]
     fn wire_roundtrip_every_variant() {
         let all = fixtures();
-        // Every SessionEventWire variant is covered (18) + every StreamEvent leaf (18).
-        assert_eq!(all.len(), 18 + 18);
+        // Every SessionEventWire variant (18) + every StreamEvent leaf (18; Stream counted once).
+        assert_eq!(all.len(), 17 + 18);
         for ev in all {
             let before = format!("{:?}", env(ev.clone()));
             let wire: WireEnvelope = env(ev).into();
@@ -754,7 +756,7 @@ mod tests {
             }),
             DaemonFrame::Refused { reason: RefuseReason::Version { daemon_version: 1, min: 1, max: 1 }, message: "no".into() },
             DaemonFrame::Pong { pid: 1, uptime_s: 2, sessions: 0 },
-            DaemonFrame::SessionList(vec![meta()]),
+            DaemonFrame::SessionList { sessions: vec![meta()] },
             DaemonFrame::Attached(AttachedWire::new(
                 ClientId(1),
                 AttachSnapshot {

--- a/crates/agent-engine/src/session/wire.rs
+++ b/crates/agent-engine/src/session/wire.rs
@@ -1,0 +1,833 @@
+//! Wire frames for the daemon UDS (PLAN-phase2 §2.9, S289 D-2 amended).
+//!
+//! Framing is `synaps rpc`'s: one JSON object per `\n`, at most
+//! [`MAX_FRAME_BYTES`]. `WireSessionEvent` is a *lossless* serde mirror of
+//! `SessionEventWire` — `StreamEvent`/`TurnError`/`ExtensionLoaderEvent` are
+//! not `Serialize`, so they are mirrored variant-for-variant here and
+//! converted only at the socket boundary. In-process transports never touch
+//! this module.
+//!
+//! Security: nothing in here carries a credential. `Welcome`/`Attached` are
+//! summaries; `ClientFrame`'s `Debug` redacts `Answer.value` and
+//! `Submit.text` so a frame can be traced by *type* without leaking bodies.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::types::*;
+use super::view::RuntimeView;
+use crate::{AgentEvent, LlmEvent, SessionEvent, StreamEvent, TurnError, TurnOutcome};
+
+/// Separate from `RPC_PROTOCOL_VERSION`; bump on any non-additive change.
+pub const PROTOCOL_VERSION: u32 = 1;
+/// Exact-match policy today (`min == max == PROTOCOL_VERSION`).
+pub const PROTOCOL_MIN: u32 = PROTOCOL_VERSION;
+pub const PROTOCOL_MAX: u32 = PROTOCOL_VERSION;
+pub const MAX_FRAME_BYTES: usize = agent_core::core::rpc_dispatch::MAX_FRAME_BYTES;
+
+/// The binary version the daemon/client report in the handshake.
+pub fn binary_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+// ── client → daemon ───────────────────────────────────────────────────────────
+
+/// Client → daemon. First frame on a connection MUST be `Hello`.
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientFrame {
+    Hello(Hello),
+    // ── lightweight control fast path: no session allocated, no Attach ──
+    Ping,
+    Sessions,
+    Shutdown {
+        #[serde(default)]
+        force: bool,
+    },
+    // ── session-scoped ──
+    Attach(Attach),
+    Cmd {
+        session_id: SessionId,
+        cmd: SessionCommand,
+    },
+    Bye,
+}
+
+impl std::fmt::Debug for ClientFrame {
+    /// Frame *types* only for anything that can carry user text or a secret.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Hello(h) => f.debug_tuple("Hello").field(h).finish(),
+            Self::Ping => f.write_str("Ping"),
+            Self::Sessions => f.write_str("Sessions"),
+            Self::Shutdown { force } => f.debug_struct("Shutdown").field("force", force).finish(),
+            Self::Attach(a) => f.debug_tuple("Attach").field(a).finish(),
+            Self::Cmd { session_id, cmd } => {
+                let cmd: &dyn std::fmt::Debug = match cmd {
+                    SessionCommand::Answer { prompt_id, value } => {
+                        return f
+                            .debug_struct("Cmd")
+                            .field("session_id", session_id)
+                            .field("cmd", &format_args!("Answer {{ prompt_id: {prompt_id}, value: <redacted {} chars> }}", value.as_ref().map_or(0, |v| v.chars().count())))
+                            .finish();
+                    }
+                    SessionCommand::Submit { text, attachments } => {
+                        return f
+                            .debug_struct("Cmd")
+                            .field("session_id", session_id)
+                            .field("cmd", &format_args!("Submit {{ text: <{} chars>, attachments: {} }}", text.chars().count(), attachments.len()))
+                            .finish();
+                    }
+                    SessionCommand::Steer { text } => {
+                        return f
+                            .debug_struct("Cmd")
+                            .field("session_id", session_id)
+                            .field("cmd", &format_args!("Steer {{ text: <{} chars> }}", text.chars().count()))
+                            .finish();
+                    }
+                    other => other,
+                };
+                f.debug_struct("Cmd").field("session_id", session_id).field("cmd", cmd).finish()
+            }
+            Self::Bye => f.write_str("Bye"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Hello {
+    pub protocol_version: u32,
+    pub client: ClientMeta,
+    pub cwd: PathBuf,
+    pub client_version: String,
+}
+
+impl Hello {
+    pub fn new(kind: ClientKind) -> Self {
+        Self {
+            protocol_version: PROTOCOL_VERSION,
+            client: ClientMeta {
+                terminal: std::env::var("TERM").ok(),
+                ..ClientMeta::new(kind)
+            },
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")),
+            client_version: binary_version(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "attach", rename_all = "snake_case")]
+pub enum Attach {
+    Existing {
+        session_id: SessionId,
+        #[serde(default = "mirror")]
+        mode: AttachMode,
+    },
+    Create {
+        #[serde(default)]
+        config: SessionConfig,
+        #[serde(default = "mirror")]
+        mode: AttachMode,
+    },
+}
+
+fn mirror() -> AttachMode {
+    AttachMode::Mirror
+}
+
+// ── daemon → client ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
+pub enum DaemonFrame {
+    Welcome(Welcome),
+    /// Then the daemon closes.
+    Refused {
+        reason: RefuseReason,
+        message: String,
+    },
+    Pong {
+        pid: u32,
+        uptime_s: u64,
+        sessions: usize,
+    },
+    SessionList(Vec<SessionMeta>),
+    Attached(AttachedWire),
+    Event(WireEnvelope),
+    Error {
+        session_id: Option<SessionId>,
+        message: String,
+    },
+    Bye,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+pub enum RefuseReason {
+    Version {
+        daemon_version: u32,
+        min: u32,
+        max: u32,
+    },
+    Protocol,
+    Busy,
+    UnknownSession,
+    Config,
+}
+
+/// Auth-status *summary* only — never key material.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Welcome {
+    pub protocol_version: u32,
+    pub daemon_version: String,
+    pub pid: u32,
+    pub profile: Option<String>,
+    pub sessions: Vec<SessionMeta>,
+    pub progressive_tool_disclosure: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WireEnvelope {
+    pub session_id: SessionId,
+    pub seq: u64,
+    pub ts: chrono::DateTime<chrono::Utc>,
+    pub event: WireSessionEvent,
+}
+
+impl From<Envelope> for WireEnvelope {
+    fn from(e: Envelope) -> Self {
+        Self {
+            session_id: e.session_id,
+            seq: e.seq,
+            ts: e.ts,
+            event: e.event.into(),
+        }
+    }
+}
+
+impl From<WireEnvelope> for Envelope {
+    fn from(e: WireEnvelope) -> Self {
+        Self {
+            session_id: e.session_id,
+            seq: e.seq,
+            ts: e.ts,
+            event: e.event.into(),
+        }
+    }
+}
+
+/// `AttachSnapshot` with a serialisable replay.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttachedWire {
+    pub client: ClientId,
+    pub meta: SessionMeta,
+    pub view: RuntimeView,
+    pub conversation: ConversationSnapshot,
+    pub streaming: bool,
+    pub replay: Vec<WireEnvelope>,
+    pub pending_prompts: Vec<PromptRequest>,
+    pub clients: Vec<(ClientId, ClientKind)>,
+}
+
+impl AttachedWire {
+    pub fn new(client: ClientId, s: AttachSnapshot) -> Self {
+        Self {
+            client,
+            meta: s.meta,
+            view: s.view,
+            conversation: s.conversation,
+            streaming: s.streaming,
+            replay: s.replay.into_iter().map(Into::into).collect(),
+            pending_prompts: s.pending_prompts,
+            clients: s.clients,
+        }
+    }
+
+    pub fn into_snapshot(self) -> (ClientId, AttachSnapshot) {
+        (
+            self.client,
+            AttachSnapshot {
+                meta: self.meta,
+                view: self.view,
+                conversation: self.conversation,
+                streaming: self.streaming,
+                replay: self.replay.into_iter().map(Into::into).collect(),
+                pending_prompts: self.pending_prompts,
+                clients: self.clients,
+            },
+        )
+    }
+}
+
+// ── lossless mirror of SessionEventWire ───────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "ev", rename_all = "snake_case")]
+pub enum WireSessionEvent {
+    Stream { event: WireStreamEvent },
+    TurnStarted { turn_baseline: usize, trigger: TurnTrigger },
+    Conversation { snapshot: ConversationSnapshot },
+    Prompt { request: PromptRequest },
+    PromptResolved { prompt_id: u64 },
+    External { event: crate::events::types::Event },
+    AutoTurnCapReached { cap: u32 },
+    Steered { text: String, delivered: bool },
+    Dequeued { text: String },
+    SystemNotice { text: String },
+    LoaderProgress { event: WireLoaderEvent },
+    ExtensionNotification { extension_id: String, method: String, params: serde_json::Value },
+    SettingChanged { applied: SettingApplied },
+    QueryResult { id: u64, value: serde_json::Value },
+    Attached { client: ClientId, snapshot: AttachedWire },
+    ClientJoined { client: ClientId, kind: ClientKind },
+    ClientLeft { client: ClientId },
+    Ended { reason: EndReason },
+    /// Forward-compat: an additive variant from a newer daemon.
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum WireStreamEvent {
+    Llm(WireLlmEvent),
+    Session(WireSessionStreamEvent),
+    Agent(WireAgentEvent),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "llm", rename_all = "snake_case")]
+pub enum WireLlmEvent {
+    Thinking { text: String },
+    Text { text: String },
+    ToolUseStart { tool_name: String, tool_id: String },
+    ToolUseDelta { tool_id: String, delta: String },
+    ToolUse { tool_name: String, tool_id: String, input: serde_json::Value },
+    ToolResult { tool_id: String, result: String },
+    ToolResultDelta { tool_id: String, delta: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "session", rename_all = "snake_case")]
+pub enum WireSessionStreamEvent {
+    MessageHistory { messages: Vec<crate::SharedMessage> },
+    Usage {
+        input_tokens: u64,
+        output_tokens: u64,
+        cache_read_input_tokens: u64,
+        cache_creation_input_tokens: u64,
+        cache_creation_5m: Option<u64>,
+        cache_creation_1h: Option<u64>,
+        model: Option<String>,
+    },
+    Done,
+    Error { message: String, outcome: TurnOutcome },
+    Notice { text: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "agent", rename_all = "snake_case")]
+pub enum WireAgentEvent {
+    SubagentStart { subagent_id: u64, agent_name: String, task_preview: String },
+    SubagentUpdate { subagent_id: u64, agent_name: String, status: String },
+    SubagentDone { subagent_id: u64, agent_name: String, result_preview: String, duration_secs: f64 },
+    SteeringDelivered { message: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WireLoadFailure {
+    pub plugin: String,
+    pub manifest_path: Option<PathBuf>,
+    pub reason: String,
+    pub hint: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "loader", rename_all = "snake_case")]
+pub enum WireLoaderEvent {
+    Started,
+    Loaded { plugin: String, loaded: usize, failed: usize },
+    Failed { failure: WireLoadFailure, loaded: usize, failed: usize },
+    Finished { loaded: Vec<String>, failed: Vec<WireLoadFailure> },
+}
+
+type LoadFailure = crate::extensions::manager::ExtensionLoadFailure;
+type LoaderEvent = crate::extensions::loader::ExtensionLoaderEvent;
+
+impl From<LoadFailure> for WireLoadFailure {
+    fn from(f: LoadFailure) -> Self {
+        Self { plugin: f.plugin, manifest_path: f.manifest_path, reason: f.reason, hint: f.hint }
+    }
+}
+impl From<WireLoadFailure> for LoadFailure {
+    fn from(f: WireLoadFailure) -> Self {
+        Self { plugin: f.plugin, manifest_path: f.manifest_path, reason: f.reason, hint: f.hint }
+    }
+}
+impl From<LoaderEvent> for WireLoaderEvent {
+    fn from(e: LoaderEvent) -> Self {
+        match e {
+            LoaderEvent::Started => Self::Started,
+            LoaderEvent::Loaded { plugin, loaded, failed } => Self::Loaded { plugin, loaded, failed },
+            LoaderEvent::Failed { failure, loaded, failed } => {
+                Self::Failed { failure: failure.into(), loaded, failed }
+            }
+            LoaderEvent::Finished { loaded, failed } => Self::Finished {
+                loaded,
+                failed: failed.into_iter().map(Into::into).collect(),
+            },
+        }
+    }
+}
+impl From<WireLoaderEvent> for LoaderEvent {
+    fn from(e: WireLoaderEvent) -> Self {
+        match e {
+            WireLoaderEvent::Started => Self::Started,
+            WireLoaderEvent::Loaded { plugin, loaded, failed } => Self::Loaded { plugin, loaded, failed },
+            WireLoaderEvent::Failed { failure, loaded, failed } => {
+                Self::Failed { failure: failure.into(), loaded, failed }
+            }
+            WireLoaderEvent::Finished { loaded, failed } => Self::Finished {
+                loaded,
+                failed: failed.into_iter().map(Into::into).collect(),
+            },
+        }
+    }
+}
+
+impl From<StreamEvent> for WireStreamEvent {
+    fn from(e: StreamEvent) -> Self {
+        match e {
+            StreamEvent::Llm(l) => Self::Llm(match l {
+                LlmEvent::Thinking(text) => WireLlmEvent::Thinking { text },
+                LlmEvent::Text(text) => WireLlmEvent::Text { text },
+                LlmEvent::ToolUseStart { tool_name, tool_id } => WireLlmEvent::ToolUseStart { tool_name, tool_id },
+                LlmEvent::ToolUseDelta { tool_id, delta } => WireLlmEvent::ToolUseDelta { tool_id, delta },
+                LlmEvent::ToolUse { tool_name, tool_id, input } => WireLlmEvent::ToolUse { tool_name, tool_id, input },
+                LlmEvent::ToolResult { tool_id, result } => WireLlmEvent::ToolResult { tool_id, result },
+                LlmEvent::ToolResultDelta { tool_id, delta } => WireLlmEvent::ToolResultDelta { tool_id, delta },
+            }),
+            StreamEvent::Session(s) => Self::Session(match s {
+                SessionEvent::MessageHistory(messages) => WireSessionStreamEvent::MessageHistory { messages },
+                SessionEvent::Usage {
+                    input_tokens,
+                    output_tokens,
+                    cache_read_input_tokens,
+                    cache_creation_input_tokens,
+                    cache_creation_5m,
+                    cache_creation_1h,
+                    model,
+                } => WireSessionStreamEvent::Usage {
+                    input_tokens,
+                    output_tokens,
+                    cache_read_input_tokens,
+                    cache_creation_input_tokens,
+                    cache_creation_5m,
+                    cache_creation_1h,
+                    model,
+                },
+                SessionEvent::Done => WireSessionStreamEvent::Done,
+                SessionEvent::Error(TurnError { message, outcome }) => WireSessionStreamEvent::Error { message, outcome },
+                SessionEvent::Notice(text) => WireSessionStreamEvent::Notice { text },
+            }),
+            StreamEvent::Agent(a) => Self::Agent(match a {
+                AgentEvent::SubagentStart { subagent_id, agent_name, task_preview } => {
+                    WireAgentEvent::SubagentStart { subagent_id, agent_name, task_preview }
+                }
+                AgentEvent::SubagentUpdate { subagent_id, agent_name, status } => {
+                    WireAgentEvent::SubagentUpdate { subagent_id, agent_name, status }
+                }
+                AgentEvent::SubagentDone { subagent_id, agent_name, result_preview, duration_secs } => {
+                    WireAgentEvent::SubagentDone { subagent_id, agent_name, result_preview, duration_secs }
+                }
+                AgentEvent::SteeringDelivered { message } => WireAgentEvent::SteeringDelivered { message },
+            }),
+        }
+    }
+}
+
+impl From<WireStreamEvent> for StreamEvent {
+    fn from(e: WireStreamEvent) -> Self {
+        match e {
+            WireStreamEvent::Llm(l) => Self::Llm(match l {
+                WireLlmEvent::Thinking { text } => LlmEvent::Thinking(text),
+                WireLlmEvent::Text { text } => LlmEvent::Text(text),
+                WireLlmEvent::ToolUseStart { tool_name, tool_id } => LlmEvent::ToolUseStart { tool_name, tool_id },
+                WireLlmEvent::ToolUseDelta { tool_id, delta } => LlmEvent::ToolUseDelta { tool_id, delta },
+                WireLlmEvent::ToolUse { tool_name, tool_id, input } => LlmEvent::ToolUse { tool_name, tool_id, input },
+                WireLlmEvent::ToolResult { tool_id, result } => LlmEvent::ToolResult { tool_id, result },
+                WireLlmEvent::ToolResultDelta { tool_id, delta } => LlmEvent::ToolResultDelta { tool_id, delta },
+            }),
+            WireStreamEvent::Session(s) => Self::Session(match s {
+                WireSessionStreamEvent::MessageHistory { messages } => SessionEvent::MessageHistory(messages),
+                WireSessionStreamEvent::Usage {
+                    input_tokens,
+                    output_tokens,
+                    cache_read_input_tokens,
+                    cache_creation_input_tokens,
+                    cache_creation_5m,
+                    cache_creation_1h,
+                    model,
+                } => SessionEvent::Usage {
+                    input_tokens,
+                    output_tokens,
+                    cache_read_input_tokens,
+                    cache_creation_input_tokens,
+                    cache_creation_5m,
+                    cache_creation_1h,
+                    model,
+                },
+                WireSessionStreamEvent::Done => SessionEvent::Done,
+                WireSessionStreamEvent::Error { message, outcome } => SessionEvent::Error(TurnError { message, outcome }),
+                WireSessionStreamEvent::Notice { text } => SessionEvent::Notice(text),
+            }),
+            WireStreamEvent::Agent(a) => Self::Agent(match a {
+                WireAgentEvent::SubagentStart { subagent_id, agent_name, task_preview } => {
+                    AgentEvent::SubagentStart { subagent_id, agent_name, task_preview }
+                }
+                WireAgentEvent::SubagentUpdate { subagent_id, agent_name, status } => {
+                    AgentEvent::SubagentUpdate { subagent_id, agent_name, status }
+                }
+                WireAgentEvent::SubagentDone { subagent_id, agent_name, result_preview, duration_secs } => {
+                    AgentEvent::SubagentDone { subagent_id, agent_name, result_preview, duration_secs }
+                }
+                WireAgentEvent::SteeringDelivered { message } => AgentEvent::SteeringDelivered { message },
+            }),
+        }
+    }
+}
+
+impl From<SessionEventWire> for WireSessionEvent {
+    fn from(e: SessionEventWire) -> Self {
+        use SessionEventWire as S;
+        match e {
+            S::Stream(ev) => Self::Stream { event: ev.into() },
+            S::TurnStarted { turn_baseline, trigger } => Self::TurnStarted { turn_baseline, trigger },
+            S::Conversation(snapshot) => Self::Conversation { snapshot },
+            S::Prompt(request) => Self::Prompt { request },
+            S::PromptResolved { prompt_id } => Self::PromptResolved { prompt_id },
+            S::External(event) => Self::External { event },
+            S::AutoTurnCapReached { cap } => Self::AutoTurnCapReached { cap },
+            S::Steered { text, delivered } => Self::Steered { text, delivered },
+            S::Dequeued { text } => Self::Dequeued { text },
+            S::SystemNotice(text) => Self::SystemNotice { text },
+            S::LoaderProgress(ev) => Self::LoaderProgress { event: ev.into() },
+            S::ExtensionNotification { extension_id, method, params } => {
+                Self::ExtensionNotification { extension_id, method, params }
+            }
+            S::SettingChanged(applied) => Self::SettingChanged { applied },
+            S::QueryResult { id, value } => Self::QueryResult { id, value },
+            S::Attached { client, snapshot } => Self::Attached { client, snapshot: AttachedWire::new(client, snapshot) },
+            S::ClientJoined { client, kind } => Self::ClientJoined { client, kind },
+            S::ClientLeft { client } => Self::ClientLeft { client },
+            S::Ended { reason } => Self::Ended { reason },
+        }
+    }
+}
+
+impl From<WireSessionEvent> for SessionEventWire {
+    fn from(e: WireSessionEvent) -> Self {
+        use WireSessionEvent as W;
+        match e {
+            W::Stream { event } => Self::Stream(event.into()),
+            W::TurnStarted { turn_baseline, trigger } => Self::TurnStarted { turn_baseline, trigger },
+            W::Conversation { snapshot } => Self::Conversation(snapshot),
+            W::Prompt { request } => Self::Prompt(request),
+            W::PromptResolved { prompt_id } => Self::PromptResolved { prompt_id },
+            W::External { event } => Self::External(event),
+            W::AutoTurnCapReached { cap } => Self::AutoTurnCapReached { cap },
+            W::Steered { text, delivered } => Self::Steered { text, delivered },
+            W::Dequeued { text } => Self::Dequeued { text },
+            W::SystemNotice { text } => Self::SystemNotice(text),
+            W::LoaderProgress { event } => Self::LoaderProgress(event.into()),
+            W::ExtensionNotification { extension_id, method, params } => {
+                Self::ExtensionNotification { extension_id, method, params }
+            }
+            W::SettingChanged { applied } => Self::SettingChanged(applied),
+            W::QueryResult { id, value } => Self::QueryResult { id, value },
+            W::Attached { snapshot, .. } => {
+                let (client, snapshot) = snapshot.into_snapshot();
+                Self::Attached { client, snapshot }
+            }
+            W::ClientJoined { client, kind } => Self::ClientJoined { client, kind },
+            W::ClientLeft { client } => Self::ClientLeft { client },
+            W::Ended { reason } => Self::Ended { reason },
+            W::Unknown => Self::SystemNotice("unknown event from a newer daemon (ignored)".into()),
+        }
+    }
+}
+
+// ── framing helpers ───────────────────────────────────────────────────────────
+
+/// Encode one frame as a single line (no embedded newline: serde_json escapes them).
+pub fn encode_line<T: Serialize>(frame: &T) -> Result<String, serde_json::Error> {
+    let mut s = serde_json::to_string(frame)?;
+    s.push('\n');
+    Ok(s)
+}
+
+/// Decode one line, enforcing [`MAX_FRAME_BYTES`].
+pub fn decode_line<'a, T: Deserialize<'a>>(line: &'a str) -> Result<T, String> {
+    if line.len() > MAX_FRAME_BYTES {
+        return Err(format!("frame exceeds {} byte limit", MAX_FRAME_BYTES));
+    }
+    serde_json::from_str(line).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BudgetDimension;
+    use std::sync::Arc;
+
+    fn view() -> RuntimeView {
+        crate::session::handle::echo::view_for()
+    }
+
+    fn meta() -> SessionMeta {
+        crate::session::handle::echo::meta_for(&SessionId::from("wire-1"))
+    }
+
+    fn prompt() -> PromptRequest {
+        PromptRequest {
+            id: 3,
+            kind: PromptKind::Secret,
+            title: "sudo".into(),
+            prompt: "password".into(),
+            raised_at: chrono::Utc::now(),
+        }
+    }
+
+    fn conv() -> ConversationSnapshot {
+        ConversationSnapshot {
+            api_messages: vec![Arc::new(serde_json::json!({"role":"user","content":"hi"}))],
+            tokens: ConversationTokens { input: 1, output: 2, cache_read: 3, cache_creation: 4 },
+            cost: 0.5,
+            abort_context: Some("ctx".into()),
+            queued_message: None,
+            pending_events_len: 2,
+            consecutive_auto_turns: 1,
+        }
+    }
+
+    fn env(event: SessionEventWire) -> Envelope {
+        Envelope { session_id: SessionId::from("wire-1"), seq: 9, ts: chrono::Utc::now(), event }
+    }
+
+    fn stream_fixtures() -> Vec<StreamEvent> {
+        vec![
+            StreamEvent::Llm(LlmEvent::Thinking("t".into())),
+            StreamEvent::Llm(LlmEvent::Text("x\ny".into())),
+            StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name: "bash".into(), tool_id: "id1".into() }),
+            StreamEvent::Llm(LlmEvent::ToolUseDelta { tool_id: "id1".into(), delta: "{\"c".into() }),
+            StreamEvent::Llm(LlmEvent::ToolUse {
+                tool_name: "bash".into(),
+                tool_id: "id1".into(),
+                input: serde_json::json!({"command":"pwd"}),
+            }),
+            StreamEvent::Llm(LlmEvent::ToolResult { tool_id: "id1".into(), result: "/tmp".into() }),
+            StreamEvent::Llm(LlmEvent::ToolResultDelta { tool_id: "id1".into(), delta: "/t".into() }),
+            StreamEvent::Session(SessionEvent::MessageHistory(vec![Arc::new(serde_json::json!({"role":"user","content":"a"}))])),
+            StreamEvent::Session(SessionEvent::Usage {
+                input_tokens: 1,
+                output_tokens: 2,
+                cache_read_input_tokens: 3,
+                cache_creation_input_tokens: 4,
+                cache_creation_5m: Some(5),
+                cache_creation_1h: None,
+                model: Some("m".into()),
+            }),
+            StreamEvent::Session(SessionEvent::Done),
+            StreamEvent::Session(SessionEvent::Error(TurnError::provider("boom", "auth_error", "turn-1-0"))),
+            StreamEvent::Session(SessionEvent::Error(TurnError::budget(BudgetDimension::ToolCalls))),
+            StreamEvent::Session(SessionEvent::Error(TurnError { message: "c".into(), outcome: TurnOutcome::Canceled })),
+            StreamEvent::Session(SessionEvent::Notice("n".into())),
+            StreamEvent::Agent(AgentEvent::SubagentStart { subagent_id: 1, agent_name: "a".into(), task_preview: "p".into() }),
+            StreamEvent::Agent(AgentEvent::SubagentUpdate { subagent_id: 1, agent_name: "a".into(), status: "s".into() }),
+            StreamEvent::Agent(AgentEvent::SubagentDone {
+                subagent_id: 1,
+                agent_name: "a".into(),
+                result_preview: "r".into(),
+                duration_secs: 1.5,
+            }),
+            StreamEvent::Agent(AgentEvent::SteeringDelivered { message: "m".into() }),
+        ]
+    }
+
+    fn fixtures() -> Vec<SessionEventWire> {
+        use SessionEventWire as S;
+        let loader = crate::extensions::loader::ExtensionLoaderEvent::Finished {
+            loaded: vec!["p".into()],
+            failed: vec![LoadFailure {
+                plugin: "bad".into(),
+                manifest_path: Some(PathBuf::from("/x/manifest.json")),
+                reason: "oops".into(),
+                hint: "fix".into(),
+            }],
+        };
+        let mut v: Vec<S> = stream_fixtures().into_iter().map(S::Stream).collect();
+        v.extend([
+            S::TurnStarted { turn_baseline: 4, trigger: TurnTrigger::EventAuto },
+            S::Conversation(conv()),
+            S::Prompt(prompt()),
+            S::PromptResolved { prompt_id: 3 },
+            S::External(crate::events::types::Event::simple("cli", "hello", None)),
+            S::AutoTurnCapReached { cap: 5 },
+            S::Steered { text: "s".into(), delivered: true },
+            S::Dequeued { text: "d".into() },
+            S::SystemNotice("sys".into()),
+            S::LoaderProgress(loader),
+            S::ExtensionNotification { extension_id: "e".into(), method: "widget.upsert".into(), params: serde_json::json!({"a":1}) },
+            S::SettingChanged(SettingApplied { setting: "model".into(), ok: true, message: None, view: view() }),
+            S::QueryResult { id: 1, value: serde_json::json!([1, 2]) },
+            S::Attached {
+                client: ClientId(2),
+                snapshot: AttachSnapshot {
+                    meta: meta(),
+                    view: view(),
+                    conversation: conv(),
+                    streaming: true,
+                    replay: vec![env(S::Stream(StreamEvent::Llm(LlmEvent::Text("partial".into()))))],
+                    pending_prompts: vec![prompt()],
+                    clients: vec![(ClientId(1), ClientKind::Tui)],
+                },
+            },
+            S::ClientJoined { client: ClientId(1), kind: ClientKind::Attach },
+            S::ClientLeft { client: ClientId(1) },
+            S::Ended { reason: EndReason::HostShutdown },
+        ]);
+        v
+    }
+
+    #[test]
+    fn wire_roundtrip_every_variant() {
+        let all = fixtures();
+        // Every SessionEventWire variant is covered (18) + every StreamEvent leaf (18).
+        assert_eq!(all.len(), 18 + 18);
+        for ev in all {
+            let before = format!("{:?}", env(ev.clone()));
+            let wire: WireEnvelope = env(ev).into();
+            let line = encode_line(&wire).unwrap();
+            assert_eq!(line.matches('\n').count(), 1, "one line per frame");
+            let back: WireEnvelope = decode_line(line.trim_end()).unwrap();
+            let after = format!("{:?}", Envelope::from(back));
+            assert_eq!(before, after);
+        }
+    }
+
+    #[test]
+    fn unknown_event_variant_tolerated() {
+        let v: WireSessionEvent = serde_json::from_str(r#"{"ev":"from_the_future","x":1}"#).unwrap();
+        assert!(matches!(v, WireSessionEvent::Unknown));
+        assert!(matches!(SessionEventWire::from(v), SessionEventWire::SystemNotice(_)));
+    }
+
+    #[test]
+    fn client_frames_roundtrip_and_daemon_frames_roundtrip() {
+        let frames = vec![
+            ClientFrame::Hello(Hello::new(ClientKind::Attach)),
+            ClientFrame::Ping,
+            ClientFrame::Sessions,
+            ClientFrame::Shutdown { force: true },
+            ClientFrame::Attach(Attach::Existing { session_id: "s".into(), mode: AttachMode::Mirror }),
+            ClientFrame::Attach(Attach::Create { config: SessionConfig::default(), mode: AttachMode::Takeover }),
+            ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::Submit { text: "hi".into(), attachments: vec![] } },
+            ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::Answer { prompt_id: 1, value: Some("pw".into()) } },
+            ClientFrame::Bye,
+        ];
+        for f in frames {
+            let line = encode_line(&f).unwrap();
+            let back: ClientFrame = decode_line(line.trim_end()).unwrap();
+            assert_eq!(serde_json::to_string(&back).unwrap(), line.trim_end());
+        }
+        let frames = vec![
+            DaemonFrame::Welcome(Welcome {
+                protocol_version: 1,
+                daemon_version: "0.9.0".into(),
+                pid: 1,
+                profile: None,
+                sessions: vec![meta()],
+                progressive_tool_disclosure: true,
+            }),
+            DaemonFrame::Refused { reason: RefuseReason::Version { daemon_version: 1, min: 1, max: 1 }, message: "no".into() },
+            DaemonFrame::Pong { pid: 1, uptime_s: 2, sessions: 0 },
+            DaemonFrame::SessionList(vec![meta()]),
+            DaemonFrame::Attached(AttachedWire::new(
+                ClientId(1),
+                AttachSnapshot {
+                    meta: meta(),
+                    view: view(),
+                    conversation: conv(),
+                    streaming: false,
+                    replay: vec![],
+                    pending_prompts: vec![],
+                    clients: vec![],
+                },
+            )),
+            DaemonFrame::Event(env(SessionEventWire::SystemNotice("x".into())).into()),
+            DaemonFrame::Error { session_id: None, message: "e".into() },
+            DaemonFrame::Bye,
+        ];
+        for f in frames {
+            let line = encode_line(&f).unwrap();
+            let back: DaemonFrame = decode_line(line.trim_end()).unwrap();
+            assert_eq!(serde_json::to_string(&back).unwrap(), line.trim_end());
+        }
+    }
+
+    #[test]
+    fn hello_must_be_first_is_a_type_level_fact_and_version_is_exact() {
+        let h = Hello::new(ClientKind::Test);
+        assert_eq!(h.protocol_version, PROTOCOL_VERSION);
+        assert_eq!(PROTOCOL_MIN, PROTOCOL_MAX);
+        let json = serde_json::to_string(&ClientFrame::Hello(h)).unwrap();
+        assert!(json.starts_with(r#"{"type":"hello""#));
+    }
+
+    #[test]
+    fn debug_redacts_answer_and_submit_bodies() {
+        let secret = "hunter2-very-secret";
+        let f = ClientFrame::Cmd {
+            session_id: "s".into(),
+            cmd: SessionCommand::Answer { prompt_id: 1, value: Some(secret.into()) },
+        };
+        let d = format!("{f:?}");
+        assert!(!d.contains(secret), "{d}");
+        assert!(d.contains("redacted"));
+        let f = ClientFrame::Cmd {
+            session_id: "s".into(),
+            cmd: SessionCommand::Submit { text: "my private prompt".into(), attachments: vec![] },
+        };
+        let d = format!("{f:?}");
+        assert!(!d.contains("private"), "{d}");
+        let f = ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::Steer { text: "steer me".into() } };
+        assert!(!format!("{f:?}").contains("steer me"));
+    }
+
+    #[test]
+    fn oversize_frame_rejected() {
+        let big = "x".repeat(MAX_FRAME_BYTES + 1);
+        assert!(decode_line::<ClientFrame>(&big).is_err());
+    }
+
+    #[test]
+    fn no_secret_bearing_fields_on_handshake_frames() {
+        // Structural guard: the JSON of Welcome/Attached must not contain key-ish names.
+        let w = serde_json::to_string(&Welcome {
+            protocol_version: 1,
+            daemon_version: "v".into(),
+            pid: 1,
+            profile: Some("p".into()),
+            sessions: vec![meta()],
+            progressive_tool_disclosure: false,
+        })
+        .unwrap()
+        .to_lowercase();
+        for bad in ["token", "secret", "api_key", "apikey", "password", "credential"] {
+            assert!(!w.contains(bad), "{bad} in Welcome");
+        }
+    }
+}

--- a/crates/agent-engine/src/session/wire.rs
+++ b/crates/agent-engine/src/session/wire.rs
@@ -1,11 +1,20 @@
 //! Wire frames for the daemon UDS (PLAN-phase2 §2.9, S289 D-2 amended).
 //!
 //! Framing is `synaps rpc`'s: one JSON object per `\n`, at most
-//! [`MAX_FRAME_BYTES`]. `WireSessionEvent` is a *lossless* serde mirror of
+//! [`DAEMON_MAX_FRAME_BYTES`] (64 MiB — distinct from rpc's 1 MiB because
+//! `Attached` carries the whole `api_messages`). Enforced symmetrically:
+//! `encode_line` refuses to build an oversize frame, `decode_line` and both
+//! readers refuse to accept one. `WireSessionEvent` is a serde mirror of
 //! `SessionEventWire` — `StreamEvent`/`TurnError`/`ExtensionLoaderEvent` are
 //! not `Serialize`, so they are mirrored variant-for-variant here and
 //! converted only at the socket boundary. In-process transports never touch
 //! this module.
+//!
+//! The one *lossy* mirror is `Conversation`: on the wire it is a
+//! [`ConversationDigest`] (len + hash + tokens/cost), never the messages.
+//! Full history travels only in `Attached` and `QueryResult{Messages}`;
+//! `SocketTransport` rebuilds the snapshot from its local mirror
+//! (`Attached` + `Stream(MessageHistory)`) and re-queries on a hash miss.
 //!
 //! Security: nothing in here carries a credential. `Welcome`/`Attached` are
 //! summaries; `ClientFrame`'s `Debug` redacts `Answer.value` and
@@ -24,7 +33,20 @@ pub const PROTOCOL_VERSION: u32 = 1;
 /// Exact-match policy today (`min == max == PROTOCOL_VERSION`).
 pub const PROTOCOL_MIN: u32 = PROTOCOL_VERSION;
 pub const PROTOCOL_MAX: u32 = PROTOCOL_VERSION;
-pub const MAX_FRAME_BYTES: usize = agent_core::core::rpc_dispatch::MAX_FRAME_BYTES;
+/// rpc's cap, kept for reference; daemon frames use [`DAEMON_MAX_FRAME_BYTES`].
+pub const RPC_MAX_FRAME_BYTES: usize = agent_core::core::rpc_dispatch::MAX_FRAME_BYTES;
+/// Hard cap on one daemon frame, both directions (`Attached` ships the
+/// whole conversation; 64 MiB is well past any context window's JSON).
+pub const DAEMON_MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
+/// Alias used by the readers/writers of this protocol.
+pub const MAX_FRAME_BYTES: usize = DAEMON_MAX_FRAME_BYTES;
+/// Query ids at or above this are reserved for the transport/daemon and
+/// never surfaced to a client as `QueryResult`.
+pub const RESERVED_QUERY_ID_BASE: u64 = 1 << 63;
+/// `SocketTransport` re-fetches `api_messages` under this id on a digest miss.
+pub const DIGEST_RESYNC_QUERY_ID: u64 = RESERVED_QUERY_ID_BASE;
+/// The daemon's idle monitor probes `Status` under this id.
+pub const IDLE_PROBE_QUERY_ID: u64 = RESERVED_QUERY_ID_BASE + 1;
 
 /// The binary version the daemon/client report in the handshake.
 pub fn binary_version() -> String {
@@ -264,7 +286,75 @@ impl AttachedWire {
     }
 }
 
-// ── lossless mirror of SessionEventWire ───────────────────────────────────────
+// ── conversation digest ───────────────────────────────────────────────────────
+
+/// `ConversationSnapshot` minus `api_messages`: what `Conversation` carries
+/// on the wire. `messages_hash` is FNV-1a over each message's JSON so a
+/// client can tell whether its local mirror is current.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConversationDigest {
+    pub messages_len: usize,
+    pub messages_hash: u64,
+    pub tokens: ConversationTokens,
+    pub cost: f64,
+    pub abort_context: Option<String>,
+    pub queued_message: Option<String>,
+    pub pending_events_len: usize,
+    pub consecutive_auto_turns: u32,
+}
+
+/// FNV-1a 64 over the canonical JSON of every message (stable across
+/// binaries, unlike `DefaultHasher`).
+pub fn messages_hash(messages: &[crate::SharedMessage]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    let mut feed = |b: u8| {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    };
+    for m in messages {
+        if let Ok(bytes) = serde_json::to_vec(&**m) {
+            for b in bytes {
+                feed(b);
+            }
+        }
+        feed(0x1f);
+    }
+    h
+}
+
+impl ConversationDigest {
+    pub fn of(s: &ConversationSnapshot) -> Self {
+        Self {
+            messages_len: s.api_messages.len(),
+            messages_hash: messages_hash(&s.api_messages),
+            tokens: s.tokens.clone(),
+            cost: s.cost,
+            abort_context: s.abort_context.clone(),
+            queued_message: s.queued_message.clone(),
+            pending_events_len: s.pending_events_len,
+            consecutive_auto_turns: s.consecutive_auto_turns,
+        }
+    }
+
+    pub fn matches(&self, messages: &[crate::SharedMessage]) -> bool {
+        self.messages_len == messages.len() && self.messages_hash == messages_hash(messages)
+    }
+
+    /// Rebuild a snapshot around `messages` (the caller's mirror).
+    pub fn into_snapshot(self, api_messages: Vec<crate::SharedMessage>) -> ConversationSnapshot {
+        ConversationSnapshot {
+            api_messages,
+            tokens: self.tokens,
+            cost: self.cost,
+            abort_context: self.abort_context,
+            queued_message: self.queued_message,
+            pending_events_len: self.pending_events_len,
+            consecutive_auto_turns: self.consecutive_auto_turns,
+        }
+    }
+}
+
+// ── mirror of SessionEventWire (lossless except Conversation → digest) ────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "ev", rename_all = "snake_case")]
@@ -272,7 +362,8 @@ impl AttachedWire {
 pub enum WireSessionEvent {
     Stream { event: WireStreamEvent },
     TurnStarted { turn_baseline: usize, trigger: TurnTrigger },
-    Conversation { snapshot: ConversationSnapshot },
+    /// Digest only — see module docs.
+    Conversation { digest: ConversationDigest },
     Prompt { request: PromptRequest },
     PromptResolved { prompt_id: u64 },
     External { event: crate::events::types::Event },
@@ -510,7 +601,7 @@ impl From<SessionEventWire> for WireSessionEvent {
         match e {
             S::Stream(ev) => Self::Stream { event: ev.into() },
             S::TurnStarted { turn_baseline, trigger } => Self::TurnStarted { turn_baseline, trigger },
-            S::Conversation(snapshot) => Self::Conversation { snapshot },
+            S::Conversation(snapshot) => Self::Conversation { digest: ConversationDigest::of(&snapshot) },
             S::Prompt(request) => Self::Prompt { request },
             S::PromptResolved { prompt_id } => Self::PromptResolved { prompt_id },
             S::External(event) => Self::External { event },
@@ -539,7 +630,9 @@ impl From<WireSessionEvent> for SessionEventWire {
         match e {
             W::Stream { event } => Self::Stream(event.into()),
             W::TurnStarted { turn_baseline, trigger } => Self::TurnStarted { turn_baseline, trigger },
-            W::Conversation { snapshot } => Self::Conversation(snapshot),
+            // Messages are not on the wire; `SocketTransport` fills them from
+            // its mirror before handing the envelope up.
+            W::Conversation { digest } => Self::Conversation(digest.into_snapshot(Vec::new())),
             W::Prompt { request } => Self::Prompt(request),
             W::PromptResolved { prompt_id } => Self::PromptResolved { prompt_id },
             W::External { event } => Self::External(event),
@@ -568,17 +661,26 @@ impl From<WireSessionEvent> for SessionEventWire {
 
 // ── framing helpers ───────────────────────────────────────────────────────────
 
-/// Encode one frame as a single line (no embedded newline: serde_json escapes them).
-pub fn encode_line<T: Serialize>(frame: &T) -> Result<String, serde_json::Error> {
-    let mut s = serde_json::to_string(frame)?;
+/// Human-readable form of the cap for error frames.
+pub fn frame_limit_msg() -> String {
+    format!("frame exceeds {} MiB limit", DAEMON_MAX_FRAME_BYTES / (1024 * 1024))
+}
+
+/// Encode one frame as a single line (no embedded newline: serde_json
+/// escapes them). Refuses to produce a line over [`DAEMON_MAX_FRAME_BYTES`].
+pub fn encode_line<T: Serialize>(frame: &T) -> Result<String, String> {
+    let mut s = serde_json::to_string(frame).map_err(|e| e.to_string())?;
+    if s.len() + 1 > DAEMON_MAX_FRAME_BYTES {
+        return Err(frame_limit_msg());
+    }
     s.push('\n');
     Ok(s)
 }
 
-/// Decode one line, enforcing [`MAX_FRAME_BYTES`].
+/// Decode one line, enforcing [`DAEMON_MAX_FRAME_BYTES`].
 pub fn decode_line<'a, T: Deserialize<'a>>(line: &'a str) -> Result<T, String> {
-    if line.len() > MAX_FRAME_BYTES {
-        return Err(format!("frame exceeds {} byte limit", MAX_FRAME_BYTES));
+    if line.len() > DAEMON_MAX_FRAME_BYTES {
+        return Err(frame_limit_msg());
     }
     serde_json::from_str(line).map_err(|e| e.to_string())
 }
@@ -715,6 +817,7 @@ mod tests {
         // Every SessionEventWire variant (19) + every StreamEvent leaf (18; Stream counted once).
         assert_eq!(all.len(), 18 + 18);
         for ev in all {
+            let is_conv = matches!(ev, SessionEventWire::Conversation(_));
             let e = env(ev);
             let before = format!("{e:?}");
             let wire: WireEnvelope = e.into();
@@ -722,8 +825,32 @@ mod tests {
             assert_eq!(line.matches('\n').count(), 1, "one line per frame");
             let back: WireEnvelope = decode_line(line.trim_end()).unwrap();
             let after = format!("{:?}", Envelope::from(back));
-            assert_eq!(before, after);
+            if is_conv {
+                // Digest on the wire: everything but the messages survives.
+                assert!(!line.contains("api_messages"), "{line}");
+                assert!(after.contains("api_messages: []"), "{after}");
+                assert_eq!(before.replace("api_messages: [Object {\"content\": String(\"hi\"), \"role\": String(\"user\")}]", "api_messages: []"), after);
+            } else {
+                assert_eq!(before, after);
+            }
         }
+    }
+
+    #[test]
+    fn conversation_digest_roundtrips_and_detects_drift() {
+        let c = conv();
+        let d = ConversationDigest::of(&c);
+        assert_eq!(d.messages_len, 1);
+        assert!(d.matches(&c.api_messages));
+        assert!(!d.matches(&[]));
+        let mut other = c.api_messages.clone();
+        other.push(Arc::new(serde_json::json!({"role":"assistant","content":"x"})));
+        assert!(!d.matches(&other));
+        let back = d.clone().into_snapshot(c.api_messages.clone());
+        assert_eq!(ConversationDigest::of(&back), d);
+        // stable across runs/binaries: FNV-1a offset basis for the empty list
+        assert_eq!(messages_hash(&[]), 0xcbf2_9ce4_8422_2325);
+        assert_ne!(messages_hash(&c.api_messages), messages_hash(&[]));
     }
 
     #[test]
@@ -818,9 +945,17 @@ mod tests {
     }
 
     #[test]
-    fn oversize_frame_rejected() {
-        let big = "x".repeat(MAX_FRAME_BYTES + 1);
-        assert!(decode_line::<ClientFrame>(&big).is_err());
+    fn oversize_frame_rejected_both_directions() {
+        assert!(DAEMON_MAX_FRAME_BYTES > RPC_MAX_FRAME_BYTES);
+        let big = "x".repeat(DAEMON_MAX_FRAME_BYTES + 1);
+        assert!(decode_line::<ClientFrame>(&big).unwrap_err().contains("64 MiB"));
+        // encode side: a frame that would serialise past the cap is refused
+        let f = DaemonFrame::Error { session_id: None, message: big };
+        assert!(encode_line(&f).unwrap_err().contains("64 MiB"));
+        // a > 1 MiB (rpc cap) frame is fine on the daemon wire
+        let f = DaemonFrame::Error { session_id: None, message: "y".repeat(RPC_MAX_FRAME_BYTES * 2) };
+        let line = encode_line(&f).unwrap();
+        assert!(decode_line::<DaemonFrame>(line.trim_end()).is_ok());
     }
 
     #[test]

--- a/crates/agent-engine/src/session/wire.rs
+++ b/crates/agent-engine/src/session/wire.rs
@@ -277,6 +277,7 @@ pub enum WireSessionEvent {
     PromptResolved { prompt_id: u64 },
     External { event: crate::events::types::Event },
     AutoTurnCapReached { cap: u32 },
+    Idle,
     Steered { text: String, delivered: bool },
     Dequeued { text: String },
     SystemNotice { text: String },
@@ -514,6 +515,7 @@ impl From<SessionEventWire> for WireSessionEvent {
             S::PromptResolved { prompt_id } => Self::PromptResolved { prompt_id },
             S::External(event) => Self::External { event },
             S::AutoTurnCapReached { cap } => Self::AutoTurnCapReached { cap },
+            S::Idle => Self::Idle,
             S::Steered { text, delivered } => Self::Steered { text, delivered },
             S::Dequeued { text } => Self::Dequeued { text },
             S::SystemNotice(text) => Self::SystemNotice { text },
@@ -542,6 +544,7 @@ impl From<WireSessionEvent> for SessionEventWire {
             W::PromptResolved { prompt_id } => Self::PromptResolved { prompt_id },
             W::External { event } => Self::External(event),
             W::AutoTurnCapReached { cap } => Self::AutoTurnCapReached { cap },
+            W::Idle => Self::Idle,
             W::Steered { text, delivered } => Self::Steered { text, delivered },
             W::Dequeued { text } => Self::Dequeued { text },
             W::SystemNotice { text } => Self::SystemNotice(text),
@@ -679,6 +682,7 @@ mod tests {
             S::PromptResolved { prompt_id: 3 },
             S::External(crate::events::types::Event::simple("cli", "hello", None)),
             S::AutoTurnCapReached { cap: 5 },
+            S::Idle,
             S::Steered { text: "s".into(), delivered: true },
             S::Dequeued { text: "d".into() },
             S::SystemNotice("sys".into()),
@@ -708,8 +712,8 @@ mod tests {
     #[test]
     fn wire_roundtrip_every_variant() {
         let all = fixtures();
-        // Every SessionEventWire variant (18) + every StreamEvent leaf (18; Stream counted once).
-        assert_eq!(all.len(), 17 + 18);
+        // Every SessionEventWire variant (19) + every StreamEvent leaf (18; Stream counted once).
+        assert_eq!(all.len(), 18 + 18);
         for ev in all {
             let e = env(ev);
             let before = format!("{e:?}");

--- a/crates/agent-engine/src/session/wire.rs
+++ b/crates/agent-engine/src/session/wire.rs
@@ -744,6 +744,8 @@ mod tests {
             ClientFrame::Attach(Attach::Create { config: SessionConfig::default(), mode: AttachMode::Takeover }),
             ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::Submit { text: "hi".into(), attachments: vec![] } },
             ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::Answer { prompt_id: 1, value: Some("pw".into()) } },
+            ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::EngineCommand { id: 4, name: "model".into(), arg: "x".into() } },
+            ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::Query { id: 5, query: SessionQuery::Status } },
             ClientFrame::Bye,
         ];
         for f in frames {

--- a/crates/agent-engine/tests/engine_host.rs
+++ b/crates/agent-engine/tests/engine_host.rs
@@ -167,3 +167,33 @@ async fn extensions_ready_tracks_the_loader() {
         .expect("ready → immediate");
     assert!(h.ext_manager().read().await.discovery_done().is_some());
 }
+
+/// §11 #6: a loader task that dies (panic) between `note_extensions_loading`
+/// and `mark_extensions_ready` must not strand `extensions_ready()` waiters.
+/// Fresh, uninstalled host so the installed one's state is untouched.
+#[tokio::test]
+async fn extensions_ready_returns_when_loader_panics() {
+    let _ = host().await; // base dir configured
+    let h = EngineHost::boot(HostOpts {
+        profile: None,
+        no_extensions: true,
+    })
+    .await
+    .unwrap();
+    let guard = h.extensions_loading_guard();
+    let waiter = {
+        let h = Arc::clone(&h);
+        tokio::spawn(async move { h.extensions_ready().await })
+    };
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert!(!waiter.is_finished(), "loader dispatched → waiter blocks");
+    let loader = tokio::spawn(async move {
+        let _guard = guard;
+        panic!("discovery blew up");
+    });
+    assert!(loader.await.is_err(), "loader panicked");
+    tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+        .await
+        .expect("waiter released by the guard drop")
+        .unwrap();
+}

--- a/crates/agent-engine/tests/engine_host.rs
+++ b/crates/agent-engine/tests/engine_host.rs
@@ -121,3 +121,49 @@ async fn runtime_new_is_still_fully_fresh() {
     assert!(!Arc::ptr_eq(&r.tools_shared(), &h.parts().tools));
     assert!(!Arc::ptr_eq(r.hook_bus(), &h.parts().hook_bus));
 }
+
+/// C2: `extensions_ready()` resolves immediately when no loader was
+/// dispatched, waits for a dispatched loader's `Finished`, and is immediate
+/// afterwards. Uses the installed host (no plugins under the temp home, so
+/// the walk itself is trivial) — the seam is the loader↔host handshake.
+#[tokio::test]
+async fn extensions_ready_tracks_the_loader() {
+    let h = host().await;
+    // No loader dispatched → immediate.
+    tokio::time::timeout(std::time::Duration::from_millis(200), h.extensions_ready())
+        .await
+        .expect("no loader → immediate");
+
+    // Hold the manager write lock so the dispatched loader cannot finish;
+    // a waiter must now block until we release it.
+    let guard = h.ext_manager().write().await;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let loader = agent_engine::extensions::loader::spawn_discover_and_load(
+        Arc::clone(h.ext_manager()),
+        tx,
+        Some("sess-ready".to_string()),
+    );
+    let waiter = {
+        let h = Arc::clone(&h);
+        tokio::spawn(async move {
+            h.extensions_ready().await;
+            std::time::Instant::now()
+        })
+    };
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert!(!waiter.is_finished(), "waiter must block while discovery is pending");
+    let released = std::time::Instant::now();
+    drop(guard);
+    loader.await.unwrap();
+    let woke = waiter.await.unwrap();
+    assert!(woke >= released, "woke only after the loader finished");
+    assert!(matches!(
+        rx.recv().await,
+        Some(agent_engine::extensions::loader::ExtensionLoaderEvent::Started)
+    ));
+    // Afterwards: immediate, and the manager records discovery as done.
+    tokio::time::timeout(std::time::Duration::from_millis(200), h.extensions_ready())
+        .await
+        .expect("ready → immediate");
+    assert!(h.ext_manager().read().await.discovery_done().is_some());
+}

--- a/crates/agent-engine/tests/fixtures/widget_notify_extension.py
+++ b/crates/agent-engine/tests/fixtures/widget_notify_extension.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Emits a `widget.upsert` notification on every hook it receives.
+
+Used by the daemon-mode C3 notification-router test: one sidecar, N sessions,
+every live session must receive the frame.
+"""
+import json
+import sys
+
+
+def read_message():
+    header = b""
+    while not header.endswith(b"\r\n\r\n"):
+        chunk = sys.stdin.buffer.read(1)
+        if not chunk:
+            return None
+        header += chunk
+    content_length = None
+    for line in header.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            content_length = int(line.split(b":", 1)[1].strip())
+            break
+    if content_length is None:
+        return None
+    return json.loads(sys.stdin.buffer.read(content_length).decode("utf-8"))
+
+
+def write_message(payload):
+    body = json.dumps(payload).encode("utf-8")
+    sys.stdout.buffer.write(f"Content-Length: {len(body)}\r\n\r\n".encode("utf-8"))
+    sys.stdout.buffer.write(body)
+    sys.stdout.buffer.flush()
+
+
+def main():
+    beats = 0
+    while True:
+        message = read_message()
+        if message is None:
+            break
+        method = message.get("method")
+        if method == "initialize":
+            write_message({
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {"protocol_version": 1, "capabilities": {}},
+            })
+        elif method == "hook.handle":
+            beats += 1
+            params = message.get("params", {})
+            write_message({
+                "jsonrpc": "2.0",
+                "method": "widget.upsert",
+                "params": {
+                    "id": "c3-widget",
+                    "lines": [f"beat {beats} from {params.get('session_id')}"],
+                },
+            })
+            write_message({"jsonrpc": "2.0", "id": message["id"], "result": {"action": "continue"}})
+        elif method == "shutdown":
+            break
+        else:
+            write_message({
+                "jsonrpc": "2.0",
+                "id": message.get("id"),
+                "error": {"code": -32601, "message": f"unknown method: {method}"},
+            })
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/agent-engine/tests/mcp_descriptor_cache.rs
+++ b/crates/agent-engine/tests/mcp_descriptor_cache.rs
@@ -40,6 +40,7 @@ fn spy_config(marker: &Path) -> McpServerConfig {
             format!("echo spawned >> {}", marker.display()),
         ],
         env: HashMap::new(),
+        shared: false,
     }
 }
 
@@ -614,4 +615,69 @@ fn batch_rejects_collision_with_existing_registry_tool() {
     assert_eq!(registry_snapshot(&registry), before);
     // The live builtin is untouched.
     assert!(registry.get("bash").is_some());
+}
+
+// ── daemon-mode phase 2 (C4): record_server_listing (write-back) ────────────
+
+#[test]
+fn record_server_listing_merges_sanitizes_and_locks() {
+    use agent_engine::mcp::descriptors::record_server_listing;
+
+    let dir = tmp_dir("writeback-merge");
+    let path = dir.join("mcp-descriptors.json");
+
+    // Fresh file.
+    let listing = vec![
+        CachedToolDescriptor {
+            name: "echo_tool".to_string(),
+            description: "x".repeat(TOOL_DESCRIPTION_MAX_BYTES + 50),
+            input_schema: sample_schema(),
+        },
+        CachedToolDescriptor {
+            name: "bad\u{0}name".to_string(),
+            description: String::new(),
+            input_schema: sample_schema(),
+        },
+        CachedToolDescriptor {
+            name: "not_object".to_string(),
+            description: String::new(),
+            input_schema: json!("string schema"),
+        },
+    ];
+    let recorded = record_server_listing(&path, "srv", "fp-1", &listing).unwrap();
+    assert_eq!(recorded, 1, "hostile entries dropped exactly as a load would");
+    let loaded = load_cache_from(&path).unwrap();
+    assert_eq!(loaded.servers["srv"].fingerprint, "fp-1");
+    assert_eq!(loaded.servers["srv"].tools.len(), 1);
+    assert!(loaded.servers["srv"].tools[0].description.len() <= TOOL_DESCRIPTION_MAX_BYTES);
+    assert!(path.with_file_name("mcp-descriptors.json.lock").exists());
+
+    // Merge: a second server does not clobber the first; same server replaces.
+    record_server_listing(&path, "other", "fp-o", &listing[..1]).unwrap();
+    record_server_listing(&path, "srv", "fp-2", &listing[..1]).unwrap();
+    let loaded = load_cache_from(&path).unwrap();
+    assert_eq!(loaded.servers.len(), 2);
+    assert_eq!(loaded.servers["srv"].fingerprint, "fp-2");
+    assert_eq!(loaded.servers["other"].fingerprint, "fp-o");
+
+    // Corrupt cache is replaced, not propagated.
+    std::fs::write(&path, b"{ not json").unwrap();
+    record_server_listing(&path, "srv", "fp-3", &listing[..1]).unwrap();
+    let loaded = load_cache_from(&path).unwrap();
+    assert_eq!(loaded.servers.len(), 1);
+    assert_eq!(loaded.servers["srv"].fingerprint, "fp-3");
+
+    // Invalid server name is refused typed.
+    assert!(matches!(
+        record_server_listing(&path, "bad\nname", "fp", &listing[..1]),
+        Err(DescriptorCacheError::Parse(_))
+    ));
+
+    // `shared` is excluded from the fingerprint.
+    let mut cfg = spy_config(&dir.join("marker"));
+    let fp_a = server_config_fingerprint(&cfg);
+    cfg.shared = true;
+    assert_eq!(server_config_fingerprint(&cfg), fp_a);
+
+    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/agent-engine/tests/mcp_lease_lifecycle.rs
+++ b/crates/agent-engine/tests/mcp_lease_lifecycle.rs
@@ -75,6 +75,7 @@ fn fixture(tag: &str, mode: &str, tools: Value) -> Fixture {
         command: "python3".to_string(),
         args: vec![fixture_script().display().to_string()],
         env,
+        shared: false,
     };
     Fixture { dir, spy, config }
 }
@@ -195,7 +196,10 @@ async fn zero_spawn_before_leased_execution() {
     let fx = fixture("zero-spawn", "ok", advertised_tools());
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
 
     let mut registry = ToolRegistry::new();
     registry
@@ -225,7 +229,10 @@ async fn exact_execute_starts_once_reuses_and_calls_only_exact_tool() {
     let fx = fixture("exact-once", "ok", advertised_tools());
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let cap = McpLeaseCapability::new(sid(), Arc::clone(&manager));
 
     let tools = dormant_tools_for_config(&config_with(fx.config.clone()), &seeded_cache(&fp));
@@ -259,7 +266,10 @@ async fn concurrent_first_calls_are_single_flight() {
     let fx = fixture("single-flight", "ok", advertised_tools());
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let digest = SchemaDigest::of_schema(&echo_schema());
 
     let session = sid();
@@ -296,7 +306,10 @@ async fn sibling_stays_gate_denied_and_is_never_called() {
     let fx = fixture("sibling", "ok", advertised_tools());
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let cap = McpLeaseCapability::new(sid(), Arc::clone(&manager));
 
     let mut registry = ToolRegistry::new();
@@ -336,7 +349,10 @@ async fn fingerprint_drift_invalidates_lease_and_gracefully_kills_child() {
     let fx = fixture("drift", "ok", advertised_tools());
     let fp = server_config_fingerprint(&fx.config);
     let (source, map) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let cap = McpLeaseCapability::new(sid(), Arc::clone(&manager));
 
     let tools = dormant_tools_for_config(&config_with(fx.config.clone()), &seeded_cache(&fp));
@@ -393,7 +409,10 @@ async fn name_and_schema_mismatch_deny_before_any_call() {
     let fx = fixture("mismatch", "ok", hostile);
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
 
     let digest = SchemaDigest::of_schema(&echo_schema());
     let err = manager
@@ -431,7 +450,10 @@ async fn session_end_guard_revocation_and_idle_reap_kill_children() {
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
     // idle_max ZERO: any pre-existing lease is idle by the next acquisition.
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::ZERO));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::ZERO)
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let cap = McpLeaseCapability::new(sid(), Arc::clone(&manager));
     let digest = SchemaDigest::of_schema(&echo_schema());
 
@@ -506,7 +528,10 @@ async fn hostile_and_oversized_provider_data_is_bounded_and_withheld() {
     let fx = fixture("huge", "huge", advertised_tools());
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let digest = SchemaDigest::of_schema(&echo_schema());
     let err = manager
         .call_exact(
@@ -529,7 +554,10 @@ async fn hostile_and_oversized_provider_data_is_bounded_and_withheld() {
     let fx = fixture("hostile-err", "error", advertised_tools());
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let err = manager
         .call_exact(
             &sid(),
@@ -553,7 +581,10 @@ async fn lease_lifecycle_never_mutates_the_catalog() {
     let fx = fixture("no-drift", "ok", advertised_tools());
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let cap = McpLeaseCapability::new(sid(), Arc::clone(&manager));
 
     let mut registry = ToolRegistry::new();
@@ -583,7 +614,10 @@ async fn durable_shared_scope_survives_turns_and_only_last_owner_terminates() {
     let fx = fixture("durable-scope", "ok", advertised_tools());
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let digest = SchemaDigest::of_schema(&echo_schema());
     let session = sid();
 
@@ -696,7 +730,10 @@ async fn fingerprint_drift_revokes_exact_grant_but_not_siblings_or_core() {
     let fx = fixture("grant-drift", "ok", advertised_tools());
     let fp = server_config_fingerprint(&fx.config);
     let (source, map) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let cap = McpLeaseCapability::new(sid(), Arc::clone(&manager));
 
     let mut registry = ToolRegistry::new();
@@ -781,7 +818,10 @@ async fn schema_mismatch_revokes_grant_but_transport_errors_do_not() {
     let fx = fixture("grant-mismatch", "ok", hostile);
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let cap = McpLeaseCapability::new(sid(), Arc::clone(&manager));
 
     let mut registry = ToolRegistry::new();
@@ -813,7 +853,10 @@ async fn schema_mismatch_revokes_grant_but_transport_errors_do_not() {
     let fx = fixture("grant-transport", "huge", advertised_tools());
     let fp = server_config_fingerprint(&fx.config);
     let (source, _) = shared_source(fx.config.clone());
-    let manager = Arc::new(McpRuntimeManager::new(source, Duration::from_secs(300)));
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
     let cap = McpLeaseCapability::new(sid(), Arc::clone(&manager));
     let mut registry = ToolRegistry::new();
     let tools = dormant_tools_for_config(&config_with(fx.config.clone()), &seeded_cache(&fp));
@@ -885,5 +928,275 @@ fn revoke_exact_is_typed_and_reap_scan_covers_full_cap() {
         Err(ExactRevocationError::NotActivated(echo_id.clone()))
     );
     assert_eq!(set.schema_generation(), generation + 1);
+    fx.cleanup();
+}
+
+// ── daemon-mode phase 2 (C4): shared leases + descriptor-cache write-back ───
+
+/// The kill-switch test mutates a process-global env var; the write-back
+/// test must not observe it mid-flight.
+static WRITEBACK_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+fn sid_named(name: &str) -> SessionId {
+    SessionId::parse(name).unwrap()
+}
+
+fn shared_fixture(tag: &str) -> Fixture {
+    let mut fx = fixture(tag, "ok", advertised_tools());
+    fx.config.shared = true;
+    fx
+}
+
+#[tokio::test]
+async fn mcp_shared_lease_key_is_star() {
+    let fx = shared_fixture("shared-key");
+    let fp = server_config_fingerprint(&fx.config);
+    let (source, _) = shared_source(fx.config.clone());
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
+    let digest = SchemaDigest::of_schema(&echo_schema());
+
+    // `shared` is launch-irrelevant: the fingerprint must not move.
+    let mut unshared = fx.config.clone();
+    unshared.shared = false;
+    assert_eq!(server_config_fingerprint(&unshared), fp);
+
+    for session in ["sess-A", "sess-B"] {
+        manager
+            .call_exact(
+                &sid_named(session),
+                "srv",
+                &fp,
+                "echo_tool",
+                &digest,
+                json!({"text": session}),
+            )
+            .await
+            .unwrap();
+    }
+    assert_eq!(
+        manager.lease_keys_for_tests(),
+        vec![(agent_engine::mcp::lease::SHARED_SESSION_KEY.to_string(), "srv".to_string())]
+    );
+    assert_eq!(fx.count("spawn"), 1, "two sessions, ONE shared child");
+    assert_eq!(fx.count("request:tools/call:echo_tool"), 2);
+    // Liveness seam resolves through the shared key for either session.
+    assert!(manager.lease_liveness_for_tests(&sid_named("sess-B"), "srv").is_some());
+    manager.terminate_all();
+    assert_eq!(manager.lease_count(), 0);
+    fx.cleanup();
+}
+
+#[tokio::test]
+async fn terminate_session_spares_shared() {
+    let fx = shared_fixture("shared-spare");
+    let fp = server_config_fingerprint(&fx.config);
+    let (source, _) = shared_source(fx.config.clone());
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
+    let digest = SchemaDigest::of_schema(&echo_schema());
+    manager
+        .call_exact(
+            &sid_named("sess-A"),
+            "srv",
+            &fp,
+            "echo_tool",
+            &digest,
+            json!({"text": "a"}),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(manager.terminate_session(&sid_named("sess-A")), 0);
+    drop(McpSessionEndGuard::new(
+        sid_named("sess-A"),
+        Arc::clone(&manager),
+    ));
+    assert_eq!(manager.lease_count(), 1, "session end must not kill a shared child");
+    assert_eq!(fx.count("eof"), 0);
+
+    // Another session keeps using the same child.
+    manager
+        .call_exact(
+            &sid_named("sess-B"),
+            "srv",
+            &fp,
+            "echo_tool",
+            &digest,
+            json!({"text": "b"}),
+        )
+        .await
+        .unwrap();
+    assert_eq!(fx.count("spawn"), 1);
+
+    // Explicit revocation (poisoned lease) still works through the shared key.
+    manager.revoke_server_lease(&sid_named("sess-B"), "srv");
+    assert_eq!(manager.lease_count(), 0);
+    assert!(wait_until(|| fx.count("eof") == 1).await);
+    fx.cleanup();
+}
+
+#[tokio::test]
+async fn reap_idle_reaps_shared() {
+    let fx = shared_fixture("shared-reap");
+    let fp = server_config_fingerprint(&fx.config);
+    let (source, _) = shared_source(fx.config.clone());
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::ZERO)
+            .with_cache_path(fx.dir.join("descriptors.json")),
+    );
+    let digest = SchemaDigest::of_schema(&echo_schema());
+    manager
+        .call_exact(
+            &sid_named("sess-A"),
+            "srv",
+            &fp,
+            "echo_tool",
+            &digest,
+            json!({"text": "a"}),
+        )
+        .await
+        .unwrap();
+    assert_eq!(manager.lease_count(), 1);
+    manager.reap_idle();
+    assert_eq!(manager.lease_count(), 0, "idle reap applies to shared leases");
+    assert!(wait_until(|| fx.count("eof") == 1).await);
+
+    // terminate_all covers shared too.
+    manager
+        .call_exact(
+            &sid_named("sess-A"),
+            "srv",
+            &fp,
+            "echo_tool",
+            &digest,
+            json!({"text": "b"}),
+        )
+        .await
+        .unwrap();
+    assert_eq!(fx.count("spawn"), 2);
+    manager.terminate_all();
+    assert_eq!(manager.lease_count(), 0);
+    assert!(wait_until(|| fx.count("eof") == 2).await);
+    fx.cleanup();
+}
+
+#[tokio::test]
+async fn descriptor_cache_written_after_list_tools() {
+    use agent_engine::mcp::descriptors::load_cache_from;
+
+    let _env = WRITEBACK_ENV_LOCK.lock().await;
+    let fx = fixture("writeback", "ok", advertised_tools());
+    let fp = server_config_fingerprint(&fx.config);
+    let cache_path = fx.dir.join("mcp-descriptors.json");
+    let (source, _) = shared_source(fx.config.clone());
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(cache_path.clone()),
+    );
+    let digest = SchemaDigest::of_schema(&echo_schema());
+    assert!(!cache_path.exists());
+
+    manager
+        .call_exact(
+            &sid(),
+            "srv",
+            &fp,
+            "echo_tool",
+            &digest,
+            json!({"text": "a"}),
+        )
+        .await
+        .unwrap();
+
+    // File exists, fingerprint matches, digests match the live listing.
+    let cache = load_cache_from(&cache_path).expect("cache written after tools/list");
+    let srv = cache.servers.get("srv").expect("server entry recorded");
+    assert_eq!(srv.fingerprint, fp);
+    assert_eq!(srv.tools.len(), 2);
+    let echo = srv.tools.iter().find(|t| t.name == "echo_tool").unwrap();
+    assert_eq!(SchemaDigest::of_schema(&echo.input_schema), digest);
+    assert_eq!(echo.description, "echoes text back");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&cache_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    // Second boot: dormant tools come from the written cache — no spawn.
+    let spawns_before = fx.count("spawn");
+    let mut registry = ToolRegistry::new();
+    let registered = registry
+        .try_register_batch(dormant_tools_for_config(
+            &config_with(fx.config.clone()),
+            &cache,
+        ))
+        .unwrap();
+    assert_eq!(registered, 2, "second boot advertises the cached tools");
+    assert_eq!(fx.count("spawn"), spawns_before, "cache hit spawns nothing");
+
+    // Merge, don't clobber: an entry for another server survives a write-back.
+    let mut other = load_cache_from(&cache_path).unwrap();
+    other.servers.insert(
+        "other".to_string(),
+        CachedServerDescriptors {
+            fingerprint: "fp-other".to_string(),
+            tools: vec![],
+        },
+    );
+    agent_engine::mcp::descriptors::store_cache_at(&cache_path, &other).unwrap();
+    manager.terminate_all();
+    manager
+        .call_exact(
+            &sid(),
+            "srv",
+            &fp,
+            "echo_tool",
+            &digest,
+            json!({"text": "b"}),
+        )
+        .await
+        .unwrap();
+    let merged = load_cache_from(&cache_path).unwrap();
+    assert!(merged.servers.contains_key("other"), "write-back merges");
+    assert_eq!(merged.servers["srv"].fingerprint, fp);
+
+    manager.terminate_all();
+    fx.cleanup();
+}
+
+#[tokio::test]
+async fn descriptor_cache_writeback_kill_switch() {
+    let _env = WRITEBACK_ENV_LOCK.lock().await;
+    let fx = fixture("writeback-off", "ok", advertised_tools());
+    let fp = server_config_fingerprint(&fx.config);
+    let cache_path = fx.dir.join("mcp-descriptors.json");
+    let (source, _) = shared_source(fx.config.clone());
+    let manager = Arc::new(
+        McpRuntimeManager::new(source, Duration::from_secs(300))
+            .with_cache_path(cache_path.clone()),
+    );
+    let digest = SchemaDigest::of_schema(&echo_schema());
+
+    std::env::set_var("SYNAPS_MCP_CACHE_WRITEBACK", "0");
+    let result = manager
+        .call_exact(
+            &sid(),
+            "srv",
+            &fp,
+            "echo_tool",
+            &digest,
+            json!({"text": "a"}),
+        )
+        .await;
+    std::env::remove_var("SYNAPS_MCP_CACHE_WRITEBACK");
+    result.unwrap();
+    assert!(!cache_path.exists(), "SYNAPS_MCP_CACHE_WRITEBACK=0 writes nothing");
+    manager.terminate_all();
     fx.cleanup();
 }

--- a/crates/agent-engine/tests/notify_router.rs
+++ b/crates/agent-engine/tests/notify_router.rs
@@ -1,0 +1,138 @@
+//! Daemon-mode phase 2 (C3): extension notification router → every live
+//! session. One sidecar, two actor-hosted sessions, one `widget.upsert`
+//! frame → both `LocalTransport`s receive `ExtensionNotification`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_engine::config;
+use agent_engine::extensions::hooks::events::HookEvent;
+use agent_engine::session::{
+    ClientKind, ClientMeta, ClientTransport, LocalTransport, SessionConfig, SessionEventWire,
+};
+use agent_engine::{EngineHost, HostOpts};
+
+fn install_widget_plugin(home: &std::path::Path) {
+    let plugin_dir = home.join("plugins/widget-notify-test");
+    std::fs::create_dir_all(plugin_dir.join(".synaps-plugin")).unwrap();
+    std::fs::create_dir_all(plugin_dir.join("extensions")).unwrap();
+    std::fs::copy(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/widget_notify_extension.py"),
+        plugin_dir.join("extensions/widget_notify_extension.py"),
+    )
+    .unwrap();
+    std::fs::write(
+        plugin_dir.join(".synaps-plugin/plugin.json"),
+        r#"{
+  "name": "widget-notify-test",
+  "version": "0.1.0",
+  "extension": {
+    "protocol_version": 1,
+    "runtime": "process",
+    "command": "python3",
+    "args": ["extensions/widget_notify_extension.py"],
+    "permissions": ["privacy.llm_content"],
+    "hooks": [{"hook": "before_message"}]
+  }
+}
+"#,
+    )
+    .unwrap();
+}
+
+async fn next_notification(t: &mut LocalTransport) -> Option<(String, String, serde_json::Value)> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let ev = tokio::time::timeout_at(deadline, t.next_event()).await.ok()??;
+        if let SessionEventWire::ExtensionNotification {
+            extension_id,
+            method,
+            params,
+        } = ev.event
+        {
+            return Some((extension_id, method, params));
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn notification_router_reaches_every_session() {
+    let home = std::env::temp_dir().join(format!("synaps-notify-router-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&home);
+    std::fs::create_dir_all(&home).unwrap();
+    config::set_base_dir_for_tests(home.clone());
+    install_widget_plugin(&home);
+
+    let host = EngineHost::boot_and_install(HostOpts {
+        profile: None,
+        no_extensions: false,
+    })
+    .await
+    .expect("host boot");
+
+    // Process-level discovery, once.
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    agent_engine::extensions::loader::spawn_discover_and_load(
+        Arc::clone(host.ext_manager()),
+        tx,
+        None,
+    );
+    host.extensions_ready().await;
+    let (loaded, failed) = host.ext_manager().read().await.discovery_done().unwrap();
+    assert_eq!(loaded, vec!["widget-notify-test".to_string()]);
+    assert!(failed.is_empty(), "{failed:?}");
+    agent_engine::extensions::notify_router::spawn_notification_router(Arc::clone(&host))
+        .await
+        .unwrap();
+
+    // Two sessions on the same host, each with an attached local client.
+    let mut transports = Vec::new();
+    for _ in 0..2 {
+        let handle = host
+            .create_session(SessionConfig {
+                persist: false,
+                ..SessionConfig::default()
+            })
+            .await
+            .expect("create_session");
+        let (t, _snapshot) = LocalTransport::attach(handle, ClientMeta::new(ClientKind::Test))
+            .await
+            .expect("attach");
+        transports.push(t);
+    }
+    assert_eq!(host.sessions().len(), 2);
+    let ids: std::collections::HashSet<_> = transports
+        .iter()
+        .map(|t| t.session_id().clone())
+        .collect();
+    assert_eq!(ids.len(), 2, "distinct sessions");
+
+    // Trigger the sidecar: one hook → one widget.upsert frame.
+    let hook_bus = Arc::clone(host.ext_manager().read().await.hook_bus());
+    let _ = hook_bus
+        .emit(&HookEvent::before_message("ping").with_session(Some("sess-trigger")))
+        .await;
+
+    // Both transports receive it (broadcast: frames carry no session id).
+    for t in transports.iter_mut() {
+        let (ext, method, params) = next_notification(t)
+            .await
+            .unwrap_or_else(|| panic!("session {} never received the frame", t.session_id()));
+        assert_eq!(ext, "widget-notify-test");
+        assert_eq!(method, "widget.upsert");
+        assert_eq!(params["id"], "c3-widget");
+        assert_eq!(params["lines"][0], "beat 1 from sess-trigger");
+    }
+
+    // Teardown: end both sessions (each fires its own on_session_end).
+    for t in transports.iter() {
+        let _ = t
+            .send(agent_engine::session::SessionCommand::End {
+                reason: agent_engine::session::EndReason::ClientQuit,
+            })
+            .await;
+    }
+    host.ext_manager().write().await.shutdown_all().await;
+    let _ = std::fs::remove_dir_all(&home);
+}

--- a/crates/agent-engine/tests/session_actor.rs
+++ b/crates/agent-engine/tests/session_actor.rs
@@ -560,3 +560,313 @@ async fn duplicate_continue_attaches_to_live_session() {
     tokio::time::sleep(Duration::from_millis(50)).await;
     assert_eq!(host.sessions().len(), 0);
 }
+
+// ── prompts + lifecycle (§11 #4) ──────────────────────────────────────────
+
+/// Turn requesting the prompting fixture tool; the stub then serves SSE_HI
+/// for the follow-up round.
+const SSE_PROMPT_TOOL_USE: &str = concat!(
+    "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_p1\",\"type\":\"message\",",
+    "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-5\",\"stop_reason\":null,",
+    "\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,",
+    "\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_prompt\",\"name\":\"prompt_fixture\"}}\n\n",
+    "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",",
+    "\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}\n\n",
+    "data: {\"type\":\"message_stop\"}\n\n",
+);
+
+/// Builtin-origin tool that asks for a secret through the stream's
+/// `SecretPromptHandle` and reports only its length (never the value).
+struct PromptFixtureTool;
+
+#[async_trait::async_trait]
+impl agent_engine::Tool for PromptFixtureTool {
+    fn name(&self) -> &str {
+        "prompt_fixture"
+    }
+    fn description(&self) -> &str {
+        "prompts for a secret"
+    }
+    fn parameters(&self) -> agent_engine::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn origin(&self) -> agent_engine::tools::ToolOrigin {
+        agent_engine::tools::ToolOrigin::Builtin
+    }
+    async fn execute(
+        &self,
+        _params: agent_engine::Value,
+        ctx: agent_engine::ToolContext,
+    ) -> agent_engine::Result<String> {
+        let handle = ctx
+            .capabilities
+            .secret_prompt
+            .expect("actor passes its SecretPromptHandle to the stream");
+        Ok(match handle.prompt("Secret".into(), "enter secret".into()).await {
+            Some(v) => format!("answered:{}", v.len()),
+            None => "cancelled".to_string(),
+        })
+    }
+}
+
+async fn prompt_host() -> Arc<EngineHost> {
+    let host = host().await;
+    host.parts()
+        .tools
+        .write()
+        .await
+        .register(Arc::new(PromptFixtureTool));
+    host
+}
+
+fn tool_results(snap: &agent_engine::session::ConversationSnapshot) -> Vec<String> {
+    snap.api_messages
+        .iter()
+        .filter_map(|m| m["content"].as_array())
+        .flat_map(|b| b.iter())
+        .filter(|b| b["type"] == "tool_result")
+        .map(|b| b["content"].as_str().unwrap_or("").to_string())
+        .collect()
+}
+
+fn prompt_id(env: &Envelope) -> Option<u64> {
+    match &env.event {
+        SessionEventWire::Prompt(p) => Some(p.id),
+        _ => None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn pending_prompt_survives_detach_and_replays_on_attach() {
+    let _h = Home::new();
+    let (url, _) = stub_seq(&[SSE_PROMPT_TOOL_USE, SSE_HI]).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = prompt_host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    a.send(submit("go")).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Prompt(_))).await;
+    let pid = prompt_id(seen.last().unwrap()).unwrap();
+    // Never replayed: prompts are not in the turn ring.
+    a.send(SessionCommand::Detach {
+        client: a.client_id(),
+    })
+    .await
+    .unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::ClientLeft { .. })).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(handle.is_alive(), "tool blocks on the prompt; session stays live");
+
+    let (mut b, snap) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
+        .await
+        .unwrap();
+    assert!(snap.streaming);
+    assert_eq!(snap.pending_prompts.len(), 1);
+    assert_eq!(snap.pending_prompts[0].id, pid);
+    assert_eq!(snap.pending_prompts[0].title, "Secret");
+    assert!(
+        !snap.replay.iter().any(|e| matches!(e.event, SessionEventWire::Prompt(_))),
+        "prompt is in pending_prompts, not in replay"
+    );
+
+    b.send(SessionCommand::Answer {
+        prompt_id: pid,
+        value: Some("s3cret".into()),
+    })
+    .await
+    .unwrap();
+    let seen = until(&mut b, |e| matches!(e, SessionEventWire::Idle)).await;
+    assert!(seen.iter().any(|e| matches!(
+        e.event,
+        SessionEventWire::PromptResolved { prompt_id } if prompt_id == pid
+    )));
+    let conv = last_conversation(&seen);
+    assert_eq!(tool_results(&conv), vec!["answered:6".to_string()]);
+    assert!(
+        !seen.iter().any(|e| format!("{:?}", e.event).contains("s3cret")),
+        "the answer never appears on the event stream"
+    );
+    end(&mut b).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn answer_dedup_on_prompt_id() {
+    let _h = Home::new();
+    let (url, _) = stub_seq(&[SSE_PROMPT_TOOL_USE, SSE_HI]).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = prompt_host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Test))
+        .await
+        .unwrap();
+    a.send(submit("go")).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Prompt(_))).await;
+    let pid = prompt_id(seen.last().unwrap()).unwrap();
+
+    // Unknown id: ignored. Same id twice: second ignored.
+    for (id, v) in [(pid + 100, "zzz"), (pid, "aaaaaa"), (pid, "bb")] {
+        a.send(SessionCommand::Answer {
+            prompt_id: id,
+            value: Some(v.into()),
+        })
+        .await
+        .unwrap();
+    }
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    let resolved = seen
+        .iter()
+        .filter(|e| matches!(e.event, SessionEventWire::PromptResolved { .. }))
+        .count();
+    assert_eq!(resolved, 1, "exactly one PromptResolved");
+    assert_eq!(tool_results(&last_conversation(&seen)), vec!["answered:6".to_string()]);
+    end(&mut a).await;
+}
+
+/// on_session_end spy: records whether the session file existed when the
+/// hook fired (save must precede it).
+struct SessionEndSpy {
+    file_present_at_hook: Arc<std::sync::Mutex<Option<bool>>>,
+}
+
+#[async_trait::async_trait]
+impl agent_engine::extensions::runtime::ExtensionHandler for SessionEndSpy {
+    fn id(&self) -> &str {
+        "session-end-spy"
+    }
+    async fn handle(
+        &self,
+        event: &agent_engine::extensions::hooks::events::HookEvent,
+    ) -> agent_engine::extensions::hooks::events::HookResult {
+        if let Some(id) = &event.session_id {
+            let present = agent_engine::core::session::Session::load(id).is_ok();
+            *self.file_present_at_hook.lock().unwrap() = Some(present);
+        }
+        agent_engine::extensions::hooks::events::HookResult::Continue
+    }
+    async fn shutdown(&self) {}
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn end_saves_then_emits_session_end_then_ended() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let at_hook = Arc::new(std::sync::Mutex::new(None));
+    host.parts()
+        .hook_bus
+        .subscribe(
+            agent_engine::extensions::hooks::events::HookKind::OnSessionEnd,
+            Arc::new(SessionEndSpy {
+                file_present_at_hook: Arc::clone(&at_hook),
+            }),
+            None,
+            None,
+            agent_engine::extensions::permissions::PermissionSet::from_strings(&[
+                "session.lifecycle".to_string(),
+            ]),
+        )
+        .await
+        .unwrap();
+
+    let handle = host
+        .create_session(SessionConfig {
+            persist: true,
+            ..cfg()
+        })
+        .await
+        .unwrap();
+    let id = handle.id.clone();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Test))
+        .await
+        .unwrap();
+    a.send(submit("hello")).await.unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+
+    a.send(SessionCommand::End {
+        reason: EndReason::ClientQuit,
+    })
+    .await
+    .unwrap();
+    let tail = until(&mut a, |e| matches!(e, SessionEventWire::Ended { .. })).await;
+    // Ended is the last envelope; the hook already ran and saw the file.
+    assert_eq!(
+        *at_hook.lock().unwrap(),
+        Some(true),
+        "on_session_end fired after save, before Ended"
+    );
+    assert!(matches!(
+        tail.last().unwrap().event,
+        SessionEventWire::Ended {
+            reason: EndReason::ClientQuit
+        }
+    ));
+    assert!(a.next_event().await.is_none(), "nothing after Ended");
+    let saved = agent_engine::core::session::Session::load(id.as_str()).expect("on disk");
+    assert_eq!(saved.api_messages.len(), 2);
+    handle.closed().await;
+}
+
+/// Host-level `daemon stop`: End{HostShutdown} to N live sessions
+/// concurrently → N session files on disk.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn host_shutdown_saves_every_session() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    const N: usize = 3;
+    let mut clients = Vec::new();
+    for i in 0..N {
+        let handle = host
+            .create_session(SessionConfig {
+                persist: true,
+                ..cfg()
+            })
+            .await
+            .unwrap();
+        let (mut t, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Test))
+            .await
+            .unwrap();
+        t.send(submit(&format!("hello {i}"))).await.unwrap();
+        until(&mut t, |e| matches!(e, SessionEventWire::Idle)).await;
+        clients.push((handle, t));
+    }
+    assert_eq!(host.sessions().len(), N);
+
+    let ends = clients.into_iter().map(|(handle, mut t)| async move {
+        t.send(SessionCommand::End {
+            reason: EndReason::HostShutdown,
+        })
+        .await
+        .unwrap();
+        until(&mut t, |e| matches!(e, SessionEventWire::Ended { .. })).await;
+        handle.closed().await;
+        handle.id.clone()
+    });
+    let ids = tokio::time::timeout(
+        Duration::from_secs(agent_engine::session::budgets::TEARDOWN_TIMEOUT_SECS),
+        futures::future::join_all(ends),
+    )
+    .await
+    .expect("all sessions end within the teardown budget");
+    for (i, id) in ids.iter().enumerate() {
+        let saved = agent_engine::core::session::Session::load(id.as_str())
+            .unwrap_or_else(|e| panic!("session {id:?} on disk: {e}"));
+        assert_eq!(saved.api_messages.len(), 2);
+        assert_eq!(saved.api_messages[0]["content"], format!("hello {i}"));
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(host.sessions().len(), 0);
+}

--- a/crates/agent-engine/tests/session_actor.rs
+++ b/crates/agent-engine/tests/session_actor.rs
@@ -485,3 +485,78 @@ async fn cancel_after_done_does_not_scrape_previous_turn() {
         .contains("ABORT CONTEXT"));
     end(&mut a).await;
 }
+
+/// §11 #2: `--continue X` while X is live on this host attaches to the
+/// running actor instead of building a second one on the same session
+/// file / per-session UDS / registry entry.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn duplicate_continue_attaches_to_live_session() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+
+    // A persisted session on disk, then ended.
+    let persisted = SessionConfig {
+        persist: true,
+        ..cfg()
+    };
+    let h0 = host.create_session(persisted.clone()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(h0.clone(), ClientMeta::new(ClientKind::Test))
+        .await
+        .unwrap();
+    a.send(submit("hello")).await.unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    end(&mut a).await;
+    h0.closed().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(host.sessions().len(), 0);
+    let id = h0.id.clone();
+
+    // --continue X, twice, plus --continue latest: one actor.
+    let cont = SessionConfig {
+        continue_session: Some(Some(id.as_str().to_string())),
+        ..persisted.clone()
+    };
+    let h1 = host.create_session(cont.clone()).await.unwrap();
+    assert_eq!(h1.id, id);
+    let reg1 = agent_engine::events::registry::find_session_registration(id.as_str())
+        .expect("registered");
+    let h2 = host.create_session(cont.clone()).await.unwrap();
+    let h3 = host
+        .create_session(SessionConfig {
+            continue_session: Some(None),
+            ..persisted.clone()
+        })
+        .await
+        .unwrap();
+    assert_eq!(h2.id, id);
+    assert_eq!(h3.id, id);
+    assert_eq!(host.sessions().len(), 1, "one actor");
+    let reg2 = agent_engine::events::registry::find_session_registration(id.as_str())
+        .expect("still registered");
+    assert_eq!(reg1.socket_path, reg2.socket_path);
+    assert!(
+        tokio::net::UnixStream::connect(&reg1.socket_path).await.is_ok(),
+        "first actor's UDS still bound"
+    );
+
+    // Same actor: a client on h2 sees the turn started via h1.
+    let (mut b, snap) = LocalTransport::attach(h2.clone(), ClientMeta::new(ClientKind::Attach))
+        .await
+        .unwrap();
+    assert_eq!(snap.conversation.api_messages.len(), 2, "continued history");
+    let (mut c, _) = LocalTransport::attach(h1.clone(), ClientMeta::new(ClientKind::Test))
+        .await
+        .unwrap();
+    c.send(submit("again")).await.unwrap();
+    let seen = until(&mut b, |e| matches!(e, SessionEventWire::Idle)).await;
+    assert_eq!(last_conversation(&seen).api_messages.len(), 4);
+
+    end(&mut c).await;
+    h1.closed().await;
+    assert!(!h2.is_alive());
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(host.sessions().len(), 0);
+}

--- a/crates/agent-engine/tests/session_actor.rs
+++ b/crates/agent-engine/tests/session_actor.rs
@@ -1,0 +1,351 @@
+//! §5.2 — `SessionActor` unit tests through `EngineHost::create_session` +
+//! `LocalTransport`, against a loopback Anthropic SSE stub.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_engine::session::{
+    ClientKind, ClientMeta, ClientTransport, EndReason, Envelope, LocalTransport, SessionCommand,
+    SessionConfig, SessionEventWire, SessionSetting,
+};
+use agent_engine::{EngineHost, HostOpts, SessionEvent, StreamEvent};
+use axum::response::IntoResponse;
+use serial_test::serial;
+
+const MODEL: &str = "claude-sonnet-4-5";
+
+const SSE_HI: &str = concat!(
+    "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"type\":\"message\",",
+    "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-5\",\"stop_reason\":null,",
+    "\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,",
+    "\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":0,",
+    "\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
+    "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",",
+    "\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":1,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}\n\n",
+    "data: {\"type\":\"message_stop\"}\n\n",
+);
+
+/// Started stream with one text delta and NO terminal event.
+const SSE_PREFIX: &str = concat!(
+    "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"type\":\"message\",",
+    "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-5\",\"stop_reason\":null,",
+    "\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,",
+    "\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":0,",
+    "\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
+);
+
+struct Home {
+    _dir: tempfile::TempDir,
+}
+
+impl Home {
+    fn new() -> Self {
+        let dir = tempfile::TempDir::new().unwrap();
+        let base = dir.path().join(".synaps-cli");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(base.join("config"), "").unwrap();
+        std::fs::write(
+            base.join("auth.json"),
+            "{\"anthropic\": {\"type\": \"oauth\", \"refresh\": \"r\", \"access\": \"synthetic-token\", \"expires\": 9999999999999}}",
+        )
+        .unwrap();
+        for k in ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"] {
+            std::env::remove_var(k);
+        }
+        std::env::set_var("HOME", dir.path());
+        std::env::set_var("SYNAPS_BASE_DIR", &base);
+        Self { _dir: dir }
+    }
+}
+
+/// `endless`: after the prefix, keep-alive comments forever (cancel fixture).
+async fn stub(body: &'static str, endless: bool) -> (String, Arc<AtomicUsize>) {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_c = Arc::clone(&hits);
+    let app = axum::Router::new().fallback(move || {
+        let hits = Arc::clone(&hits_c);
+        async move {
+            hits.fetch_add(1, Ordering::SeqCst);
+            if endless {
+                let stream = futures::stream::once(async move {
+                    Ok::<_, std::io::Error>(axum::body::Bytes::from(body))
+                })
+                .chain(futures::stream::unfold((), |()| async {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    Some((Ok(axum::body::Bytes::from(": keep-alive\n\n")), ()))
+                }));
+                axum::response::Response::builder()
+                    .status(200)
+                    .header("content-type", "text/event-stream")
+                    .body(axum::body::Body::from_stream(stream))
+                    .unwrap()
+            } else {
+                (
+                    axum::http::StatusCode::OK,
+                    [("content-type", "text/event-stream")],
+                    body.to_string(),
+                )
+                    .into_response()
+            }
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), hits)
+}
+
+use futures::StreamExt;
+
+async fn host() -> Arc<EngineHost> {
+    EngineHost::boot(HostOpts {
+        profile: None,
+        no_extensions: true,
+    })
+    .await
+    .unwrap()
+}
+
+fn cfg() -> SessionConfig {
+    SessionConfig {
+        model_override: Some(MODEL.into()),
+        persist: false,
+        ..SessionConfig::default()
+    }
+}
+
+async fn next(t: &mut LocalTransport) -> Envelope {
+    tokio::time::timeout(Duration::from_secs(30), t.next_event())
+        .await
+        .expect("timely")
+        .expect("alive")
+}
+
+async fn until(t: &mut LocalTransport, pred: impl Fn(&SessionEventWire) -> bool) -> Vec<Envelope> {
+    let mut out = Vec::new();
+    loop {
+        let env = next(t).await;
+        let done = pred(&env.event);
+        out.push(env);
+        if done {
+            return out;
+        }
+    }
+}
+
+fn submit(text: &str) -> SessionCommand {
+    SessionCommand::Submit {
+        text: text.into(),
+        attachments: vec![],
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn attach_detach_counts_and_seq_is_gapless() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+    assert_eq!(host.sessions().len(), 1);
+    assert!(host.attach(&handle.id).is_some());
+
+    let (mut a, snap_a) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    assert_eq!(snap_a.clients.len(), 1);
+    assert_eq!(snap_a.view.model, MODEL);
+    let (mut b, snap_b) =
+        LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
+            .await
+            .unwrap();
+    assert_eq!(snap_b.clients.len(), 2);
+    assert_ne!(a.client_id(), b.client_id());
+
+    a.send(submit("hello")).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    let seqs: Vec<u64> = seen.iter().map(|e| e.seq).collect();
+    assert!(seqs.windows(2).all(|w| w[1] == w[0] + 1), "gapless: {seqs:?}");
+    assert!(seen
+        .iter()
+        .any(|e| matches!(e.event, SessionEventWire::TurnStarted { .. })));
+    assert!(seen.iter().any(|e| matches!(
+        e.event,
+        SessionEventWire::Stream(StreamEvent::Session(SessionEvent::Done))
+    )));
+    let conv = seen
+        .iter()
+        .rev()
+        .find_map(|e| match &e.event {
+            SessionEventWire::Conversation(c) => Some(c.clone()),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(conv.api_messages.len(), 2);
+    assert_eq!(conv.tokens.input, 10);
+
+    // Both clients saw the same stream.
+    let seen_b = until(&mut b, |e| matches!(e, SessionEventWire::Idle)).await;
+    let sa: Vec<String> = seen
+        .iter()
+        .filter(|e| matches!(e.event, SessionEventWire::Stream(_)))
+        .map(|e| format!("{:?}", e.event))
+        .collect();
+    let sb: Vec<String> = seen_b
+        .iter()
+        .filter(|e| matches!(e.event, SessionEventWire::Stream(_)))
+        .map(|e| format!("{:?}", e.event))
+        .collect();
+    assert_eq!(sa, sb);
+
+    b.send(SessionCommand::Detach {
+        client: b.client_id(),
+    })
+    .await
+    .unwrap();
+    let left = until(&mut a, |e| matches!(e, SessionEventWire::ClientLeft { .. })).await;
+    assert!(!left.is_empty());
+    assert!(handle.is_alive());
+
+    a.send(SessionCommand::End {
+        reason: EndReason::ClientQuit,
+    })
+    .await
+    .unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Ended { .. })).await;
+    handle.closed().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(host.sessions().len(), 0, "actor removed itself from the host map");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn detach_does_not_cancel_stream_end_does() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_PREFIX, true).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Test))
+        .await
+        .unwrap();
+    a.send(submit("go")).await.unwrap();
+    until(&mut a, |e| {
+        matches!(e, SessionEventWire::Stream(StreamEvent::Llm(agent_engine::LlmEvent::Text(_))))
+    })
+    .await;
+
+    // Detach every client mid-turn: the stream keeps running.
+    a.send(SessionCommand::Detach {
+        client: a.client_id(),
+    })
+    .await
+    .unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::ClientLeft { .. })).await;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(handle.is_alive());
+
+    // A fresh client attaches mid-turn: streaming=true, replay non-empty.
+    let (mut b, snap) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
+        .await
+        .unwrap();
+    assert!(snap.streaming, "turn still running after every client detached");
+    assert!(snap
+        .replay
+        .iter()
+        .any(|e| matches!(e.event, SessionEventWire::Stream(_))));
+
+    // End cancels the turn first, then finishes.
+    b.send(SessionCommand::End {
+        reason: EndReason::HostShutdown,
+    })
+    .await
+    .unwrap();
+    let tail = until(&mut b, |e| matches!(e, SessionEventWire::Ended { .. })).await;
+    assert!(tail
+        .iter()
+        .any(|e| matches!(e.event, SessionEventWire::Conversation(_))));
+    handle.closed().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn set_applies_and_publishes_view() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Test))
+        .await
+        .unwrap();
+    a.send(SessionCommand::Set(SessionSetting::ContextWindow {
+        tokens: Some(4242),
+    }))
+    .await
+    .unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::SettingChanged(_))).await;
+    match &seen.last().unwrap().event {
+        SessionEventWire::SettingChanged(s) => {
+            assert!(s.ok);
+            assert_eq!(s.setting, "context_window");
+            assert_eq!(s.view.context_window, 4242);
+        }
+        _ => unreachable!(),
+    }
+    assert_eq!(a.view().context_window, 4242);
+    a.send(SessionCommand::End {
+        reason: EndReason::ClientQuit,
+    })
+    .await
+    .unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Ended { .. })).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn create_session_sets_cwd_and_session_id() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let tmp = tempfile::TempDir::new().unwrap();
+    let handle = host
+        .create_session(SessionConfig {
+            cwd: Some(tmp.path().to_path_buf()),
+            ..cfg()
+        })
+        .await
+        .unwrap();
+    assert_eq!(handle.meta().cwd.as_deref(), Some(tmp.path()));
+    assert_eq!(handle.meta().host_pid, std::process::id());
+    // Registered under the real session registry (synaps send path).
+    let reg = agent_engine::events::registry::find_session_registration(handle.id.as_str());
+    assert!(reg.is_some(), "session registered");
+    let (mut a, snap) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Test))
+        .await
+        .unwrap();
+    assert_eq!(snap.meta.id, handle.id);
+    a.send(SessionCommand::End {
+        reason: EndReason::ClientQuit,
+    })
+    .await
+    .unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Ended { .. })).await;
+    handle.closed().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        agent_engine::events::registry::find_session_registration(handle.id.as_str()).is_none(),
+        "unregistered at End"
+    );
+}

--- a/crates/agent-engine/tests/session_actor.rs
+++ b/crates/agent-engine/tests/session_actor.rs
@@ -106,6 +106,29 @@ async fn stub(body: &'static str, endless: bool) -> (String, Arc<AtomicUsize>) {
 
 use futures::StreamExt;
 
+/// Sequenced stub: hit `i` serves `bodies[min(i, len-1)]` (all terminal).
+async fn stub_seq(bodies: &'static [&'static str]) -> (String, Arc<AtomicUsize>) {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_c = Arc::clone(&hits);
+    let app = axum::Router::new().fallback(move || {
+        let hits = Arc::clone(&hits_c);
+        async move {
+            let i = hits.fetch_add(1, Ordering::SeqCst);
+            let body = bodies[i.min(bodies.len() - 1)];
+            (
+                axum::http::StatusCode::OK,
+                [("content-type", "text/event-stream")],
+                body.to_string(),
+            )
+                .into_response()
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), hits)
+}
+
 async fn host() -> Arc<EngineHost> {
     EngineHost::boot(HostOpts {
         profile: None,
@@ -348,4 +371,117 @@ async fn create_session_sets_cwd_and_session_id() {
         agent_engine::events::registry::find_session_registration(handle.id.as_str()).is_none(),
         "unregistered at End"
     );
+}
+
+fn last_conversation(seen: &[Envelope]) -> agent_engine::session::ConversationSnapshot {
+    seen.iter()
+        .rev()
+        .find_map(|e| match &e.event {
+            SessionEventWire::Conversation(c) => Some(c.clone()),
+            _ => None,
+        })
+        .expect("a Conversation envelope")
+}
+
+async fn end(t: &mut LocalTransport) {
+    t.send(SessionCommand::End {
+        reason: EndReason::ClientQuit,
+    })
+    .await
+    .unwrap();
+    until(t, |e| matches!(e, SessionEventWire::Ended { .. })).await;
+}
+
+/// §11 #1: `Cancel` while idle is a no-op — at most an `Idle` echo. No
+/// "aborted" notice, no Conversation (= no abort_context, no save), and the
+/// next Submit carries no `[ABORT CONTEXT` prefix.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn cancel_while_idle_is_a_noop() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Test))
+        .await
+        .unwrap();
+
+    until(&mut a, |e| matches!(e, SessionEventWire::ClientJoined { .. })).await;
+
+    // Never streamed: Cancel on a fresh session.
+    a.send(SessionCommand::Cancel).await.unwrap();
+    let env = next(&mut a).await;
+    assert!(matches!(env.event, SessionEventWire::Idle), "got {:?}", env.event);
+
+    a.send(submit("hello")).await.unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+
+    a.send(SessionCommand::Cancel).await.unwrap();
+    let env = next(&mut a).await;
+    assert!(matches!(env.event, SessionEventWire::Idle), "got {:?}", env.event);
+
+    a.send(submit("again")).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    assert!(
+        !seen.iter().any(|e| matches!(&e.event,
+            SessionEventWire::SystemNotice(n) if n.starts_with("aborted"))),
+        "no abort notice"
+    );
+    let conv = last_conversation(&seen);
+    assert_eq!(conv.api_messages.len(), 4);
+    assert_eq!(conv.api_messages[2]["content"], "again");
+    assert!(conv.abort_context.is_none());
+    end(&mut a).await;
+}
+
+/// §11 #1: a `Cancel` that lands after `Done` must not scrape the finished
+/// turn into `abort_context` (turn_log is cleared with the stream).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn cancel_after_done_does_not_scrape_previous_turn() {
+    let _h = Home::new();
+    let (url, hits) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Test))
+        .await
+        .unwrap();
+
+    a.send(submit("first")).await.unwrap();
+    // Fire Cancel the moment Done is forwarded; it queues behind the
+    // actor's Done handling and must see streaming=false.
+    until(&mut a, |e| {
+        matches!(
+            e,
+            SessionEventWire::Stream(StreamEvent::Session(SessionEvent::Done))
+        )
+    })
+    .await;
+    a.send(SessionCommand::Cancel).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    assert!(last_conversation(&seen).abort_context.is_none());
+    // Drain the Cancel's own Idle echo if it was not already consumed.
+    let mut idles = seen.iter().filter(|e| matches!(e.event, SessionEventWire::Idle)).count();
+    while idles < 2 {
+        let env = next(&mut a).await;
+        assert!(
+            matches!(env.event, SessionEventWire::Idle),
+            "only Idle may follow an idle Cancel, got {:?}",
+            env.event
+        );
+        idles += 1;
+    }
+
+    a.send(submit("second")).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    let conv = last_conversation(&seen);
+    assert_eq!(hits.load(Ordering::SeqCst), 2);
+    assert_eq!(conv.api_messages[2]["content"], "second");
+    assert!(!conv.api_messages[2]["content"]
+        .as_str()
+        .unwrap()
+        .contains("ABORT CONTEXT"));
+    end(&mut a).await;
 }

--- a/crates/agent-tui/src/tui/draw.rs
+++ b/crates/agent-tui/src/tui/draw.rs
@@ -501,7 +501,7 @@ use super::render_model::{
 /// terminal, same semantics as the old early-return in `draw()`).
 pub(crate) fn build_render_model(
     inputs: &mut ViewInputs<'_>,
-    runtime: &synaps_cli::Runtime,
+    runtime: &impl agent_engine::session::RuntimeRead,
     registry: &std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
     term_size: ratatui::layout::Size,
 ) -> Option<(std::sync::Arc<RenderModel>, RenderPatch)> {

--- a/crates/agent-tui/src/tui/settings/mod.rs
+++ b/crates/agent-tui/src/tui/settings/mod.rs
@@ -131,14 +131,14 @@ pub(crate) struct RuntimeSnapshot {
 impl RuntimeSnapshot {
     #[allow(dead_code)]
     pub fn from_runtime(
-        runtime: &synaps_cli::Runtime,
+        runtime: &impl agent_engine::session::RuntimeRead,
         registry: &synaps_cli::skills::registry::CommandRegistry,
     ) -> Self {
         Self::from_runtime_with_health(runtime, registry, Default::default())
     }
 
     pub fn from_runtime_with_health(
-        runtime: &synaps_cli::Runtime,
+        runtime: &impl agent_engine::session::RuntimeRead,
         registry: &synaps_cli::skills::registry::CommandRegistry,
         model_health: std::collections::HashMap<
             String,

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -1,0 +1,128 @@
+# Daemon mode (`synaps daemon` / `synaps attach`) — phase 2, package B
+
+**Status:** experimental, off by default. Everything here is gated by `SYNAPS_DAEMON=1`.
+Protocol v1 (`crates/agent-engine/src/session/wire.rs`), daemon in `agent-engine::daemon`
+(no `agent-tui` in its graph — `tests/daemon_no_tui_dep.rs`).
+
+## Flags and kill-switches
+
+| Env | Effect |
+|---|---|
+| `SYNAPS_DAEMON=1` | Required for `synaps daemon`, `synaps attach`, and `--attach`. Unset → exit 3 with a one-line reason (`--attach` prints a notice and runs the normal TUI). |
+| `SYNAPS_DAEMON_ALLOW_LEGACY_MCP=1` | Allow start with `progressive_tool_disclosure=false` **and** MCP servers configured (legacy `McpTool` connections would be shared across sessions). Same as `--allow-legacy-mcp`. |
+| `SYNAPS_RUNTIME_DIR` | Where the socket/lock/json/pid live (default `~/.synaps-cli/run`, 0700). |
+| `SYNAPS_SESSION_EVENTS_CAP` | Per-session broadcast capacity (default 1024). A slow client gets `SystemNotice("event stream lagged; n dropped")`. |
+| `SYNAPS_DAEMON_READY_FD` | Internal: write end of the ready pipe handed to a `--detach`ed child. Scrubbed from the env before accept. |
+
+## CLI
+
+```
+synaps daemon [--foreground|--detach] [--socket PATH] [--idle-exit SECS] [--allow-legacy-mcp] [--profile P]
+synaps daemon status [--json]        # daemon.json + flock probe + Ping → state/pid/uptime/sessions (exit 1 if not answering)
+synaps daemon stop [--force]         # Shutdown{force} over the socket, wait for the flock; --force escalates SIGTERM (10 s) → SIGKILL (+5 s)
+synaps daemon sessions [--json]
+synaps attach [ID] [--create] [--continue NAME_OR_ID] [-s PROMPT]
+synaps --attach [ID]                 # today: notice + routes to `synaps attach` (daemon-attached TUI is day 2)
+```
+
+`--detach` forks `current_exe daemon --foreground` under `setsid`, stdout → null, stderr → pipe,
+and waits ≤ 5 s for `R` on an anonymous ready pipe (EOF before `R` = child died → error with its
+stderr tail). Measured on bella: ready in ~75 ms.
+
+`synaps attach` is a thin line client: stdin lines → `Submit` (or `Steer` while streaming);
+`/abort` → `Cancel`; `/detach`, `/quit` or **Ctrl-C → `Detach` + `Bye` — the turn keeps running**;
+`/model NAME`; `/cmd NAME [ARG]` (engine command); `/save`; `/new`; `/sessions` (status query).
+Prompts render as `[prompt #id] title: prompt > `; `Secret` prompts turn terminal echo off.
+With no ID: attaches to the single live session, creates one if none, lists if several.
+
+## Files (under `registry_dir()`, one set per profile: `daemon-<P>.*`)
+
+| File | Mode | Purpose |
+|---|---|---|
+| `daemon.sock` | 0600 | UDS listener (symlinks refused on cleanup) |
+| `daemon.lock` | 0600 | **flock = liveness oracle.** Alive iff someone holds it. Nobody unlinks on ECONNREFUSED alone; `reap_stale` unlinks sock/json/pid only when the lock is free. A second daemon on the same paths is refused. |
+| `daemon.json` | 0600 | `{pid, protocol_version, daemon_version, profile, started_at, socket}` — never credentials |
+| `daemon.pid` | 0600 | pid |
+
+## Protocol summary (line-JSON over UDS, `MAX_FRAME_BYTES` = 1 MiB, same framing as `synaps rpc`)
+
+```
+C: {"type":"hello", protocol_version, client:{kind,terminal,instance}, cwd, client_version}   ← MUST be first
+D: {"type":"welcome", protocol_version, daemon_version, pid, profile, sessions:[SessionMeta], progressive_tool_disclosure}
+   | {"type":"refused", reason:{reason:"version",daemon_version,min,max}|"protocol"|…, message}   → daemon closes
+C: ping | sessions | shutdown{force}          → D: pong{pid,uptime_s,sessions} | session_list{sessions} | bye   (no session allocated)
+C: {"type":"attach", attach:"existing", session_id, mode} | {"type":"attach", attach:"create", config:SessionConfig, mode}
+D: {"type":"attached", client, meta, view, conversation, streaming, replay:[WireEnvelope], pending_prompts, clients} | error
+C: {"type":"cmd", session_id, cmd:SessionCommand} …      → D: {"type":"event", session_id, seq, ts, event:WireSessionEvent} …
+C: bye | socket close = Detach (turn keeps running)
+```
+
+- Version policy: exact match on `protocol_version` (min == max == 1) → `Refused{Version}` **loudly**
+  (client exit 2). Different *binary* version, same protocol → allowed; `attach` prints a notice.
+  `WireSessionEvent` has `#[serde(other)] Unknown` so additive variants from a newer daemon are tolerated.
+- `WireSessionEvent` is a lossless mirror of `SessionEventWire` (`StreamEvent`/`TurnError`/
+  `ExtensionLoaderEvent` mirrored variant-for-variant; round-trip test covers every variant).
+  Conversion happens only at the socket boundary; in-process transports never serialise.
+- First frame not `Hello` / malformed → `Refused{Protocol}`; oversize frame → `Error` + close;
+  `Cmd` before `Attach` → `Error`, connection stays open.
+- `Attach::Create` fills `cwd` from `Hello.cwd`; it must be absolute and exist.
+
+## Security posture
+
+- Socket 0600 in a 0700 dir; same trust domain as every existing per-session socket.
+- **No secret ever crosses daemon → client.** `Welcome`/`Attached` carry summaries only (grep-tested for
+  token/secret/key names). Client → daemon `Answer.value` (e.g. a sudo password) is forwarded to the actor
+  and nowhere else: `ClientFrame`'s `Debug` redacts `Answer`/`Submit`/`Steer` bodies, and
+  `tests/daemon_no_tui_dep.rs::daemon_never_traces_answer_bodies` greps the daemon + socket transport
+  sources for any `tracing::` line mentioning `answer`/`value`.
+- Backpressure, never silent drops: bounded writer queues both ways (`CMD_CHAN_CAP` = 256);
+  `send` returns `TransportError::Backpressure`; the daemon replies `Error{"backpressure…"}`.
+
+## Lifecycle
+
+- Extension discovery runs **once** per daemon before accept (bounded 10 s) — sidecars are per daemon.
+- Daemon SIGTERM/SIGINT/`Shutdown` → `End{HostShutdown}` to every session **concurrently** under ONE
+  `TEARDOWN_TIMEOUT` (SAVE + HOOKS) budget, then `ExtensionManager::shutdown_all`, then unlink files.
+  Attached clients see `Ended` before `Bye`.
+- `--idle-exit SECS`: exit after SECS with zero connections **and** zero live sessions (default: never).
+- Refuse-to-start (exit 3): flag unset; legacy MCP conflict (above); another daemon holds the lock.
+
+## cwd caveats (risk §6.1)
+
+Tools, shell and the memory tool honour the session `cwd` (`Runtime.cwd`). Still process-wide in the
+daemon today: memory project scope, `host_project_root`, project-local plugin discovery, extension
+process cwd. Start the daemon in the project you care about until day 2's `memory_project_scope(cwd)`.
+
+## Memory acceptance — `DAEMON=1 SYNAPS_DAEMON=1 scripts/memprof/bench-sessions.sh BIN 1 2 3`
+
+bella, 2026-09-04, release build @ B6, **real `SessionActor` sessions** (A merged), 2 sidecars
+(synaps-chronos, munder-hive-god), settle 8 s, median of 3:
+
+| N | PSS total (daemon tree ∪ clients) | daemon tree PSS | daemon process PSS | marginal PSS | procs beyond daemon / session | daemon procs | attach ready |
+|---|---|---|---|---|---|---|---|
+| 1 | 108.1 MB | 85.0 MB | 31.5 MB | – | 1.00 | 3 | 47 ms |
+| 2 | 128.1 MB | 82.2 MB | ~28 MB | 19.9 MB | 1.00 | 3 | 46 ms |
+| 3 | 145.6 MB | 81.8 MB | 27.5 MB | 17.6 MB | 1.00 | 3 | 46 ms |
+
+Reading:
+- **procs/session == 1** (the attach client) and **daemon procs constant (3)** across N: sidecars spawn
+  once per daemon, not per session. Gates pass.
+- **Daemon-side marginal cost per idle session ≈ 0 MB** (daemon tree PSS is flat/slightly down 85 → 82 MB
+  as text pages get shared with more clients).
+- **Marginal PSS as measured (17.6–19.9 MB) is above the 15 MB gate**, and it is entirely the
+  `synaps attach` client process (PSS ≈ 21.5 MB, RssAnon ≈ 19.3 MB each, 10 threads): it is the full
+  22 MB `synaps` binary with jemalloc + a tokio runtime. The plan lists the attach client RSS as
+  informational ("≪ 40 MB"); the ≤ 15 MB gate was written for actor/session allocations in the daemon,
+  which are within noise here. Cutting the client below 15 MB is a client-diet task (single-thread runtime,
+  no jemalloc arenas, lazy statics), not a daemon one.
+- Compare in-process (Phase 1 gates): PSS(N=3) ≤ 160 MB with 3 procs/session → daemon mode at 145.6 MB
+  with 1 proc/session, and every additional session costs a 20 MB thin client instead of a full engine.
+
+Raw runs: `/tmp/memprof-synaps-b-daemon-N<N>-r<i>.txt` on bella.
+
+## Not landed today (day 2/3)
+
+`--attach` driving the TUI over `SocketTransport` (needs A4); `--continue X` attach-if-live; `Resync` after
+`Lagged` via `turn_replay`; delta coalescing; `--tcp`; HTTP+SSE front-end; `prompt_over_wire` and
+`detach_without_abort_over_socket` integration tests (need a secret-prompting tool fixture + `Endless`
+script through the actor — the paths are exercised by the actor unit tests and the socket tests above).

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -44,7 +44,7 @@ With no ID: attaches to the single live session, creates one if none, lists if s
 | `daemon.json` | 0600 | `{pid, protocol_version, daemon_version, profile, started_at, socket}` — never credentials |
 | `daemon.pid` | 0600 | pid |
 
-## Protocol summary (line-JSON over UDS, `MAX_FRAME_BYTES` = 1 MiB, same framing as `synaps rpc`)
+## Protocol summary (line-JSON over UDS, `DAEMON_MAX_FRAME_BYTES` = 64 MiB, same framing as `synaps rpc`)
 
 ```
 C: {"type":"hello", protocol_version, client:{kind,terminal,instance}, cwd, client_version}   ← MUST be first
@@ -60,11 +60,31 @@ C: bye | socket close = Detach (turn keeps running)
 - Version policy: exact match on `protocol_version` (min == max == 1) → `Refused{Version}` **loudly**
   (client exit 2). Different *binary* version, same protocol → allowed; `attach` prints a notice.
   `WireSessionEvent` has `#[serde(other)] Unknown` so additive variants from a newer daemon are tolerated.
-- `WireSessionEvent` is a lossless mirror of `SessionEventWire` (`StreamEvent`/`TurnError`/
-  `ExtensionLoaderEvent` mirrored variant-for-variant; round-trip test covers every variant).
-  Conversion happens only at the socket boundary; in-process transports never serialise.
+- `WireSessionEvent` mirrors `SessionEventWire` variant-for-variant (`StreamEvent`/`TurnError`/
+  `ExtensionLoaderEvent` included; round-trip test covers every variant), with **one lossy variant**:
+  `Conversation` goes over the wire as a `ConversationDigest` `{messages_len, messages_hash (FNV-1a),
+  tokens, cost, abort_context, queued_message, pending_events_len, consecutive_auto_turns}` — never the
+  messages. Full `api_messages` travel only in `Attached` and `QueryResult{Messages}`. `SocketTransport`
+  keeps a local mirror (seeded by `Attached`, updated by `Stream(MessageHistory)`), fills the digest in
+  when the hash matches, and on a miss (compaction, abort repair, flushed events) issues one
+  `Query{Messages}` under the reserved id `DIGEST_RESYNC_QUERY_ID` (= 2^63) and re-emits the
+  `Conversation` with the fetched history. Per-event wire cost is O(1) in history size; the O(history)
+  cost is paid once per attach and once per tool round (`MessageHistory`, which the engine emits anyway).
+- **Frame cap: 64 MiB both directions**, distinct from rpc's 1 MiB (an `Attached` for a long session is
+  several MiB). Enforced symmetrically: `encode_line` refuses to build an oversize frame (the daemon sends
+  `Error{"daemon could not encode a frame: …"}` and closes), both readers are `take()`-bounded and reply
+  `Error{"frame exceeds 64 MiB limit"}` + close. Tested: a > 1 MiB history attaches
+  (`attach_to_session_with_history_over_1mib`), a 2 MiB `ping` is answered, a 64 MiB + 10 B frame is refused.
+- Query ids ≥ `RESERVED_QUERY_ID_BASE` (2^63) belong to the transport/daemon (`DIGEST_RESYNC_QUERY_ID`,
+  `IDLE_PROBE_QUERY_ID`); `SocketTransport` never surfaces them as `QueryResult`.
 - First frame not `Hello` / malformed → `Refused{Protocol}`; oversize frame → `Error` + close;
   `Cmd` before `Attach` → `Error`, connection stays open.
+- **Client command whitelist** (`conn.rs::client_may_send`): an attached client may send `Submit`,
+  `Steer`, `Cancel`, `Answer`, `Set`, `Compact`, `NewSession`, `Save`, `Query`, `EngineCommand`, and
+  `Detach` **for its own client id only**. `Detach{other}`, `Attach`, `Resync`, `End`, `HostEvent` →
+  `Error{"refused: …"}` and nothing reaches the actor. Sessions are ended by `synaps daemon stop`, not
+  by clients. This is a footgun guard on a same-uid 0600 socket, not an auth boundary
+  (`client_commands_are_whitelisted`).
 - `Attach::Create` fills `cwd` from `Hello.cwd`; it must be absolute and exist.
 
 ## Security posture
@@ -77,6 +97,9 @@ C: bye | socket close = Detach (turn keeps running)
   sources for any `tracing::` line mentioning `answer`/`value`.
 - Backpressure, never silent drops: bounded writer queues both ways (`CMD_CHAN_CAP` = 256);
   `send` returns `TransportError::Backpressure`; the daemon replies `Error{"backpressure…"}`.
+- **The daemon trusts its uid.** Anyone who can open the socket can `shutdown`, `Attach::Create` with any
+  `SessionConfig` (`prompt_manifest`, `auto_approve_confirms`, `persist:false`), and `Cancel`/`Compact`
+  a session someone else is attached to. That is the same trust as the shell that started the daemon.
 
 ## Lifecycle
 
@@ -84,7 +107,25 @@ C: bye | socket close = Detach (turn keeps running)
 - Daemon SIGTERM/SIGINT/`Shutdown` → `End{HostShutdown}` to every session **concurrently** under ONE
   `TEARDOWN_TIMEOUT` (SAVE + HOOKS) budget, then `ExtensionManager::shutdown_all`, then unlink files.
   Attached clients see `Ended` before `Bye`.
-- `--idle-exit SECS`: exit after SECS with zero connections **and** zero live sessions (default: never).
+- `--idle-exit SECS`: exit after SECS of **zero connections and no session running a turn** (default:
+  never). Sessions never end on their own (no `Parked` yet), so the monitor probes each client-less
+  session with `Query{Status}` (reserved id `IDLE_PROBE_QUERY_ID`) and treats `streaming:true`, a pending
+  prompt, or **no answer within 2 s** (actor inside `compact()`/preflight, queue full) as busy — the
+  daemon never exits under a running turn and never aborts one. Idle client-less sessions are ended
+  through the normal `End{HostShutdown}` path (saved to `sessions/<id>.json`; `synaps attach --continue`
+  brings them back). Tested: `idle_exit_counts_clientless_idle_sessions_and_never_a_running_turn`.
+- **Extension notification router** (`extensions::notify_router`) is spawned by `run_foreground` after
+  discovery: every sidecar's `widget.*` frames fan out to **every** live session as
+  `ExtensionNotification`. Frames carry no session id, so **widgets are daemon-global under
+  `SYNAPS_DAEMON=1`** (a widget upsert from work in session A shows in session B's client). Per-session
+  routing needs `params.session_id` from the extension contract — day 2; `heartbeat`/`jawz-widget` are
+  last-writer-wins until then (`docs/extensions/session-id.md`).
+- **Compaction is inline in the actor**: `Attach`/`Detach`/`Cancel` wait behind a running `compact()`;
+  `SocketTransport::attach` gives up after `ATTACH_TIMEOUT` (5 s) with "attach timed out" — retry.
+  Spawned compaction is day 2.
+- `daemon stop` while a turn is streaming cancels it **and captures an abort context** (`finish()` →
+  `cancel_turn()`), so the session is "aborted" on disk; the TUI's quit-mid-turn only cancels the token.
+  Defensible (the next `--continue` tells the model the previous answer was cut), documented here.
 - Refuse-to-start (exit 3): flag unset; legacy MCP conflict (above); another daemon holds the lock.
 
 ## cwd caveats (risk §6.1)
@@ -92,6 +133,28 @@ C: bye | socket close = Detach (turn keeps running)
 Tools, shell and the memory tool honour the session `cwd` (`Runtime.cwd`). Still process-wide in the
 daemon today: memory project scope, `host_project_root`, project-local plugin discovery, extension
 process cwd. Start the daemon in the project you care about until day 2's `memory_project_scope(cwd)`.
+
+## What changes on the default (in-process) path — read before merging
+
+Honest list of behaviour changes on this branch with `SYNAPS_DAEMON` **unset**:
+
+1. **`synaps chat` runs on `SessionActor`** (`LocalTransport`, in-process). The differential test
+   (`tests/session_actor_differential.rs`) compares the actor against a *frozen re-derivation* of the
+   inline engine halves (not a verbatim copy; it has no abort/prompt/save) on **three scenarios only**:
+   plain turn, provider error repairing history, idle auto-turn to cap. **Tool loop, steer-mid-stream,
+   queue-while-busy, cancel/abort-context, secret-prompt round-trip are asserted by actor unit tests, not
+   by the differential.** `tests/chat_stdin.rs` is unchanged and green but never runs a turn through a
+   stub. The kill-switch `SYNAPS_CHAT_INLINE=1` only exists in a `--features legacy_inline` build.
+   One byte-level difference: **chat's abort context is now `"{ctx}\n\n{msg}"` (context first, wrapper
+   applied once — the TUI shape)** where inline chat built `"{msg}\n\n[ABORT CONTEXT…{ctx}…]"` and
+   re-wrapped; only visible on `synaps chat --continue` of an aborted session.
+2. **MCP descriptor cache write-back is ON by default, in-process too** (`docs/mcp.md`): after the first
+   `tools/list` on an exact lease the listing is written to `~/.synaps-cli/mcp-descriptors.json`, so the
+   *next* boot registers dormant MCP tools it did not know before → tool list, system prompt and the
+   provider prompt-cache prefix differ between run 1 and run 2 for every MCP user. Intended (the cache
+   finally has a writer), but it is a default-path change. `SYNAPS_MCP_CACHE_WRITEBACK=0` restores the
+   old read-only behaviour.
+3. Hook events carry `session_id` (additive; `SYNAPS_HOOK_SESSION_ID=0`).
 
 ## Memory acceptance — `DAEMON=1 SYNAPS_DAEMON=1 scripts/memprof/bench-sessions.sh BIN 1 2 3`
 
@@ -122,7 +185,7 @@ Raw runs: `/tmp/memprof-synaps-b-daemon-N<N>-r<i>.txt` on bella.
 
 ## Not landed today (day 2/3)
 
-`--attach` driving the TUI over `SocketTransport` (needs A4); `--continue X` attach-if-live; `Resync` after
+`--attach` driving the TUI over `SocketTransport` (needs A4); `Resync` after
 `Lagged` via `turn_replay`; delta coalescing; `--tcp`; HTTP+SSE front-end; `prompt_over_wire` and
 `detach_without_abort_over_socket` integration tests (need a secret-prompting tool fixture + `Endless`
 script through the actor — the paths are exercised by the actor unit tests and the socket tests above).

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -183,6 +183,47 @@ Reading:
 
 Raw runs: `/tmp/memprof-synaps-b-daemon-N<N>-r<i>.txt` on bella.
 
+### Fix round: daemon-tree RssAnon column (§9 of the phase-2 review)
+
+`bench-sessions.sh` DAEMON=1 now prints `daemon_anon` (Σ RssAnon over the daemon tree) and
+`anon_marginal` (= daemon-side RssAnon cost of one idle session — the number the ≤ 15 MB gate was
+written for; PSS "≈ 0 marginal" above was a sharing artefact). bella, 2026-09-04, release @ fix round,
+REPEAT=1, real actors, same 2 sidecars. `before` = multi-thread attach client, `after` = current-thread
+attach client (commit "attach client diet"):
+
+| binary | settle | N | PSS total | daemon tree PSS | daemon_anon (tree) | daemon proc RssAnon | **anon_marginal / session** | attach client RssAnon | client threads |
+|---|---|---|---|---|---|---|---|---|---|
+| before | 8 s | 1 | 111.1 MB | 85.8 MB | 36.4 MB | 23.6 MB | – | 21.4 MB | 10 |
+| before | 8 s | 3 | 128.9 MB | 82.7 MB | 34.9 MB | 22.0 MB | **−0.7 MB** | 19.1 / 19.1 / 1.7 MB | 10 |
+| before | 15 s | 1 | 82.3 MB | 61.6 MB | 18.5 MB | 7.4 MB | – | 1.7 MB | 10 |
+| before | 15 s | 3 | 70.3 MB | 61.9 MB | 20.6 MB | 7.4 MB | **+1.0 MB** | 1.7 / 1.7 / 1.8 MB | 10 |
+| after | 8 s | 1 | 98.8 MB | 83.9 MB | 34.0 MB | ~21 MB | – | ~11 MB | 4 |
+| after | 8 s | 3 | 77.8 MB | 66.6 MB | 18.6 MB | 5.9 MB | **−7.7 MB** | 1.4 / 1.4 / 1.4 MB | 4 |
+| after | 15 s | 1 | 91.8 MB | 78.2 MB | 33.0 MB | 20.6 MB | – | 11.1 MB | 4 |
+| after | 15 s | 3 | 116.2 MB | 77.4 MB | 33.5 MB | 20.6 MB | **+0.25 MB** | 11.1 / 11.1 / 13.1 MB | 4 |
+
+Reading, honestly:
+- **Daemon-side RssAnon per idle session is ≈ 0–1 MB** (−0.7, +1.0, −7.7, +0.25 MB across the four
+  pairs). A `SessionActor` + `Runtime` + `ConversationState` with no turn is small; the registries are
+  `Arc`-shared. The ≤ 15 MB daemon-side gate passes with a wide margin. This is the number the gate was
+  about; it was simply unmeasured before.
+- **Everything else in this table is jemalloc purge timing, not code.** The daemon process swings
+  7 → 23 MB and the *same* attach binary reads 1.7 MB or 19 MB depending on whether jemalloc's background
+  thread (sleeps up to 10 s when idle) has purged the startup garbage before the sample. An 8 s or 15 s
+  settle lands on either side of that window at random. `bench-turns.sh`-style double settle (> 20 s) or
+  a `mallctl("arena.<i>.purge")` before sampling is the day-2 fix for the *script*.
+- **Client diet**: the current-thread runtime for `synaps attach` cuts threads 10 → 4 and removes the
+  worker pool; its RssAnon effect cannot be resolved under the purge noise above (both binaries bottom
+  out at 1.4–1.8 MB once purged, i.e. the post-purge client is already tiny — the 21 MB PSS headline is
+  mostly shared text of the 22 MB binary). Remaining day-2 diet items: skip `EngineHost`/config/skills
+  statics on the attach path (nothing in `main.rs` boots them before dispatch today — verified), and
+  `narenas:1,background_thread:false` for the client via a per-command `MALLOC_CONF` (needs the static
+  conf to move to a runtime `mallctl`).
+- procs/session == 1.00 and daemon procs == 3 held in all eight runs.
+
+Raw runs: `/tmp/memprof-synaps-fb-{before,after}-daemon-N<N>-r1.txt` on bella (the 15 s runs
+overwrote the 8 s ones for the same N; the 8 s values above are transcribed from the earlier console).
+
 ## Not landed today (day 2/3)
 
 `--attach` driving the TUI over `SocketTransport` (needs A4); `Resync` after

--- a/docs/extensions/session-id.md
+++ b/docs/extensions/session-id.md
@@ -1,0 +1,63 @@
+# `session_id` on hook events
+
+Since daemon-mode phase 2 (C1), **every** hook event carries the owning
+conversation id in the `session_id` field — not only the session-lifecycle
+hooks.
+
+| Hook                  | `session_id` before | `session_id` now                          |
+|-----------------------|---------------------|-------------------------------------------|
+| `before_tool_call`    | `null`              | `"<conversation id>"` (foreground session) |
+| `after_tool_call`     | `null`              | `"<conversation id>"`                      |
+| `before_message`      | `null`              | `"<conversation id>"`                      |
+| `on_message_complete` | `null`              | `"<conversation id>"`                      |
+| `on_compaction`       | new session id      | unchanged                                  |
+| `on_session_start`    | session id          | unchanged                                  |
+| `on_session_end`      | session id          | unchanged                                  |
+
+The field already existed as `Option<String>` in the JSON schema
+(`docs/extensions/contract.json`), so the change is **additive**: an
+extension that ignores `session_id` sees the same shape it always did.
+
+## When it is still `null`
+
+- **Workers / subagents.** A worker runtime has no conversation id
+  (`Runtime.session_id == None`), so its tool hooks still emit `null` —
+  exactly as before. Plugins must not assume every tool call belongs to a
+  session.
+- **Extension-originated `tool.invoke`.** A tool invoked by a sidecar via the
+  extension protocol runs outside a conversation turn; `null`.
+- **Kill-switch `SYNAPS_HOOK_SESSION_ID=0`** (also `false`/`off`): forces
+  `null` on the four tool/message hooks. Use it if a plugin misbehaves on the
+  new value. Session-lifecycle hooks are unaffected.
+
+## Why: one sidecar, many sessions
+
+In daemon mode one extension process serves every session in the daemon.
+"Last tool call"-style state keyed on nothing is now keyed on the wrong thing:
+two sessions interleave their hooks on the same stdin. Key per-session state
+on `params.session_id`, and treat `null` as "no session (worker)".
+
+The in-tree helper is `HookEvent::with_session(Option<&str>)`; the runtime
+emitters `emit_before_tool_call` / `emit_after_tool_call` take a trailing
+`session_id: Option<&str>`.
+
+## In-tree plugin audit (2026-09, jade 16 / bella 2)
+
+Plugins with hook handlers and what the new field means for them:
+
+| Plugin (host)            | Hooks                                                   | Finding |
+|--------------------------|---------------------------------------------------------|---------|
+| `heartbeat` (jade)       | on_session_start, on_message_complete, on_session_end   | Captures `session_id` from **any** hook into a single global `STATE["session_id"]` ("defensive"). Single session: identical (same id). Daemon mode: last-writer-wins → beats target whichever session most recently completed a message. Needs per-session state on day 2; not broken. |
+| `munder-hive-god` (bella)| before/after_tool_call, on_message_complete, session start/end | `payload.session_id = payload.session_id \|\| SESSION_ID` — it already prefers the hook's id and falls back to a registry-recovered one (comment notes "HookEvent.session_id is always null"). Now the hook value wins; correct per-session in daemon mode. Comment at `bridge.cjs:45` is stale. |
+| `synaps-tasks` (jade)    | before_message, on_session_start, on_session_end        | Reads `session_id` only in `on_session_end` (velocity record). Unaffected. |
+| `jawz-widget` (jade)     | before_message, on_message_complete, before/after_tool_call | Switches on `kind` only; keeps a global `mode` (thinking/coding/done). Ignores `session_id`; in daemon mode the widget reflects the union of sessions. Cosmetic. |
+| `axel` (jade, Rust)      | before_message, on_session_start, on_session_end        | No `session_id` handling in hook path. Unaffected. |
+| `chronos` (jade+bella)   | before_message                                          | Stateless inject. Unaffected. |
+| `d20` (jade)             | before_message                                          | Stateless. Unaffected. |
+| `crush` (jade, Rust)     | after_tool_call                                         | Stateless transform. Unaffected. |
+| `jimmy-provider` (jade)  | on_session_start                                        | Already receives the id. Unaffected. |
+| others (finlens, hubspot-tools, misfire, pria-dev-plugin, sample-sidecar, tmux-tools, weather-lens, web-tools) | none | No hook handlers. |
+
+No plugin breaks on the additive field. Two (`heartbeat`, `jawz-widget`) hold
+process-global "current session" state that becomes last-writer-wins under a
+shared daemon sidecar — the day-2 audit item.

--- a/docs/extensions/session-id.md
+++ b/docs/extensions/session-id.md
@@ -33,6 +33,10 @@ extension that ignores `session_id` sees the same shape it always did.
 ## Why: one sidecar, many sessions
 
 In daemon mode one extension process serves every session in the daemon.
+The reverse direction is fanned out too: `synaps daemon` runs the
+notification router (`extensions::notify_router`), which delivers every
+sidecar's `widget.*` frames to **every** live session — widgets are
+daemon-global under `SYNAPS_DAEMON=1` until frames carry `params.session_id`.
 "Last tool call"-style state keyed on nothing is now keyed on the wrong thing:
 two sessions interleave their hooks on the same stdin. Key per-session state
 on `params.session_id`, and treat `null` as "no session (worker)".

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,87 @@
+# MCP servers
+
+Configured in `~/.synaps-cli/mcp.json` (profile variant honoured):
+
+```json
+{
+  "mcpServers": {
+    "fs":         { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "."] },
+    "playwright": { "command": "npx", "args": ["@playwright/mcp"], "shared": true }
+  }
+}
+```
+
+| Field     | Default | Meaning |
+|-----------|---------|---------|
+| `command` | —       | Executable to spawn (stdio JSON-RPC). |
+| `args`    | `[]`    | Arguments. |
+| `env`     | `{}`    | Extra environment for the child. |
+| `shared`  | `false` | Daemon mode: one child for **every** session in the process (see below). |
+
+## Exact leases (progressive disclosure)
+
+Under progressive tool disclosure MCP tools are *dormant* registry entries
+built from the descriptor cache; nothing is spawned until a gate-authorized
+call needs a server. `McpRuntimeManager` then holds one **lease** per
+`(session, server)`: one child process per session per server, initialised
+and `tools/list`ed once, every call re-validated against the pinned listing
+(name + schema digest), terminated at session end (`McpSessionEndGuard`),
+on revocation, or after `idle_max` (default 300 s).
+
+## `shared: true` — one child per process (opt-in)
+
+In daemon mode N sessions × M servers would mean N×M children. A server
+marked `shared: true` is instead keyed under the process-wide lease key
+`"*"`:
+
+- **one child** serves every session in the daemon;
+- **the server sees every session's calls and holds cross-session state**
+  (roots, cwd, open browser tabs, …). Only opt in for servers that are
+  stateless per call or whose state you *want* shared;
+- `terminate_session` / `McpSessionEndGuard` **never** terminate it;
+  `reap_idle` (idle past `idle_max`), explicit revocation
+  (`revoke_server_lease` on fingerprint drift / listing mismatch — the lease
+  is poisoned for everyone) and `terminate_all` (process shutdown) do;
+- exactness is unchanged: sharing widens the *child*, never the *grant*.
+  Every call still passes the per-session execution gate and the pinned
+  digest check;
+- `shared` is **excluded from the config fingerprint** — it changes the
+  lease key, not the launched process — so flipping it keeps cached
+  descriptors valid and simply starts a fresh lease under the other key.
+
+Never the default. In single-session (in-process) mode `shared` only
+changes the key string; behaviour is identical.
+
+## Descriptor cache write-back
+
+`~/.synaps-cli/mcp-descriptors.json` is the operator-local descriptor cache
+that `setup_lazy_mcp` reads at boot to register dormant tools without
+spawning anything. Since daemon-mode phase 2 it is also **written**: after a
+lease's first successful `tools/list`, the listing is merged into the cache
+under the server name, keyed by the config fingerprint
+(`descriptors::record_server_listing`).
+
+Effect: the next boot (daemon restart, or the next `synaps` process)
+advertises the same tool schemas as the last run without connecting — the
+first turn's tool block, and thus the provider prompt-cache prefix, is
+stable across restarts.
+
+Safety properties:
+
+- only the **exact-lease path** writes (a server the operator configured,
+  started for an already gate-authorized call). The legacy server-wide
+  `connect_mcp_server` gateway never writes — it is not exact-tool
+  authorized and must not be a cache-poisoning bridge;
+- entries pass the same sanitisation as a load (name bounds, object
+  schemas, ≤ 64 KiB per schema, ≤ 256 tools per server, descriptions
+  clamped);
+- exclusive `fs4` lock on `mcp-descriptors.json.lock` around
+  read-merge-write; `0600` file in a `0700` dir; atomic rename. Two daemons
+  / profiles / an in-process TUI writing concurrently serialise on the lock;
+- an unreadable cache (corrupt, oversize, wrong version) is replaced rather
+  than propagated — the reader would have refused it anyway;
+- a write-back failure is logged and never surfaces: the lease is already
+  live.
+
+Kill-switch: `SYNAPS_MCP_CACHE_WRITEBACK=0` (also `false`/`off`) — never
+write. The cache remains a supported *input*.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -83,5 +83,14 @@ Safety properties:
 - a write-back failure is logged and never surfaces: the lease is already
   live.
 
+**This is on by default in every mode, including the single-session TUI /
+`synaps chat` with `SYNAPS_DAEMON` unset.** Before: exact mode with no cache
+meant "MCP tools are not discoverable this run", every run. After: run 1
+writes the cache, run 2 registers dormant tools at boot — the tool list,
+system prompt and provider prompt-cache prefix differ between the first and
+second run for every MCP user. That is the feature working, but it is the
+one default-path behaviour change of daemon-mode phase 2; it is listed in
+`docs/daemon-mode.md` under "What changes on the default path".
+
 Kill-switch: `SYNAPS_MCP_CACHE_WRITEBACK=0` (also `false`/`off`) — never
 write. The cache remains a supported *input*.

--- a/scripts/memprof/bench-sessions.sh
+++ b/scripts/memprof/bench-sessions.sh
@@ -10,6 +10,12 @@
 # startup time to '○ ready'. Prints one summary line per run and writes raw
 # output to $OUT (default /tmp/memprof-<binary>-N<N>-r<i>.txt).
 #
+# DAEMON=1 mode (PLAN-phase2 §5.5): one `synaps daemon --foreground` in tmux
+# window `d`, then N `synaps attach --create` thin clients. PSS is measured
+# over {daemon tree} ∪ {attach pids}; procs/session = (total − daemon tree)/N.
+# Extra columns: daemon_pss, marginal_pss (PSS(N) − PSS(N−1)). Requires
+# SYNAPS_DAEMON=1 (exported here). Sessions are REAL SessionActors.
+#
 # Never touches tmux servers other than `-L bench`. No root needed.
 set -u
 HERE=$(cd "$(dirname "$0")" && pwd)
@@ -18,6 +24,8 @@ NS=${*:-1 2 3}
 REPEAT=${REPEAT:-3}
 SETTLE=${SETTLE:-12}
 TAG=$(basename "$BIN")
+DAEMON=${DAEMON:-0}
+[ "$DAEMON" = 1 ] && export SYNAPS_DAEMON=1
 
 median() { sort -n | awk '{a[NR]=$1} END{ if (NR==0) print "n/a"; else if (NR%2) print a[(NR+1)/2]; else print (a[NR/2]+a[NR/2+1])/2 }'; }
 
@@ -46,6 +54,65 @@ run_once() { # N i -> prints "pss_kb rss_anon_kb_of_first_engine procs startup_m
   tmux -L bench kill-server 2>/dev/null
   echo "$pss $anon $procs ${starts[0]} $out"
 }
+
+run_once_daemon() { # N i -> prints "pss_kb daemon_pss_kb procs_beyond_daemon startup_ms out"
+  local n=$1 i=$2 out=/tmp/memprof-$TAG-daemon-N$n-r$i.txt
+  tmux -L bench kill-server 2>/dev/null; sleep 1
+  "$BIN" daemon stop >/dev/null 2>&1
+  local t0 t1
+  t0=$(date +%s%N)
+  tmux -L bench new -d -s d -x 120 -y 40 "exec $BIN daemon --foreground"
+  for _ in $(seq 1 500); do sleep 0.02; "$BIN" daemon status --json 2>/dev/null | grep -q '"ok":true' && break; done
+  t1=$(date +%s%N)
+  local dstart=$(( (t1-t0)/1000000 ))
+  local dpid; dpid=$(tmux -L bench list-panes -t d -F '#{pane_pid}')
+  local starts=()
+  for s in $(seq 1 "$n"); do
+    starts+=("$("$HERE/launch.sh" "s$s" "$BIN" attach --create | sed -E 's/.*ready after ([0-9]+) ms.*/\1/')")
+    sleep 0.3
+  done
+  sleep "$SETTLE"
+  local apids; apids=$(for s in $(seq 1 "$n"); do tmux -L bench list-panes -t "s$s" -F '#{pane_pid}'; done | tr '\n' ' ')
+  {
+    echo "== $BIN DAEMON N=$n run=$i daemon_start_ms=$dstart attach_start_ms=${starts[*]}"
+    echo "-- daemon tree"; "$HERE/mem.sh" "$dpid"
+    echo "-- attach clients"; "$HERE/mem.sh" $apids
+    echo "-- all"; "$HERE/mem.sh" "$dpid" $apids
+    for p in $dpid $apids; do echo -n "pid=$p "; grep -E 'RssAnon|Threads' "/proc/$p/status" | tr '\n' ' '; echo; done
+    "$BIN" daemon status --json 2>/dev/null
+    "$BIN" status --memory --json --pid "$dpid" 2>/dev/null
+  } > "$out"
+  local pss dpss procs dprocs
+  pss=$(awk '/^-- all/{f=1} f&&/^TOTAL/{for(k=1;k<=NF;k++) if($k ~ /^PSS=/){sub("PSS=","",$k); print $k; exit}}' "$out")
+  procs=$(awk '/^-- all/{f=1} f&&/^TOTAL/{for(k=1;k<=NF;k++) if($k ~ /^procs=/){sub("procs=","",$k); print $k; exit}}' "$out")
+  dpss=$(awk '/^-- daemon tree/{f=1} f&&/^TOTAL/{for(k=1;k<=NF;k++) if($k ~ /^PSS=/){sub("PSS=","",$k); print $k; exit}}' "$out")
+  dprocs=$(awk '/^-- daemon tree/{f=1} f&&/^TOTAL/{for(k=1;k<=NF;k++) if($k ~ /^procs=/){sub("procs=","",$k); print $k; exit}}' "$out")
+  "$BIN" daemon stop >/dev/null 2>&1
+  tmux -L bench kill-server 2>/dev/null
+  echo "$pss $dpss $((procs-dprocs)) $dprocs ${starts[0]:-0} $out"
+}
+
+if [ "$DAEMON" = 1 ]; then
+  echo "binary=$BIN repeat=$REPEAT settle=${SETTLE}s mode=DAEMON"
+  printf "%-4s %-10s %-12s %-14s %-12s %-12s %-10s\n" N "PSS_MB(med)" "daemon_pss" "marginal_pss" "procs/sess" "daemon_procs" "attach_ms(med)"
+  prev=""
+  for n in $NS; do
+    P=(); D=(); C=(); DP=(); S=()
+    for i in $(seq 1 "$REPEAT"); do
+      read -r pss dpss procs dprocs start out < <(run_once_daemon "$n" "$i")
+      P+=("$pss"); D+=("$dpss"); C+=("$procs"); DP+=("$dprocs"); S+=("$start")
+    done
+    pss_med=$(printf '%s\n' "${P[@]}" | median)
+    d_med=$(printf '%s\n' "${D[@]}" | median)
+    st_med=$(printf '%s\n' "${S[@]}" | median)
+    procs_per=$(awk -v c="${C[0]}" -v n="$n" 'BEGIN{printf "%.2f", c/n}')
+    marg=$( [ -n "$prev" ] && awk -v a="$pss_med" -v b="$prev" 'BEGIN{printf "%.1f", (a-b)/1024}' || echo "-" )
+    printf "%-4s %-10.1f %-12.1f %-14s %-12s %-12s %-10s\n" "$n" "$(awk -v k="$pss_med" 'BEGIN{print k/1024}')" "$(awk -v k="$d_med" 'BEGIN{print k/1024}')" "$marg" "$procs_per" "${DP[0]}" "$st_med"
+    prev=$pss_med
+  done
+  echo "gates: marginal_pss <= 15 MB; procs/sess == 1.00 (the attach client); daemon_procs constant across N"
+  exit 0
+fi
 
 echo "binary=$BIN repeat=$REPEAT settle=${SETTLE}s"
 printf "%-4s %-10s %-14s %-12s %-10s\n" N "PSS_MB(med)" "RssAnon_MB(med)" "procs/sess" "startup_ms(med)"

--- a/scripts/memprof/bench-sessions.sh
+++ b/scripts/memprof/bench-sessions.sh
@@ -13,8 +13,12 @@
 # DAEMON=1 mode (PLAN-phase2 §5.5): one `synaps daemon --foreground` in tmux
 # window `d`, then N `synaps attach --create` thin clients. PSS is measured
 # over {daemon tree} ∪ {attach pids}; procs/session = (total − daemon tree)/N.
-# Extra columns: daemon_pss, marginal_pss (PSS(N) − PSS(N−1)). Requires
-# SYNAPS_DAEMON=1 (exported here). Sessions are REAL SessionActors.
+# Extra columns: daemon_pss, marginal_pss (PSS(N) − PSS(N−1)), daemon_anon
+# (sum of RssAnon over the daemon tree — PSS is a sharing artefact once the
+# clients map the same binary, RssAnon is the honest daemon-side number) and
+# anon_marginal (daemon_anon(N) − daemon_anon(N−1) = daemon-side cost of one
+# idle session). Requires SYNAPS_DAEMON=1 (exported here). Sessions are REAL
+# SessionActors.
 #
 # Never touches tmux servers other than `-L bench`. No root needed.
 set -u
@@ -79,38 +83,56 @@ run_once_daemon() { # N i -> prints "pss_kb daemon_pss_kb procs_beyond_daemon st
     echo "-- attach clients"; "$HERE/mem.sh" $apids
     echo "-- all"; "$HERE/mem.sh" "$dpid" $apids
     for p in $dpid $apids; do echo -n "pid=$p "; grep -E 'RssAnon|Threads' "/proc/$p/status" | tr '\n' ' '; echo; done
+    echo "-- daemon tree RssAnon"; tree_anon "$dpid"
     "$BIN" daemon status --json 2>/dev/null
     "$BIN" status --memory --json --pid "$dpid" 2>/dev/null
   } > "$out"
-  local pss dpss procs dprocs
+  local pss dpss procs dprocs danon
+  danon=$(awk '/^-- daemon tree RssAnon/{f=1} f&&/^TREE_ANON/{print $2; exit}' "$out")
   pss=$(awk '/^-- all/{f=1} f&&/^TOTAL/{for(k=1;k<=NF;k++) if($k ~ /^PSS=/){sub("PSS=","",$k); print $k; exit}}' "$out")
   procs=$(awk '/^-- all/{f=1} f&&/^TOTAL/{for(k=1;k<=NF;k++) if($k ~ /^procs=/){sub("procs=","",$k); print $k; exit}}' "$out")
   dpss=$(awk '/^-- daemon tree/{f=1} f&&/^TOTAL/{for(k=1;k<=NF;k++) if($k ~ /^PSS=/){sub("PSS=","",$k); print $k; exit}}' "$out")
   dprocs=$(awk '/^-- daemon tree/{f=1} f&&/^TOTAL/{for(k=1;k<=NF;k++) if($k ~ /^procs=/){sub("procs=","",$k); print $k; exit}}' "$out")
   "$BIN" daemon stop >/dev/null 2>&1
   tmux -L bench kill-server 2>/dev/null
-  echo "$pss $dpss $((procs-dprocs)) $dprocs ${starts[0]:-0} $out"
+  echo "$pss $dpss $((procs-dprocs)) $dprocs ${starts[0]:-0} ${danon:-0} $out"
+}
+
+# Sum RssAnon (kB) over PID and all descendants; prints per-pid lines + TREE_ANON <kB>.
+tree_anon() {
+  local root=$1 tot=0
+  descendants() { local p=$1; echo "$p"; for c in $(pgrep -P "$p"); do descendants "$c"; done; }
+  for p in $(descendants "$root"); do
+    [ -r "/proc/$p/status" ] || continue
+    local a; a=$(awk '/^RssAnon:/{print $2}' "/proc/$p/status")
+    echo "pid=$p RssAnon_kB=${a:-0} $(ps -o args= -p "$p" | cut -c1-60)"
+    tot=$((tot + ${a:-0}))
+  done
+  echo "TREE_ANON $tot"
 }
 
 if [ "$DAEMON" = 1 ]; then
   echo "binary=$BIN repeat=$REPEAT settle=${SETTLE}s mode=DAEMON"
-  printf "%-4s %-10s %-12s %-14s %-12s %-12s %-10s\n" N "PSS_MB(med)" "daemon_pss" "marginal_pss" "procs/sess" "daemon_procs" "attach_ms(med)"
-  prev=""
+  printf "%-4s %-10s %-12s %-14s %-12s %-14s %-12s %-12s %-10s\n" N "PSS_MB(med)" "daemon_pss" "marginal_pss" "daemon_anon" "anon_marginal" "procs/sess" "daemon_procs" "attach_ms(med)"
+  prev=""; prev_anon=""
   for n in $NS; do
-    P=(); D=(); C=(); DP=(); S=()
+    P=(); D=(); C=(); DP=(); S=(); AN=()
     for i in $(seq 1 "$REPEAT"); do
-      read -r pss dpss procs dprocs start out < <(run_once_daemon "$n" "$i")
-      P+=("$pss"); D+=("$dpss"); C+=("$procs"); DP+=("$dprocs"); S+=("$start")
+      read -r pss dpss procs dprocs start danon out < <(run_once_daemon "$n" "$i")
+      P+=("$pss"); D+=("$dpss"); C+=("$procs"); DP+=("$dprocs"); S+=("$start"); AN+=("$danon")
     done
     pss_med=$(printf '%s\n' "${P[@]}" | median)
     d_med=$(printf '%s\n' "${D[@]}" | median)
+    an_med=$(printf '%s\n' "${AN[@]}" | median)
     st_med=$(printf '%s\n' "${S[@]}" | median)
     procs_per=$(awk -v c="${C[0]}" -v n="$n" 'BEGIN{printf "%.2f", c/n}')
     marg=$( [ -n "$prev" ] && awk -v a="$pss_med" -v b="$prev" 'BEGIN{printf "%.1f", (a-b)/1024}' || echo "-" )
-    printf "%-4s %-10.1f %-12.1f %-14s %-12s %-12s %-10s\n" "$n" "$(awk -v k="$pss_med" 'BEGIN{print k/1024}')" "$(awk -v k="$d_med" 'BEGIN{print k/1024}')" "$marg" "$procs_per" "${DP[0]}" "$st_med"
-    prev=$pss_med
+    amarg=$( [ -n "$prev_anon" ] && awk -v a="$an_med" -v b="$prev_anon" 'BEGIN{printf "%.1f", (a-b)/1024}' || echo "-" )
+    printf "%-4s %-10.1f %-12.1f %-14s %-12.1f %-14s %-12s %-12s %-10s\n" "$n" "$(awk -v k="$pss_med" 'BEGIN{print k/1024}')" "$(awk -v k="$d_med" 'BEGIN{print k/1024}')" "$marg" "$(awk -v k="$an_med" 'BEGIN{print k/1024}')" "$amarg" "$procs_per" "${DP[0]}" "$st_med"
+    prev=$pss_med; prev_anon=$an_med
   done
-  echo "gates: marginal_pss <= 15 MB; procs/sess == 1.00 (the attach client); daemon_procs constant across N"
+  echo "gates: anon_marginal (daemon-side RssAnon per idle session) <= 15 MB; procs/sess == 1.00 (the attach client); daemon_procs constant across N"
+  echo "note: marginal_pss is dominated by the attach client and PSS divides shared text by sharers — read anon_marginal for the daemon"
   exit 0
 fi
 

--- a/src/cmd/attach.rs
+++ b/src/cmd/attach.rs
@@ -204,8 +204,9 @@ pub(crate) async fn run(profile: Option<String>, args: AttachArgs) -> anyhow::Re
 
     let (t, snap) = SocketTransport::attach(conn, attach).await.map_err(|e| anyhow::anyhow!("attach: {e}"))?;
     let mut c = Client { t, streaming: snap.streaming, pending: snap.pending_prompts.clone(), stdout: std::io::stdout() };
+    // "○ ready" is the marker scripts/memprof/launch.sh polls for.
     c.out(&format!(
-        "[attached {} as client #{}  model={}  messages={}{}]\n",
+        "[attached {} as client #{}  model={}  messages={}{}] ○ ready\n",
         snap.meta.id,
         c.t.client_id().0,
         snap.view.model,

--- a/src/cmd/attach.rs
+++ b/src/cmd/attach.rs
@@ -1,0 +1,263 @@
+//! `synaps attach [ID] [--create] [--continue X]` — thin line client over
+//! `SocketTransport` (PLAN-phase2 §2.11, B5).
+//!
+//! stdin lines → `Submit` (or `Steer` while streaming); `/abort` → `Cancel`;
+//! `/detach` or Ctrl-C → `Detach` (the turn keeps running); `/sessions`;
+//! prompts render as `[prompt #id] title: prompt > ` (echo off for Secret).
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use agent_engine::daemon::{registry, EXIT_VERSION};
+use agent_engine::session::socket_transport::SocketTransport;
+use agent_engine::session::wire::*;
+use agent_engine::session::*;
+use agent_engine::{LlmEvent, SessionEvent, StreamEvent, TurnOutcome};
+use clap::Args;
+
+#[derive(Args, Debug, Clone, Default)]
+pub(crate) struct AttachArgs {
+    /// Session id to attach to (omit with --create).
+    pub id: Option<String>,
+    /// Create a new session in the daemon (cwd = this process's cwd).
+    #[arg(long)]
+    pub create: bool,
+    /// Create by continuing a saved session (name or id).
+    #[arg(long = "continue", value_name = "NAME_OR_ID")]
+    pub continue_session: Option<String>,
+    /// System prompt for a created session.
+    #[arg(long = "system", short = 's')]
+    pub system: Option<String>,
+}
+
+struct Client {
+    t: SocketTransport,
+    streaming: bool,
+    pending: Vec<PromptRequest>,
+    stdout: std::io::Stdout,
+}
+
+impl Client {
+    fn out(&mut self, s: &str) {
+        let _ = self.stdout.write_all(s.as_bytes());
+        let _ = self.stdout.flush();
+    }
+
+    fn render(&mut self, env: &Envelope) {
+        match &env.event {
+            SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(t))) => self.out(t),
+            SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Thinking(_))) => {}
+            SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::ToolUse { tool_name, .. })) => {
+                self.out(&format!("\n[tool: {tool_name}]\n"))
+            }
+            SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::ToolResult { result, .. })) => {
+                let short: String = result.chars().take(400).collect();
+                self.out(&format!("[result] {short}\n"))
+            }
+            SessionEventWire::Stream(StreamEvent::Session(SessionEvent::Done)) => {
+                self.streaming = false;
+                self.out("\n");
+            }
+            SessionEventWire::Stream(StreamEvent::Session(SessionEvent::Error(e))) => {
+                self.streaming = false;
+                let label = if matches!(e.outcome, TurnOutcome::Canceled) { "canceled" } else { "error" };
+                self.out(&format!("\n[{label}] {} ({})\n", e.message, e.category_label()));
+            }
+            SessionEventWire::Stream(StreamEvent::Session(SessionEvent::Notice(n))) => self.out(&format!("[notice] {n}\n")),
+            SessionEventWire::Stream(StreamEvent::Agent(a)) => self.out(&format!("[agent] {a:?}\n")),
+            SessionEventWire::Stream(_) => {}
+            SessionEventWire::TurnStarted { .. } => self.streaming = true,
+            SessionEventWire::Prompt(p) => {
+                self.pending.push(p.clone());
+                self.out(&format!("[prompt #{}] {}: {} > ", p.id, p.title, p.prompt));
+            }
+            SessionEventWire::PromptResolved { prompt_id } => self.pending.retain(|p| p.id != *prompt_id),
+            SessionEventWire::SystemNotice(s) => self.out(&format!("[system] {s}\n")),
+            SessionEventWire::Steered { text, delivered } => {
+                self.out(&format!("{} {text}\n", if *delivered { "→ steering:" } else { "queued:" }))
+            }
+            SessionEventWire::Dequeued { text } => self.out(&format!("[dequeued] {text}\n")),
+            SessionEventWire::AutoTurnCapReached { cap } => self.out(&format!("[auto-turn cap {cap} reached]\n")),
+            SessionEventWire::External(e) => self.out(&format!("[event {}] {}\n", e.source.name, e.content.text)),
+            SessionEventWire::ClientJoined { client, kind } => self.out(&format!("[client #{} joined ({kind:?})]\n", client.0)),
+            SessionEventWire::ClientLeft { client } => self.out(&format!("[client #{} left]\n", client.0)),
+            SessionEventWire::Ended { reason } => self.out(&format!("[session ended: {reason:?}]\n")),
+            SessionEventWire::SettingChanged(a) => {
+                self.out(&format!("[{}: {}]\n", a.setting, if a.ok { "ok" } else { a.message.as_deref().unwrap_or("failed") }))
+            }
+            SessionEventWire::QueryResult { value, .. } => self.out(&format!("{value}\n")),
+            SessionEventWire::Conversation(_)
+            | SessionEventWire::LoaderProgress(_)
+            | SessionEventWire::ExtensionNotification { .. }
+            | SessionEventWire::Attached { .. } => {}
+        }
+    }
+
+    /// stdin line → command. Returns `false` to detach.
+    async fn line(&mut self, line: &str) -> bool {
+        let line = line.trim_end_matches(['\n', '\r']);
+        if let Some(p) = self.pending.first().cloned() {
+            let value = if line.is_empty() { None } else { Some(line.to_string()) };
+            let _ = self.t.send(SessionCommand::Answer { prompt_id: p.id, value }).await;
+            self.pending.remove(0);
+            if p.kind == PromptKind::Secret {
+                set_echo(true);
+                self.out("\n");
+            }
+            return true;
+        }
+        match line {
+            "" => return true,
+            "/detach" | "/quit" | "/exit" => return false,
+            "/abort" => {
+                let _ = self.t.send(SessionCommand::Cancel).await;
+            }
+            "/sessions" => {
+                let _ = self.t.send(SessionCommand::Query { id: 1, query: SessionQuery::Status }).await;
+            }
+            "/save" => {
+                let _ = self.t.send(SessionCommand::Save).await;
+            }
+            "/new" => {
+                let _ = self.t.send(SessionCommand::NewSession).await;
+            }
+            "/help" => self.out("/detach /abort /save /new /sessions /model NAME\n"),
+            _ if line.starts_with("/model ") => {
+                let model = line["/model ".len()..].trim().to_string();
+                let _ = self.t.send(SessionCommand::Set(SessionSetting::Model { model })).await;
+            }
+            text => {
+                let cmd = if self.streaming {
+                    SessionCommand::Steer { text: text.to_string() }
+                } else {
+                    SessionCommand::Submit { text: text.to_string(), attachments: vec![] }
+                };
+                match self.t.send(cmd).await {
+                    Ok(()) => {}
+                    Err(TransportError::Backpressure) => self.out("[backpressure: try again]\n"),
+                    Err(e) => self.out(&format!("[send failed: {e}]\n")),
+                }
+            }
+        }
+        true
+    }
+}
+
+fn set_echo(on: bool) {
+    #[cfg(unix)]
+    {
+        let _ = std::process::Command::new("stty")
+            .arg(if on { "echo" } else { "-echo" })
+            .stdin(std::process::Stdio::inherit())
+            .status();
+    }
+}
+
+pub(crate) async fn run(profile: Option<String>, args: AttachArgs) -> anyhow::Result<()> {
+    if let Err(code) = super::daemon::require_enabled("synaps attach") {
+        std::process::exit(code);
+    }
+    let paths = registry::daemon_paths(profile.as_deref());
+    if !registry::is_alive(&paths) {
+        anyhow::bail!("daemon not running (start it with `synaps daemon --detach`)");
+    }
+    let conn = match SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Attach)).await {
+        Ok(c) => c,
+        Err(TransportError::Version { client, daemon }) => {
+            eprintln!("synaps attach: protocol version mismatch (client {client}, daemon {daemon}); restart the daemon with this binary");
+            std::process::exit(EXIT_VERSION);
+        }
+        Err(e) => anyhow::bail!("connect: {e}"),
+    };
+    if conn.welcome.daemon_version != binary_version() {
+        eprintln!("[notice] daemon binary {} differs from client {} (same protocol)", conn.welcome.daemon_version, binary_version());
+    }
+
+    let attach = if args.create || args.continue_session.is_some() {
+        Attach::Create {
+            config: SessionConfig {
+                continue_session: args.continue_session.clone().map(Some),
+                system: args.system.clone(),
+                cwd: Some(std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"))),
+                ..Default::default()
+            },
+            mode: AttachMode::Mirror,
+        }
+    } else if let Some(id) = &args.id {
+        let id = resolve_id(&conn.welcome.sessions, id).unwrap_or_else(|| SessionId::from(id.as_str()));
+        Attach::Existing { session_id: id, mode: AttachMode::Mirror }
+    } else if conn.welcome.sessions.len() == 1 {
+        Attach::Existing { session_id: conn.welcome.sessions[0].id.clone(), mode: AttachMode::Mirror }
+    } else if conn.welcome.sessions.is_empty() {
+        Attach::Create {
+            config: SessionConfig { cwd: std::env::current_dir().ok(), ..Default::default() },
+            mode: AttachMode::Mirror,
+        }
+    } else {
+        eprintln!("several sessions; pick one:");
+        for m in &conn.welcome.sessions {
+            eprintln!("  {}  model={}", m.id, m.model);
+        }
+        std::process::exit(1);
+    };
+
+    let (t, snap) = SocketTransport::attach(conn, attach).await.map_err(|e| anyhow::anyhow!("attach: {e}"))?;
+    let mut c = Client { t, streaming: snap.streaming, pending: snap.pending_prompts.clone(), stdout: std::io::stdout() };
+    c.out(&format!(
+        "[attached {} as client #{}  model={}  messages={}{}]\n",
+        snap.meta.id,
+        c.t.client_id().0,
+        snap.view.model,
+        snap.conversation.api_messages.len(),
+        if snap.streaming { "  streaming" } else { "" }
+    ));
+    for env in &snap.replay {
+        c.render(env);
+    }
+    for p in &snap.pending_prompts {
+        c.out(&format!("[prompt #{}] {}: {} > ", p.id, p.title, p.prompt));
+    }
+
+    let mut stdin = tokio::io::BufReader::new(tokio::io::stdin());
+    let mut line = String::new();
+    loop {
+        line.clear();
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                c.out("\n[detaching; the session keeps running]\n");
+                break;
+            }
+            r = tokio::io::AsyncBufReadExt::read_line(&mut stdin, &mut line) => {
+                match r {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {
+                        if !c.line(&line).await { break; }
+                        if let Some(p) = c.pending.first() { if p.kind == PromptKind::Secret { set_echo(false); } }
+                    }
+                }
+            }
+            ev = c.t.next_event() => {
+                match ev {
+                    Some(env) => {
+                        let ended = matches!(env.event, SessionEventWire::Ended { .. });
+                        c.render(&env);
+                        if let Some(p) = c.pending.first() { if p.kind == PromptKind::Secret { set_echo(false); } }
+                        if ended { set_echo(true); return Ok(()); }
+                    }
+                    None => { c.out("[connection closed]\n"); set_echo(true); return Ok(()); }
+                }
+            }
+        }
+    }
+    set_echo(true);
+    c.t.detach().await;
+    Ok(())
+}
+
+fn resolve_id(sessions: &[SessionMeta], q: &str) -> Option<SessionId> {
+    sessions
+        .iter()
+        .find(|m| m.id.as_str() == q || m.name.as_deref() == Some(q))
+        .or_else(|| sessions.iter().find(|m| m.id.as_str().starts_with(q)))
+        .map(|m| m.id.clone())
+}

--- a/src/cmd/attach.rs
+++ b/src/cmd/attach.rs
@@ -122,7 +122,15 @@ impl Client {
             "/new" => {
                 let _ = self.t.send(SessionCommand::NewSession).await;
             }
-            "/help" => self.out("/detach /abort /save /new /sessions /model NAME\n"),
+            "/help" => self.out("/detach /abort /save /new /sessions /model NAME /cmd NAME [ARG]\n"),
+            _ if line.starts_with("/cmd ") => {
+                let rest = line["/cmd ".len()..].trim();
+                let (name, arg) = rest.split_once(' ').unwrap_or((rest, ""));
+                let _ = self
+                    .t
+                    .send(SessionCommand::EngineCommand { id: 2, name: name.to_string(), arg: arg.trim().to_string() })
+                    .await;
+            }
             _ if line.starts_with("/model ") => {
                 let model = line["/model ".len()..].trim().to_string();
                 let _ = self.t.send(SessionCommand::Set(SessionSetting::Model { model })).await;

--- a/src/cmd/attach.rs
+++ b/src/cmd/attach.rs
@@ -78,6 +78,7 @@ impl Client {
             }
             SessionEventWire::Dequeued { text } => self.out(&format!("[dequeued] {text}\n")),
             SessionEventWire::AutoTurnCapReached { cap } => self.out(&format!("[auto-turn cap {cap} reached]\n")),
+            SessionEventWire::Idle => {}
             SessionEventWire::External(e) => self.out(&format!("[event {}] {}\n", e.source.name, e.content.text)),
             SessionEventWire::ClientJoined { client, kind } => self.out(&format!("[client #{} joined ({kind:?})]\n", client.0)),
             SessionEventWire::ClientLeft { client } => self.out(&format!("[client #{} left]\n", client.0)),

--- a/src/cmd/chat.rs
+++ b/src/cmd/chat.rs
@@ -12,24 +12,36 @@
 //! Exactly ONE waiter on notified() exists while idle at the prompt.
 //! Piped stdin, EOF, and CRLF behaviour are preserved.
 
+#[cfg(feature = "legacy_inline")]
 use futures::StreamExt;
+#[cfg(feature = "legacy_inline")]
 use serde_json::json;
+#[cfg(feature = "legacy_inline")]
 use std::io::{self, Write};
+#[cfg(feature = "legacy_inline")]
 use synaps_cli::engine::commands::{self, CommandResult};
+#[cfg(feature = "legacy_inline")]
 use synaps_cli::engine::reactor::{
     claim_auto_turn, drain_event_queue, wake_action, WakeAction, AUTO_TURN_CAP,
 };
+#[cfg(feature = "legacy_inline")]
 use synaps_cli::engine::session::ConversationState;
+#[cfg(feature = "legacy_inline")]
 use synaps_cli::engine::setup::{self, EngineOpts};
+#[cfg(feature = "legacy_inline")]
 use synaps_cli::engine::stream::{self, EngineStreamEvent, StreamCompletion, SubagentTracker};
+#[cfg(feature = "legacy_inline")]
 use synaps_cli::runtime::compaction::{
     apply_compaction, compact_conversation, preview_compaction_disclosure, CompactionPolicy,
     CompactionTransition,
 };
+#[cfg(feature = "legacy_inline")]
 use synaps_cli::{flush_stdout, CancellationToken};
+#[cfg(feature = "legacy_inline")]
 use tokio::io::{AsyncBufReadExt, BufReader as TokioBufReader};
 
 /// What was read while waiting at the prompt.
+#[cfg(feature = "legacy_inline")]
 enum PromptRead {
     /// User typed (or pipe delivered) a line.
     Line(String),
@@ -42,7 +54,25 @@ enum PromptRead {
     Error(std::io::Error),
 }
 
+/// Entry point. Runs on the `SessionActor` via `LocalTransport` (A2); the
+/// pre-actor inline loop is kept behind `--features legacy_inline` +
+/// `SYNAPS_CHAT_INLINE=1` until day 3.
 pub async fn run(
+    continue_session: Option<String>,
+    system: Option<String>,
+    agent: Option<String>,
+    profile: Option<String>,
+    no_extensions: bool,
+) -> synaps_cli::Result<()> {
+    #[cfg(feature = "legacy_inline")]
+    if std::env::var("SYNAPS_CHAT_INLINE").map(|v| v == "1").unwrap_or(false) {
+        return run_inline(continue_session, system, agent, profile, no_extensions).await;
+    }
+    actor::run(continue_session, system, agent, profile, no_extensions).await
+}
+
+#[cfg(feature = "legacy_inline")]
+async fn run_inline(
     continue_session: Option<String>,
     system: Option<String>,
     agent: Option<String>,
@@ -660,4 +690,428 @@ pub async fn run(
         )));
     }
     Ok(())
+}
+
+// ── A2: `synaps chat` on the SessionActor ─────────────────────────────────────
+
+mod actor {
+    //! Same stdin/stdout/stderr rendering as the inline loop; the turn
+    //! machine (submit, usage, save, auto-turns, compaction) lives in the
+    //! actor. stdin is only polled while the session is idle, so a piped
+    //! line is always a `Submit` — exactly the inline loop's sequencing.
+
+    use std::io::{self, Write};
+
+    use synaps_cli::engine::commands;
+    use agent_engine::session::{
+        ClientKind, ClientMeta, ClientTransport, EndReason, Envelope, LocalTransport,
+        SessionCommand, SessionConfig, SessionEventWire, SessionQuery, SessionSetting,
+    };
+    use agent_engine::{EngineHost, HostOpts};
+    use synaps_cli::flush_stdout;
+    use synaps_cli::{AgentEvent, LlmEvent, SessionEvent, StreamEvent};
+    use tokio::io::{AsyncBufReadExt, BufReader as TokioBufReader};
+
+    struct Render {
+        is_tty: bool,
+        in_thinking: bool,
+        streaming: bool,
+        idle: bool,
+        fatal: Option<synaps_cli::TurnError>,
+        cost: f64,
+        ended: bool,
+    }
+
+    impl Render {
+        fn end_thinking(&mut self) {
+            if self.in_thinking {
+                eprintln!("\x1b[0m");
+                self.in_thinking = false;
+            }
+        }
+
+        async fn on_event(&mut self, transport: &LocalTransport, env: Envelope) {
+            match env.event {
+                SessionEventWire::Stream(ev) => self.on_stream(ev),
+                SessionEventWire::TurnStarted { .. } => {
+                    self.streaming = true;
+                    self.idle = false;
+                }
+                SessionEventWire::Conversation(c) => self.cost = c.cost,
+                SessionEventWire::Idle => self.idle = true,
+                SessionEventWire::Prompt(pr) => {
+                    // Headless chat has no prompt UI: cancel, as the inline
+                    // loop did by passing no SecretPromptHandle.
+                    let _ = transport
+                        .send(SessionCommand::Answer {
+                            prompt_id: pr.id,
+                            value: None,
+                        })
+                        .await;
+                }
+                SessionEventWire::External(event) => {
+                    eprintln!(
+                        "\x1b[36m⚡ [event] {}\x1b[0m",
+                        synaps_cli::events::format_event_for_agent(&event)
+                    );
+                }
+                SessionEventWire::AutoTurnCapReached { cap } => {
+                    eprintln!(
+                        "\x1b[2m[auto-turn cap ({}) reached — waiting for user input]\x1b[0m",
+                        cap
+                    );
+                }
+                SessionEventWire::SystemNotice(text) => eprintln!("\x1b[2m{}\x1b[0m", text),
+                SessionEventWire::Ended { .. } => self.ended = true,
+                _ => {}
+            }
+        }
+
+        fn on_stream(&mut self, ev: StreamEvent) {
+            match ev {
+                StreamEvent::Llm(LlmEvent::Thinking(text)) => {
+                    if !self.in_thinking {
+                        eprint!("\x1b[2m");
+                        self.in_thinking = true;
+                    }
+                    eprint!("{}", text);
+                    io::stderr().flush().ok();
+                }
+                StreamEvent::Llm(LlmEvent::Text(text)) => {
+                    self.end_thinking();
+                    print!("{}", text);
+                    flush_stdout();
+                }
+                StreamEvent::Llm(LlmEvent::ToolUseStart { tool_name, .. }) => {
+                    self.end_thinking();
+                    eprint!("\x1b[33m⚙ {}\x1b[0m", tool_name);
+                    io::stderr().flush().ok();
+                }
+                StreamEvent::Llm(LlmEvent::ToolUse {
+                    tool_name, input, ..
+                }) => {
+                    let input_preview = serde_json::to_string(&input).unwrap_or_default();
+                    let preview: String = input_preview.chars().take(60).collect();
+                    eprintln!("\x1b[33m ⚙ {} ({})\x1b[0m", tool_name, preview);
+                }
+                StreamEvent::Llm(LlmEvent::ToolResult { result, .. }) => {
+                    let preview: String = result.chars().take(80).collect();
+                    eprintln!("\x1b[32m  → {}\x1b[0m", preview);
+                }
+                StreamEvent::Agent(AgentEvent::SubagentStart {
+                    agent_name,
+                    task_preview,
+                    ..
+                }) => eprintln!("\x1b[35m🎭 [{}] {}\x1b[0m", agent_name, task_preview),
+                StreamEvent::Agent(AgentEvent::SubagentDone {
+                    result_preview,
+                    duration_secs,
+                    ..
+                }) => {
+                    let status = if result_preview.starts_with("[TIMED OUT") {
+                        "\u{26a0} timed out".to_string()
+                    } else if result_preview.starts_with("ERROR") {
+                        let preview: String = result_preview.chars().take(40).collect();
+                        format!("\u{2718} {}", preview)
+                    } else {
+                        let preview: String = result_preview.chars().take(40).collect();
+                        format!("\u{2714} {}", preview)
+                    };
+                    eprintln!("\x1b[32m✔ {} ({:.1}s)\x1b[0m", status, duration_secs);
+                }
+                StreamEvent::Agent(AgentEvent::SteeringDelivered { message }) => {
+                    eprintln!("\x1b[33m→ [steering] {}\x1b[0m", message);
+                }
+                StreamEvent::Session(SessionEvent::Notice(text)) => {
+                    eprintln!("\x1b[2m{}\x1b[0m", text);
+                }
+                StreamEvent::Session(SessionEvent::Done) => {
+                    self.end_thinking();
+                    println!();
+                    self.streaming = false;
+                }
+                StreamEvent::Session(SessionEvent::Error(err)) => {
+                    eprintln!("\x1b[31m❌ {}\x1b[0m", err.message);
+                    self.end_thinking();
+                    println!();
+                    eprintln!("\x1b[31m❌ turn failed [{}]\x1b[0m", err.category_label());
+                    self.fatal = Some(err);
+                    self.streaming = false;
+                }
+                _ => {}
+            }
+        }
+
+        /// Pump events until the reply for query `id` arrives.
+        async fn reply(&mut self, t: &mut LocalTransport, id: u64) -> serde_json::Value {
+            while let Some(env) = t.next_event().await {
+                if let SessionEventWire::QueryResult { id: rid, value } = &env.event {
+                    if *rid == id {
+                        return value.clone();
+                    }
+                }
+                self.on_event(t, env).await;
+                if self.ended {
+                    break;
+                }
+            }
+            serde_json::Value::Null
+        }
+    }
+
+    pub(super) async fn run(
+        continue_session: Option<String>,
+        system: Option<String>,
+        agent: Option<String>,
+        profile: Option<String>,
+        no_extensions: bool,
+    ) -> synaps_cli::Result<()> {
+        // Agent prompt resolves before any session work (inline loop: exit 1).
+        let agent_prompt = match agent {
+            Some(ref agent_name) => match synaps_cli::tools::resolve_agent_prompt(agent_name) {
+                Ok(p) => {
+                    eprintln!("🎭 Agent: {}", agent_name);
+                    Some(p)
+                }
+                Err(e) => {
+                    eprintln!("❌ {}", e);
+                    std::process::exit(1);
+                }
+            },
+            None => None,
+        };
+
+        let host = EngineHost::boot_and_install(HostOpts {
+            profile,
+            no_extensions,
+        })
+        .await?;
+        // Extension discovery completes BEFORE the session exists, so
+        // `on_session_start` reaches subscribers and the first API call sees
+        // extension-registered tools (piped stdin is ready immediately).
+        if !no_extensions {
+            host.ext_manager().write().await.discover_and_load().await;
+        }
+
+        let handle = host
+            .create_session(SessionConfig {
+                continue_session: continue_session.map(Some),
+                system,
+                auto_compact: true,
+                ..SessionConfig::default()
+            })
+            .await?;
+        let (mut t, snap) = LocalTransport::attach(handle, ClientMeta::new(ClientKind::Chat))
+            .await
+            .map_err(|e| synaps_cli::RuntimeError::Session(e.to_string()))?;
+        if let Some(p) = agent_prompt {
+            let _ = t.send(SessionCommand::Set(SessionSetting::SystemPrompt { text: p })).await;
+        }
+
+        let session_id = snap.meta.id.as_str().to_string();
+        eprintln!(
+            "synaps {} | {} | session {}",
+            env!("CARGO_PKG_VERSION"),
+            snap.view.model,
+            &session_id[..8.min(session_id.len())]
+        );
+        if snap.meta.continued {
+            eprintln!(
+                "↳ resumed session ({} messages)",
+                snap.conversation.api_messages.len()
+            );
+        }
+        if host.mcp_server_count() > 0 {
+            eprintln!("↳ {} MCP servers available", host.mcp_server_count());
+        }
+        eprintln!();
+
+        let mut r = Render {
+            is_tty: std::io::IsTerminal::is_terminal(&std::io::stdin()),
+            in_thinking: false,
+            streaming: false,
+            idle: true,
+            fatal: None,
+            cost: snap.conversation.cost,
+            ended: false,
+        };
+        let mut stdin_lines = TokioBufReader::new(tokio::io::stdin()).lines();
+        let mut next_query: u64 = 1;
+        let mut prompt_shown = false;
+
+        loop {
+            if r.idle && r.is_tty && !prompt_shown {
+                eprint!("❯ ");
+                io::stderr().flush().ok();
+                prompt_shown = true;
+            }
+            // stdin only while idle: a piped line is always a Submit.
+            let line = tokio::select! {
+                biased;
+                ev = t.next_event() => match ev {
+                    Some(env) => {
+                        r.on_event(&t, env).await;
+                        if r.ended { break; }
+                        // Headless (piped): an unrecovered failure terminates
+                        // after the turn settles; TTY users keep their session.
+                        if r.idle && r.fatal.is_some() && !r.is_tty { break; }
+                        if r.idle && r.fatal.is_some() { r.fatal = None; }
+                        continue;
+                    }
+                    None => break,
+                },
+                line = stdin_lines.next_line(), if r.idle => match line {
+                    Ok(Some(l)) => l,
+                    Ok(None) => break,
+                    Err(e) => { eprintln!("input error: {}", e); break; }
+                },
+            };
+            prompt_shown = false;
+
+            let trimmed = line.trim_end_matches('\r').trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            if let Some((cmd, arg)) = commands::parse_command(trimmed) {
+                let id = next_query;
+                next_query += 1;
+                let _ = t
+                    .send(SessionCommand::EngineCommand {
+                        id,
+                        name: cmd.to_string(),
+                        arg: arg.to_string(),
+                    })
+                    .await;
+                let reply = r.reply(&mut t, id).await;
+                if r.ended {
+                    break;
+                }
+                match reply["kind"].as_str().unwrap_or("none") {
+                    "quit" => break,
+                    "notice" => eprintln!("{}", reply["text"].as_str().unwrap_or("")),
+                    "error" => eprintln!("error: {}", reply["text"].as_str().unwrap_or("")),
+                    "output" => println!("{}", reply["text"].as_str().unwrap_or("")),
+                    "unhandled" => match cmd {
+                        "clear" => {
+                            let _ = t.send(SessionCommand::NewSession).await;
+                        }
+                        "sessions" => {
+                            let id = next_query;
+                            next_query += 1;
+                            let _ = t
+                                .send(SessionCommand::Query {
+                                    id,
+                                    query: SessionQuery::Status,
+                                })
+                                .await;
+                            let status = r.reply(&mut t, id).await;
+                            let current = status["session"].as_str().unwrap_or("");
+                            match synaps_cli::list_recent_sessions(20) {
+                                Ok(sessions) => {
+                                    for s in sessions.iter().take(20) {
+                                        let marker = if s.id == current { "→ " } else { "  " };
+                                        eprintln!(
+                                            "{}{} {} ({}, ${:.4})",
+                                            marker,
+                                            &s.id[..8],
+                                            s.title,
+                                            s.model,
+                                            s.session_cost
+                                        );
+                                    }
+                                }
+                                Err(e) => eprintln!("error: {}", e),
+                            }
+                        }
+                        "status" => {
+                            let id = next_query;
+                            next_query += 1;
+                            let _ = t
+                                .send(SessionCommand::Query {
+                                    id,
+                                    query: SessionQuery::Status,
+                                })
+                                .await;
+                            let st = r.reply(&mut t, id).await;
+                            let id2 = next_query;
+                            next_query += 1;
+                            let _ = t
+                                .send(SessionCommand::Query {
+                                    id: id2,
+                                    query: SessionQuery::ContextAssessment,
+                                })
+                                .await;
+                            let ctx = r.reply(&mut t, id2).await;
+                            let sid = st["session"].as_str().unwrap_or("");
+                            eprintln!("session: {}", &sid[..8.min(sid.len())]);
+                            eprintln!("model: {}", st["model"].as_str().unwrap_or(""));
+                            eprintln!(
+                                "tokens: {}↑ {}↓",
+                                st["tokens"]["input"].as_u64().unwrap_or(0),
+                                st["tokens"]["output"].as_u64().unwrap_or(0)
+                            );
+                            eprintln!("cost: ${:.4}", st["cost"].as_f64().unwrap_or(0.0));
+                            eprintln!("messages: {}", st["messages"].as_u64().unwrap_or(0));
+                            eprintln!(
+                                "context: ~{} of {} budget tokens ({} window)",
+                                ctx["used_tokens"].as_u64().unwrap_or(0),
+                                ctx["budget_tokens"].as_u64().unwrap_or(0),
+                                ctx["provider_window"].as_u64().unwrap_or(0)
+                            );
+                        }
+                        "help" => {
+                            eprintln!("commands: /model /thinking /compact /clear /sessions /status /quit");
+                        }
+                        _ => eprintln!("unknown command: /{} (try /help)", cmd),
+                    },
+                    _ => {}
+                }
+                continue;
+            }
+
+            // Regular user message.
+            r.idle = false;
+            if t
+                .send(SessionCommand::Submit {
+                    text: trimmed.to_string(),
+                    attachments: Vec::new(),
+                })
+                .await
+                .is_err()
+            {
+                break;
+            }
+        }
+
+        // ── Shutdown: End → actor saves, fires on_session_end, unregisters ──
+        if !r.ended {
+            let _ = t
+                .send(SessionCommand::End {
+                    reason: EndReason::ClientQuit,
+                })
+                .await;
+            while !r.ended {
+                match t.next_event().await {
+                    Some(env) => r.on_event(&t, env).await,
+                    None => break,
+                }
+            }
+        }
+
+        eprintln!(
+            "session saved: {} (${:.4})",
+            &session_id[..8.min(session_id.len())],
+            r.cost
+        );
+
+        if let Some(err) = r.fatal {
+            return Err(synaps_cli::RuntimeError::Session(format!(
+                "turn failed: {} [{}]",
+                err.message,
+                err.category_label()
+            )));
+        }
+        Ok(())
+    }
 }

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -1,0 +1,222 @@
+//! `synaps daemon {start,status,stop,sessions}` (PLAN-phase2 §2.11, B4).
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use agent_engine::daemon::{self, registry, DaemonOpts, EXIT_REFUSED};
+use agent_engine::session::socket_transport::SocketTransport;
+use clap::{Args, Subcommand};
+
+#[derive(Args, Debug, Clone)]
+pub(crate) struct DaemonArgs {
+    #[command(subcommand)]
+    pub action: Option<DaemonAction>,
+    #[command(flatten)]
+    pub start: StartArgs,
+}
+
+#[derive(Args, Debug, Clone, Default)]
+pub(crate) struct StartArgs {
+    /// Run in this terminal (default).
+    #[arg(long, conflicts_with = "detach")]
+    pub foreground: bool,
+    /// Fork into the background (setsid) and return once the socket is ready.
+    #[arg(long)]
+    pub detach: bool,
+    /// Socket path override (lock/json/pid stay under the run dir).
+    #[arg(long, value_name = "PATH")]
+    pub socket: Option<PathBuf>,
+    /// Exit after SECS with zero clients and zero sessions.
+    #[arg(long, value_name = "SECS")]
+    pub idle_exit: Option<u64>,
+    /// Allow legacy (non-progressive) MCP with servers configured.
+    #[arg(long)]
+    pub allow_legacy_mcp: bool,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(crate) enum DaemonAction {
+    /// Start the daemon (same as no subcommand).
+    Start(StartArgs),
+    /// Registry + flock probe + Ping.
+    Status {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Graceful Shutdown{force} over the socket; --force escalates to SIGTERM/SIGKILL.
+    Stop {
+        #[arg(long)]
+        force: bool,
+    },
+    /// List live sessions in the daemon.
+    Sessions {
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+fn opts_from(profile: Option<String>, a: &StartArgs) -> DaemonOpts {
+    DaemonOpts {
+        socket: a.socket.clone(),
+        profile,
+        idle_exit: a.idle_exit.map(Duration::from_secs),
+        allow_legacy_mcp: a.allow_legacy_mcp,
+        runtime_dir: None,
+        factory: None,
+    }
+}
+
+/// Exit code 3 + one-line reason when the flag is off.
+pub(crate) fn require_enabled(what: &str) -> Result<(), i32> {
+    if daemon::enabled() {
+        return Ok(());
+    }
+    eprintln!("{what}: experimental; set SYNAPS_DAEMON=1 to enable");
+    Err(EXIT_REFUSED)
+}
+
+pub(crate) async fn run(profile: Option<String>, args: DaemonArgs) -> anyhow::Result<()> {
+    match args.action {
+        None => start(profile, args.start).await,
+        Some(DaemonAction::Start(a)) => start(profile, a).await,
+        Some(DaemonAction::Status { json }) => status(profile, json).await,
+        Some(DaemonAction::Stop { force }) => stop(profile, force).await,
+        Some(DaemonAction::Sessions { json }) => sessions(profile, json).await,
+    }
+}
+
+async fn start(profile: Option<String>, a: StartArgs) -> anyhow::Result<()> {
+    if let Err(code) = require_enabled("synaps daemon") {
+        std::process::exit(code);
+    }
+    let opts = opts_from(profile, &a);
+    if a.detach {
+        let paths = opts.paths();
+        if registry::is_alive(&paths) {
+            let pid = registry::read_daemon_json(&paths).map(|i| i.pid);
+            println!("daemon already running (pid {})", pid.map_or("?".into(), |p| p.to_string()));
+            return Ok(());
+        }
+        let pid = daemon::spawn_detached(&opts)?;
+        println!("daemon started (pid {pid}, socket {})", opts.paths().sock.display());
+        return Ok(());
+    }
+    match daemon::run_foreground(opts).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            eprintln!("synaps daemon: {e}");
+            std::process::exit(EXIT_REFUSED);
+        }
+    }
+}
+
+async fn status(profile: Option<String>, json: bool) -> anyhow::Result<()> {
+    let paths = registry::daemon_paths(profile.as_deref());
+    let info = registry::read_daemon_json(&paths);
+    let alive = registry::is_alive(&paths);
+    let pong = if alive { SocketTransport::ping(&paths.sock).await.ok() } else { None };
+    let state = match (info.is_some(), alive, pong.is_some()) {
+        (_, true, true) => "running",
+        (_, true, false) => "running (not answering)",
+        (true, false, _) => "stale (pid dead)",
+        (false, false, _) => "stopped",
+    };
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "state": state,
+                "ok": pong.is_some(),
+                "socket": paths.sock,
+                "pid": pong.as_ref().map(|p| p.pid).or(info.as_ref().map(|i| i.pid)),
+                "uptime_s": pong.as_ref().map(|p| p.uptime_s),
+                "sessions": pong.as_ref().map(|p| p.sessions),
+                "daemon_version": info.as_ref().map(|i| i.daemon_version.clone()),
+                "protocol_version": info.as_ref().map(|i| i.protocol_version),
+                "profile": info.as_ref().and_then(|i| i.profile.clone()),
+            })
+        );
+    } else {
+        println!("daemon: {state}");
+        println!("socket: {}", paths.sock.display());
+        if let Some(i) = &info {
+            println!("pid: {}  version: {}  protocol: {}  started: {}", i.pid, i.daemon_version, i.protocol_version, i.started_at);
+        }
+        if let Some(p) = &pong {
+            println!("uptime: {}s  sessions: {}", p.uptime_s, p.sessions);
+        }
+    }
+    if pong.is_none() {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+async fn stop(profile: Option<String>, force: bool) -> anyhow::Result<()> {
+    let paths = registry::daemon_paths(profile.as_deref());
+    if !registry::is_alive(&paths) {
+        println!("daemon not running");
+        registry::reap_stale(&paths);
+        return Ok(());
+    }
+    let pid = registry::read_daemon_json(&paths).map(|i| i.pid);
+    match SocketTransport::shutdown(&paths.sock, force).await {
+        Ok(()) => {}
+        Err(e) => eprintln!("shutdown request failed: {e}"),
+    }
+    // Wait for the flock to be released.
+    let grace = Duration::from_secs(if force { 10 } else { 30 });
+    let t0 = std::time::Instant::now();
+    while registry::is_alive(&paths) {
+        if t0.elapsed() > grace {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    #[cfg(unix)]
+    if force && registry::is_alive(&paths) {
+        if let Some(pid) = pid {
+            eprintln!("daemon still alive after {grace:?}; SIGTERM {pid}");
+            let _ = std::process::Command::new("kill").args(["-TERM", &pid.to_string()]).status();
+            let t1 = std::time::Instant::now();
+            while registry::is_alive(&paths) && t1.elapsed() < Duration::from_secs(5) {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            if registry::is_alive(&paths) {
+                eprintln!("SIGKILL {pid}");
+                let _ = std::process::Command::new("kill").args(["-KILL", &pid.to_string()]).status();
+            }
+        }
+    }
+    if registry::is_alive(&paths) {
+        anyhow::bail!("daemon did not stop");
+    }
+    registry::reap_stale(&paths);
+    println!("daemon stopped{}", pid.map_or(String::new(), |p| format!(" (pid {p})")));
+    Ok(())
+}
+
+async fn sessions(profile: Option<String>, json: bool) -> anyhow::Result<()> {
+    let paths = registry::daemon_paths(profile.as_deref());
+    if !registry::is_alive(&paths) {
+        anyhow::bail!("daemon not running");
+    }
+    let list = SocketTransport::sessions(&paths.sock).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&list)?);
+    } else if list.is_empty() {
+        println!("no sessions");
+    } else {
+        for m in list {
+            println!(
+                "{}  model={}  cwd={}  created={}{}",
+                m.id,
+                m.model,
+                m.cwd.as_deref().map_or("-".into(), |p| p.display().to_string()),
+                m.created_at.format("%H:%M:%S"),
+                m.name.as_deref().map_or(String::new(), |n| format!("  name={n}"))
+            );
+        }
+    }
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,6 +1,8 @@
 pub(crate) mod agent;
+pub(crate) mod attach;
 pub(crate) mod auth_broker;
 pub(crate) mod chat;
+pub(crate) mod daemon;
 pub(crate) mod login;
 pub(crate) mod prompt;
 pub(crate) mod retention;

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,12 +305,22 @@ fn worker_threads_from(raw: Option<&str>, ncpu: usize) -> Option<usize> {
     }
 }
 
+/// `synaps attach` / `--attach` is a thin line client: one socket, one stdin.
+/// A current-thread runtime saves the worker pool (client diet, day 2 §9).
+fn is_thin_client() -> bool {
+    std::env::args().skip(1).any(|a| a == "attach" || a == "--attach" || a.starts_with("--attach="))
+}
+
 fn main() -> anyhow::Result<()> {
-    let mut builder = tokio::runtime::Builder::new_multi_thread();
-    if let Some(n) = worker_threads() {
-        builder.worker_threads(n);
-    }
-    let rt = builder.enable_all().thread_name("synaps-rt").build()?;
+    let rt = if is_thin_client() {
+        tokio::runtime::Builder::new_current_thread().enable_all().thread_name("synaps-rt").build()?
+    } else {
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        if let Some(n) = worker_threads() {
+            builder.worker_threads(n);
+        }
+        builder.enable_all().thread_name("synaps-rt").build()?
+    };
     // The log-appender guard lives on the process `EngineHost` (a static —
     // never dropped by Rust). Flush it on every exit path so the teardown
     // burst (session save, hooks, extension shutdown) reaches disk.

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,12 @@ struct Cli {
     #[arg(long)]
     no_extensions: bool,
 
+    /// EXPERIMENTAL (SYNAPS_DAEMON=1): attach to a daemon session instead of
+    /// running in-process. Optionally a session ID. Today routes to
+    /// `synaps attach` (the daemon-attached TUI lands in phase 2 day 2).
+    #[arg(long = "attach", value_name = "ID", global = true, num_args = 0..=1)]
+    attach: Option<Option<String>>,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -203,6 +209,10 @@ enum Command {
         #[arg(long)]
         insecure_http: bool,
     },
+    /// EXPERIMENTAL: session daemon (SYNAPS_DAEMON=1) — start/status/stop/sessions
+    Daemon(cmd::daemon::DaemonArgs),
+    /// EXPERIMENTAL: thin line client attached to a daemon session (SYNAPS_DAEMON=1)
+    Attach(cmd::attach::AttachArgs),
     /// Headless line-JSON RPC server on stdin/stdout (synaps-bridge IPC)
     Rpc {
         /// Resume an existing session by ID, name, or prefix.
@@ -327,6 +337,32 @@ async fn async_main() -> anyhow::Result<()> {
     }
 
     match cli.command {
+        None if cli.attach.is_some() => {
+            if !agent_engine::daemon::enabled() {
+                eprintln!("--attach ignored: set SYNAPS_DAEMON=1 to enable daemon mode");
+                tui::run(
+                    cli.continue_session,
+                    cli.system,
+                    cli.prompt_manifest,
+                    cli.profile,
+                    cli.no_extensions,
+                )
+                .await?;
+            } else {
+                eprintln!("daemon-attached TUI lands in phase 2 day 2; using `synaps attach`");
+                let id = cli.attach.flatten();
+                cmd::attach::run(
+                    cli.profile,
+                    cmd::attach::AttachArgs {
+                        id,
+                        create: false,
+                        continue_session: cli.continue_session.flatten(),
+                        system: cli.system,
+                    },
+                )
+                .await?;
+            }
+        }
         None => {
             tui::run(
                 cli.continue_session,
@@ -432,6 +468,12 @@ async fn async_main() -> anyhow::Result<()> {
         }
         Some(Command::Retention { action }) => {
             cmd::retention::run(action)?;
+        }
+        Some(Command::Daemon(args)) => {
+            cmd::daemon::run(cli.profile, args).await?;
+        }
+        Some(Command::Attach(args)) => {
+            cmd::attach::run(cli.profile, args).await?;
         }
         Some(Command::Rpc {
             continue_id,

--- a/tests/daemon_handshake.rs
+++ b/tests/daemon_handshake.rs
@@ -1,0 +1,170 @@
+//! Handshake + refusal paths over a real UDS (PLAN-phase2 §5.3), driven with
+//! a raw client so the daemon's behaviour is tested, not the transport's.
+
+#[path = "support/phase2/mod.rs"]
+#[allow(dead_code)]
+mod phase2;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_engine::daemon::{self, Daemon, DaemonOpts};
+use agent_engine::session::wire::*;
+use agent_engine::session::*;
+use agent_engine::{EngineHost, HostOpts};
+use phase2::HomeGuard;
+use serial_test::serial;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+async fn start(runtime_dir: &std::path::Path) -> Daemon {
+    let host: Arc<EngineHost> =
+        EngineHost::boot_and_install(HostOpts { profile: None, no_extensions: true }).await.expect("host boot");
+    Daemon::start(host, DaemonOpts { runtime_dir: Some(runtime_dir.to_path_buf()), factory: Some(daemon::echo_factory()), ..Default::default() })
+        .await
+        .expect("daemon start")
+}
+
+struct Raw {
+    r: BufReader<tokio::net::unix::OwnedReadHalf>,
+    w: tokio::net::unix::OwnedWriteHalf,
+}
+
+impl Raw {
+    async fn connect(p: &std::path::Path) -> Self {
+        let (r, w) = UnixStream::connect(p).await.unwrap().into_split();
+        Self { r: BufReader::new(r), w }
+    }
+    async fn send_line(&mut self, s: &str) {
+        self.w.write_all(s.as_bytes()).await.unwrap();
+        self.w.write_all(b"\n").await.unwrap();
+    }
+    async fn send(&mut self, f: &ClientFrame) {
+        self.w.write_all(encode_line(f).unwrap().as_bytes()).await.unwrap();
+    }
+    /// `None` = EOF.
+    async fn recv(&mut self) -> Option<DaemonFrame> {
+        let mut line = String::new();
+        let n = tokio::time::timeout(Duration::from_secs(3), self.r.read_line(&mut line)).await.expect("timely").unwrap();
+        if n == 0 {
+            return None;
+        }
+        Some(decode_line(line.trim_end()).unwrap())
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn handshake_refuses_version_mismatch_and_protocol_violations() {
+    let guard = HomeGuard::new();
+    let d = start(&guard.base_dir().join("run")).await;
+    let sock = d.paths.sock.clone();
+
+    // version mismatch → Refused{Version} then EOF
+    let mut c = Raw::connect(&sock).await;
+    let mut hello = Hello::new(ClientKind::Test);
+    hello.protocol_version = 99;
+    c.send(&ClientFrame::Hello(hello)).await;
+    match c.recv().await {
+        Some(DaemonFrame::Refused { reason: RefuseReason::Version { daemon_version, min, max }, message }) => {
+            assert_eq!((daemon_version, min, max), (PROTOCOL_VERSION, PROTOCOL_MIN, PROTOCOL_MAX));
+            assert!(message.contains("99"), "{message}");
+        }
+        other => panic!("{other:?}"),
+    }
+    assert!(c.recv().await.is_none(), "daemon closes after refusal");
+
+    // Hello not first → Refused{Protocol} then EOF
+    let mut c = Raw::connect(&sock).await;
+    c.send(&ClientFrame::Ping).await;
+    assert!(matches!(c.recv().await, Some(DaemonFrame::Refused { reason: RefuseReason::Protocol, .. })));
+    assert!(c.recv().await.is_none());
+
+    // malformed first frame → Refused{Protocol}
+    let mut c = Raw::connect(&sock).await;
+    c.send_line("{not json").await;
+    assert!(matches!(c.recv().await, Some(DaemonFrame::Refused { reason: RefuseReason::Protocol, .. })));
+
+    // oversize frame (> 1 MiB) → Error + close
+    let mut c = Raw::connect(&sock).await;
+    c.send(&ClientFrame::Hello(Hello::new(ClientKind::Test))).await;
+    assert!(matches!(c.recv().await, Some(DaemonFrame::Welcome(_))));
+    let big = format!("{{\"type\":\"ping\",\"pad\":\"{}\"}}", "x".repeat(MAX_FRAME_BYTES + 10));
+    c.send_line(&big).await;
+    match c.recv().await {
+        Some(DaemonFrame::Error { message, .. }) => assert!(message.contains("1 MiB"), "{message}"),
+        other => panic!("{other:?}"),
+    }
+    assert!(c.recv().await.is_none());
+
+    // different binary version, same protocol → allowed (Welcome carries daemon_version)
+    let mut c = Raw::connect(&sock).await;
+    let mut hello = Hello::new(ClientKind::Test);
+    hello.client_version = "0.0.0-other".into();
+    c.send(&ClientFrame::Hello(hello)).await;
+    match c.recv().await {
+        Some(DaemonFrame::Welcome(w)) => {
+            assert_eq!(w.protocol_version, PROTOCOL_VERSION);
+            assert_eq!(w.daemon_version, binary_version());
+            assert_eq!(w.pid, std::process::id());
+        }
+        other => panic!("{other:?}"),
+    }
+    // Cmd before Attach → Error, connection stays open; Sessions still answered
+    c.send(&ClientFrame::Cmd { session_id: "x".into(), cmd: SessionCommand::Save }).await;
+    assert!(matches!(c.recv().await, Some(DaemonFrame::Error { .. })));
+    c.send(&ClientFrame::Sessions).await;
+    assert!(matches!(c.recv().await, Some(DaemonFrame::SessionList { .. })));
+    c.send(&ClientFrame::Bye).await;
+    assert!(matches!(c.recv().await, Some(DaemonFrame::Bye)));
+
+    d.shutdown_token().cancel();
+    d.wait().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn control_fast_path_allocates_no_session() {
+    let guard = HomeGuard::new();
+    let d = start(&guard.base_dir().join("run")).await;
+    let sock = d.paths.sock.clone();
+    let mut c = Raw::connect(&sock).await;
+    c.send(&ClientFrame::Hello(Hello::new(ClientKind::Test))).await;
+    assert!(matches!(c.recv().await, Some(DaemonFrame::Welcome(_))));
+    for _ in 0..3 {
+        c.send(&ClientFrame::Ping).await;
+        match c.recv().await {
+            Some(DaemonFrame::Pong { sessions, pid, .. }) => {
+                assert_eq!(sessions, 0);
+                assert_eq!(pid, std::process::id());
+            }
+            other => panic!("{other:?}"),
+        }
+        c.send(&ClientFrame::Sessions).await;
+        assert!(matches!(c.recv().await, Some(DaemonFrame::SessionList { sessions }) if sessions.is_empty()));
+    }
+    assert!(d.state.live_sessions().is_empty());
+    assert!(d.state.host.sessions().is_empty());
+    d.shutdown_token().cancel();
+    d.wait().await;
+}
+
+#[tokio::test]
+#[serial]
+async fn create_refuses_relative_or_missing_cwd() {
+    let guard = HomeGuard::new();
+    let d = start(&guard.base_dir().join("run")).await;
+    let sock = d.paths.sock.clone();
+    let mut c = Raw::connect(&sock).await;
+    c.send(&ClientFrame::Hello(Hello::new(ClientKind::Test))).await;
+    assert!(matches!(c.recv().await, Some(DaemonFrame::Welcome(_))));
+    c.send(&ClientFrame::Attach(Attach::Create {
+        config: SessionConfig { cwd: Some("/definitely/not/here".into()), ..Default::default() },
+        mode: AttachMode::Mirror,
+    }))
+    .await;
+    assert!(matches!(c.recv().await, Some(DaemonFrame::Error { message, .. }) if message.contains("cwd")));
+    assert!(d.state.live_sessions().is_empty());
+    d.shutdown_token().cancel();
+    d.wait().await;
+}

--- a/tests/daemon_handshake.rs
+++ b/tests/daemon_handshake.rs
@@ -39,6 +39,11 @@ impl Raw {
         self.w.write_all(s.as_bytes()).await.unwrap();
         self.w.write_all(b"\n").await.unwrap();
     }
+    /// For oversize probes: the daemon may close before the tail is written.
+    async fn send_line_lossy(&mut self, s: &str) {
+        let _ = self.w.write_all(s.as_bytes()).await;
+        let _ = self.w.write_all(b"\n").await;
+    }
     async fn send(&mut self, f: &ClientFrame) {
         self.w.write_all(encode_line(f).unwrap().as_bytes()).await.unwrap();
     }
@@ -85,14 +90,19 @@ async fn handshake_refuses_version_mismatch_and_protocol_violations() {
     c.send_line("{not json").await;
     assert!(matches!(c.recv().await, Some(DaemonFrame::Refused { reason: RefuseReason::Protocol, .. })));
 
-    // oversize frame (> 1 MiB) → Error + close
+    // > rpc's 1 MiB but under DAEMON_MAX_FRAME_BYTES → accepted (Pong)
     let mut c = Raw::connect(&sock).await;
     c.send(&ClientFrame::Hello(Hello::new(ClientKind::Test))).await;
     assert!(matches!(c.recv().await, Some(DaemonFrame::Welcome(_))));
-    let big = format!("{{\"type\":\"ping\",\"pad\":\"{}\"}}", "x".repeat(MAX_FRAME_BYTES + 10));
-    c.send_line(&big).await;
+    let mid = format!("{{\"type\":\"ping\",\"pad\":\"{}\"}}", "x".repeat(RPC_MAX_FRAME_BYTES * 2));
+    c.send_line(&mid).await;
+    assert!(matches!(c.recv().await, Some(DaemonFrame::Pong { .. })));
+
+    // oversize frame (> DAEMON_MAX_FRAME_BYTES = 64 MiB) → Error + close
+    let big = format!("{{\"type\":\"ping\",\"pad\":\"{}\"}}", "x".repeat(DAEMON_MAX_FRAME_BYTES + 10));
+    c.send_line_lossy(&big).await;
     match c.recv().await {
-        Some(DaemonFrame::Error { message, .. }) => assert!(message.contains("1 MiB"), "{message}"),
+        Some(DaemonFrame::Error { message, .. }) => assert!(message.contains("64 MiB"), "{message}"),
         other => panic!("{other:?}"),
     }
     assert!(c.recv().await.is_none());

--- a/tests/daemon_no_tui_dep.rs
+++ b/tests/daemon_no_tui_dep.rs
@@ -1,0 +1,71 @@
+//! `synaps-engine` (where the daemon lives) must have no dependency path to
+//! `synaps-tui` (S289 D-1 amended; PLAN-phase2 §5.3). Uses `cargo metadata`
+//! so the check is about the graph, not about what happened to link.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::process::Command;
+
+#[test]
+fn daemon_no_tui_dep() {
+    let out = Command::new(std::env::var("CARGO").unwrap_or_else(|_| "cargo".into()))
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("cargo metadata");
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    let meta: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let pkgs = meta["packages"].as_array().unwrap();
+    // name → set of dependency package names (workspace members only)
+    let mut deps: HashMap<String, HashSet<String>> = HashMap::new();
+    for p in pkgs {
+        let name = p["name"].as_str().unwrap().to_string();
+        let set: HashSet<String> = p["dependencies"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|d| d["kind"].is_null()) // normal deps only (dev-deps excluded)
+            .map(|d| d["name"].as_str().unwrap().to_string())
+            .collect();
+        deps.insert(name, set);
+    }
+    assert!(deps.contains_key("synaps-engine"), "workspace has synaps-engine");
+    assert!(deps.contains_key("synaps-tui"), "workspace has synaps-tui");
+    // BFS from synaps-engine over normal deps
+    let mut seen = HashSet::new();
+    let mut q = VecDeque::from(["synaps-engine".to_string()]);
+    while let Some(n) = q.pop_front() {
+        if !seen.insert(n.clone()) {
+            continue;
+        }
+        if let Some(ds) = deps.get(&n) {
+            for d in ds {
+                q.push_back(d.clone());
+            }
+        }
+    }
+    assert!(!seen.contains("synaps-tui"), "synaps-engine reaches synaps-tui: {seen:?}");
+}
+
+/// Source-grep guard (risk §6.5): the daemon and socket transport never
+/// trace an `Answer` body.
+#[test]
+fn daemon_never_traces_answer_bodies() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/agent-engine/src");
+    let files = [
+        root.join("daemon/mod.rs"),
+        root.join("daemon/conn.rs"),
+        root.join("daemon/listener.rs"),
+        root.join("daemon/lifecycle.rs"),
+        root.join("daemon/registry.rs"),
+        root.join("session/socket_transport.rs"),
+    ];
+    for f in files {
+        let src = std::fs::read_to_string(&f).unwrap();
+        for (i, line) in src.lines().enumerate() {
+            if line.contains("tracing::") {
+                let l = line.to_ascii_lowercase();
+                assert!(!l.contains("answer") && !l.contains("value"), "{}:{}: {line}", f.display(), i + 1);
+            }
+        }
+    }
+}

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -156,6 +156,71 @@ async fn socket_roundtrip_real_uds() {
     assert!(ended, "attached client sees Ended on daemon stop");
 }
 
+/// §4 HIGH: a session whose history is past rpc's 1 MiB cap must still
+/// attach (`Attached` carries the whole history) and stream (`Conversation`
+/// is a digest, so the per-event cost is O(1) regardless of history size).
+#[tokio::test]
+#[serial]
+async fn attach_to_session_with_history_over_1mib() {
+    let guard = HomeGuard::new();
+    let run = guard.base_dir().join("run");
+    let d = start(&run).await;
+    let paths = d.paths.clone();
+
+    let conn = SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Test)).await.unwrap();
+    let (mut t, _) = SocketTransport::attach(
+        conn,
+        Attach::Create { config: SessionConfig { cwd: Some(guard.home.path().to_path_buf()), ..Default::default() }, mode: AttachMode::Mirror },
+    )
+    .await
+    .unwrap();
+    assert!(matches!(next(&mut t).await.event, SessionEventWire::ClientJoined { .. }));
+
+    // echo: user + assistant both carry the text → history ≈ 2 × 700 KiB > 1 MiB
+    let big = "z".repeat(700 * 1024);
+    t.send(SessionCommand::Submit { text: big.clone(), attachments: vec![] }).await.unwrap();
+    let mut conv = None;
+    let mut saw_history = false;
+    loop {
+        let e = next(&mut t).await;
+        match e.event {
+            SessionEventWire::Stream(StreamEvent::Session(SessionEvent::MessageHistory(m))) => saw_history = m.len() == 2,
+            SessionEventWire::Conversation(c) => {
+                conv = Some(c);
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(saw_history, "MessageHistory (> 1 MiB) delivered over the daemon wire");
+    let conv = conv.unwrap();
+    assert_eq!(conv.api_messages.len(), 2, "digest matched the MessageHistory mirror");
+    assert_eq!(conv.api_messages[1]["content"], big);
+    let bytes: usize = conv.api_messages.iter().map(|m| serde_json::to_vec(&**m).unwrap().len()).sum();
+    assert!(bytes > RPC_MAX_FRAME_BYTES, "history is {bytes} B, must exceed rpc's cap for this test to mean anything");
+
+    // a fresh client attaches to that session: Attached > 1 MiB
+    let conn2 = SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Attach)).await.unwrap();
+    let (mut t2, snap2) = SocketTransport::attach(conn2, Attach::Existing { session_id: t.session_id().clone(), mode: AttachMode::Mirror })
+        .await
+        .expect("attach to a > 1 MiB session");
+    assert_eq!(snap2.conversation.api_messages.len(), 2);
+    assert_eq!(snap2.conversation.api_messages[1]["content"], big);
+    assert_eq!(t2.messages().len(), 2);
+    assert!(matches!(next(&mut t2).await.event, SessionEventWire::ClientJoined { .. }));
+
+    // the second client's mirror also survives a Cancel (echo re-emits Conversation, digest-only)
+    t2.send(SessionCommand::Cancel).await.unwrap();
+    let e = next(&mut t2).await;
+    match e.event {
+        SessionEventWire::Conversation(c) => assert_eq!(c.api_messages.len(), 2),
+        other => panic!("{other:?}"),
+    }
+
+    d.shutdown_token().cancel();
+    d.wait().await;
+}
+
 #[tokio::test]
 #[serial]
 async fn stale_socket_reaped_and_second_daemon_refused() {

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -221,6 +221,70 @@ async fn attach_to_session_with_history_over_1mib() {
     d.wait().await;
 }
 
+/// §4 MED: a client may only send the user-facing subset; `Detach` only for
+/// its own id; `End`/`Attach`/`Resync` are refused with an `Error` frame and
+/// the session stays alive for everyone else.
+#[tokio::test]
+#[serial]
+async fn client_commands_are_whitelisted() {
+    let guard = HomeGuard::new();
+    let run = guard.base_dir().join("run");
+    let d = start(&run).await;
+    let paths = d.paths.clone();
+
+    let conn = SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Test)).await.unwrap();
+    let (mut a, _) = SocketTransport::attach(
+        conn,
+        Attach::Create { config: SessionConfig { cwd: Some(guard.home.path().to_path_buf()), ..Default::default() }, mode: AttachMode::Mirror },
+    )
+    .await
+    .unwrap();
+    assert!(matches!(next(&mut a).await.event, SessionEventWire::ClientJoined { .. }));
+    let conn2 = SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Attach)).await.unwrap();
+    let (mut b, _) = SocketTransport::attach(conn2, Attach::Existing { session_id: a.session_id().clone(), mode: AttachMode::Mirror }).await.unwrap();
+    assert!(matches!(next(&mut a).await.event, SessionEventWire::ClientJoined { .. }));
+    assert!(matches!(next(&mut b).await.event, SessionEventWire::ClientJoined { .. }));
+    let other = a.client_id();
+    assert_ne!(other, b.client_id());
+
+    // Errors surface as SystemNotice("refused: …") on the sender only.
+    async fn refused(t: &mut SocketTransport) -> String {
+        match next(t).await.event {
+            SessionEventWire::SystemNotice(m) => {
+                assert!(m.starts_with("refused:"), "{m}");
+                m
+            }
+            o => panic!("{o:?}"),
+        }
+    }
+    b.send(SessionCommand::Detach { client: other }).await.unwrap();
+    assert!(refused(&mut b).await.contains("not your client id"));
+    b.send(SessionCommand::End { reason: EndReason::ClientQuit }).await.unwrap();
+    assert!(refused(&mut b).await.contains("end:"));
+    b.send(SessionCommand::Attach { client: ClientMeta::new(ClientKind::Test), mode: AttachMode::Mirror }).await.unwrap();
+    assert!(refused(&mut b).await.contains("attach:"));
+    b.send(SessionCommand::Resync { client: other, since_seq: 0 }).await.unwrap();
+    assert!(refused(&mut b).await.contains("resync:"));
+    assert_eq!(d.state.live_sessions().len(), 1, "session survives refused End");
+
+    // a is untouched: nothing was forwarded to the actor (Save round-trips as an echo notice)
+    a.send(SessionCommand::Save).await.unwrap();
+    match next(&mut a).await.event {
+        SessionEventWire::SystemNotice(m) => assert!(m.starts_with("echo:"), "{m}"),
+        o => panic!("{o:?}"),
+    }
+    // whitelisted command from b reaches the actor and fans out to both
+    b.send(SessionCommand::Steer { text: "ok".into() }).await.unwrap();
+    assert!(matches!(next(&mut a).await.event, SessionEventWire::Steered { .. }));
+    assert!(matches!(next(&mut b).await.event, SessionEventWire::Steered { .. }));
+    // Detach{own} is allowed and only b leaves
+    b.send(SessionCommand::Detach { client: b.client_id() }).await.unwrap();
+    assert!(matches!(next(&mut a).await.event, SessionEventWire::ClientLeft { client } if client == b.client_id()));
+
+    d.shutdown_token().cancel();
+    d.wait().await;
+}
+
 #[tokio::test]
 #[serial]
 async fn stale_socket_reaped_and_second_daemon_refused() {

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -115,8 +115,10 @@ async fn socket_roundtrip_real_uds() {
         SocketTransport::attach(conn2, Attach::Existing { session_id: list[0].id.clone(), mode: AttachMode::Mirror }).await.unwrap();
     assert_eq!(snap2.conversation.api_messages.len(), 2);
     assert_ne!(t2.client_id(), t.client_id());
-    // t sees t2 join
+    // both see t2 join
     let j = next(&mut t).await;
+    assert!(matches!(j.event, SessionEventWire::ClientJoined { .. }));
+    let j = next(&mut t2).await;
     assert!(matches!(j.event, SessionEventWire::ClientJoined { .. }));
 
     // detach t without ending the session

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -269,9 +269,11 @@ async fn client_commands_are_whitelisted() {
 
     // a is untouched: nothing was forwarded to the actor (Save round-trips as an echo notice)
     a.send(SessionCommand::Save).await.unwrap();
-    match next(&mut a).await.event {
-        SessionEventWire::SystemNotice(m) => assert!(m.starts_with("echo:"), "{m}"),
-        o => panic!("{o:?}"),
+    for t in [&mut a, &mut b] {
+        match next(t).await.event {
+            SessionEventWire::SystemNotice(m) => assert!(m.starts_with("echo:"), "{m}"),
+            o => panic!("{o:?}"),
+        }
     }
     // whitelisted command from b reaches the actor and fans out to both
     b.send(SessionCommand::Steer { text: "ok".into() }).await.unwrap();

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -1,0 +1,194 @@
+//! Real-UDS round trip against `agent_engine::daemon` (PLAN-phase2 §5.3).
+//! Sessions are EchoActor-backed until A1 (`EngineHost::create_session`)
+//! merges; everything else — flock, socket perms, daemon.json, handshake,
+//! control fast path, pump, detach-without-abort — is the real code.
+
+#[path = "support/phase2/mod.rs"]
+#[allow(dead_code)]
+mod phase2;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_engine::daemon::{self, registry, Daemon, DaemonOpts};
+use agent_engine::session::socket_transport::SocketTransport;
+use agent_engine::session::wire::*;
+use agent_engine::session::*;
+use agent_engine::{EngineHost, HostOpts, LlmEvent, SessionEvent, StreamEvent};
+use phase2::HomeGuard;
+use serial_test::serial;
+
+async fn host() -> Arc<EngineHost> {
+    EngineHost::boot_and_install(HostOpts { profile: None, no_extensions: true })
+        .await
+        .expect("host boot")
+}
+
+async fn start(runtime_dir: &std::path::Path) -> Daemon {
+    Daemon::start(
+        host().await,
+        DaemonOpts {
+            runtime_dir: Some(runtime_dir.to_path_buf()),
+            factory: Some(daemon::echo_factory()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("daemon start")
+}
+
+async fn next(t: &mut SocketTransport) -> Envelope {
+    tokio::time::timeout(Duration::from_secs(3), t.next_event())
+        .await
+        .expect("timely")
+        .expect("open")
+}
+
+fn mode_of(p: &std::path::Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(p).unwrap().permissions().mode() & 0o777
+}
+
+#[tokio::test]
+#[serial]
+async fn socket_roundtrip_real_uds() {
+    let guard = HomeGuard::new();
+    let run = guard.base_dir().join("run");
+    let d = start(&run).await;
+    let paths = d.paths.clone();
+
+    // perms + registry
+    assert_eq!(mode_of(&paths.dir), 0o700);
+    assert_eq!(mode_of(&paths.sock), 0o600);
+    assert_eq!(mode_of(&paths.json), 0o600);
+    let info = registry::read_daemon_json(&paths).expect("daemon.json");
+    assert_eq!(info.pid, std::process::id());
+    assert_eq!(info.protocol_version, PROTOCOL_VERSION);
+    assert!(registry::is_alive(&paths), "flock held");
+    assert!(!registry::reap_stale(&paths), "live daemon never reaped");
+
+    // control fast path allocates no session
+    let pong = SocketTransport::ping(&paths.sock).await.unwrap();
+    assert_eq!(pong.pid, std::process::id());
+    assert_eq!(pong.sessions, 0);
+    assert!(SocketTransport::sessions(&paths.sock).await.unwrap().is_empty());
+    assert!(d.state.live_sessions().is_empty());
+
+    // attach + create
+    let conn = SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Test)).await.unwrap();
+    assert_eq!(conn.welcome.pid, std::process::id());
+    let (mut t, snap) = SocketTransport::attach(
+        conn,
+        Attach::Create { config: SessionConfig { cwd: Some(guard.home.path().to_path_buf()), ..Default::default() }, mode: AttachMode::Mirror },
+    )
+    .await
+    .unwrap();
+    assert_eq!(snap.meta.id, *t.session_id());
+    assert_eq!(d.state.live_sessions().len(), 1);
+    let joined = next(&mut t).await;
+    assert!(matches!(joined.event, SessionEventWire::ClientJoined { .. }));
+
+    t.send(SessionCommand::Submit { text: "hi".into(), attachments: vec![] }).await.unwrap();
+    let mut seen = Vec::new();
+    loop {
+        let e = next(&mut t).await;
+        let done = matches!(e.event, SessionEventWire::Conversation(_));
+        seen.push(e);
+        if done {
+            break;
+        }
+    }
+    assert!(matches!(seen[0].event, SessionEventWire::TurnStarted { .. }));
+    match &seen[1].event {
+        SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(s))) => assert_eq!(s, "hi"),
+        o => panic!("{o:?}"),
+    }
+    assert!(matches!(seen[3].event, SessionEventWire::Stream(StreamEvent::Session(SessionEvent::Done))));
+    let seqs: Vec<u64> = seen.iter().map(|e| e.seq).collect();
+    assert!(seqs.windows(2).all(|w| w[1] == w[0] + 1), "gapless {seqs:?}");
+
+    // a second client sees the same session in the list and can attach to it
+    let list = SocketTransport::sessions(&paths.sock).await.unwrap();
+    assert_eq!(list.len(), 1);
+    let conn2 = SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Attach)).await.unwrap();
+    let (mut t2, snap2) =
+        SocketTransport::attach(conn2, Attach::Existing { session_id: list[0].id.clone(), mode: AttachMode::Mirror }).await.unwrap();
+    assert_eq!(snap2.conversation.api_messages.len(), 2);
+    assert_ne!(t2.client_id(), t.client_id());
+    // t sees t2 join
+    let j = next(&mut t).await;
+    assert!(matches!(j.event, SessionEventWire::ClientJoined { .. }));
+
+    // detach t without ending the session
+    t.detach().await;
+    assert!(t.next_event().await.is_none());
+    let left = next(&mut t2).await;
+    assert!(matches!(left.event, SessionEventWire::ClientLeft { .. }));
+    assert_eq!(d.state.live_sessions().len(), 1, "detach never ends a session");
+
+    // unknown session refused with Error
+    let conn3 = SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Attach)).await.unwrap();
+    let err = SocketTransport::attach(conn3, Attach::Existing { session_id: "nope".into(), mode: AttachMode::Mirror })
+        .await
+        .err()
+        .unwrap();
+    assert!(matches!(err, TransportError::Protocol(ref m) if m.contains("unknown session")), "{err}");
+
+    // shutdown over the socket: sessions ended, files unlinked, lock released
+    SocketTransport::shutdown(&paths.sock, false).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(10), d.wait()).await.expect("daemon wait");
+    assert!(!paths.sock.exists());
+    assert!(!paths.json.exists());
+    assert!(!registry::is_alive(&paths));
+    let ended = tokio::time::timeout(Duration::from_secs(3), async {
+        loop {
+            match t2.next_event().await {
+                Some(e) if matches!(e.event, SessionEventWire::Ended { .. }) => return true,
+                Some(_) => continue,
+                None => return false,
+            }
+        }
+    })
+    .await
+    .unwrap();
+    assert!(ended, "attached client sees Ended on daemon stop");
+}
+
+#[tokio::test]
+#[serial]
+async fn stale_socket_reaped_and_second_daemon_refused() {
+    let guard = HomeGuard::new();
+    let run = guard.base_dir().join("run");
+    std::fs::create_dir_all(&run).unwrap();
+    let paths = registry::daemon_paths_in(&run, None);
+    // stale leftovers: socket + json with a dead pid, nobody holding the lock
+    std::os::unix::net::UnixListener::bind(&paths.sock).unwrap();
+    registry::write_daemon_json(
+        &paths,
+        &registry::DaemonInfo {
+            pid: 4_000_000,
+            protocol_version: PROTOCOL_VERSION,
+            daemon_version: "old".into(),
+            profile: None,
+            started_at: chrono::Utc::now(),
+            socket: paths.sock.to_string_lossy().into_owned(),
+        },
+    )
+    .unwrap();
+    let d = start(&run).await;
+    assert_eq!(registry::read_daemon_json(&paths).unwrap().pid, std::process::id());
+    assert!(SocketTransport::ping(&paths.sock).await.is_ok());
+
+    // a second daemon on the same paths is refused by the flock
+    let second = Daemon::start(
+        host().await,
+        DaemonOpts { runtime_dir: Some(run.clone()), factory: Some(daemon::echo_factory()), ..Default::default() },
+    )
+    .await;
+    assert!(second.is_err());
+    assert!(second.err().unwrap().to_string().contains("another daemon"));
+    assert!(SocketTransport::ping(&paths.sock).await.is_ok(), "first daemon untouched");
+
+    d.shutdown_token().cancel();
+    d.wait().await;
+}

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -325,3 +325,69 @@ async fn stale_socket_reaped_and_second_daemon_refused() {
     d.shutdown_token().cancel();
     d.wait().await;
 }
+
+/// §5 / §11.8c: `--idle-exit` is no longer inert once a session exists —
+/// a client-less session between turns is idle-eligible; a session that
+/// reports `streaming` (or does not answer the probe) pins the daemon up.
+#[tokio::test]
+#[serial]
+async fn idle_exit_counts_clientless_idle_sessions_and_never_a_running_turn() {
+    use agent_engine::session::wire::IDLE_PROBE_QUERY_ID;
+
+    // 1. probe semantics against a hand-rolled actor
+    let meta = agent_engine::session::handle::echo::meta_for(&SessionId::from("probe"));
+    let view = agent_engine::session::handle::echo::view_for();
+    let (h, mut ep) = SessionHandle::new(meta, view);
+    let events = ep.events.clone();
+    let sid = h.id.clone();
+    let streaming = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let s2 = Arc::clone(&streaming);
+    let actor = tokio::spawn(async move {
+        while let Some(cmd) = ep.cmd_rx.recv().await {
+            if let SessionCommand::Query { id, query: SessionQuery::Status } = cmd {
+                assert_eq!(id, IDLE_PROBE_QUERY_ID);
+                let value = serde_json::json!({ "streaming": s2.load(std::sync::atomic::Ordering::SeqCst), "pending_prompts": 0 });
+                let _ = events.send(Envelope { session_id: sid.clone(), seq: 0, ts: chrono::Utc::now(), event: SessionEventWire::QueryResult { id, value } });
+            }
+        }
+    });
+    assert!(!daemon::session_is_idle(&h).await, "streaming → busy");
+    streaming.store(false, std::sync::atomic::Ordering::SeqCst);
+    assert!(daemon::session_is_idle(&h).await, "between turns → idle");
+    actor.abort();
+    let _ = actor.await;
+
+    // 2. end to end: a created-then-detached echo session lets the daemon exit
+    let guard = HomeGuard::new();
+    let run = guard.base_dir().join("run");
+    let d = Daemon::start(
+        host().await,
+        DaemonOpts {
+            runtime_dir: Some(run.clone()),
+            factory: Some(daemon::echo_factory()),
+            idle_exit: Some(Duration::from_millis(300)),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let paths = d.paths.clone();
+    let conn = SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Test)).await.unwrap();
+    let (mut t, _) = SocketTransport::attach(
+        conn,
+        Attach::Create { config: SessionConfig { cwd: Some(guard.home.path().to_path_buf()), ..Default::default() }, mode: AttachMode::Mirror },
+    )
+    .await
+    .unwrap();
+    assert!(matches!(next(&mut t).await.event, SessionEventWire::ClientJoined { .. }));
+    // attached client pins the daemon regardless of session state
+    tokio::time::sleep(Duration::from_millis(700)).await;
+    assert!(!d.state.shutdown.is_cancelled(), "a connected client blocks idle-exit");
+    assert!(!daemon::daemon_is_idle(&d.state).await);
+    t.detach().await;
+    assert!(t.next_event().await.is_none());
+    assert_eq!(d.state.live_sessions().len(), 1, "session outlives the client");
+    // now: zero connections + one client-less idle session → exits
+    tokio::time::timeout(Duration::from_secs(5), d.wait()).await.expect("idle-exit fired with a live idle session");
+    assert!(!paths.sock.exists());
+}

--- a/tests/daemon_two_sessions.rs
+++ b/tests/daemon_two_sessions.rs
@@ -20,12 +20,12 @@ async fn next(t: &mut SocketTransport) -> Envelope {
     tokio::time::timeout(Duration::from_secs(10), t.next_event()).await.expect("timely").expect("open")
 }
 
-/// Everything up to and including the next `Conversation`.
+/// Everything up to and including `Idle` (stream ended, no auto-turn followed).
 async fn turn(t: &mut SocketTransport) -> Vec<Envelope> {
     let mut seen = Vec::new();
     loop {
         let e = next(t).await;
-        let done = matches!(e.event, SessionEventWire::Conversation(_));
+        let done = matches!(e.event, SessionEventWire::Idle);
         seen.push(e);
         if done {
             return seen;
@@ -97,8 +97,6 @@ async fn two_sessions_one_daemon_isolated() {
     let sb = turn(&mut b).await;
 
     for (s, who) in [(&sa, "a"), (&sb, "b")] {
-        let kinds: Vec<String> = s.iter().map(|e| format!("{:?}", e.event).chars().take(60).collect()).collect();
-        eprintln!("{who}: {kinds:#?}");
         assert!(matches!(s[0].event, SessionEventWire::TurnStarted { .. }), "{who}: {:?}", s[0].event);
         assert_eq!(text_of(s), "hi", "{who}");
         assert!(s.iter().any(|e| matches!(e.event, SessionEventWire::Stream(StreamEvent::Session(SessionEvent::Done)))), "{who}");
@@ -109,9 +107,14 @@ async fn two_sessions_one_daemon_isolated() {
     assert!(sa.iter().all(|e| &e.session_id == a.session_id()));
     assert!(sb.iter().all(|e| &e.session_id == b.session_id()));
     // the Conversation snapshot is per session: one user turn each
-    let conv = |s: &[Envelope]| match &s.last().unwrap().event {
-        SessionEventWire::Conversation(c) => c.api_messages.clone(),
-        o => panic!("{o:?}"),
+    let conv = |s: &[Envelope]| {
+        s.iter()
+            .rev()
+            .find_map(|e| match &e.event {
+                SessionEventWire::Conversation(c) => Some(c.api_messages.clone()),
+                _ => None,
+            })
+            .expect("Conversation snapshot")
     };
     let ma = conv(&sa);
     let mb = conv(&sb);

--- a/tests/daemon_two_sessions.rs
+++ b/tests/daemon_two_sessions.rs
@@ -128,11 +128,12 @@ async fn two_sessions_one_daemon_isolated() {
     let bodies = bodies.lock().unwrap();
     let b0 = String::from_utf8_lossy(&bodies[0]);
     let b1 = String::from_utf8_lossy(&bodies[1]);
-    let msgs = |b: &str| -> serde_json::Value { serde_json::from_str::<serde_json::Value>(b).unwrap()["messages"].clone() };
+    // Compare the `messages` array only: the system prompt legitimately contains
+    // English like "from a file".
+    let msgs = |b: &str| serde_json::from_str::<serde_json::Value>(b).unwrap()["messages"].to_string();
     let (m0, m1) = (msgs(&b0), msgs(&b1));
-    eprintln!("b0 messages: {m0}\nb1 messages: {m1}");
-    assert!(b0.contains("from a") && !b0.contains("from b"), "{m0}");
-    assert!(b1.contains("from b") && !b1.contains("from a"), "{m1}");
+    assert!(m0.contains("from a") && !m0.contains("from b"), "{m0}");
+    assert!(m1.contains("from b") && !m1.contains("from a"), "{m1}");
 
     // detach a mid-life: session stays; b unaffected
     a.detach().await;

--- a/tests/daemon_two_sessions.rs
+++ b/tests/daemon_two_sessions.rs
@@ -1,0 +1,151 @@
+//! Two REAL sessions (SessionActor via `EngineHost::create_session`, A1) in
+//! one daemon, each answered by a loopback Anthropic stub (PLAN-phase2 §5.3).
+
+#[path = "support/phase2/mod.rs"]
+#[allow(dead_code)]
+mod phase2;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_engine::daemon::{Daemon, DaemonOpts};
+use agent_engine::session::socket_transport::SocketTransport;
+use agent_engine::session::wire::*;
+use agent_engine::session::*;
+use agent_engine::{EngineHost, HostOpts, LlmEvent, SessionEvent, StreamEvent};
+use phase2::{spawn_stub, HomeGuard, Script, ANTHROPIC_SSE};
+use serial_test::serial;
+
+async fn next(t: &mut SocketTransport) -> Envelope {
+    tokio::time::timeout(Duration::from_secs(10), t.next_event()).await.expect("timely").expect("open")
+}
+
+/// Everything up to and including the next `Conversation`.
+async fn turn(t: &mut SocketTransport) -> Vec<Envelope> {
+    let mut seen = Vec::new();
+    loop {
+        let e = next(t).await;
+        let done = matches!(e.event, SessionEventWire::Conversation(_));
+        seen.push(e);
+        if done {
+            return seen;
+        }
+    }
+}
+
+fn text_of(seen: &[Envelope]) -> String {
+    seen.iter()
+        .filter_map(|e| match &e.event {
+            SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(t))) => Some(t.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn two_sessions_one_daemon_isolated() {
+    let guard = HomeGuard::new();
+    let (url, hits, bodies) = spawn_stub(Script::Sse(ANTHROPIC_SSE)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host: Arc<EngineHost> =
+        EngineHost::boot_and_install(HostOpts { profile: None, no_extensions: true }).await.expect("host boot");
+    let d = Daemon::start(host.clone(), DaemonOpts { runtime_dir: Some(guard.base_dir().join("run")), ..Default::default() })
+        .await
+        .expect("daemon start");
+    let sock = d.paths.sock.clone();
+
+    let cwd_a = guard.home.path().join("a");
+    let cwd_b = guard.home.path().join("b");
+    std::fs::create_dir_all(&cwd_a).unwrap();
+    std::fs::create_dir_all(&cwd_b).unwrap();
+
+    let mut clients = Vec::new();
+    for cwd in [&cwd_a, &cwd_b] {
+        let conn = SocketTransport::connect(&sock, Hello::new(ClientKind::Test)).await.unwrap();
+        let (t, snap) = SocketTransport::attach(
+            conn,
+            Attach::Create {
+                config: SessionConfig {
+                    cwd: Some(cwd.clone()),
+                    model_override: Some("claude-sonnet-4-5".into()),
+                    persist: false,
+                    ..Default::default()
+                },
+                mode: AttachMode::Mirror,
+            },
+        )
+        .await
+        .expect("attach create");
+        assert_eq!(snap.meta.cwd.as_deref(), Some(cwd.as_path()));
+        assert_eq!(snap.meta.host_pid, std::process::id());
+        assert_eq!(snap.view.model, "claude-sonnet-4-5");
+        clients.push(t);
+    }
+    let [mut a, mut b]: [SocketTransport; 2] = clients.try_into().ok().unwrap();
+    assert_ne!(a.session_id(), b.session_id());
+    assert_eq!(host.sessions().len(), 2, "both live on the host");
+    assert_eq!(d.state.live_sessions().len(), 2);
+
+    // ClientJoined for each
+    assert!(matches!(next(&mut a).await.event, SessionEventWire::ClientJoined { .. }));
+    assert!(matches!(next(&mut b).await.event, SessionEventWire::ClientJoined { .. }));
+
+    a.send(SessionCommand::Submit { text: "from a".into(), attachments: vec![] }).await.unwrap();
+    let sa = turn(&mut a).await;
+    b.send(SessionCommand::Submit { text: "from b".into(), attachments: vec![] }).await.unwrap();
+    let sb = turn(&mut b).await;
+
+    for (s, who) in [(&sa, "a"), (&sb, "b")] {
+        assert!(matches!(s[0].event, SessionEventWire::TurnStarted { .. }), "{who}: {:?}", s[0].event);
+        assert_eq!(text_of(s), "hi", "{who}");
+        assert!(s.iter().any(|e| matches!(e.event, SessionEventWire::Stream(StreamEvent::Session(SessionEvent::Done)))), "{who}");
+        let seqs: Vec<u64> = s.iter().map(|e| e.seq).collect();
+        assert!(seqs.windows(2).all(|w| w[1] == w[0] + 1), "{who} gapless {seqs:?}");
+    }
+    // each envelope is stamped with its own session id
+    assert!(sa.iter().all(|e| &e.session_id == a.session_id()));
+    assert!(sb.iter().all(|e| &e.session_id == b.session_id()));
+    // the Conversation snapshot is per session: one user turn each
+    let conv = |s: &[Envelope]| match &s.last().unwrap().event {
+        SessionEventWire::Conversation(c) => c.api_messages.clone(),
+        o => panic!("{o:?}"),
+    };
+    let ma = conv(&sa);
+    let mb = conv(&sb);
+    assert_eq!(ma.len(), 2);
+    assert_eq!(mb.len(), 2);
+    assert_eq!(ma[0]["content"], "from a");
+    assert_eq!(mb[0]["content"], "from b");
+
+    // provider saw exactly two requests, each carrying only its own session's prompt
+    assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 2);
+    let bodies = bodies.lock().unwrap();
+    let b0 = String::from_utf8_lossy(&bodies[0]);
+    let b1 = String::from_utf8_lossy(&bodies[1]);
+    assert!(b0.contains("from a") && !b0.contains("from b"));
+    assert!(b1.contains("from b") && !b1.contains("from a"));
+
+    // detach a mid-life: session stays; b unaffected
+    a.detach().await;
+    assert!(a.next_event().await.is_none());
+    assert_eq!(host.sessions().len(), 2);
+
+    // daemon stop ends both sessions
+    SocketTransport::shutdown(&sock, false).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(15), d.wait()).await.expect("daemon wait");
+    let ended = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match b.next_event().await {
+                Some(e) if matches!(e.event, SessionEventWire::Ended { .. }) => return true,
+                Some(_) => continue,
+                None => return false,
+            }
+        }
+    })
+    .await
+    .unwrap();
+    assert!(ended);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert!(host.sessions().is_empty(), "host map drained after End");
+}

--- a/tests/daemon_two_sessions.rs
+++ b/tests/daemon_two_sessions.rs
@@ -128,8 +128,11 @@ async fn two_sessions_one_daemon_isolated() {
     let bodies = bodies.lock().unwrap();
     let b0 = String::from_utf8_lossy(&bodies[0]);
     let b1 = String::from_utf8_lossy(&bodies[1]);
-    assert!(b0.contains("from a") && !b0.contains("from b"));
-    assert!(b1.contains("from b") && !b1.contains("from a"));
+    let msgs = |b: &str| -> serde_json::Value { serde_json::from_str::<serde_json::Value>(b).unwrap()["messages"].clone() };
+    let (m0, m1) = (msgs(&b0), msgs(&b1));
+    eprintln!("b0 messages: {m0}\nb1 messages: {m1}");
+    assert!(b0.contains("from a") && !b0.contains("from b"), "{m0}");
+    assert!(b1.contains("from b") && !b1.contains("from a"), "{m1}");
 
     // detach a mid-life: session stays; b unaffected
     a.detach().await;

--- a/tests/daemon_two_sessions.rs
+++ b/tests/daemon_two_sessions.rs
@@ -97,6 +97,8 @@ async fn two_sessions_one_daemon_isolated() {
     let sb = turn(&mut b).await;
 
     for (s, who) in [(&sa, "a"), (&sb, "b")] {
+        let kinds: Vec<String> = s.iter().map(|e| format!("{:?}", e.event).chars().take(60).collect()).collect();
+        eprintln!("{who}: {kinds:#?}");
         assert!(matches!(s[0].event, SessionEventWire::TurnStarted { .. }), "{who}: {:?}", s[0].event);
         assert_eq!(text_of(s), "hi", "{who}");
         assert!(s.iter().any(|e| matches!(e.event, SessionEventWire::Stream(StreamEvent::Session(SessionEvent::Done)))), "{who}");

--- a/tests/extensions_e2e.rs
+++ b/tests/extensions_e2e.rs
@@ -1806,3 +1806,228 @@ async fn hook_json_carries_session_id() {
 
     manager.shutdown_all().await;
 }
+
+// ── daemon-mode phase 2 (C2): discovery once per process, sessions per session ─
+
+#[tokio::test(flavor = "current_thread")]
+async fn discover_and_load_twice_is_idempotent() {
+    let _guard = BASE_DIR_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tempfile::tempdir().unwrap();
+    config::set_base_dir_for_tests(home.path().to_path_buf());
+    let log_path = install_session_id_echo_plugin(home.path(), "idem-test");
+
+    let hook_bus = Arc::new(HookBus::new());
+    let manager = Arc::new(tokio::sync::RwLock::new(ExtensionManager::new(
+        hook_bus.clone(),
+    )));
+    assert!(manager.read().await.discovery_done().is_none());
+
+    let first = manager.write().await.discover_and_load().await;
+    assert_eq!(first.0, vec!["idem-test".to_string()]);
+    assert!(first.1.is_empty(), "{:?}", first.1);
+    let handlers_first = manager.read().await.handlers();
+
+    // Second host / second loader call in the same process: same result,
+    // no "already loaded" failures, no new process.
+    let second = manager.write().await.discover_and_load().await;
+    assert_eq!(second, first, "second discover must replay the first result");
+    assert_eq!(
+        manager.read().await.discovery_done(),
+        Some(first.clone())
+    );
+    let handlers_second = manager.read().await.handlers();
+    assert_eq!(handlers_first.len(), 1);
+    assert!(
+        Arc::ptr_eq(&handlers_first[0].1, &handlers_second[0].1),
+        "handler must be the same process, not a respawn"
+    );
+
+    // The loader entry point is the same seam: a third call through it also
+    // replays and still fires on_session_start for ITS session.
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    synaps_cli::extensions::loader::spawn_discover_and_load(
+        manager.clone(),
+        tx,
+        Some("sess-loader".to_string()),
+    )
+    .await
+    .unwrap();
+    let mut events = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        events.push(ev);
+    }
+    assert!(matches!(
+        events.last(),
+        Some(synaps_cli::extensions::loader::ExtensionLoaderEvent::Finished { loaded, failed })
+            if loaded == &first.0 && failed.is_empty()
+    ), "loader replays Finished from the record: {events:?}");
+
+    // Sidecar spawned ONCE: every logged hook came from the same pid.
+    let _ = hook_bus
+        .emit(&HookEvent::before_message("x").with_session(Some("sess-loader")))
+        .await;
+    let seen = read_jsonl(&log_path);
+    let pids: std::collections::HashSet<u64> =
+        seen.iter().map(|e| e["pid"].as_u64().unwrap()).collect();
+    assert_eq!(pids.len(), 1, "one sidecar for three discover calls: {seen:?}");
+    assert!(seen.iter().any(|e| e["kind"] == "on_session_start" && e["session_id"] == "sess-loader"));
+
+    manager.write().await.shutdown_all().await;
+    // Shutdown resets the record so a genuine restart can re-walk.
+    assert!(manager.read().await.discovery_done().is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn session_start_end_per_session() {
+    let _guard = BASE_DIR_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tempfile::tempdir().unwrap();
+    config::set_base_dir_for_tests(home.path().to_path_buf());
+    let log_path = install_session_id_echo_plugin(home.path(), "per-session-test");
+
+    let hook_bus = Arc::new(HookBus::new());
+    let mut manager = ExtensionManager::new(hook_bus.clone());
+    let (loaded, failed) = manager.discover_and_load().await;
+    assert_eq!(loaded, vec!["per-session-test".to_string()]);
+    assert!(failed.is_empty(), "{failed:?}");
+
+    use synaps_cli::extensions::loader::{emit_session_end, emit_session_start};
+    // Two sessions in one host: two starts with distinct ids …
+    assert!(!emit_session_start(&hook_bus, "sess-A").await, "fixture does not inject");
+    assert!(!emit_session_start(&hook_bus, "sess-B").await);
+    // … keyed injections stay isolated (phase 1 keyed injection) …
+    hook_bus.set_session_injection_for("sess-A", "A-only".into()).await;
+    hook_bus.set_session_injection_for("sess-B", "B-only".into()).await;
+    assert_eq!(hook_bus.session_injection_for("sess-A").await.as_deref(), Some("A-only"));
+    assert_eq!(hook_bus.session_injection_for("sess-B").await.as_deref(), Some("B-only"));
+    // … and two ends, each clearing only its own injection.
+    assert!(emit_session_end(&hook_bus, "sess-A", None, Duration::from_secs(5)).await);
+    assert_eq!(hook_bus.session_injection_for("sess-A").await, None);
+    assert_eq!(hook_bus.session_injection_for("sess-B").await.as_deref(), Some("B-only"));
+    assert!(emit_session_end(&hook_bus, "sess-B", None, Duration::from_secs(5)).await);
+    assert_eq!(hook_bus.session_injection_for("sess-B").await, None);
+
+    let seen = read_jsonl(&log_path);
+    let lifecycle: Vec<(String, String)> = seen
+        .iter()
+        .filter(|e| e["kind"] == "on_session_start" || e["kind"] == "on_session_end")
+        .map(|e| {
+            (
+                e["kind"].as_str().unwrap().to_string(),
+                e["session_id"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        lifecycle,
+        vec![
+            ("on_session_start".into(), "sess-A".into()),
+            ("on_session_start".into(), "sess-B".into()),
+            ("on_session_end".into(), "sess-A".into()),
+            ("on_session_end".into(), "sess-B".into()),
+        ],
+        "session lifecycle fires per session, not per process: {seen:?}"
+    );
+    let pids: std::collections::HashSet<u64> =
+        seen.iter().map(|e| e["pid"].as_u64().unwrap()).collect();
+    assert_eq!(pids.len(), 1, "one sidecar served both sessions");
+
+    manager.shutdown_all().await;
+}
+
+/// S310/S311 regression: session A loading a plugin mid-round (a catalog
+/// generation bump on the SHARED registry) must not invalidate session B's
+/// activated tools — phase 1 carry-forward re-pins them at B's next round.
+#[tokio::test(flavor = "current_thread")]
+async fn plugin_load_in_one_session_keeps_other_sessions_activations() {
+    use synaps_cli::mcp::descriptors::{
+        dormant_tools_for_config, server_config_fingerprint, CachedServerDescriptors,
+        CachedToolDescriptor, McpDescriptorCache,
+    };
+    use synaps_cli::mcp::{McpConfig, McpServerConfig};
+    use synaps_cli::tools::activation::{
+        activate_exact_for_user, ExecutionGate, SessionId, SessionToolSet,
+    };
+    use synaps_cli::tools::catalog::ToolId;
+
+    let hook_bus = Arc::new(HookBus::new());
+    let tools = Arc::new(tokio::sync::RwLock::new(
+        synaps_cli::ToolRegistry::without_subagent(),
+    ));
+    let mut manager = ExtensionManager::new_with_tools(hook_bus, tools.clone());
+
+    // Session B's world: a dormant MCP tool it has exactly activated.
+    let srv = McpServerConfig {
+        command: "/bin/true".into(),
+        args: vec![],
+        env: Default::default(),
+        shared: false,
+    };
+    let fp = server_config_fingerprint(&srv);
+    let mut cache = McpDescriptorCache::empty();
+    cache.servers.insert(
+        "srv".into(),
+        CachedServerDescriptors {
+            fingerprint: fp,
+            tools: vec![CachedToolDescriptor {
+                name: "echo_tool".into(),
+                description: "echo".into(),
+                input_schema: json!({"type":"object","properties":{}}),
+            }],
+        },
+    );
+    let config = McpConfig {
+        mcp_servers: [("srv".to_string(), srv)].into_iter().collect(),
+    };
+    tools
+        .write()
+        .await
+        .try_register_batch(dormant_tools_for_config(&config, &cache))
+        .unwrap();
+    let sid_b = SessionId::parse("sess-B").unwrap();
+    let echo_id = ToolId::mcp("srv", "echo_tool");
+    let (mut set_b, gen_before) = {
+        let reg = tools.read().await;
+        let mut set = SessionToolSet::progressive_core_for_catalog(sid_b.clone(), reg.catalog());
+        activate_exact_for_user(&mut set, reg.catalog(), &echo_id).unwrap();
+        ExecutionGate::authorize_wire_call(&reg, &set, "ext__srv__echo_tool").unwrap();
+        (set, reg.catalog().generation())
+    };
+
+    // Session A loads a tool-registering plugin mid-round: catalog bumps.
+    let fixture = std::env::current_dir()
+        .unwrap()
+        .join("tests/fixtures/register_tool_extension.py")
+        .to_string_lossy()
+        .to_string();
+    let manifest = synaps_cli::extensions::manifest::ExtensionManifest {
+        theme_tokens: Default::default(),
+        deferred: None,
+        protocol_version: synaps_cli::extensions::manifest::CURRENT_EXTENSION_PROTOCOL_VERSION,
+        runtime: synaps_cli::extensions::manifest::ExtensionRuntime::Process,
+        command: "python3".to_string(),
+        setup: None,
+        prebuilt: ::std::collections::HashMap::new(),
+        args: vec![fixture],
+        permissions: vec!["tools.register".to_string()],
+        hooks: vec![],
+        config: vec![],
+    };
+    manager.load("session-a-plugin", &manifest).await.unwrap();
+
+    {
+        let reg = tools.read().await;
+        assert!(reg.get("session-a-plugin:echo").is_some(), "A's tool registered");
+        assert_ne!(reg.catalog().generation(), gen_before, "catalog generation bumped");
+        assert!(set_b.is_stale(reg.catalog()), "B sees the bump …");
+        // … but B's next round-top carry-forward keeps every activation.
+        let (next, dropped) = set_b.rebuilt_for_catalog(reg.catalog(), true);
+        assert!(dropped.is_empty(), "nothing drifted: {dropped:?}");
+        assert!(next.activation(&echo_id).is_some(), "B's activation survives A's plugin load");
+        ExecutionGate::authorize_wire_call(&reg, &next, "ext__srv__echo_tool")
+            .expect("gate still executes B's carried activation");
+        set_b = next;
+    }
+    assert!(!set_b.is_stale(tools.read().await.catalog()));
+
+    manager.shutdown_all().await;
+}

--- a/tests/extensions_e2e.rs
+++ b/tests/extensions_e2e.rs
@@ -184,6 +184,7 @@ async fn modify_hook_replaces_tool_input_and_after_hook_sees_modified_input() {
         "bash",
         None,
         serde_json::json!({"command": "rm -rf /tmp/nope"}),
+        None,
     )
     .await;
     let decision = synaps_cli::runtime::resolve_before_tool_call_decision(
@@ -244,6 +245,7 @@ async fn modify_hook_replaces_tool_input_and_after_hook_sees_modified_input() {
         input,
         output,
         256 * 1024,
+        None,
     )
     .await;
     // No after_tool_call transform handler registered → output unchanged.
@@ -300,6 +302,7 @@ async fn after_tool_call_replace_substitutes_output_via_real_extension() {
         json!({"command": "echo big"}),
         raw,
         256 * 1024,
+        None,
     )
     .await;
 
@@ -1667,4 +1670,139 @@ async fn on_session_start_injection_reaches_the_session() {
 
     manager.shutdown_all().await;
     std::env::remove_var("SYNAPS_SESSION_START_LOG");
+}
+
+// ── daemon-mode phase 2 (C1): session_id on tool/message hook events ─────────
+
+/// Installs the `session_id_echo_extension.py` fixture as a user plugin under
+/// `home` subscribed to every hook kind; returns the JSONL log path.
+fn install_session_id_echo_plugin(home: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let plugin_dir = home.join("plugins").join(name);
+    let log_path = plugin_dir.join("session-id.jsonl");
+    fs::create_dir_all(plugin_dir.join(".synaps-plugin")).unwrap();
+    fs::create_dir_all(plugin_dir.join("extensions")).unwrap();
+    fs::copy(
+        std::env::current_dir()
+            .unwrap()
+            .join("tests/fixtures/session_id_echo_extension.py"),
+        plugin_dir.join("extensions/session_id_echo_extension.py"),
+    )
+    .unwrap();
+    fs::write(
+        plugin_dir.join(".synaps-plugin/plugin.json"),
+        format!(
+            r#"{{
+  "name": "{name}",
+  "version": "0.1.0",
+  "extension": {{
+    "protocol_version": 1,
+    "runtime": "process",
+    "command": "python3",
+    "args": ["extensions/session_id_echo_extension.py"],
+    "permissions": ["tools.intercept", "privacy.llm_content", "session.lifecycle"],
+    "hooks": [
+      {{"hook": "before_tool_call"}},
+      {{"hook": "after_tool_call"}},
+      {{"hook": "before_message"}},
+      {{"hook": "on_message_complete"}},
+      {{"hook": "on_session_start"}},
+      {{"hook": "on_session_end"}}
+    ]
+  }}
+}}
+"#
+        ),
+    )
+    .unwrap();
+    log_path
+}
+
+fn read_jsonl(path: &std::path::Path) -> Vec<Value> {
+    fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect()
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn hook_json_carries_session_id() {
+    let _guard = BASE_DIR_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tempfile::tempdir().unwrap();
+    config::set_base_dir_for_tests(home.path().to_path_buf());
+    let log_path = install_session_id_echo_plugin(home.path(), "session-id-test");
+
+    let hook_bus = Arc::new(HookBus::new());
+    let mut manager = ExtensionManager::new(hook_bus.clone());
+    let (loaded, failed) = manager.discover_and_load().await;
+    assert_eq!(loaded, vec!["session-id-test".to_string()]);
+    assert!(failed.is_empty(), "unexpected discovery failures: {failed:?}");
+
+    // Two sessions in one process → distinct ids on the wire.
+    let _ = synaps_cli::runtime::emit_before_tool_call(
+        &hook_bus,
+        "bash",
+        None,
+        json!({"command": "true"}),
+        Some("sess-A"),
+    )
+    .await;
+    let _ = synaps_cli::runtime::emit_after_tool_call(
+        &hook_bus,
+        "bash",
+        None,
+        json!({"command": "true"}),
+        "ok".to_string(),
+        1024,
+        Some("sess-B"),
+    )
+    .await;
+    let _ = hook_bus
+        .emit(&HookEvent::before_message("hi").with_session(Some("sess-A")))
+        .await;
+    let _ = hook_bus
+        .emit(&HookEvent::on_message_complete("done", json!({})).with_session(Some("sess-B")))
+        .await;
+    // Worker path: no owning conversation → still null.
+    let _ = synaps_cli::runtime::emit_before_tool_call(
+        &hook_bus,
+        "bash",
+        None,
+        json!({"command": "true"}),
+        None,
+    )
+    .await;
+
+    // Kill-switch: SYNAPS_HOOK_SESSION_ID=0 → null even when the caller has an id.
+    std::env::set_var("SYNAPS_HOOK_SESSION_ID", "0");
+    let killed = HookEvent::before_tool_call("bash", json!({})).with_session(Some("sess-A"));
+    std::env::remove_var("SYNAPS_HOOK_SESSION_ID");
+    assert_eq!(killed.session_id, None, "kill-switch must force null");
+    let _ = hook_bus.emit(&killed).await;
+
+    let seen = read_jsonl(&log_path);
+    let ids: Vec<(String, Option<String>)> = seen
+        .iter()
+        .map(|e| {
+            (
+                e["kind"].as_str().unwrap().to_string(),
+                e["session_id"].as_str().map(str::to_string),
+            )
+        })
+        .collect();
+    assert_eq!(
+        ids,
+        vec![
+            ("before_tool_call".into(), Some("sess-A".into())),
+            ("after_tool_call".into(), Some("sess-B".into())),
+            ("before_message".into(), Some("sess-A".into())),
+            ("on_message_complete".into(), Some("sess-B".into())),
+            ("before_tool_call".into(), None),
+            ("before_tool_call".into(), None),
+        ],
+        "hook JSON must carry the owning session id (log: {seen:?})"
+    );
+
+    manager.shutdown_all().await;
 }

--- a/tests/fixtures/session_id_echo_extension.py
+++ b/tests/fixtures/session_id_echo_extension.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Records every hook's `kind`, `session_id` and `tool_name` to a JSONL log.
+
+Used by daemon-mode phase 2 (C1/C2) tests: tool/message hooks carry the
+owning conversation id; on_session_start/end fire once per session.
+"""
+import json
+import os
+import sys
+
+LOG_PATH = os.environ.get("SYNAPS_SESSION_ID_LOG")
+if not LOG_PATH:
+    # Host scrubs extension envs (env_clear) — fall back to <plugin_dir>/session-id.jsonl.
+    LOG_PATH = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "session-id.jsonl"
+    )
+
+
+def read_message():
+    header = b""
+    while not header.endswith(b"\r\n\r\n"):
+        chunk = sys.stdin.buffer.read(1)
+        if not chunk:
+            return None
+        header += chunk
+    content_length = None
+    for line in header.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            content_length = int(line.split(b":", 1)[1].strip())
+            break
+    if content_length is None:
+        return None
+    return json.loads(sys.stdin.buffer.read(content_length).decode("utf-8"))
+
+
+def write_message(payload):
+    body = json.dumps(payload).encode("utf-8")
+    sys.stdout.buffer.write(f"Content-Length: {len(body)}\r\n\r\n".encode("utf-8"))
+    sys.stdout.buffer.write(body)
+    sys.stdout.buffer.flush()
+
+
+def append_log(entry):
+    with open(LOG_PATH, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry) + "\n")
+
+
+def main():
+    while True:
+        message = read_message()
+        if message is None:
+            break
+        method = message.get("method")
+        if method == "initialize":
+            write_message({
+                "jsonrpc": "2.0",
+                "id": message["id"],
+                "result": {"protocol_version": 1, "capabilities": {}},
+            })
+        elif method == "hook.handle":
+            params = message.get("params", {})
+            append_log({
+                "kind": params.get("kind"),
+                "session_id": params.get("session_id"),
+                "tool_name": params.get("tool_name"),
+                "pid": os.getpid(),
+            })
+            write_message({"jsonrpc": "2.0", "id": message["id"], "result": {"action": "continue"}})
+        elif method == "shutdown":
+            break
+        else:
+            write_message({
+                "jsonrpc": "2.0",
+                "id": message.get("id"),
+                "error": {"code": -32601, "message": f"unknown method: {method}"},
+            })
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/phase3_activation.rs
+++ b/tests/phase3_activation.rs
@@ -233,6 +233,7 @@ fn mcp_fixture(tag: &str, tools: Value) -> McpFixture {
                 .display()
                 .to_string()],
             env,
+            shared: false,
         },
     }
 }
@@ -294,10 +295,15 @@ fn mcp_config_with(cfg: McpServerConfig) -> McpConfig {
 
 fn mcp_manager(cfg: &McpServerConfig) -> Arc<McpRuntimeManager> {
     let cfg = cfg.clone();
-    Arc::new(McpRuntimeManager::new(
-        Arc::new(move |server: &str| (server == "srv").then(|| cfg.clone())),
-        Duration::from_secs(300),
-    ))
+    // Descriptor write-back (daemon-mode C4) must not touch the real cache.
+    let cache = tmp_dir("mcp-cache").join("descriptors.json");
+    Arc::new(
+        McpRuntimeManager::new(
+            Arc::new(move |server: &str| (server == "srv").then(|| cfg.clone())),
+            Duration::from_secs(300),
+        )
+        .with_cache_path(cache),
+    )
 }
 
 /// Extension fixture plumbing (mirrors extension_lease_lifecycle).

--- a/tests/session_actor_differential.rs
+++ b/tests/session_actor_differential.rs
@@ -1,0 +1,293 @@
+//! §5.1 — byte-identical proof for `LocalTransport`: the same scripted
+//! session runs through the FROZEN reference reactor (`support/reference_reactor.rs`,
+//! today's inline engine halves) and through `EngineHost::create_session` +
+//! `LocalTransport`; the `StreamEvent` sequences, the final `api_messages`
+//! and the auto-turn counters must be identical.
+
+#[path = "support/phase2/mod.rs"]
+mod support;
+#[path = "support/reference_reactor.rs"]
+mod reference_reactor;
+
+use std::sync::Arc;
+
+use agent_engine::session::{
+    ClientKind, ClientMeta, ClientTransport, EndReason, LocalTransport, SessionCommand,
+    SessionConfig, SessionEventWire,
+};
+use agent_engine::{EngineHost, HostOpts};
+use reference_reactor::ReferenceReactor;
+use serial_test::serial;
+use support::*;
+use synaps_cli::{SessionEvent, StreamEvent};
+
+const MODEL: &str = "claude-sonnet-4-5";
+
+/// `// FROZEN`: the oracle never changes after A5.
+#[test]
+fn reference_reactor_is_frozen() {
+    use sha2::{Digest, Sha256};
+    let src = include_str!("support/reference_reactor.rs");
+    let hex = format!("{:x}", Sha256::digest(src.as_bytes()));
+    assert_eq!(
+        hex, "b76c57a9543aaac7749af602e44e9209db99d83a3dcebaf30b9e040c35feaa71",
+        "tests/support/reference_reactor.rs is a frozen oracle — do not edit"
+    );
+}
+
+async fn host() -> Arc<EngineHost> {
+    EngineHost::boot(HostOpts {
+        profile: None,
+        no_extensions: true,
+    })
+    .await
+    .expect("host boot")
+}
+
+async fn oracle(host: &Arc<EngineHost>) -> ReferenceReactor {
+    let mut rt = host.foreground_runtime().await.unwrap();
+    rt.set_model(MODEL.to_string());
+    ReferenceReactor::new(rt)
+}
+
+struct ActorRun {
+    t: LocalTransport,
+    seen: Vec<String>,
+    api_messages: Vec<synaps_cli::SharedMessage>,
+    consecutive_auto_turns: u32,
+    conversations_after_terminal: usize,
+    cap_notices: u32,
+}
+
+async fn actor(host: &Arc<EngineHost>) -> ActorRun {
+    let handle = host
+        .create_session(SessionConfig {
+            model_override: Some(MODEL.into()),
+            persist: false,
+            ..SessionConfig::default()
+        })
+        .await
+        .expect("create_session");
+    let (t, _snap) = LocalTransport::attach(handle, ClientMeta::new(ClientKind::Test))
+        .await
+        .unwrap();
+    ActorRun {
+        t,
+        seen: Vec::new(),
+        api_messages: Vec::new(),
+        consecutive_auto_turns: 0,
+        conversations_after_terminal: 0,
+        cap_notices: 0,
+    }
+}
+
+impl ActorRun {
+    /// Pump until `Idle` (the actor's own "turn machine parked" signal).
+    async fn drive_to_idle(&mut self) {
+        let mut expect_conv = false;
+        loop {
+            let env = tokio::time::timeout(std::time::Duration::from_secs(30), self.t.next_event())
+                .await
+                .expect("actor hung")
+                .expect("actor alive");
+            match env.event {
+                SessionEventWire::Stream(ev) => {
+                    self.seen.push(format!("{:?}", ev));
+                    if matches!(
+                        ev,
+                        StreamEvent::Session(SessionEvent::Done)
+                            | StreamEvent::Session(SessionEvent::Error(_))
+                            | StreamEvent::Session(SessionEvent::MessageHistory(_))
+                    ) {
+                        expect_conv = true;
+                    }
+                }
+                SessionEventWire::Conversation(c) => {
+                    if expect_conv {
+                        self.conversations_after_terminal += 1;
+                        expect_conv = false;
+                    }
+                    self.api_messages = c.api_messages;
+                    self.consecutive_auto_turns = c.consecutive_auto_turns;
+                }
+                SessionEventWire::AutoTurnCapReached { .. } => self.cap_notices += 1,
+                SessionEventWire::Idle => break,
+                SessionEventWire::Ended { .. } => panic!("ended early"),
+                _ => {}
+            }
+        }
+    }
+
+    async fn end(mut self) {
+        self.t
+            .send(SessionCommand::End {
+                reason: EndReason::ClientQuit,
+            })
+            .await
+            .unwrap();
+        while let Some(env) = self.t.next_event().await {
+            if matches!(env.event, SessionEventWire::Ended { .. }) {
+                break;
+            }
+        }
+    }
+}
+
+fn msgs_json(m: &[synaps_cli::SharedMessage]) -> String {
+    serde_json::to_string(m).unwrap()
+}
+
+/// `TurnError.correlation_id` comes from a process-global counter
+/// (`next_turn_correlation_id`) — the only legitimately run-dependent bytes.
+fn normalise(seen: &[String]) -> Vec<String> {
+    let re = regex::Regex::new(r#"correlation_id: "turn-[0-9]+-[0-9]+""#).unwrap();
+    seen.iter()
+        .map(|s| re.replace_all(s, r#"correlation_id: "turn-N-N""#).into_owned())
+        .collect()
+}
+
+fn assert_same(o: &ReferenceReactor, a: &ActorRun) {
+    assert_eq!(
+        normalise(&o.seen),
+        normalise(&a.seen),
+        "StreamEvent sequence differs"
+    );
+    assert_eq!(
+        msgs_json(&o.api_messages),
+        msgs_json(&a.api_messages),
+        "final api_messages differ"
+    );
+    assert_eq!(o.consecutive_auto_turns, a.consecutive_auto_turns);
+    assert_eq!(o.cap_notices, a.cap_notices);
+}
+
+/// Deterministic event: id + timestamp fixed so the formatted injection is
+/// identical through both paths.
+fn fixed_event(i: usize) -> synaps_cli::events::types::Event {
+    let mut ev =
+        synaps_cli::events::types::Event::simple("differential", &format!("event {i}"), None);
+    ev.id = format!("evt-{i}");
+    ev.timestamp = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    ev
+}
+
+/// Inject an event through the session's real UDS (the `synaps send` path).
+async fn inject(session_id: &str, ev: &synaps_cli::events::types::Event) {
+    use tokio::io::AsyncWriteExt;
+    let path = synaps_cli::events::registry::socket_path_for_session(session_id);
+    let mut s = tokio::net::UnixStream::connect(&path).await.expect("session socket");
+    s.write_all(serde_json::to_string(ev).unwrap().as_bytes()).await.unwrap();
+    s.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn plain_turn() {
+    let _guard = HomeGuard::new();
+    let (url, _hits, _) = spawn_stub(Script::Sse(ANTHROPIC_SSE)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+
+    let mut o = oracle(&host).await;
+    o.submit("hello".into()).await;
+    o.drive_to_idle().await;
+
+    let mut a = actor(&host).await;
+    a.t.send(SessionCommand::Submit {
+        text: "hello".into(),
+        attachments: vec![],
+    })
+    .await
+    .unwrap();
+    a.drive_to_idle().await;
+
+    assert!(o.seen.iter().any(|s| s.contains("Done")));
+    assert_same(&o, &a);
+    assert!(a.conversations_after_terminal >= 1, "mirror invariant");
+    a.end().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn error_repairs_history() {
+    let _guard = HomeGuard::new();
+    let (url, _hits, _) = spawn_stub(Script::AlwaysFailEcho(500)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+
+    let mut o = oracle(&host).await;
+    o.submit("fail me".into()).await;
+    o.drive_to_idle().await;
+
+    let mut a = actor(&host).await;
+    a.t.send(SessionCommand::Submit {
+        text: "fail me".into(),
+        attachments: vec![],
+    })
+    .await
+    .unwrap();
+    a.drive_to_idle().await;
+
+    assert!(o.seen.iter().any(|s| s.contains("Error")));
+    assert_same(&o, &a);
+    // The prompt that started the turn survives repair in both.
+    assert_eq!(a.api_messages.len(), 1);
+    a.end().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn event_injection_idle_autoturn_until_cap() {
+    let _guard = HomeGuard::new();
+    let (url, _hits, _) = spawn_stub(Script::Sse(ANTHROPIC_SSE)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+
+    // Oracle: push into the queue directly, wake, drive — 6×; the 6th parks.
+    let mut o = oracle(&host).await;
+    for i in 0..6 {
+        o.runtime.event_queue().push(fixed_event(i)).unwrap();
+        o.on_queue_wake().await;
+        o.drive_to_idle().await;
+    }
+
+    // Actor: same events via its real per-session socket.
+    let mut a = actor(&host).await;
+    let sid = a.t.session_id().as_str().to_string();
+    for i in 0..6 {
+        inject(&sid, &fixed_event(i)).await;
+        // Wait for the External card, then either a turn or the cap notice.
+        let mut saw_turn = false;
+        loop {
+            let env = tokio::time::timeout(std::time::Duration::from_secs(30), a.t.next_event())
+                .await
+                .expect("actor hung")
+                .expect("alive");
+            match env.event {
+                SessionEventWire::TurnStarted { .. } => {
+                    saw_turn = true;
+                    break;
+                }
+                SessionEventWire::AutoTurnCapReached { .. } => {
+                    a.cap_notices += 1;
+                    break;
+                }
+                SessionEventWire::Conversation(c) => {
+                    a.api_messages = c.api_messages;
+                    a.consecutive_auto_turns = c.consecutive_auto_turns;
+                }
+                _ => {}
+            }
+        }
+        if saw_turn {
+            a.drive_to_idle().await;
+        }
+    }
+
+    assert_eq!(o.consecutive_auto_turns, 5);
+    assert_eq!(o.cap_notices, 1);
+    assert_same(&o, &a);
+    a.end().await;
+}

--- a/tests/session_actor_differential.rs
+++ b/tests/session_actor_differential.rs
@@ -30,7 +30,7 @@ fn reference_reactor_is_frozen() {
     let src = include_str!("support/reference_reactor.rs");
     let hex = format!("{:x}", Sha256::digest(src.as_bytes()));
     assert_eq!(
-        hex, "b76c57a9543aaac7749af602e44e9209db99d83a3dcebaf30b9e040c35feaa71",
+        hex, "080bbdd63a5b141cb0cc2ab8d360aec8276c75956ef5cd364548d017ce162c87",
         "tests/support/reference_reactor.rs is a frozen oracle — do not edit"
     );
 }

--- a/tests/support/reference_reactor.rs
+++ b/tests/support/reference_reactor.rs
@@ -1,0 +1,241 @@
+//! FROZEN reference reactor — the oracle for `tests/session_actor_differential.rs`.
+//!
+//! A verbatim copy of today's engine-half reactor logic driving a `Runtime`
+//! directly, exactly as the inline TUI/chat hosts do @ e640cafb:
+//!   - `crates/agent-tui/src/tui/dispatch.rs:1231-1288`  Submit
+//!   - `crates/agent-tui/src/tui/dispatch.rs:134-192`    Abort
+//!   - `crates/agent-tui/src/tui/dispatch.rs:1369-1378`  StreamingInput (steer/queue)
+//!   - `crates/agent-tui/src/tui/stream_handler.rs:40-248`  handle_stream_event (engine half)
+//!   - `crates/agent-tui/src/tui/stream_handler.rs:256-391` handle_event_queue_arm
+//!   - `crates/agent-tui/src/tui/stream_handler.rs:393-545` handle_stream_arm
+//!
+//! It is an oracle, not shared code. NEVER edit after A5 — the differential
+//! test asserts this file's sha256 against a constant.
+
+#![allow(dead_code, clippy::collapsible_match)]
+
+use futures::StreamExt;
+use synaps_cli::engine::reactor::{
+    claim_auto_turn, drain_event_queue, wake_action, EventDisposition, WakeAction, AUTO_TURN_CAP,
+};
+use synaps_cli::{AgentEvent, CancellationToken, Runtime, SessionEvent, StreamEvent};
+
+pub type ActiveStream = std::pin::Pin<Box<dyn futures::Stream<Item = StreamEvent> + Send>>;
+
+pub struct ReferenceReactor {
+    pub runtime: Runtime,
+    pub api_messages: Vec<synaps_cli::SharedMessage>,
+    pub pending_events: Vec<String>,
+    pub queued_message: Option<String>,
+    pub abort_context: Option<String>,
+    pub consecutive_auto_turns: u32,
+    pub turn_baseline: usize,
+    pub streaming: bool,
+    pub stream: Option<ActiveStream>,
+    pub cancel: Option<CancellationToken>,
+    pub steer_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
+    /// `format!("{:?}", StreamEvent)` in arrival order.
+    pub seen: Vec<String>,
+    /// Cap notices in order (stream_handler.rs:368-378 / :528-533).
+    pub cap_notices: u32,
+}
+
+impl ReferenceReactor {
+    pub fn new(runtime: Runtime) -> Self {
+        Self {
+            runtime,
+            api_messages: Vec::new(),
+            pending_events: Vec::new(),
+            queued_message: None,
+            abort_context: None,
+            consecutive_auto_turns: 0,
+            turn_baseline: 0,
+            streaming: false,
+            stream: None,
+            cancel: None,
+            steer_tx: None,
+            seen: Vec::new(),
+            cap_notices: 0,
+        }
+    }
+
+    async fn start_stream(&mut self) {
+        let ct = CancellationToken::new();
+        let (s_tx, s_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        self.streaming = true;
+        self.turn_baseline = self.api_messages.len();
+        self.stream = Some(
+            self.runtime
+                .run_stream_with_messages(
+                    self.api_messages.clone(),
+                    ct.clone(),
+                    Some(s_rx),
+                    None,
+                    false,
+                )
+                .await,
+        );
+        self.cancel = Some(ct);
+        self.steer_tx = Some(s_tx);
+    }
+
+    /// dispatch.rs:1231-1288
+    pub async fn submit(&mut self, input: String) {
+        self.consecutive_auto_turns = 0;
+        let api_content = if let Some(ref ctx) = self.abort_context {
+            let combined = format!("{}\n\n{}", ctx, input);
+            self.abort_context = None;
+            combined
+        } else {
+            input
+        };
+        self.api_messages.push(std::sync::Arc::new(
+            serde_json::json!({"role": "user", "content": api_content}),
+        ));
+        self.start_stream().await;
+    }
+
+    /// dispatch.rs:1369-1378
+    pub fn steer(&mut self, input: String) -> bool {
+        let steered = self
+            .steer_tx
+            .as_ref()
+            .map(|tx| tx.send(input.clone()).is_ok())
+            .unwrap_or(false);
+        self.queued_message = Some(input);
+        steered
+    }
+
+    /// stream_handler.rs:256-391 (engine half)
+    pub async fn on_queue_wake(&mut self) {
+        let busy = self.streaming;
+        let drained = drain_event_queue(
+            self.runtime.event_queue(),
+            &mut self.api_messages,
+            &mut self.pending_events,
+            busy,
+            self.steer_tx.as_ref(),
+        );
+        if drained.is_empty() {
+            return;
+        }
+        let auto_turn_enabled = true;
+        let action = wake_action(
+            &drained,
+            &self.api_messages,
+            busy,
+            auto_turn_enabled,
+            self.consecutive_auto_turns,
+        );
+        match action {
+            WakeAction::RunTurn => {
+                if self.stream.is_none() {
+                    self.consecutive_auto_turns += 1;
+                    self.start_stream().await;
+                }
+            }
+            WakeAction::Forward => {
+                let hit_cap = drained
+                    .iter()
+                    .any(|d| d.disposition == EventDisposition::Injected)
+                    && !busy
+                    && auto_turn_enabled
+                    && self.consecutive_auto_turns >= AUTO_TURN_CAP;
+                if hit_cap {
+                    self.cap_notices += 1;
+                }
+            }
+            WakeAction::Nothing => {}
+        }
+    }
+
+    /// Drive the active stream to its terminal event, applying
+    /// stream_handler.rs:40-248 + :393-545 (engine halves), including any
+    /// auto-continuation turns. Returns when the machine is idle.
+    pub async fn drive_to_idle(&mut self) {
+        while let Some(stream) = self.stream.as_mut() {
+            let Some(event) = stream.next().await else {
+                self.stream = None;
+                self.streaming = false;
+                break;
+            };
+            self.seen.push(format!("{:?}", event));
+            enum Action {
+                Continue,
+                AutoSendQueued(String),
+                AutoTriggerEvents,
+            }
+            let mut action = Action::Continue;
+            match event {
+                StreamEvent::Session(SessionEvent::MessageHistory(history)) => {
+                    self.api_messages = history;
+                }
+                StreamEvent::Agent(AgentEvent::SteeringDelivered { message }) => {
+                    if self.queued_message.as_ref() == Some(&message) {
+                        self.queued_message = None;
+                    }
+                }
+                StreamEvent::Session(SessionEvent::Done) => {
+                    self.streaming = false;
+                    let had_pending = !self.pending_events.is_empty();
+                    for formatted in self.pending_events.drain(..) {
+                        self.api_messages
+                            .push(std::sync::Arc::new(serde_json::json!({
+                                "role": "user",
+                                "content": formatted
+                            })));
+                    }
+                    if let Some(queued) = self.queued_message.take() {
+                        action = Action::AutoSendQueued(queued);
+                    } else if had_pending {
+                        action = Action::AutoTriggerEvents;
+                    }
+                }
+                StreamEvent::Session(SessionEvent::Error(_)) => {
+                    self.streaming = false;
+                    synaps_cli::engine::stream::repair_history_after_failure(
+                        &mut self.api_messages,
+                        self.turn_baseline,
+                    );
+                }
+                _ => {}
+            }
+            match action {
+                Action::Continue => {
+                    if !self.streaming {
+                        self.stream = None;
+                        self.cancel = None;
+                        self.steer_tx = None;
+                    }
+                }
+                Action::AutoSendQueued(queued) => {
+                    drop(self.stream.take());
+                    drop(self.cancel.take());
+                    drop(self.steer_tx.take());
+                    self.consecutive_auto_turns = 0;
+                    let api_content = if let Some(ref ctx) = self.abort_context {
+                        let combined = format!("{}\n\n{}", ctx, queued);
+                        self.abort_context = None;
+                        combined
+                    } else {
+                        queued
+                    };
+                    self.api_messages.push(std::sync::Arc::new(
+                        serde_json::json!({"role": "user", "content": api_content}),
+                    ));
+                    self.start_stream().await;
+                }
+                Action::AutoTriggerEvents => {
+                    drop(self.stream.take());
+                    drop(self.cancel.take());
+                    drop(self.steer_tx.take());
+                    if claim_auto_turn(&mut self.consecutive_auto_turns) {
+                        self.start_stream().await;
+                    } else {
+                        self.cap_notices += 1;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/support/reference_reactor.rs
+++ b/tests/support/reference_reactor.rs
@@ -1,16 +1,29 @@
 //! FROZEN reference reactor — the oracle for `tests/session_actor_differential.rs`.
 //!
-//! A verbatim copy of today's engine-half reactor logic driving a `Runtime`
-//! directly, exactly as the inline TUI/chat hosts do @ e640cafb:
+//! A frozen RE-DERIVATION (not a verbatim copy) of the engine-half reactor
+//! logic that the inline TUI/chat hosts run against a `Runtime` @ e640cafb,
+//! written from these sites:
 //!   - `crates/agent-tui/src/tui/dispatch.rs:1231-1288`  Submit
-//!   - `crates/agent-tui/src/tui/dispatch.rs:134-192`    Abort
 //!   - `crates/agent-tui/src/tui/dispatch.rs:1369-1378`  StreamingInput (steer/queue)
 //!   - `crates/agent-tui/src/tui/stream_handler.rs:40-248`  handle_stream_event (engine half)
 //!   - `crates/agent-tui/src/tui/stream_handler.rs:256-391` handle_event_queue_arm
 //!   - `crates/agent-tui/src/tui/stream_handler.rs:393-545` handle_stream_arm
 //!
-//! It is an oracle, not shared code. NEVER edit after A5 — the differential
-//! test asserts this file's sha256 against a constant.
+//! What it deliberately OMITS (so the differential cannot cover them):
+//!   - Abort (`dispatch.rs:134-192`): there is no cancel path; `abort_context`
+//!     is only consumed on Submit, never produced.
+//!   - Secret prompts: `run_stream_with_messages` is called with `None` for
+//!     the prompt handle (the actor passes `Some(handle)`).
+//!   - Save: nothing is persisted; save cadence is not compared.
+//!
+//! Because it was written by the same author from the same reading of the
+//! TUI as `SessionActor`, it is a regression guard against drift between
+//! the two — NOT an independent oracle: a misreading shared by both passes.
+//!
+//! It is an oracle, not shared code. NEVER edit the code below this header
+//! — the differential test asserts this file's sha256 against a constant
+//! (re-pinned once for this header rewrite; see the SHA in
+//! `session_actor_differential.rs`).
 
 #![allow(dead_code, clippy::collapsible_match)]
 


### PR DESCRIPTION
**Stacked on #105 (feat/engine-host).** Merge #105 first; this PR's base is that branch. 56 commits, +11,255 / −139, 58 files.

## What
Phase 2 of daemon mode — **EXPERIMENTAL, default off** (`SYNAPS_DAEMON=1` required for `synaps daemon` and `--attach` to do anything; otherwise exit 3 with a one-line reason).

- **`SessionActor`** owns one `Runtime` + `ConversationState` per session (never cloned — `Runtime::clone` resets TTL latches). The reactor loop that was copy-pasted in TUI/server/rpc/chat is one task per session. Forward-before-act ordering; detach never aborts an in-flight turn; pending permission prompts are held across detach and replayed on attach.
- **`ClientTransport`**: `LocalTransport` (in-process, moves un-serialised `StreamEvent`s through a channel — the byte-identical path) and `SocketTransport` (line-JSON v1 over a 0700/0600 UDS, 64 MiB daemon frames distinct from rpc's 1 MiB, `Conversation` as a digest with local mirror + resync query).
- **`synaps daemon {start,status,stop,sessions}`**, **`synaps attach`** thin line client, global `--attach`. flock as liveness oracle + stale reap, ready-fd detach, exact-match protocol version refusal, lightweight control fast-path (ping/sessions/send allocate no session), client-command whitelist (`Detach` only for own id; `End` is `daemon stop`'s job), idle-exit only when zero clients AND no session is streaming or awaiting a prompt — never aborts a turn.
- **`synaps chat` now runs on the actor** via `LocalTransport`. `tests/chat_stdin.rs` unchanged and green. Kill-switch is build-time: `--features legacy_inline` + `SYNAPS_CHAT_INLINE=1` (verified compiling + passing on bella; the default binary carries no chat kill-switch — stated plainly).
- **Shared extension host**: discovery idempotent (one sidecar PID across N sessions, tested), `on_session_start/end` per session, hook events carry `session_id` (additive; `SYNAPS_HOOK_SESSION_ID=0`), notification router wired into `synaps daemon` (widgets are daemon-global under `SYNAPS_DAEMON=1`), `EngineHost.extensions_ready` with drop-guard + 30 s bound. MCP `shared: true` per-server leases; **descriptor-cache write-back after `tools/list` is a default-on in-process change** (`SYNAPS_MCP_CACHE_WRITEBACK=0`).
- TUI: exactly two getter-only signatures accept `impl RuntimeRead`. No behaviour change, snapshots untouched. TUI-over-socket is day 2.

## Proof
- **Differential** vs a frozen re-derivation of the inline reactor (SHA-pinned; omits Abort/prompt/save — it's a drift guard, not an independent oracle): plain turn, provider error → history repair, idle auto-turn to cap through the real per-session UDS — `StreamEvent` sequences, `api_messages`, counters identical. **Tool loop / steer / cancel / secret prompt are NOT in the differential** — covered by actor unit tests only.
- Actor tests: attach/detach seq gapless, detach-doesn't-cancel/end-does, cancel-while-idle is a no-op (was: poisoned the next message), cancel-after-done doesn't scrape the previous turn, duplicate `--continue X` attaches-if-live (was: two actors on one id), pending prompt survives detach + replays on attach, answer dedup, end saves → session_end → Ended ordering, host shutdown saves every session, `extensions_ready` returns when the loader panics.
- Daemon tests (real UDS): perms 0700/0600, two clients, >1 MiB history attaches, >64 MiB frame → Error + close, version 99 refused, Hello-not-first / malformed / oversize handled, two real `SessionActor` sessions with isolated messages/cwd/seq, stale reap + second-daemon flock refusal, whitelist, idle-exit never during a running turn, no-tui-dep graph check.
- **`cargo test --workspace --no-fail-fast` on bella: 3905 passed / 0 failed / 21 ignored, EXIT=0** (133 suites).
- Reviewed (static, 11-point): NO-SHIP 6/10 → all 9 must-fix items closed in the fix round.

## Bench (bella, `DAEMON=1`, real sessions, release)
| N | PSS total | procs/session beyond daemon | daemon RssAnon | anon marginal/session |
|---|---:|---:|---:|---:|
| 1 | 108 MB | 1 | ~21 MB | — |
| 3 | 146 MB | 1 | ~21 MB | **≈ 0–1 MB** |

Sidecars once per daemon; daemon-side cost per idle session is within jemalloc purge noise. The remaining marginal (~11–19 MB depending on sample instant) is the **attach client process** — client diet (current_thread runtime for `attach`, threads 10→4) landed; more is day 2. Base `dev` marginal was 40.8 MB; #105 alone 35.1 MB.

## Not in this PR (day 2/3, designed in `~/Jawz/workspace/daemon-mode/PLAN-phase2.md` + SPEC §7–8)
TUI `--attach` over the socket (61 Runtime sites), `Parked` state (evict a detached idle session's Runtime, reload on attach), spawned compaction (currently inline — Attach/Detach/Cancel wait during a compaction), differential scenarios for tool loop / steer / cancel / prompt, per-session keying for `heartbeat` and `jawz-widget` plugins (last-writer-wins under a shared sidecar today), attach-client diet, bench purge-before-sample, `--tcp`.

## Design trail
`~/Jawz/workspace/daemon-mode/`: RECON-jcode.md, MEASUREMENTS.md, SYNAPS-SEAMS.md, SPEC-daemon-mode.md, PLAN-phase2.md, REVIEW-phase2-shady.md, docs/daemon-mode.md on the branch.

Refs #343.