### PR TITLE
feat(daemon): phase 3 engine — Parked sessions, input ownership, spawned compaction, daemon reload-in-place, 10-scenario differential (experimental, default off)

### DIFF
--- a/crates/agent-engine/src/daemon/conn.rs
+++ b/crates/agent-engine/src/daemon/conn.rs
@@ -216,8 +216,12 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
                     })
                     .await;
             }
+            // C2: jemalloc purge in the daemon (bench hygiene); reply Pong.
             Ok(Read::Frame(ClientFrame::Purge)) => {
-                let _ = tx.send(DaemonFrame::Error { session_id: None, message: "purge not implemented in this build".into() }).await;
+                agent_core::core::memstat::purge_arenas();
+                let _ = tx
+                    .send(DaemonFrame::Pong { pid: std::process::id(), uptime_s: state.uptime_s(), sessions: state.live_sessions().len() })
+                    .await;
             }
             Ok(Read::Frame(ClientFrame::Hello(_))) => {
                 let _ = tx.send(DaemonFrame::Error { session_id: None, message: "duplicate hello".into() }).await;

--- a/crates/agent-engine/src/daemon/conn.rs
+++ b/crates/agent-engine/src/daemon/conn.rs
@@ -4,6 +4,7 @@
 //! `Answer`/`Submit`/`Steer`); `Answer` values are forwarded to the actor
 //! and nowhere else.
 
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -174,7 +175,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
         profile: state.profile.clone(),
         sessions: state.session_metas(),
         progressive_tool_disclosure: state.host.parts().progressive_tool_disclosure,
-        generation: 1,
+        generation: state.generation,
     };
     if tx.send(DaemonFrame::Welcome(welcome)).await.is_err() {
         return;
@@ -185,6 +186,11 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     let attach = loop {
         let frame = tokio::select! {
             _ = shutdown.cancelled() => { let _ = tx.send(DaemonFrame::Bye { reason: None }).await; let _ = writer.await; return; }
+            _ = state.reload_announce.cancelled() => {
+                let _ = tx.send(DaemonFrame::Bye { reason: Some(reload_bye(&state)) }).await;
+                let _ = writer.await;
+                return;
+            }
             r = read_frame(&mut reader, &mut line) => r,
         };
         match frame {
@@ -203,18 +209,41 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
                 state.request_shutdown(force);
                 return;
             }
-            Ok(Read::Frame(ClientFrame::Attach(a))) => break a,
+            Ok(Read::Frame(ClientFrame::Attach(a))) => {
+                if matches!(a, Attach::Create { .. }) && state.reloading.load(Ordering::SeqCst) {
+                    let _ = tx
+                        .send(DaemonFrame::Refused { reason: RefuseReason::Busy, message: "daemon reloading; retry in a moment".into() })
+                        .await;
+                    continue;
+                }
+                break a;
+            }
             Ok(Read::Frame(ClientFrame::Cmd { session_id, .. })) => {
                 let _ = tx.send(DaemonFrame::Error { session_id: Some(session_id), message: "not attached".into() }).await;
             }
-            // C3 / C2 serve these; until then they are honest refusals.
-            Ok(Read::Frame(ClientFrame::Reload { .. })) => {
-                let _ = tx
-                    .send(DaemonFrame::Refused {
-                        reason: RefuseReason::ReloadRefused { why: "reload not implemented in this build".into() },
-                        message: "reload not implemented in this build".into(),
-                    })
-                    .await;
+            // C3: the whole §2.8 sequence runs on this connection's task;
+            // on success the process is replaced and this never returns.
+            Ok(Read::Frame(ref f @ ClientFrame::Reload { .. })) => {
+                let req = super::reload::ReloadRequest::from_frame(f).expect("reload frame");
+                match super::reload::prepare(&state, &state.paths, req).await {
+                    Err(super::reload::ReloadError::Refused(why)) => {
+                        let _ = tx
+                            .send(DaemonFrame::Refused { reason: RefuseReason::ReloadRefused { why: why.clone() }, message: why })
+                            .await;
+                    }
+                    Err(super::reload::ReloadError::ExecFailed(e)) => {
+                        let _ = tx.send(DaemonFrame::Error { session_id: None, message: format!("reload: {e}") }).await;
+                    }
+                    Ok(prepared) => {
+                        // Tell the requester, flush, close — then exec.
+                        let _ = tx.send(DaemonFrame::Bye { reason: Some(reload_bye(&state)) }).await;
+                        drop(tx);
+                        let _ = tokio::time::timeout(Duration::from_secs(1), writer).await;
+                        let e = super::reload::exec(&state, &state.paths, prepared).await;
+                        tracing::error!(error = %e, "daemon: reload did not exec");
+                        return;
+                    }
+                }
             }
             // C2: jemalloc purge in the daemon (bench hygiene); reply Pong.
             Ok(Read::Frame(ClientFrame::Purge)) => {
@@ -332,10 +361,29 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     let sid = handle.id.clone();
     let fwd_tx = tx.clone();
     let fwd_handle = handle.clone();
+    let fwd_announce = state.reload_announce.clone();
     // Not tied to `shutdown`: on daemon stop the client must still see `Ended`.
     let mut forward = tokio::spawn(async move {
         loop {
-            match rx.recv().await {
+            let next = tokio::select! {
+                biased;
+                r = rx.recv() => r,
+                // C3: reload announced — the checkpoint's events (abort
+                // notice, Conversation with abort_context) are already in
+                // the broadcast; drain what is there, then stop.
+                _ = fwd_announce.cancelled() => {
+                    while let Ok(env) = rx.try_recv() {
+                        if matches!(env.event, SessionEventWire::Attached { .. }) {
+                            continue;
+                        }
+                        if fwd_tx.send(DaemonFrame::Event(env.into())).await.is_err() {
+                            break;
+                        }
+                    }
+                    break;
+                }
+            };
+            match next {
                 Ok(env) => {
                     // Attached is addressed to one client; ours already went out as a frame.
                     if matches!(env.event, SessionEventWire::Attached { .. }) {
@@ -368,9 +416,11 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
 
     let mut ended = false;
     let mut stopping = false;
+    let mut reloading = false;
     loop {
         let frame = tokio::select! {
             _ = shutdown.cancelled() => { stopping = true; break; }
+            _ = state.reload_announce.cancelled() => { reloading = true; break; }
             _ = handle.closed() => { ended = true; break; }
             r = read_frame(&mut reader, &mut line) => r,
         };
@@ -382,6 +432,12 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
                 }
                 if let Err(why) = client_may_send(&cmd, client) {
                     let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: format!("refused: {why}") }).await;
+                    continue;
+                }
+                if state.reloading.load(Ordering::SeqCst)
+                    && matches!(cmd, SessionCommand::Submit { .. } | SessionCommand::SubmitPrepared { .. } | SessionCommand::Compact { .. })
+                {
+                    let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: "daemon reloading; retry in a moment".into() }).await;
                     continue;
                 }
                 match handle.send_from(client, cmd).await {
@@ -428,6 +484,30 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
         }
     }
 
+    // C3: reload — the session is checkpointed and will be rehydrated by
+    // the next image; tell the client to reconnect and stop forwarding.
+    if reloading {
+        // The forwarder drains and exits on the announce; bound it anyway.
+        if tokio::time::timeout(Duration::from_secs(1), &mut forward).await.is_err() {
+            forward.abort();
+            let _ = forward.await;
+        }
+        let (generation, retry_after_ms) = match reload_bye(&state) {
+            ByeReason::Reloading { generation, retry_after_ms } => (generation, retry_after_ms),
+            _ => unreachable!(),
+        };
+        let env = crate::session::Envelope {
+            session_id: sid.clone(),
+            seq: u64::MAX,
+            ts: chrono::Utc::now(),
+            event: SessionEventWire::Reloading { generation, retry_after_ms },
+        };
+        let _ = tx.send(DaemonFrame::Event(env.into())).await;
+        let _ = tx.send(DaemonFrame::Bye { reason: Some(ByeReason::Reloading { generation, retry_after_ms }) }).await;
+        let _ = tokio::time::timeout(Duration::from_secs(1), writer).await;
+        return;
+    }
+
     // Socket gone / Bye = Detach. The turn keeps running (§8).
     if stopping {
         // Daemon stop: let the forwarder deliver Ended inside the lifecycle budget.
@@ -452,4 +532,11 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     drop(tx);
     let _ = tokio::time::timeout(Duration::from_millis(500), writer).await;
     tracing::debug!(session = %sid, client = client.0, "daemon: client detached");
+}
+
+fn reload_bye(state: &DaemonState) -> ByeReason {
+    ByeReason::Reloading {
+        generation: state.reload_generation.load(Ordering::SeqCst),
+        retry_after_ms: super::reload::RETRY_AFTER_MS,
+    }
 }

--- a/crates/agent-engine/src/daemon/conn.rs
+++ b/crates/agent-engine/src/daemon/conn.rs
@@ -56,6 +56,7 @@ fn client_may_send(cmd: &SessionCommand, own: ClientId) -> Result<(), &'static s
         C::End { reason: EndReason::ClientQuit } => Ok(()),
         C::End { .. } => Err("end: only ClientQuit may come from a client (host reasons are the daemon's)"),
         C::Resync { .. } => Err("resync: not a client command"),
+        C::Park => Err("park: not a client command"),
         C::HostEvent(_) => Err("host_event: not a client command"),
     }
 }

--- a/crates/agent-engine/src/daemon/conn.rs
+++ b/crates/agent-engine/src/daemon/conn.rs
@@ -51,7 +51,10 @@ fn client_may_send(cmd: &SessionCommand, own: ClientId) -> Result<(), &'static s
         C::Detach { client } if *client == own => Ok(()),
         C::Detach { .. } => Err("detach: not your client id"),
         C::Attach { .. } => Err("attach: already attached (one session per connection)"),
-        C::End { .. } => Err("end: sessions are ended by `synaps daemon stop`, not by clients"),
+        // C4: an owner may end its session (`/end`); the actor enforces
+        // ownership (B1 `is_input_command`), the conn only screens reasons.
+        C::End { reason: EndReason::ClientQuit } => Ok(()),
+        C::End { .. } => Err("end: only ClientQuit may come from a client (host reasons are the daemon's)"),
         C::Resync { .. } => Err("resync: not a client command"),
         C::HostEvent(_) => Err("host_event: not a client command"),
     }

--- a/crates/agent-engine/src/daemon/conn.rs
+++ b/crates/agent-engine/src/daemon/conn.rs
@@ -188,9 +188,10 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
 
     // ── control loop (no session allocated) ──
     let attach = loop {
+        let announce = state.announce();
         let frame = tokio::select! {
             _ = shutdown.cancelled() => { let _ = tx.send(DaemonFrame::Bye { reason: None }).await; let _ = writer.await; return; }
-            _ = state.reload_announce.cancelled() => {
+            _ = announce.cancelled() => {
                 let _ = tx.send(DaemonFrame::Bye { reason: Some(reload_bye(&state)) }).await;
                 let _ = writer.await;
                 return;
@@ -365,7 +366,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     let sid = handle.id.clone();
     let fwd_tx = tx.clone();
     let fwd_handle = handle.clone();
-    let fwd_announce = state.reload_announce.clone();
+    let fwd_announce = state.announce();
     // Not tied to `shutdown`: on daemon stop the client must still see `Ended`.
     let mut forward = tokio::spawn(async move {
         loop {
@@ -421,10 +422,11 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     let mut ended = false;
     let mut stopping = false;
     let mut reloading = false;
+    let announce = state.announce();
     loop {
         let frame = tokio::select! {
             _ = shutdown.cancelled() => { stopping = true; break; }
-            _ = state.reload_announce.cancelled() => { reloading = true; break; }
+            _ = announce.cancelled() => { reloading = true; break; }
             _ = handle.closed() => { ended = true; break; }
             r = read_frame(&mut reader, &mut line) => r,
         };

--- a/crates/agent-engine/src/daemon/conn.rs
+++ b/crates/agent-engine/src/daemon/conn.rs
@@ -15,7 +15,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::DaemonState;
 use crate::session::handle::CMD_CHAN_CAP;
-use crate::session::transport::{TransportError, ATTACH_TIMEOUT};
+use crate::session::transport::{TransportError, ATTACH_TIMEOUT, ATTACH_TIMEOUT_PARKED};
 use crate::session::wire::*;
 use crate::session::*;
 
@@ -36,12 +36,17 @@ fn client_may_send(cmd: &SessionCommand, own: ClientId) -> Result<(), &'static s
         | C::Steer { .. }
         | C::Cancel
         | C::Answer { .. }
-        | C::Set(_)
+        | C::Set { .. }
         | C::Compact { .. }
         | C::NewSession
         | C::Save
         | C::Query { .. }
-        | C::EngineCommand { .. } => Ok(()),
+        | C::EngineCommand { .. }
+        | C::SubmitPrepared { .. }
+        | C::PluginCommand { .. }
+        | C::Resume { .. }
+        | C::Checkpoint { .. }
+        | C::KeepWarm { .. } => Ok(()),
         C::Detach { client } if *client == own => Ok(()),
         C::Detach { .. } => Err("detach: not your client id"),
         C::Attach { .. } => Err("attach: already attached (one session per connection)"),
@@ -86,7 +91,7 @@ fn spawn_writer(mut w: OwnedWriteHalf) -> (mpsc::Sender<DaemonFrame>, tokio::tas
     let (tx, mut rx) = mpsc::channel::<DaemonFrame>(CMD_CHAN_CAP);
     let task = tokio::spawn(async move {
         while let Some(frame) = rx.recv().await {
-            let bye = matches!(frame, DaemonFrame::Bye | DaemonFrame::Refused { .. });
+            let bye = matches!(frame, DaemonFrame::Bye { .. } | DaemonFrame::Refused { .. });
             match encode_line(&frame) {
                 Ok(line) => {
                     if w.write_all(line.as_bytes()).await.is_err() {
@@ -169,6 +174,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
         profile: state.profile.clone(),
         sessions: state.session_metas(),
         progressive_tool_disclosure: state.host.parts().progressive_tool_disclosure,
+        generation: 1,
     };
     if tx.send(DaemonFrame::Welcome(welcome)).await.is_err() {
         return;
@@ -178,7 +184,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     // ── control loop (no session allocated) ──
     let attach = loop {
         let frame = tokio::select! {
-            _ = shutdown.cancelled() => { let _ = tx.send(DaemonFrame::Bye).await; let _ = writer.await; return; }
+            _ = shutdown.cancelled() => { let _ = tx.send(DaemonFrame::Bye { reason: None }).await; let _ = writer.await; return; }
             r = read_frame(&mut reader, &mut line) => r,
         };
         match frame {
@@ -192,7 +198,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
             }
             Ok(Read::Frame(ClientFrame::Shutdown { force })) => {
                 tracing::info!(force, "daemon: shutdown requested over the socket");
-                let _ = tx.send(DaemonFrame::Bye).await;
+                let _ = tx.send(DaemonFrame::Bye { reason: None }).await;
                 let _ = writer.await;
                 state.request_shutdown(force);
                 return;
@@ -201,11 +207,23 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
             Ok(Read::Frame(ClientFrame::Cmd { session_id, .. })) => {
                 let _ = tx.send(DaemonFrame::Error { session_id: Some(session_id), message: "not attached".into() }).await;
             }
+            // C3 / C2 serve these; until then they are honest refusals.
+            Ok(Read::Frame(ClientFrame::Reload { .. })) => {
+                let _ = tx
+                    .send(DaemonFrame::Refused {
+                        reason: RefuseReason::ReloadRefused { why: "reload not implemented in this build".into() },
+                        message: "reload not implemented in this build".into(),
+                    })
+                    .await;
+            }
+            Ok(Read::Frame(ClientFrame::Purge)) => {
+                let _ = tx.send(DaemonFrame::Error { session_id: None, message: "purge not implemented in this build".into() }).await;
+            }
             Ok(Read::Frame(ClientFrame::Hello(_))) => {
                 let _ = tx.send(DaemonFrame::Error { session_id: None, message: "duplicate hello".into() }).await;
             }
             Ok(Read::Frame(ClientFrame::Bye)) | Ok(Read::Eof) | Err(_) => {
-                let _ = tx.send(DaemonFrame::Bye).await;
+                let _ = tx.send(DaemonFrame::Bye { reason: None }).await;
                 let _ = writer.await;
                 return;
             }
@@ -229,7 +247,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
                 let _ = tx
                     .send(DaemonFrame::Error { session_id: Some(session_id), message: "unknown session".into() })
                     .await;
-                let _ = tx.send(DaemonFrame::Bye).await;
+                let _ = tx.send(DaemonFrame::Bye { reason: None }).await;
                 let _ = writer.await;
                 return;
             }
@@ -246,7 +264,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
                             message: format!("cwd must be an absolute existing directory: {}", cwd.display()),
                         })
                         .await;
-                    let _ = tx.send(DaemonFrame::Bye).await;
+                    let _ = tx.send(DaemonFrame::Bye { reason: None }).await;
                     let _ = writer.await;
                     return;
                 }
@@ -255,7 +273,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
                 Ok(h) => (h, mode),
                 Err(e) => {
                     let _ = tx.send(DaemonFrame::Error { session_id: None, message: format!("create session: {e}") }).await;
-                    let _ = tx.send(DaemonFrame::Bye).await;
+                    let _ = tx.send(DaemonFrame::Bye { reason: None }).await;
                     let _ = writer.await;
                     return;
                 }
@@ -266,18 +284,19 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     let mut rx = handle.subscribe();
     if let Err(e) = handle.send(SessionCommand::Attach { client: hello.client.clone(), mode }).await {
         let _ = tx.send(DaemonFrame::Error { session_id: Some(handle.id.clone()), message: format!("attach: {e}") }).await;
-        let _ = tx.send(DaemonFrame::Bye).await;
+        let _ = tx.send(DaemonFrame::Bye { reason: None }).await;
         let _ = writer.await;
         return;
     }
-    let attached = tokio::time::timeout(ATTACH_TIMEOUT, async {
+    let attach_budget = if handle.lifecycle() == SessionLifecycle::Parked { ATTACH_TIMEOUT_PARKED } else { ATTACH_TIMEOUT };
+    let attached = tokio::time::timeout(attach_budget, async {
         loop {
             match rx.recv().await {
-                Ok(env) => {
-                    if let SessionEventWire::Attached { client, snapshot } = env.event {
-                        return Some((client, snapshot));
-                    }
-                }
+                Ok(env) => match env.event {
+                    SessionEventWire::Attached { client, snapshot } => return Some(Ok((client, snapshot))),
+                    SessionEventWire::AttachRefused { message } => return Some(Err(message)),
+                    _ => {}
+                },
                 Err(broadcast::error::RecvError::Lagged(_)) => continue,
                 Err(broadcast::error::RecvError::Closed) => return None,
             }
@@ -285,10 +304,16 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     })
     .await;
     let (client, snapshot) = match attached {
-        Ok(Some(x)) => x,
+        Ok(Some(Ok(x))) => x,
+        Ok(Some(Err(message))) => {
+            let _ = tx.send(DaemonFrame::Error { session_id: Some(handle.id.clone()), message }).await;
+            let _ = tx.send(DaemonFrame::Bye { reason: None }).await;
+            let _ = writer.await;
+            return;
+        }
         _ => {
             let _ = tx.send(DaemonFrame::Error { session_id: Some(handle.id.clone()), message: "attach timed out".into() }).await;
-            let _ = tx.send(DaemonFrame::Bye).await;
+            let _ = tx.send(DaemonFrame::Bye { reason: None }).await;
             let _ = writer.await;
             return;
         }
@@ -355,7 +380,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
                     let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: format!("refused: {why}") }).await;
                     continue;
                 }
-                match handle.send(cmd).await {
+                match handle.send_from(client, cmd).await {
                     Ok(()) => {}
                     Err(TransportError::Backpressure) => {
                         let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: "backpressure: command queue full".into() }).await;
@@ -378,12 +403,15 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
                 let _ = tx.send(DaemonFrame::SessionList { sessions: state.session_metas() }).await;
             }
             Ok(Read::Frame(ClientFrame::Shutdown { force })) => {
-                let _ = tx.send(DaemonFrame::Bye).await;
+                let _ = tx.send(DaemonFrame::Bye { reason: None }).await;
                 state.request_shutdown(force);
                 break;
             }
             Ok(Read::Frame(ClientFrame::Attach(_))) | Ok(Read::Frame(ClientFrame::Hello(_))) => {
                 let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: "already attached".into() }).await;
+            }
+            Ok(Read::Frame(ClientFrame::Reload { .. })) | Ok(Read::Frame(ClientFrame::Purge)) => {
+                let _ = tx.send(DaemonFrame::Error { session_id: Some(sid.clone()), message: "control frames are not accepted on an attached connection".into() }).await;
             }
             Ok(Read::Frame(ClientFrame::Bye)) | Ok(Read::Eof) | Err(_) => break,
             Ok(Read::Oversize) => {
@@ -416,7 +444,7 @@ pub async fn serve(state: Arc<DaemonState>, stream: UnixStream, shutdown: Cancel
     if !handle.is_alive() {
         state.remove(&sid);
     }
-    let _ = tx.send(DaemonFrame::Bye).await;
+    let _ = tx.send(DaemonFrame::Bye { reason: None }).await;
     drop(tx);
     let _ = tokio::time::timeout(Duration::from_millis(500), writer).await;
     tracing::debug!(session = %sid, client = client.0, "daemon: client detached");

--- a/crates/agent-engine/src/daemon/lifecycle.rs
+++ b/crates/agent-engine/src/daemon/lifecycle.rs
@@ -25,7 +25,9 @@ pub async fn shutdown_all(state: &Arc<DaemonState>, force: bool) {
     if tokio::time::timeout(budget, futures::future::join_all(ends)).await.is_err() {
         tracing::warn!(budget = ?budget, "daemon: session shutdown budget exceeded; continuing");
     }
-    state.sessions.lock().unwrap_or_else(|e| e.into_inner()).clear();
+    for h in &sessions {
+        state.host.remove_session(&h.id);
+    }
 
     let ext = Arc::clone(state.host.ext_manager());
     let ext_shutdown = async move { ext.write().await.shutdown_all().await };

--- a/crates/agent-engine/src/daemon/listener.rs
+++ b/crates/agent-engine/src/daemon/listener.rs
@@ -17,7 +17,18 @@ pub fn bind(path: &Path) -> std::io::Result<UnixListener> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::io::AsRawFd;
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        // Reload (C3) execs the daemon in place: the listener must NOT
+        // survive exec — the new image rebinds the path. tokio sets
+        // FD_CLOEXEC; assert it rather than trust it.
+        let fd = listener.as_raw_fd();
+        // SAFETY: fcntl on our own fd.
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        if flags >= 0 && flags & libc::FD_CLOEXEC == 0 {
+            // SAFETY: as above.
+            unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) };
+        }
     }
     Ok(listener)
 }

--- a/crates/agent-engine/src/daemon/mod.rs
+++ b/crates/agent-engine/src/daemon/mod.rs
@@ -12,11 +12,12 @@ pub mod listener;
 pub mod registry;
 pub mod reload;
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use tokio_util::sync::CancellationToken;

--- a/crates/agent-engine/src/daemon/mod.rs
+++ b/crates/agent-engine/src/daemon/mod.rs
@@ -126,8 +126,10 @@ pub struct DaemonState {
     pub reloading: AtomicBool,
     /// Generation announced in `Reloading`/`Bye{Reloading}`.
     pub reload_generation: std::sync::atomic::AtomicU64,
-    /// Cancelled once per process life: every conn sends `Reloading` + `Bye`.
-    pub reload_announce: CancellationToken,
+    /// Cancelled once per reload attempt: every conn sends `Reloading` +
+    /// `Bye`. Replaced with a fresh token when the exec fails (M4) so the
+    /// surviving image accepts connections again — read via `announce()`.
+    pub reload_announce: Mutex<CancellationToken>,
     /// The flock, held here (not on `Daemon`) so `reload` can hand its fd
     /// to the next image.
     pub lock_fd: Mutex<Option<DaemonLock>>,
@@ -139,6 +141,24 @@ pub struct DaemonState {
 impl DaemonState {
     pub fn uptime_s(&self) -> u64 {
         self.started.elapsed().as_secs()
+    }
+
+    /// The current reload-announce token (clone; select on `.cancelled()`).
+    pub fn announce(&self) -> CancellationToken {
+        self.reload_announce
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// Fire the announce (every conn says `Reloading` + `Bye`).
+    pub fn fire_announce(&self) {
+        self.announce().cancel();
+    }
+
+    /// Exec failed: arm a fresh token so new connections are served again.
+    pub fn reset_announce(&self) {
+        *self.reload_announce.lock().unwrap_or_else(|e| e.into_inner()) = CancellationToken::new();
     }
 
     /// B4: ONE session map — `EngineHost` owns it; these delegate.
@@ -269,7 +289,7 @@ impl Daemon {
             generation,
             reloading: AtomicBool::new(false),
             reload_generation: std::sync::atomic::AtomicU64::new(generation),
-            reload_announce: CancellationToken::new(),
+            reload_announce: Mutex::new(CancellationToken::new()),
             lock_fd: Mutex::new(Some(lock)),
             reload_aliases: Mutex::new(HashMap::new()),
         });

--- a/crates/agent-engine/src/daemon/mod.rs
+++ b/crates/agent-engine/src/daemon/mod.rs
@@ -11,12 +11,11 @@ pub mod lifecycle;
 pub mod listener;
 pub mod registry;
 
-use std::collections::HashMap;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tokio_util::sync::CancellationToken;
@@ -113,7 +112,6 @@ pub struct DaemonState {
     pub host: Arc<EngineHost>,
     pub profile: Option<String>,
     pub started: Instant,
-    pub sessions: Mutex<HashMap<SessionId, SessionHandle>>,
     pub factory: SessionFactory,
     pub connections: AtomicUsize,
     pub shutdown: CancellationToken,
@@ -125,30 +123,26 @@ impl DaemonState {
         self.started.elapsed().as_secs()
     }
 
-    /// Live handles only (dead actors are dropped on read).
+    /// B4: ONE session map — `EngineHost` owns it; these delegate.
     pub fn live_sessions(&self) -> Vec<SessionHandle> {
-        let mut map = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
-        map.retain(|_, h| h.is_alive());
-        map.values().cloned().collect()
+        self.host.session_handles()
     }
 
+    /// Listing metas with lifecycle / clients / input_owner / journal_id.
     pub fn session_metas(&self) -> Vec<SessionMeta> {
-        self.live_sessions().iter().map(|h| h.meta().clone()).collect()
+        self.host.sessions()
     }
 
     pub fn attach(&self, id: &SessionId) -> Option<SessionHandle> {
-        self.live_sessions().into_iter().find(|h| &h.id == id)
+        self.host.attach(id).filter(|h| h.is_alive())
     }
 
     pub fn insert(&self, handle: SessionHandle) {
-        self.sessions
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(handle.id.clone(), handle);
+        self.host.adopt_session(handle);
     }
 
     pub fn remove(&self, id: &SessionId) {
-        self.sessions.lock().unwrap_or_else(|e| e.into_inner()).remove(id);
+        self.host.remove_session(id);
     }
 
     pub async fn create(&self, cfg: SessionConfig) -> Result<SessionHandle, String> {
@@ -222,7 +216,6 @@ impl Daemon {
             host,
             profile: opts.profile.clone(),
             started: Instant::now(),
-            sessions: Mutex::new(HashMap::new()),
             factory,
             connections: AtomicUsize::new(0),
             shutdown: CancellationToken::new(),

--- a/crates/agent-engine/src/daemon/mod.rs
+++ b/crates/agent-engine/src/daemon/mod.rs
@@ -149,8 +149,18 @@ impl DaemonState {
         map.values().cloned().collect()
     }
 
+    /// Metas with the handle cells filled in (`lifecycle`, `journal_id`);
+    /// `clients`/`input_owner`/`awaiting_input` come with B4's cells.
     pub fn session_metas(&self) -> Vec<SessionMeta> {
-        self.live_sessions().iter().map(|h| h.meta().clone()).collect()
+        self.live_sessions()
+            .iter()
+            .map(|h| {
+                let mut m = h.meta().clone();
+                m.lifecycle = h.lifecycle();
+                m.journal_id = h.journal_id();
+                m
+            })
+            .collect()
     }
 
     pub fn attach(&self, id: &SessionId) -> Option<SessionHandle> {

--- a/crates/agent-engine/src/daemon/mod.rs
+++ b/crates/agent-engine/src/daemon/mod.rs
@@ -278,7 +278,11 @@ const IDLE_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 /// as busy: the daemon never exits under a running turn (jcode mistake #1).
 pub async fn session_is_idle(handle: &SessionHandle) -> bool {
     use crate::session::wire::IDLE_PROBE_QUERY_ID;
-    use crate::session::{SessionCommand, SessionEventWire, SessionQuery};
+    use crate::session::{SessionCommand, SessionEventWire, SessionLifecycle, SessionQuery};
+    // B3: a parked session is idle by construction — no probe, no wake.
+    if handle.lifecycle() == SessionLifecycle::Parked {
+        return true;
+    }
     let mut rx = handle.subscribe();
     if handle.send(SessionCommand::Query { id: IDLE_PROBE_QUERY_ID, query: SessionQuery::Status }).await.is_err() {
         return false;

--- a/crates/agent-engine/src/daemon/mod.rs
+++ b/crates/agent-engine/src/daemon/mod.rs
@@ -10,6 +10,7 @@ pub mod conn;
 pub mod lifecycle;
 pub mod listener;
 pub mod registry;
+pub mod reload;
 
 use std::collections::HashMap;
 use std::future::Future;
@@ -111,6 +112,7 @@ impl DaemonOpts {
 /// Shared by the accept loop and every connection.
 pub struct DaemonState {
     pub host: Arc<EngineHost>,
+    pub paths: DaemonPaths,
     pub profile: Option<String>,
     pub started: Instant,
     pub sessions: Mutex<HashMap<SessionId, SessionHandle>>,
@@ -118,6 +120,21 @@ pub struct DaemonState {
     pub connections: AtomicUsize,
     pub shutdown: CancellationToken,
     pub force_shutdown: AtomicBool,
+    // ── C3 reload ──
+    /// Reload counter (`Welcome.generation`; starts at 1).
+    pub generation: u64,
+    /// Drain: refuse `Attach::Create` / new turns while set.
+    pub reloading: AtomicBool,
+    /// Generation announced in `Reloading`/`Bye{Reloading}`.
+    pub reload_generation: std::sync::atomic::AtomicU64,
+    /// Cancelled once per process life: every conn sends `Reloading` + `Bye`.
+    pub reload_announce: CancellationToken,
+    /// The flock, held here (not on `Daemon`) so `reload` can hand its fd
+    /// to the next image.
+    pub lock_fd: Mutex<Option<DaemonLock>>,
+    /// `old id → new id` for one generation (ids differ only if a
+    /// LinkedSuccessor compaction happened since boot).
+    pub reload_aliases: Mutex<HashMap<String, String>>,
 }
 
 impl DaemonState {
@@ -137,7 +154,11 @@ impl DaemonState {
     }
 
     pub fn attach(&self, id: &SessionId) -> Option<SessionHandle> {
-        self.live_sessions().into_iter().find(|h| &h.id == id)
+        let live = self.live_sessions();
+        live.iter().find(|h| &h.id == id).cloned().or_else(|| {
+            let alias = self.reload_aliases.lock().unwrap_or_else(|e| e.into_inner()).get(id.as_str()).cloned()?;
+            live.into_iter().find(|h| h.id.as_str() == alias)
+        })
     }
 
     pub fn insert(&self, handle: SessionHandle) {
@@ -170,7 +191,6 @@ pub struct Daemon {
     pub paths: DaemonPaths,
     pub state: Arc<DaemonState>,
     accept: tokio::task::JoinHandle<()>,
-    _lock: DaemonLock,
 }
 
 /// Refuse-to-start check (§2.11): legacy `McpTool` connections would be
@@ -203,23 +223,37 @@ impl Daemon {
         if let Some(msg) = legacy_mcp_conflict(&host, opts.allow_legacy_mcp) {
             anyhow::bail!("refusing to start: {msg}");
         }
-        registry::reap_stale(&paths);
-        let lock = match DaemonLock::try_acquire(&paths)? {
-            Some(l) => l,
+        // C3: after `reload` the new image ADOPTS the inherited flock and
+        // skips `reap_stale` (the old image's files are ours).
+        let adopted = reload::adopt_from_env()?;
+        let (lock, reload_state) = match adopted {
+            Some((lock, rs, rs_path)) => {
+                let _ = std::fs::remove_file(&rs_path);
+                (lock, Some(rs))
+            }
             None => {
-                let who = registry::read_daemon_json(&paths).map(|i| i.pid);
-                anyhow::bail!(
-                    "another daemon holds {} (pid {})",
-                    paths.lock.display(),
-                    who.map_or("unknown".to_string(), |p| p.to_string())
-                );
+                registry::reap_stale(&paths);
+                let lock = match DaemonLock::try_acquire(&paths)? {
+                    Some(l) => l,
+                    None => {
+                        let who = registry::read_daemon_json(&paths).map(|i| i.pid);
+                        anyhow::bail!(
+                            "another daemon holds {} (pid {})",
+                            paths.lock.display(),
+                            who.map_or("unknown".to_string(), |p| p.to_string())
+                        );
+                    }
+                };
+                (lock, None)
             }
         };
+        let generation = reload_state.as_ref().map_or(1, |rs| rs.generation);
         let listener = listener::bind(&paths.sock)?;
 
         let factory = opts.factory.clone().unwrap_or_else(|| host_factory(&host));
         let state = Arc::new(DaemonState {
             host,
+            paths: paths.clone(),
             profile: opts.profile.clone(),
             started: Instant::now(),
             sessions: Mutex::new(HashMap::new()),
@@ -227,6 +261,12 @@ impl Daemon {
             connections: AtomicUsize::new(0),
             shutdown: CancellationToken::new(),
             force_shutdown: AtomicBool::new(false),
+            generation,
+            reloading: AtomicBool::new(false),
+            reload_generation: std::sync::atomic::AtomicU64::new(generation),
+            reload_announce: CancellationToken::new(),
+            lock_fd: Mutex::new(Some(lock)),
+            reload_aliases: Mutex::new(HashMap::new()),
         });
 
         let info = DaemonInfo {
@@ -236,16 +276,23 @@ impl Daemon {
             profile: opts.profile.clone(),
             started_at: chrono::Utc::now(),
             socket: paths.sock.to_string_lossy().into_owned(),
+            exe: registry::read_daemon_json(&paths).and_then(|i| i.exe).or_else(|| Some(reload::resolve_exe())),
+            generation,
         };
         registry::write_daemon_json(&paths, &info)?;
+
+        // C3: rehydrate BEFORE accepting so a reconnecting client finds its session.
+        if let Some(rs) = &reload_state {
+            reload::rehydrate(&state, rs).await;
+        }
 
         let accept = tokio::spawn(listener::accept_loop(Arc::clone(&state), listener, state.shutdown.clone()));
         if let Some(idle) = opts.idle_exit {
             tokio::spawn(idle_monitor(Arc::clone(&state), idle));
         }
         signal_ready();
-        tracing::info!(sock = %paths.sock.display(), pid = info.pid, "daemon: listening");
-        Ok(Self { paths, state, accept, _lock: lock })
+        tracing::info!(sock = %paths.sock.display(), pid = info.pid, generation, "daemon: listening");
+        Ok(Self { paths, state, accept })
     }
 
     pub fn shutdown_token(&self) -> CancellationToken {
@@ -264,7 +311,8 @@ impl Daemon {
             crate::events::socket::cleanup_socket(&p.to_string_lossy());
         }
         tracing::info!("daemon: stopped");
-        // `_lock` drops here → flock released.
+        // Release the flock last.
+        drop(self.state.lock_fd.lock().unwrap_or_else(|e| e.into_inner()).take());
     }
 }
 

--- a/crates/agent-engine/src/daemon/registry.rs
+++ b/crates/agent-engine/src/daemon/registry.rs
@@ -22,6 +22,17 @@ pub struct DaemonInfo {
     pub profile: Option<String>,
     pub started_at: chrono::DateTime<chrono::Utc>,
     pub socket: String,
+    /// Executable to re-exec on `reload` (argv[0] canonicalised at first
+    /// start; `--exe` overrides and is recorded). C3.
+    #[serde(default)]
+    pub exe: Option<std::path::PathBuf>,
+    /// Reload counter (starts at 1; `Welcome.generation`). C3.
+    #[serde(default = "one")]
+    pub generation: u64,
+}
+
+fn one() -> u64 {
+    1
 }
 
 #[cfg(unix)]
@@ -44,6 +55,11 @@ fn write_atomic(path: &Path, body: &[u8]) -> io::Result<()> {
     std::fs::write(&tmp, body)?;
     chmod_600(&tmp);
     std::fs::rename(&tmp, path)
+}
+
+/// 0600 tmp + rename (reload-state).
+pub fn write_private_atomic(path: &Path, body: &[u8]) -> io::Result<()> {
+    write_atomic(path, body)
 }
 
 pub fn read_daemon_json(paths: &DaemonPaths) -> Option<DaemonInfo> {
@@ -72,6 +88,37 @@ impl DaemonLock {
         } else {
             Ok(None)
         }
+    }
+}
+
+impl DaemonLock {
+    /// Adopt an already-locked fd inherited across `execv` (reload). The
+    /// flock travels with the open file description, so the new image
+    /// holds the SAME lock without a release/acquire gap.
+    #[cfg(unix)]
+    pub fn adopt(fd: i32) -> io::Result<Self> {
+        use std::os::unix::io::FromRawFd;
+        if fd < 0 {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "negative lock fd"));
+        }
+        // SAFETY: the parent image cleared CLOEXEC on exactly this fd and
+        // handed it to us via SYNAPS_DAEMON_LOCK_FD; we take ownership.
+        let file = unsafe { File::from_raw_fd(fd) };
+        // Restore CLOEXEC so tool subprocesses never inherit the lock.
+        // SAFETY: fcntl on our own fd.
+        unsafe {
+            let flags = libc::fcntl(fd, libc::F_GETFD);
+            if flags >= 0 {
+                libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC);
+            }
+        }
+        Ok(Self { file })
+    }
+
+    #[cfg(unix)]
+    pub fn raw_fd(&self) -> i32 {
+        use std::os::unix::io::AsRawFd;
+        self.file.as_raw_fd()
     }
 }
 
@@ -142,6 +189,8 @@ mod tests {
             profile: None,
             started_at: chrono::Utc::now(),
             socket: p.sock.to_string_lossy().into_owned(),
+            exe: None,
+            generation: 1,
         };
         write_daemon_json(&p, &info).unwrap();
         assert_eq!(read_daemon_json(&p).unwrap(), info);

--- a/crates/agent-engine/src/daemon/reload.rs
+++ b/crates/agent-engine/src/daemon/reload.rs
@@ -7,12 +7,16 @@
 //! What reload cannot preserve (§2.8, stated once): in-flight turns
 //! (checkpointed = cancelled with abort context), pending prompts (answered
 //! `None`), PTY/background shells (closed, announced), `turn_replay`,
-//! un-persisted `TurnLog`, the prompt manifest path and non-persisted
-//! runtime settings (`settings_replay` is B3's — until it lands only what
-//! the journal holds comes back: messages, model, thinking, system prompt,
-//! abort context). What it preserves: every session's journal, its id
-//! (the rehydrated session continues the same journal), its cwd, its
-//! keep-warm pin and parked/live state (recorded; honoured once B3 lands).
+//! un-persisted `TurnLog`, input ownership (the owner reclaims it on
+//! reconnect via `was_owner`). What it preserves — each session's
+//! `Checkpoint{Reload}` reply carries a `SessionReloadRecord`: its journal
+//! and id (the rehydrated session continues the same journal), its
+//! `SessionConfig` as created (cwd, system, prompt manifest, compaction
+//! policy, auto-compact, …), its keep-warm pin, its lifecycle (a Parked
+//! session comes back Parked), the non-persisted runtime knobs
+//! (`settings_replay`: context window, compaction model, retries,
+//! timeouts, tool-output cap, worker grants, `/system`), and the CURRENT
+//! model/thinking (`/model` mid-session survives).
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
@@ -26,7 +30,7 @@ use super::DaemonState;
 use crate::session::wire::{ClientFrame, CHECKPOINT_QUERY_ID, PROTOCOL_VERSION};
 use crate::session::{
     CheckpointReason, SessionCommand, SessionConfig, SessionEventWire, SessionHandle,
-    SessionLifecycle,
+    SessionLifecycle, SessionReloadRecord, SessionSetting,
 };
 
 /// Env: path of the reload-state file handed to the new image.
@@ -101,6 +105,9 @@ pub struct ReloadSession {
     pub config: SessionConfig,
     pub keep_warm: bool,
     pub lifecycle: SessionLifecycle,
+    /// Non-persisted knobs re-`Set` after create (incl. `/system`).
+    #[serde(default)]
+    pub settings_replay: Vec<SessionSetting>,
     pub input_owner_kind: Option<crate::session::ClientKind>,
 }
 
@@ -193,46 +200,66 @@ pub async fn probe_version(exe: &Path) -> Result<PrintVersion, String> {
         .map_err(|e| format!("{} --print-version: unparsable output ({e})", exe.display()))
 }
 
-async fn checkpoint_one(handle: SessionHandle) -> bool {
+/// `Checkpoint{Reload}` → the actor's `SessionReloadRecord` (`None` when
+/// the checkpoint did not confirm in budget).
+async fn checkpoint_one(handle: SessionHandle) -> Option<SessionReloadRecord> {
     let mut rx = handle.subscribe();
     if handle
         .send(SessionCommand::Checkpoint { reason: CheckpointReason::Reload })
         .await
         .is_err()
     {
-        return false;
+        return None;
     }
     let wait = async {
         loop {
             match rx.recv().await {
                 Ok(env) => {
-                    if let SessionEventWire::QueryResult { id, .. } = env.event {
+                    if let SessionEventWire::QueryResult { id, value } = env.event {
                         if id == CHECKPOINT_QUERY_ID {
-                            return true;
+                            return serde_json::from_value(value["record"].clone()).ok();
                         }
                     }
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => return false,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
             }
         }
     };
-    tokio::time::timeout(CHECKPOINT_BUDGET, wait).await.unwrap_or(false)
+    tokio::time::timeout(CHECKPOINT_BUDGET, wait).await.unwrap_or(None)
 }
 
-fn record(handle: &SessionHandle) -> ReloadSession {
+/// The session as it IS: the actor's record when the checkpoint confirmed,
+/// else what the handle alone knows (journal, cwd, keep-warm, lifecycle,
+/// current model from the published view).
+fn record(handle: &SessionHandle, rec: Option<SessionReloadRecord>) -> ReloadSession {
     let meta = handle.meta();
+    let journal_id = handle.journal_id();
+    let (config, keep_warm, lifecycle, settings_replay, model) = match rec {
+        Some(r) => (r.config, r.keep_warm, r.lifecycle, r.settings_replay, r.model),
+        None => (
+            SessionConfig {
+                cwd: meta.cwd.clone(),
+                ..SessionConfig::default()
+            },
+            false,
+            handle.lifecycle(),
+            Vec::new(),
+            handle.view().model.clone(),
+        ),
+    };
     ReloadSession {
         id: meta.id.as_str().to_string(),
-        journal_id: handle.journal_id(),
+        journal_id: journal_id.clone(),
         config: SessionConfig {
-            continue_session: Some(Some(handle.journal_id())),
-            cwd: meta.cwd.clone(),
-            model_override: Some(meta.model.clone()),
-            ..SessionConfig::default()
+            continue_session: Some(Some(journal_id)),
+            model_override: Some(model),
+            keep_warm,
+            ..config
         },
-        keep_warm: false,
-        lifecycle: handle.lifecycle(),
+        keep_warm,
+        lifecycle,
+        settings_replay,
         input_owner_kind: None,
     }
 }
@@ -291,17 +318,19 @@ pub async fn prepare(
     }
     let handles = state.live_sessions();
     let results = futures::future::join_all(handles.iter().cloned().map(checkpoint_one)).await;
-    for (h, ok) in handles.iter().zip(results) {
-        if !ok {
-            tracing::warn!(session = %h.id, "reload: checkpoint did not confirm; continuing");
+    let mut sessions = Vec::with_capacity(handles.len());
+    for (h, rec) in handles.iter().zip(results) {
+        if rec.is_none() {
+            tracing::warn!(session = %h.id, "reload: checkpoint did not confirm; recording from the handle");
         }
+        sessions.push(record(h, rec));
     }
 
     // 3. reload-state (0600, atomic).
     let rs = ReloadState {
         generation,
         written_at: chrono::Utc::now(),
-        sessions: handles.iter().map(record).collect(),
+        sessions,
         expected_clients: state.connections.load(Ordering::SeqCst),
     };
     let rs_path = reload_state_path(paths);
@@ -421,9 +450,26 @@ pub fn adopt_from_env() -> anyhow::Result<Option<(DaemonLock, ReloadState, PathB
 /// Rehydrate every recorded session BEFORE accepting. A session that
 /// fails to come back is logged and skipped (its journal is on disk;
 /// `--continue` brings it back).
+///
+/// A session whose journal was never written (no turn yet — `save` skips
+/// an empty conversation) cannot be continued; it is recreated fresh under
+/// a new id and aliased from the old one.
 pub async fn rehydrate(state: &Arc<DaemonState>, rs: &ReloadState) {
     for s in &rs.sessions {
-        match state.create(s.config.clone()).await {
+        let created = match state.create(s.config.clone()).await {
+            Ok(h) => Ok(h),
+            Err(e) if s.config.continue_session.is_some() => {
+                tracing::warn!(session = %s.id, error = %e, "daemon: journal not continuable; recreating fresh");
+                state
+                    .create(SessionConfig {
+                        continue_session: None,
+                        ..s.config.clone()
+                    })
+                    .await
+            }
+            Err(e) => Err(e),
+        };
+        match created {
             Ok(h) => {
                 let new_id = h.id.as_str().to_string();
                 if new_id != s.id {
@@ -433,10 +479,22 @@ pub async fn rehydrate(state: &Arc<DaemonState>, rs: &ReloadState) {
                         .unwrap_or_else(|e| e.into_inner())
                         .insert(s.id.clone(), new_id.clone());
                 }
+                // Non-persisted knobs (host-originated `Set`: no owner check).
+                for (i, setting) in s.settings_replay.iter().enumerate() {
+                    let _ = h
+                        .send(SessionCommand::Set {
+                            id: u64::MAX - i as u64,
+                            setting: setting.clone(),
+                        })
+                        .await;
+                }
                 if s.keep_warm {
                     let _ = h.send(SessionCommand::KeepWarm { on: true }).await;
                 }
-                tracing::info!(old = %s.id, new = %new_id, "daemon: session rehydrated after reload");
+                if matches!(s.lifecycle, SessionLifecycle::Parked | SessionLifecycle::Parking) {
+                    let _ = h.send(SessionCommand::Park).await;
+                }
+                tracing::info!(old = %s.id, new = %new_id, lifecycle = ?s.lifecycle, "daemon: session rehydrated after reload");
             }
             Err(e) => tracing::warn!(session = %s.id, error = %e, "daemon: session could not be rehydrated"),
         }

--- a/crates/agent-engine/src/daemon/reload.rs
+++ b/crates/agent-engine/src/daemon/reload.rs
@@ -1,0 +1,473 @@
+//! `synaps daemon reload` (PLAN-phase3 §2.8, C3): version gate → drain →
+//! `Checkpoint{Reload}` every session → reload-state → announce
+//! `Reloading`/`Bye{Reloading}` → `execv` self (same pid, adopted flock,
+//! CLOEXEC listener) → new image rehydrates sessions from reload-state
+//! BEFORE accepting.
+//!
+//! What reload cannot preserve (§2.8, stated once): in-flight turns
+//! (checkpointed = cancelled with abort context), pending prompts (answered
+//! `None`), PTY/background shells (closed, announced), `turn_replay`,
+//! un-persisted `TurnLog`, the prompt manifest path and non-persisted
+//! runtime settings (`settings_replay` is B3's — until it lands only what
+//! the journal holds comes back: messages, model, thinking, system prompt,
+//! abort context). What it preserves: every session's journal, its id
+//! (the rehydrated session continues the same journal), its cwd, its
+//! keep-warm pin and parked/live state (recorded; honoured once B3 lands).
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use super::registry::{self, DaemonLock, DaemonPaths};
+use super::DaemonState;
+use crate::session::wire::{ClientFrame, CHECKPOINT_QUERY_ID, PROTOCOL_VERSION};
+use crate::session::{
+    CheckpointReason, SessionCommand, SessionConfig, SessionEventWire, SessionHandle,
+    SessionLifecycle,
+};
+
+/// Env: path of the reload-state file handed to the new image.
+pub const RELOAD_STATE_ENV: &str = "SYNAPS_DAEMON_RELOAD_STATE";
+/// Env: inherited `daemon.lock` fd (mandatory when `RELOAD_STATE_ENV` is set).
+pub const LOCK_FD_ENV: &str = "SYNAPS_DAEMON_LOCK_FD";
+/// Env: default drain budget in seconds.
+pub const DRAIN_SECS_ENV: &str = "SYNAPS_DAEMON_RELOAD_DRAIN_SECS";
+const DEFAULT_DRAIN: Duration = Duration::from_secs(30);
+const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+const CHECKPOINT_BUDGET: Duration =
+    Duration::from_secs(crate::session::budgets::SAVE_TIMEOUT_SECS + 1);
+/// What clients are told to wait before reconnecting.
+pub const RETRY_AFTER_MS: u64 = 500;
+
+#[derive(Debug, Clone, Default)]
+pub struct ReloadRequest {
+    pub now: bool,
+    pub drain_secs: Option<u64>,
+    pub exe: Option<PathBuf>,
+}
+
+impl ReloadRequest {
+    pub fn from_frame(frame: &ClientFrame) -> Option<Self> {
+        match frame {
+            ClientFrame::Reload { now, drain_secs, exe } => {
+                Some(Self { now: *now, drain_secs: *drain_secs, exe: exe.clone() })
+            }
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ReloadError {
+    /// Refused before anything was disturbed (`RefuseReason::ReloadRefused`).
+    Refused(String),
+    /// `execv` returned: the old image continues; sessions are checkpointed.
+    ExecFailed(String),
+}
+
+impl std::fmt::Display for ReloadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Refused(w) => write!(f, "reload refused: {w}"),
+            Self::ExecFailed(e) => write!(f, "reload exec failed: {e}"),
+        }
+    }
+}
+
+/// `<exe> daemon --print-version` output.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PrintVersion {
+    pub binary_version: String,
+    pub protocol_version: u32,
+}
+
+impl PrintVersion {
+    pub fn current() -> Self {
+        Self {
+            binary_version: crate::session::wire::binary_version(),
+            protocol_version: PROTOCOL_VERSION,
+        }
+    }
+}
+
+/// One recorded session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReloadSession {
+    pub id: String,
+    pub journal_id: String,
+    pub config: SessionConfig,
+    pub keep_warm: bool,
+    pub lifecycle: SessionLifecycle,
+    pub input_owner_kind: Option<crate::session::ClientKind>,
+}
+
+/// `registry_dir()/daemon[-P].reload.json` body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReloadState {
+    pub generation: u64,
+    pub written_at: chrono::DateTime<chrono::Utc>,
+    pub sessions: Vec<ReloadSession>,
+    pub expected_clients: usize,
+}
+
+pub fn reload_state_path(paths: &DaemonPaths) -> PathBuf {
+    let stem = paths
+        .json
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "daemon".into());
+    paths.dir.join(format!("{stem}.reload.json"))
+}
+
+/// The executable to re-exec: argv[0] canonicalised (NOT `/proc/self/exe`,
+/// which reads "(deleted)" after an in-place rebuild); `current_exe` only
+/// as a fallback when argv[0] is not resolvable (e.g. bare name on PATH).
+pub fn resolve_exe() -> PathBuf {
+    if let Some(a0) = std::env::args_os().next() {
+        let p = PathBuf::from(&a0);
+        if p.components().count() > 1 {
+            if let Ok(c) = p.canonicalize() {
+                return c;
+            }
+        }
+    }
+    std::env::current_exe().unwrap_or_else(|_| PathBuf::from("synaps"))
+}
+
+fn semver_tuple(s: &str) -> Option<(u64, u64, u64)> {
+    let core = s.split(['-', '+']).next()?;
+    let mut it = core.split('.').map(|p| p.parse::<u64>().ok());
+    Some((it.next()??, it.next()??, it.next()??))
+}
+
+/// Directional gate (§2.1): new protocol ≥ ours (clients must still be able
+/// to reconnect) and new binary ≥ ours (newer OR EQUAL; same-version
+/// rebuilds are the common case).
+pub fn version_gate(current: &PrintVersion, new: &PrintVersion) -> Result<(), String> {
+    if new.protocol_version < current.protocol_version {
+        return Err(format!(
+            "new binary speaks protocol {} < {}: reconnecting clients would be refused",
+            new.protocol_version, current.protocol_version
+        ));
+    }
+    match (semver_tuple(&current.binary_version), semver_tuple(&new.binary_version)) {
+        (Some(c), Some(n)) if n < c => Err(format!(
+            "new binary {} is older than the running {} (reload is newer-or-equal only)",
+            new.binary_version, current.binary_version
+        )),
+        (Some(_), Some(_)) => Ok(()),
+        _ => Err(format!(
+            "cannot compare versions {:?} vs {:?}",
+            current.binary_version, new.binary_version
+        )),
+    }
+}
+
+/// Run `<exe> daemon --print-version` (5 s) and parse it.
+pub async fn probe_version(exe: &Path) -> Result<PrintVersion, String> {
+    let out = tokio::time::timeout(
+        VERSION_PROBE_TIMEOUT,
+        tokio::process::Command::new(exe)
+            .args(["daemon", "--print-version"])
+            .env("SYNAPS_DAEMON", "1")
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .output(),
+    )
+    .await
+    .map_err(|_| format!("{} --print-version timed out", exe.display()))?
+    .map_err(|e| format!("cannot run {}: {e}", exe.display()))?;
+    if !out.status.success() {
+        return Err(format!(
+            "{} --print-version exited {:?}: {}",
+            exe.display(),
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    serde_json::from_slice(&out.stdout)
+        .map_err(|e| format!("{} --print-version: unparsable output ({e})", exe.display()))
+}
+
+async fn checkpoint_one(handle: SessionHandle) -> bool {
+    let mut rx = handle.subscribe();
+    if handle
+        .send(SessionCommand::Checkpoint { reason: CheckpointReason::Reload })
+        .await
+        .is_err()
+    {
+        return false;
+    }
+    let wait = async {
+        loop {
+            match rx.recv().await {
+                Ok(env) => {
+                    if let SessionEventWire::QueryResult { id, .. } = env.event {
+                        if id == CHECKPOINT_QUERY_ID {
+                            return true;
+                        }
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return false,
+            }
+        }
+    };
+    tokio::time::timeout(CHECKPOINT_BUDGET, wait).await.unwrap_or(false)
+}
+
+fn record(handle: &SessionHandle) -> ReloadSession {
+    let meta = handle.meta();
+    ReloadSession {
+        id: meta.id.as_str().to_string(),
+        journal_id: handle.journal_id(),
+        config: SessionConfig {
+            continue_session: Some(Some(handle.journal_id())),
+            cwd: meta.cwd.clone(),
+            model_override: Some(meta.model.clone()),
+            ..SessionConfig::default()
+        },
+        keep_warm: false,
+        lifecycle: handle.lifecycle(),
+        input_owner_kind: None,
+    }
+}
+
+/// Steps 1–4 (§2.8): gate, drain, checkpoint, reload-state, announce.
+/// Nothing irreversible has happened when this returns `Ok`; the caller
+/// (the requesting connection) sends its own `Bye{Reloading}`, flushes,
+/// then calls [`exec`].
+pub struct Prepared {
+    pub exe: PathBuf,
+    pub rs_path: PathBuf,
+    pub generation: u64,
+}
+
+pub async fn prepare(
+    state: &Arc<DaemonState>,
+    paths: &DaemonPaths,
+    req: ReloadRequest,
+) -> Result<Prepared, ReloadError> {
+    // 1. version gate — before anything is disturbed.
+    let exe = req.exe.clone().unwrap_or_else(|| {
+        registry::read_daemon_json(paths)
+            .and_then(|i| i.exe)
+            .unwrap_or_else(resolve_exe)
+    });
+    let new = probe_version(&exe).await.map_err(ReloadError::Refused)?;
+    version_gate(&PrintVersion::current(), &new).map_err(ReloadError::Refused)?;
+    if state.reloading.swap(true, Ordering::SeqCst) {
+        return Err(ReloadError::Refused("a reload is already in progress".into()));
+    }
+    let generation = state.generation + 1;
+    tracing::info!(exe = %exe.display(), new = %new.binary_version, generation, "daemon: reload accepted");
+
+    // 2. drain (refuse new work), then checkpoint every session concurrently.
+    let drain = if req.now {
+        Duration::ZERO
+    } else {
+        req.drain_secs
+            .map(Duration::from_secs)
+            .or_else(|| std::env::var(DRAIN_SECS_ENV).ok()?.parse().ok().map(Duration::from_secs))
+            .unwrap_or(DEFAULT_DRAIN)
+    };
+    let t0 = std::time::Instant::now();
+    while t0.elapsed() < drain {
+        let mut all_idle = true;
+        for h in state.live_sessions() {
+            if !super::session_is_idle(&h).await {
+                all_idle = false;
+                break;
+            }
+        }
+        if all_idle {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    let handles = state.live_sessions();
+    let results = futures::future::join_all(handles.iter().cloned().map(checkpoint_one)).await;
+    for (h, ok) in handles.iter().zip(results) {
+        if !ok {
+            tracing::warn!(session = %h.id, "reload: checkpoint did not confirm; continuing");
+        }
+    }
+
+    // 3. reload-state (0600, atomic).
+    let rs = ReloadState {
+        generation,
+        written_at: chrono::Utc::now(),
+        sessions: handles.iter().map(record).collect(),
+        expected_clients: state.connections.load(Ordering::SeqCst),
+    };
+    let rs_path = reload_state_path(paths);
+    let body = serde_json::to_vec_pretty(&rs).map_err(|e| ReloadError::ExecFailed(e.to_string()))?;
+    registry::write_private_atomic(&rs_path, &body).map_err(|e| ReloadError::ExecFailed(e.to_string()))?;
+
+    // 4. announce — every OTHER conn selects on `reload_announce` and sends
+    //    Event(Reloading) + Bye{Reloading}; give their writers ≤ 1 s.
+    state.reload_generation.store(generation, Ordering::SeqCst);
+    state.reload_announce.cancel();
+    let t1 = std::time::Instant::now();
+    while state.connections.load(Ordering::SeqCst) > 1 && t1.elapsed() < Duration::from_secs(1) {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    Ok(Prepared { exe, rs_path, generation })
+}
+
+/// Step 5: rewrite `daemon.json` (generation+1, same pid), stop sidecars,
+/// hand the flock to the next image and `execv`. Returns only on failure —
+/// then `daemon.json`/reload-state are restored and the old image keeps
+/// serving (sessions checkpointed but alive; clients that got `Bye`
+/// reconnect to THIS image — a `reconnect_of.generation` mismatch is
+/// tolerated, the daemon answers with its own generation).
+pub async fn exec(state: &Arc<DaemonState>, paths: &DaemonPaths, p: Prepared) -> ReloadError {
+    let mut info = registry::read_daemon_json(paths).unwrap_or_else(|| registry::DaemonInfo {
+        pid: std::process::id(),
+        protocol_version: PROTOCOL_VERSION,
+        daemon_version: crate::session::wire::binary_version(),
+        profile: state.profile.clone(),
+        started_at: chrono::Utc::now(),
+        socket: paths.sock.to_string_lossy().into_owned(),
+        exe: None,
+        generation: 1,
+    });
+    let prev_generation = info.generation;
+    info.generation = p.generation;
+    info.started_at = chrono::Utc::now();
+    info.exe = Some(p.exe.clone());
+    let _ = registry::write_daemon_json(paths, &info);
+    let _ = tokio::time::timeout(
+        Duration::from_secs(5),
+        async { state.host.ext_manager().write().await.shutdown_all().await },
+    )
+    .await;
+
+    let err = exec_self(&p.exe, &p.rs_path, state);
+    tracing::error!(error = %err, "daemon: reload exec failed; continuing on the old image");
+    info.generation = prev_generation;
+    let _ = registry::write_daemon_json(paths, &info);
+    let _ = std::fs::remove_file(&p.rs_path);
+    state.reloading.store(false, Ordering::SeqCst);
+    ReloadError::ExecFailed(err)
+}
+
+#[cfg(unix)]
+fn exec_self(exe: &Path, rs_path: &Path, state: &DaemonState) -> String {
+    use std::os::unix::process::CommandExt;
+    let Some(lock_fd) = state.lock_fd.lock().unwrap_or_else(|e| e.into_inner()).as_ref().map(|l| l.raw_fd()) else {
+        return "no lock fd to inherit".into();
+    };
+    // Clear FD_CLOEXEC on the lock so the new image adopts the SAME flock
+    // (liveness oracle never flickers). The listener keeps CLOEXEC: it is
+    // closed at exec and the new image rebinds the path.
+    // SAFETY: fcntl on an fd we own.
+    unsafe {
+        let flags = libc::fcntl(lock_fd, libc::F_GETFD);
+        if flags >= 0 {
+            libc::fcntl(lock_fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC);
+        }
+    }
+    let mut args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+    if args.is_empty() || args.iter().all(|a| a != "daemon") {
+        args = vec!["daemon".into(), "--foreground".into()];
+    }
+    let mut cmd = std::process::Command::new(exe);
+    cmd.args(&args)
+        .env("SYNAPS_DAEMON", "1")
+        .env(LOCK_FD_ENV, lock_fd.to_string())
+        .env(RELOAD_STATE_ENV, rs_path);
+    let e = cmd.exec();
+    // Only reached on failure: restore CLOEXEC.
+    // SAFETY: as above.
+    unsafe {
+        let flags = libc::fcntl(lock_fd, libc::F_GETFD);
+        if flags >= 0 {
+            libc::fcntl(lock_fd, libc::F_SETFD, flags | libc::FD_CLOEXEC);
+        }
+    }
+    e.to_string()
+}
+
+#[cfg(not(unix))]
+fn exec_self(_exe: &Path, _rs_path: &Path, _state: &DaemonState) -> String {
+    "reload is unix-only".into()
+}
+
+/// New-image side (`Daemon::start`): when `RELOAD_STATE_ENV` is set, the
+/// lock is ADOPTED from `LOCK_FD_ENV` (mandatory — refuse to start without
+/// it, risk §6.8) and the recorded generation is returned.
+pub fn adopt_from_env() -> anyhow::Result<Option<(DaemonLock, ReloadState, PathBuf)>> {
+    let Some(rs_path) = std::env::var_os(RELOAD_STATE_ENV) else {
+        return Ok(None);
+    };
+    let rs_path = PathBuf::from(rs_path);
+    std::env::remove_var(RELOAD_STATE_ENV);
+    let fd: i32 = std::env::var(LOCK_FD_ENV)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| anyhow::anyhow!("{RELOAD_STATE_ENV} set without {LOCK_FD_ENV}: refusing to start (the flock is the liveness oracle)"))?;
+    std::env::remove_var(LOCK_FD_ENV);
+    let lock = DaemonLock::adopt(fd)?;
+    let body = std::fs::read_to_string(&rs_path)?;
+    let rs: ReloadState = serde_json::from_str(&body)?;
+    Ok(Some((lock, rs, rs_path)))
+}
+
+/// Rehydrate every recorded session BEFORE accepting. A session that
+/// fails to come back is logged and skipped (its journal is on disk;
+/// `--continue` brings it back).
+pub async fn rehydrate(state: &Arc<DaemonState>, rs: &ReloadState) {
+    for s in &rs.sessions {
+        match state.create(s.config.clone()).await {
+            Ok(h) => {
+                let new_id = h.id.as_str().to_string();
+                if new_id != s.id {
+                    state
+                        .reload_aliases
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .insert(s.id.clone(), new_id.clone());
+                }
+                if s.keep_warm {
+                    let _ = h.send(SessionCommand::KeepWarm { on: true }).await;
+                }
+                tracing::info!(old = %s.id, new = %new_id, "daemon: session rehydrated after reload");
+            }
+            Err(e) => tracing::warn!(session = %s.id, error = %e, "daemon: session could not be rehydrated"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pv(b: &str, p: u32) -> PrintVersion {
+        PrintVersion { binary_version: b.into(), protocol_version: p }
+    }
+
+    #[test]
+    fn gate_is_directional_newer_or_equal() {
+        let cur = pv("0.9.0", 2);
+        assert!(version_gate(&cur, &pv("0.9.0", 2)).is_ok(), "equal allowed");
+        assert!(version_gate(&cur, &pv("0.9.1", 2)).is_ok());
+        assert!(version_gate(&cur, &pv("1.0.0-rc1", 3)).is_ok());
+        assert!(version_gate(&cur, &pv("0.8.9", 2)).is_err(), "older refused");
+        assert!(version_gate(&cur, &pv("0.9.0", 1)).is_err(), "older protocol refused");
+        assert!(version_gate(&cur, &pv("garbage", 2)).is_err());
+    }
+
+    #[test]
+    fn reload_state_path_follows_profile() {
+        let d = tempfile::tempdir().unwrap();
+        let p = registry::daemon_paths_in(d.path(), Some("work"));
+        assert!(reload_state_path(&p).ends_with("daemon-work.reload.json"), "{:?}", reload_state_path(&p));
+        let p = registry::daemon_paths_in(d.path(), None);
+        assert!(reload_state_path(&p).ends_with("daemon.reload.json"));
+    }
+}

--- a/crates/agent-engine/src/daemon/reload.rs
+++ b/crates/agent-engine/src/daemon/reload.rs
@@ -173,6 +173,50 @@ pub fn version_gate(current: &PrintVersion, new: &PrintVersion) -> Result<(), St
     }
 }
 
+/// M8: `--exe` must be something we would trust to `execv` in our own pid:
+/// an existing regular file (canonicalised), executable, owned by our uid
+/// (or root — package-installed binaries), not group/world-writable.
+/// Returns the canonical path. Same-uid 0600 socket → not a privilege
+/// boundary; this is a footgun guard, not a sandbox.
+#[cfg(unix)]
+pub fn validate_exe(exe: &Path) -> Result<PathBuf, String> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    let canon = exe
+        .canonicalize()
+        .map_err(|e| format!("--exe {}: {e}", exe.display()))?;
+    let md = std::fs::metadata(&canon).map_err(|e| format!("--exe {}: {e}", canon.display()))?;
+    if !md.is_file() {
+        return Err(format!("--exe {}: not a regular file", canon.display()));
+    }
+    let mode = md.permissions().mode();
+    if mode & 0o111 == 0 {
+        return Err(format!("--exe {}: not executable", canon.display()));
+    }
+    // SAFETY: getuid has no preconditions.
+    let uid = unsafe { libc::getuid() };
+    if md.uid() != uid && md.uid() != 0 {
+        return Err(format!(
+            "--exe {}: owned by uid {} (expected {} or root)",
+            canon.display(),
+            md.uid(),
+            uid
+        ));
+    }
+    if mode & 0o022 != 0 {
+        return Err(format!(
+            "--exe {}: group/world-writable (mode {:o})",
+            canon.display(),
+            mode & 0o777
+        ));
+    }
+    Ok(canon)
+}
+
+#[cfg(not(unix))]
+pub fn validate_exe(exe: &Path) -> Result<PathBuf, String> {
+    exe.canonicalize().map_err(|e| format!("--exe {}: {e}", exe.display()))
+}
+
 /// Run `<exe> daemon --print-version` (5 s) and parse it.
 pub async fn probe_version(exe: &Path) -> Result<PrintVersion, String> {
     let out = tokio::time::timeout(
@@ -285,6 +329,7 @@ pub async fn prepare(
             .and_then(|i| i.exe)
             .unwrap_or_else(resolve_exe)
     });
+    let exe = validate_exe(&exe).map_err(ReloadError::Refused)?;
     let new = probe_version(&exe).await.map_err(ReloadError::Refused)?;
     version_gate(&PrintVersion::current(), &new).map_err(ReloadError::Refused)?;
     if state.reloading.swap(true, Ordering::SeqCst) {
@@ -340,7 +385,7 @@ pub async fn prepare(
     // 4. announce — every OTHER conn selects on `reload_announce` and sends
     //    Event(Reloading) + Bye{Reloading}; give their writers ≤ 1 s.
     state.reload_generation.store(generation, Ordering::SeqCst);
-    state.reload_announce.cancel();
+    state.fire_announce();
     let t1 = std::time::Instant::now();
     while state.connections.load(Ordering::SeqCst) > 1 && t1.elapsed() < Duration::from_secs(1) {
         tokio::time::sleep(Duration::from_millis(20)).await;
@@ -350,10 +395,12 @@ pub async fn prepare(
 
 /// Step 5: rewrite `daemon.json` (generation+1, same pid), stop sidecars,
 /// hand the flock to the next image and `execv`. Returns only on failure —
-/// then `daemon.json`/reload-state are restored and the old image keeps
-/// serving (sessions checkpointed but alive; clients that got `Bye`
-/// reconnect to THIS image — a `reconnect_of.generation` mismatch is
-/// tolerated, the daemon answers with its own generation).
+/// then `daemon.json`/reload-state are restored, extension discovery is
+/// re-spawned (the sidecars were stopped for the exec — M4: no zombie
+/// daemon without hooks), and the old image keeps serving (sessions
+/// checkpointed but alive; clients that got `Bye` reconnect to THIS image
+/// — a `reconnect_of.generation` mismatch is tolerated, the daemon answers
+/// with its own generation).
 pub async fn exec(state: &Arc<DaemonState>, paths: &DaemonPaths, p: Prepared) -> ReloadError {
     let mut info = registry::read_daemon_json(paths).unwrap_or_else(|| registry::DaemonInfo {
         pid: std::process::id(),
@@ -381,6 +428,27 @@ pub async fn exec(state: &Arc<DaemonState>, paths: &DaemonPaths, p: Prepared) ->
     info.generation = prev_generation;
     let _ = registry::write_daemon_json(paths, &info);
     let _ = std::fs::remove_file(&p.rs_path);
+    state.reload_generation.store(prev_generation, Ordering::SeqCst);
+    state.reset_announce();
+    // Sidecars were shut down for the exec: bring them back (bounded like
+    // `run_foreground`'s first discovery) so the surviving image has hooks.
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let _loader = crate::extensions::loader::spawn_discover_and_load(
+        Arc::clone(state.host.ext_manager()),
+        tx,
+        None,
+    );
+    let wait = async {
+        while let Some(ev) = rx.recv().await {
+            if let crate::extensions::loader::ExtensionLoaderEvent::Finished { loaded, failed } = ev {
+                tracing::info!(loaded = loaded.len(), failed = failed.len(), "daemon: extensions re-discovered after failed reload");
+                break;
+            }
+        }
+    };
+    if tokio::time::timeout(Duration::from_secs(10), wait).await.is_err() {
+        tracing::warn!("daemon: extension re-discovery still running after 10 s");
+    }
     state.reloading.store(false, Ordering::SeqCst);
     ReloadError::ExecFailed(err)
 }
@@ -518,6 +586,27 @@ mod tests {
         assert!(version_gate(&cur, &pv("0.8.9", 2)).is_err(), "older refused");
         assert!(version_gate(&cur, &pv("0.9.0", 1)).is_err(), "older protocol refused");
         assert!(version_gate(&cur, &pv("garbage", 2)).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_exe_refuses_missing_dirs_non_exec_and_writable() {
+        use std::os::unix::fs::PermissionsExt;
+        let d = tempfile::tempdir().unwrap();
+        assert!(validate_exe(&d.path().join("nope")).unwrap_err().contains("nope"));
+        assert!(validate_exe(d.path()).unwrap_err().contains("not a regular file"));
+        let f = d.path().join("bin");
+        std::fs::write(&f, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(validate_exe(&f).unwrap_err().contains("not executable"));
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o777)).unwrap();
+        assert!(validate_exe(&f).unwrap_err().contains("writable"));
+        std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert_eq!(validate_exe(&f).unwrap(), f.canonicalize().unwrap());
+        // A symlink resolves to its target.
+        let l = d.path().join("link");
+        std::os::unix::fs::symlink(&f, &l).unwrap();
+        assert_eq!(validate_exe(&l).unwrap(), f.canonicalize().unwrap());
     }
 
     #[test]

--- a/crates/agent-engine/src/engine/session.rs
+++ b/crates/agent-engine/src/engine/session.rs
@@ -101,6 +101,7 @@ impl ConversationState {
         consecutive_auto_turns: u32,
     ) -> crate::session::ConversationSnapshot {
         crate::session::ConversationSnapshot {
+            header: crate::session::SessionHeader::from(&self.session),
             api_messages: self.api_messages.clone(),
             tokens: crate::session::ConversationTokens {
                 input: self.total_input_tokens,

--- a/crates/agent-engine/src/engine/setup.rs
+++ b/crates/agent-engine/src/engine/setup.rs
@@ -327,7 +327,6 @@ pub(crate) fn spawn_session_background(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum IndexRecord {
     Start,
-    #[allow(dead_code)] // B3 unpark / C3 rehydrate
     Skip,
 }
 

--- a/crates/agent-engine/src/engine/setup.rs
+++ b/crates/agent-engine/src/engine/setup.rs
@@ -327,6 +327,7 @@ pub(crate) fn spawn_session_background(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum IndexRecord {
     Start,
+    #[allow(dead_code)] // B3 unpark / C3 rehydrate
     Skip,
 }
 

--- a/crates/agent-engine/src/engine/setup.rs
+++ b/crates/agent-engine/src/engine/setup.rs
@@ -144,7 +144,7 @@ pub async fn boot(opts: EngineOpts) -> Result<EngineBoot> {
 
     let background = spawn_session_background(&runtime, &sb.session)?;
 
-    finish_session_setup(&mut runtime, &config, &sb.session, None);
+    finish_session_setup(&mut runtime, &config, &sb.session, None, IndexRecord::Start);
 
     // Extension manager: host-owned.
     let ext_manager = Arc::clone(host.ext_manager());
@@ -322,6 +322,14 @@ pub(crate) fn spawn_session_background(
     })
 }
 
+/// Whether `finish_session_setup` appends the session START index record.
+/// `Skip` on unpark (B3) / reload rehydrate (C3): the session already has one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum IndexRecord {
+    Start,
+    Skip,
+}
+
 /// Foreground turn budget + session start index record (code motion from
 /// `boot()`). `cwd` = the session's configured cwd (`None` → process cwd).
 pub(crate) fn finish_session_setup(
@@ -329,6 +337,7 @@ pub(crate) fn finish_session_setup(
     config: &crate::SynapsConfig,
     session: &Session,
     cwd: Option<std::path::PathBuf>,
+    index_record: IndexRecord,
 ) {
     // Task 23: the engine's interactive session runs under the FOREGROUND
     // turn budget with typed per-role config overrides applied.
@@ -345,7 +354,7 @@ pub(crate) fn finish_session_setup(
     // point delivered the event to an empty bus in every host — the hook had
     // never once reached an extension. It is now emitted by the loader, after
     // subscribers exist.
-    {
+    if index_record == IndexRecord::Start {
         let mut index_record =
             crate::core::session_index::SessionIndexRecord::start(&session.id);
         index_record.model = Some(session.model.clone());

--- a/crates/agent-engine/src/extensions/notify_router.rs
+++ b/crates/agent-engine/src/extensions/notify_router.rs
@@ -6,9 +6,11 @@
 //! `SessionEventWire::ExtensionNotification` via
 //! [`crate::host::EngineHost::broadcast_extension_notification`].
 //!
-//! Frames carry no session id today, so every session receives every frame
-//! (documented; per-session routing arrives when the extension contract adds
-//! `params.session_id`, day 2). Delivery is non-blocking: a session whose
+//! Routing (phase 3, C2): a frame whose `params.session_id` is a string is
+//! delivered to THAT session only (dropped with a `debug!` if it is not
+//! live); a frame without one is daemon-global and goes to every session
+//! (the pre-phase-3 behaviour — `docs/extensions/session-id.md` §plugin
+//! contract). Delivery is non-blocking: a session whose
 //! command queue is full drops the frame with a `warn!` — widget upserts are
 //! idempotent last-writer-wins UI state (`loop_arms.rs` semantics), and
 //! blocking would backpressure the extension's lossless fan-out and stall
@@ -63,11 +65,43 @@ pub async fn forward_extension_notifications(
                     "ignoring malformed widget frame");
                 continue;
             }
-            let delivered = host
-                .broadcast_extension_notification(&ext_id, &frame.method, frame.params)
-                .await;
+            let delivered = match route_target(&frame.params) {
+                Some(sid) => {
+                    let id = crate::session::SessionId(sid.to_string());
+                    match host.attach(&id) {
+                        Some(handle) => {
+                            let cmd = crate::session::SessionCommand::HostEvent(
+                                crate::session::HostEvent::ExtensionNotification {
+                                    extension_id: ext_id.clone(),
+                                    method: frame.method.clone(),
+                                    params: frame.params,
+                                },
+                            );
+                            match handle.send(cmd).await {
+                                Ok(()) => 1,
+                                Err(err) => {
+                                    tracing::warn!(session = %id, extension = %ext_id,
+                                        method = %frame.method, error = %err,
+                                        "dropping extension notification for session");
+                                    0
+                                }
+                            }
+                        }
+                        None => {
+                            tracing::debug!(session = %id, extension = %ext_id,
+                                method = %frame.method,
+                                "extension notification for a session that is not live; dropped");
+                            0
+                        }
+                    }
+                }
+                None => {
+                    host.broadcast_extension_notification(&ext_id, &frame.method, frame.params)
+                        .await
+                }
+            };
             tracing::trace!(extension = %ext_id, method = %frame.method, sessions = delivered,
-                "extension notification broadcast");
+                "extension notification routed");
         }
         // Channel closed (EOF/restart). Stop if the extension is gone for
         // good; otherwise wait and resubscribe.
@@ -83,5 +117,31 @@ pub async fn forward_extension_notifications(
             tracing::debug!(extension = %ext_id, "notification router: extension unloaded; stopping");
             return;
         }
+    }
+}
+
+/// `params.session_id` when it is a non-empty string — the frame is
+/// session-scoped; otherwise daemon-global (broadcast).
+pub fn route_target(params: &serde_json::Value) -> Option<&str> {
+    params
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::route_target;
+
+    #[test]
+    fn route_target_is_session_id_string_or_global() {
+        assert_eq!(
+            route_target(&serde_json::json!({"id": "w", "session_id": "s-1"})),
+            Some("s-1")
+        );
+        assert_eq!(route_target(&serde_json::json!({"id": "w"})), None);
+        assert_eq!(route_target(&serde_json::json!({"session_id": ""})), None);
+        assert_eq!(route_target(&serde_json::json!({"session_id": 7})), None);
+        assert_eq!(route_target(&serde_json::json!(null)), None);
     }
 }

--- a/crates/agent-engine/src/host.rs
+++ b/crates/agent-engine/src/host.rs
@@ -339,16 +339,42 @@ impl EngineHost {
         }
         let (handle, task) = SessionActor::create(self, cfg).await?;
         let id = handle.id.clone();
-        self.sessions
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(id.clone(), handle.clone());
+        self.adopt_session(handle.clone());
         let host = Arc::clone(self);
         tokio::spawn(async move {
-            task.run().await;
+            // A panicking actor must still leave the map (§6 #12): the
+            // handle would otherwise be listed forever and attach → Closed.
+            use futures::FutureExt;
+            if std::panic::AssertUnwindSafe(task.run())
+                .catch_unwind()
+                .await
+                .is_err()
+            {
+                tracing::error!(session = %id, "session actor panicked");
+            }
             host.remove_session(&id);
         });
         Ok(handle)
+    }
+
+    /// Register a handle built elsewhere (daemon test factories). The
+    /// caller owns the task; `remove_session` when it ends.
+    pub fn adopt_session(&self, handle: SessionHandle) {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(handle.id.clone(), handle);
+    }
+
+    /// Every registered handle (B4: THE session map; `DaemonState`
+    /// delegates here). Dead handles are dropped defensively — the task
+    /// removes itself, so this should never actually find one.
+    pub fn session_handles(&self) -> Vec<SessionHandle> {
+        let mut map = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
+        let before = map.len();
+        map.retain(|_, h| h.is_alive());
+        debug_assert_eq!(before, map.len(), "a dead session handle lingered in the host map");
+        map.values().cloned().collect()
     }
 
     /// Resolve a `continue_session` request the same way
@@ -389,13 +415,12 @@ impl EngineHost {
             .cloned()
     }
 
-    /// Metadata of every live session.
+    /// Metadata of every live session, with the live cells filled
+    /// (lifecycle, clients, input_owner, awaiting_input, journal_id).
     pub fn sessions(&self) -> Vec<SessionMeta> {
-        self.sessions
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .values()
-            .map(|h| h.meta().clone())
+        self.session_handles()
+            .iter()
+            .map(|h| h.meta_live())
             .collect()
     }
 

--- a/crates/agent-engine/src/host.rs
+++ b/crates/agent-engine/src/host.rs
@@ -367,13 +367,21 @@ impl EngineHost {
     }
 
     /// Every registered handle (B4: THE session map; `DaemonState`
-    /// delegates here). Dead handles are dropped defensively — the task
-    /// removes itself, so this should never actually find one.
+    /// delegates here). Dead handles are dropped defensively: the actor
+    /// task drops `cmd_rx` when `run()` returns and `remove_session` runs
+    /// *after* — a listing in that window sees `is_alive() == false`. That
+    /// is an ordering window, not an invariant violation, so it is logged
+    /// at debug, never asserted.
     pub fn session_handles(&self) -> Vec<SessionHandle> {
         let mut map = self.sessions.lock().unwrap_or_else(|e| e.into_inner());
         let before = map.len();
         map.retain(|_, h| h.is_alive());
-        debug_assert_eq!(before, map.len(), "a dead session handle lingered in the host map");
+        if before != map.len() {
+            tracing::debug!(
+                pruned = before - map.len(),
+                "session_handles: pruned ended sessions ahead of their self-removal"
+            );
+        }
         map.values().cloned().collect()
     }
 

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -1294,6 +1294,12 @@ impl Runtime {
         &self.hook_bus
     }
 
+    /// Background shell/PTY sessions owned by this runtime (`Checkpoint`
+    /// and `Parked` close them via `shutdown_all`).
+    pub fn session_manager(&self) -> &Arc<crate::tools::shell::SessionManager> {
+        &self.session_manager
+    }
+
     /// Runtime-scoped tool-session identity used by the stream execution
     /// gate (Task 16). Shared by clones (which share the tool registry);
     /// fresh per independently constructed `Runtime`.

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -1282,6 +1282,13 @@ impl Runtime {
         &self.event_queue
     }
 
+    /// Install a session-lifetime queue (B3 unpark: the queue outlives the
+    /// `Runtime` so `synaps send` keeps resolving while parked). Must be
+    /// called before the first turn — in-flight streams hold a clone.
+    pub fn set_event_queue(&mut self, queue: Arc<crate::events::EventQueue>) {
+        self.event_queue = queue;
+    }
+
     /// Get a shared reference to the extension hook bus.
     pub fn hook_bus(&self) -> &Arc<crate::extensions::hooks::HookBus> {
         &self.hook_bus

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -766,6 +766,17 @@ fn canonical_trusted_worker_model(model: &str) -> String {
     }
 }
 
+/// The owning runtime stops its shell-session reaper when it goes away
+/// (clones carry `None`). Without this every dropped `Runtime` — a parked
+/// session, a finished worker — left a 30 s ticker holding the manager.
+impl Drop for Runtime {
+    fn drop(&mut self) {
+        if let Some(c) = &self.reaper_cancel {
+            c.cancel();
+        }
+    }
+}
+
 impl Runtime {
     pub async fn new() -> Result<Self> {
         // UNCHANGED semantics: fresh everything (tests, `synaps agent`).

--- a/crates/agent-engine/src/runtime/subagent.rs
+++ b/crates/agent-engine/src/runtime/subagent.rs
@@ -75,7 +75,8 @@ pub fn safe_failure_message(category: &TerminalCategory) -> &'static str {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SubagentStatus {
     Running,
     Completed,
@@ -134,7 +135,8 @@ impl Default for SubagentState {
 
 /// Snapshot row produced by SubagentRegistry::display_rows().
 /// Used by the TUI reconcile path as the registry's liveness authority.
-#[derive(Debug, Clone)]
+/// Serde: travels in `SessionEventWire::SubagentRows` (phase 3).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SubagentDisplayRow {
     pub subagent_id: u64,
     pub agent_name: String,

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -1023,6 +1023,7 @@ impl SessionActor {
                 self.conv.clear(&self.runtime).await;
                 self.runtime
                     .set_session_id(Some(self.conv.session.id.clone()));
+                self.journal_id.store(Arc::new(self.conv.session.id.clone()));
                 self.emit(SessionEventWire::SystemNotice(format!(
                     "session cleared → {}",
                     &self.conv.session.id[..8.min(self.conv.session.id.len())]

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -363,6 +363,8 @@ pub struct SessionActor {
     pub(crate) lifecycle: Arc<std::sync::atomic::AtomicU8>,
     /// Mirrors `handle.journal_id()` (B2 stores the successor id).
     pub(crate) journal_id: Arc<arc_swap::ArcSwap<String>>,
+    /// Mirrors `handle.presence()` (clients / owner / pending prompts).
+    pub(crate) presence: Arc<arc_swap::ArcSwap<super::handle::Presence>>,
 }
 
 impl SessionActor {
@@ -469,6 +471,7 @@ impl SessionActor {
                 view,
                 lifecycle,
                 journal_id,
+                presence,
             },
         ) = SessionHandle::new(meta.clone(), view);
         let (sp_tx, secret_prompt_rx) = mpsc::unbounded_channel();
@@ -511,6 +514,7 @@ impl SessionActor {
             subagent_tick: None,
             lifecycle,
             journal_id,
+            presence,
         };
         Ok((handle, SessionTask(actor)))
     }
@@ -561,9 +565,18 @@ impl SessionActor {
         }
     }
 
+    pub(crate) fn publish_presence(&self) {
+        self.presence.store(Arc::new(super::handle::Presence {
+            clients: self.attached.len(),
+            input_owner: self.input_owner,
+            awaiting_input: self.pending_prompts.len(),
+        }));
+    }
+
     /// Recomputes `state` from clients/streaming and (re)arms or disarms the
     /// park grace timer. A no-op while Parking/Parked.
     pub(crate) fn update_attach_state(&mut self) {
+        self.publish_presence();
         if matches!(self.state, AttachState::Parking | AttachState::Parked) {
             return;
         }
@@ -1336,6 +1349,7 @@ impl SessionActor {
             raised_at: chrono::Utc::now(),
         };
         self.pending_prompts.push_back((pr.clone(), req.response_tx));
+        self.publish_presence();
         self.emit(SessionEventWire::Prompt(pr));
     }
 
@@ -1345,6 +1359,7 @@ impl SessionActor {
         };
         let (_, tx) = self.pending_prompts.remove(pos).expect("position");
         let _ = tx.send(value);
+        self.publish_presence();
         self.emit(SessionEventWire::PromptResolved { prompt_id });
     }
 
@@ -1600,6 +1615,7 @@ impl SessionActor {
                 reason,
             });
         }
+        self.publish_presence();
         let snapshot = self.snapshot();
         self.emit(SessionEventWire::Attached {
             client: cid,
@@ -1633,6 +1649,7 @@ impl SessionActor {
                 to: next,
                 reason: OwnerChangeReason::OwnerDetached,
             });
+            self.publish_presence();
         }
     }
 

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -803,6 +803,15 @@ impl SessionActor {
             self.steer(text);
             return;
         }
+        if self.compact.is_some() {
+            // dispatch.rs:1233-1237: queued until the compaction lands.
+            self.emit(SessionEventWire::Steered {
+                text: text.clone(),
+                delivered: false,
+            });
+            self.conv.queued_message = Some(text);
+            return;
+        }
         // Real user send — reset auto-turn counter.
         self.consecutive_auto_turns = 0;
         // Inject abort context if previous response was interrupted
@@ -839,6 +848,13 @@ impl SessionActor {
     /// `abort_context`, save, or emit "aborted".
     pub(crate) async fn cancel_turn(&mut self) {
         if !self.streaming {
+            if self.compact.is_some() {
+                self.abort_compaction();
+                if let Some(q) = self.conv.queued_message.take() {
+                    self.emit(SessionEventWire::Dequeued { text: q });
+                }
+                self.update_attach_state();
+            }
             self.emit(SessionEventWire::Idle);
             return;
         }
@@ -1049,7 +1065,10 @@ impl SessionActor {
                     if self.config.auto_compact {
                         self.post_turn_chat().await;
                     }
-                    self.emit(SessionEventWire::Idle);
+                    // A spawned compaction emits Idle when it lands.
+                    if self.compact.is_none() {
+                        self.emit(SessionEventWire::Idle);
+                    }
                 }
             }
             StreamEvent::Session(SessionEvent::Error(_)) => {
@@ -1071,11 +1090,19 @@ impl SessionActor {
                 if self.config.auto_compact {
                     self.post_turn_chat().await;
                 }
-                self.emit(SessionEventWire::Idle);
+                if self.compact.is_none() {
+                    self.emit(SessionEventWire::Idle);
+                }
             }
             After::AutoSendQueued(queued) => {
                 if self.config.auto_compact {
                     self.post_turn_chat().await;
+                }
+                if self.compact.is_some() {
+                    // Rides the compaction transition (queued_message
+                    // restored last); the TUI reports it, never re-sends.
+                    self.conv.queued_message = Some(queued);
+                    return;
                 }
                 // Auto-send the queued message (user-authored — reset counter)
                 self.consecutive_auto_turns = 0;
@@ -1095,6 +1122,9 @@ impl SessionActor {
             After::AutoTriggerEvents => {
                 if self.config.auto_compact {
                     self.post_turn_chat().await;
+                }
+                if self.compact.is_some() {
+                    return;
                 }
                 // Central claim gate: allows turns 1-5, denies the 6th.
                 if claim_auto_turn(&mut self.consecutive_auto_turns) {
@@ -1120,9 +1150,136 @@ impl SessionActor {
         }
     }
 
-    /// chat.rs `/compact` + auto-compaction body (inline; the TUI's spawned
-    /// compaction task is day 2).
+    /// `SYNAPS_SESSION_COMPACT_INLINE=1`: one-release kill-switch back to the
+    /// #107 inline body (deleted in phase 4).
+    fn compact_inline_env() -> bool {
+        matches!(
+            std::env::var("SYNAPS_SESSION_COMPACT_INLINE").as_deref(),
+            Ok("1") | Ok("true")
+        )
+    }
+
+    /// `/compact` + auto-compaction entry (B2): spawns `compact_conversation`
+    /// on a `Runtime::clone()` (the same clone the TUI makes at
+    /// dispatch.rs:450 — the clone never runs turns) and returns; the
+    /// `select!` arm `on_compaction_done` applies the outcome. While a job
+    /// is in flight Attach/Detach/Cancel/Query are serviced, `Submit` is
+    /// queued (`Steered{delivered:false}`), auto-turns see `busy`.
     pub(crate) async fn compact(&mut self, instructions: Option<String>, source: &str) {
+        if Self::compact_inline_env() {
+            return self.compact_inline(instructions, source).await;
+        }
+        if self.compact.is_some() {
+            self.emit(SessionEventWire::SystemNotice(
+                "compaction already in progress".into(),
+            ));
+            return;
+        }
+        if self.streaming {
+            self.emit(SessionEventWire::SystemNotice(
+                "cannot compact while a turn is running".into(),
+            ));
+            return;
+        }
+        let disclosure =
+            preview_compaction_disclosure(&self.runtime, &self.conv.api_messages).render_line();
+        self.emit(SessionEventWire::CompactionStarted {
+            source: source.to_string(),
+            disclosure,
+        });
+        let msgs = self.conv.api_messages.clone();
+        let rt: Runtime = (*self.runtime).clone();
+        let task = tokio::spawn(async move {
+            compact_conversation(&msgs, &rt, instructions.as_deref()).await
+        });
+        self.compact = Some(CompactionJob {
+            task,
+            source: source.to_string(),
+            started: tokio::time::Instant::now(),
+        });
+        self.update_attach_state();
+    }
+
+    /// `select!` arm: the spawned job finished (or was aborted). Applies via
+    /// the ONE engine transition with the configured policy; pending events
+    /// and the queued message ride the transition (loop_arms.rs:761-836).
+    async fn on_compaction_done(
+        &mut self,
+        res: std::result::Result<
+            Result<crate::runtime::compaction::CompactionOutcome>,
+            tokio::task::JoinError,
+        >,
+    ) {
+        let Some(job) = self.compact.take() else {
+            return;
+        };
+        let msg_count = self.conv.api_messages.len();
+        match res {
+            Err(join) => {
+                if !join.is_cancelled() {
+                    self.emit(SessionEventWire::CompactionFailed {
+                        message: join.to_string(),
+                        panicked: true,
+                    });
+                }
+            }
+            Ok(Err(e)) => self.emit(SessionEventWire::CompactionFailed {
+                message: e.to_string(),
+                panicked: false,
+            }),
+            Ok(Ok(outcome)) => {
+                let policy: CompactionPolicy = self.config.compaction_policy.into();
+                let queued = self.conv.queued_message.clone();
+                let applied = apply_compaction(
+                    &self.runtime,
+                    &self.conv.session,
+                    &self.conv.api_messages,
+                    &outcome,
+                    CompactionTransition {
+                        policy,
+                        pending_events: self.conv.pending_events.clone(),
+                        queued_message: queued.clone(),
+                        hook_source: job.source.clone(),
+                    },
+                )
+                .await;
+                match applied {
+                    Ok(applied) => {
+                        let previous = applied.previous_session_id.clone();
+                        self.conv.session = applied.session;
+                        self.conv.api_messages = applied.api_messages;
+                        self.conv.pending_events.clear();
+                        self.conv.queued_message = None;
+                        if policy == CompactionPolicy::LinkedSuccessor {
+                            self.conv.total_input_tokens = 0;
+                            self.conv.total_output_tokens = 0;
+                            self.conv.session_cost = 0.0;
+                        }
+                        let new_id = self.conv.session.id.clone();
+                        self.runtime.set_session_id(Some(new_id.clone()));
+                        self.journal_id.store(Arc::new(new_id.clone()));
+                        self.emit(SessionEventWire::CompactionApplied {
+                            previous_session_id: previous,
+                            session_id: new_id,
+                            chains_advanced: applied.chains_advanced,
+                            queued_restored: queued,
+                            msg_count,
+                        });
+                    }
+                    Err(e) => self.emit(SessionEventWire::CompactionFailed {
+                        message: e.to_string(),
+                        panicked: false,
+                    }),
+                }
+            }
+        }
+        self.emit_conversation();
+        self.update_attach_state();
+        self.emit(SessionEventWire::Idle);
+    }
+
+    /// #107 inline body (kill-switch only).
+    async fn compact_inline(&mut self, instructions: Option<String>, source: &str) {
         self.emit(SessionEventWire::SystemNotice(format!(
             "[{}]",
             preview_compaction_disclosure(&self.runtime, &self.conv.api_messages).render_line()
@@ -1514,7 +1671,7 @@ impl SessionActor {
         });
     }
 
-    /// B2 fills this in (abort the spawned task + `CompactionCancelled`).
+    /// Abort the spawned job (`CompactionCancelled`); prior state intact.
     pub(crate) fn abort_compaction(&mut self) {
         if let Some(job) = self.compact.take() {
             job.task.abort();
@@ -1768,6 +1925,15 @@ async fn next_tick(tick: &mut Option<tokio::time::Interval>) {
     }
 }
 
+async fn poll_compaction(
+    job: &mut Option<CompactionJob>,
+) -> std::result::Result<Result<crate::runtime::compaction::CompactionOutcome>, tokio::task::JoinError> {
+    match job {
+        Some(j) => (&mut j.task).await,
+        None => std::future::pending().await,
+    }
+}
+
 async fn park_timer(deadline: Option<tokio::time::Instant>) {
     match deadline {
         Some(t) => tokio::time::sleep_until(t).await,
@@ -1808,6 +1974,7 @@ impl SessionTask {
                 _ = queue.notified() => actor.on_queue_wake().await,
                 _ = next_tick(&mut actor.subagent_tick) => actor.publish_subagent_rows(),
                 _ = park_timer(actor.park_deadline) => actor.park().await,
+                res = poll_compaction(&mut actor.compact) => actor.on_compaction_done(res).await,
                 _ = ext_ready(&mut actor.ext_ready) => {
                     actor.ext_ready = None;
                     let id = (**actor.journal_id.load()).clone();

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -159,6 +159,69 @@ impl TurnLog {
     }
 }
 
+/// One attached client: its meta + the mode it attached with (B1 ownership
+/// needs the mode to pick the next owner when the owner detaches).
+pub(crate) struct AttachedClient {
+    pub(crate) meta: ClientMeta,
+    pub(crate) mode: AttachMode,
+}
+
+/// B2: a spawned `compact_conversation` (§2.5).
+pub(crate) struct CompactionJob {
+    pub(crate) task: tokio::task::JoinHandle<Result<crate::runtime::compaction::CompactionOutcome>>,
+    pub(crate) source: String,
+    #[allow(dead_code)]
+    pub(crate) started: tokio::time::Instant,
+}
+
+/// Commands that only the input owner may send (B1). Everything else
+/// (`Answer`, `Query`, `Save`, `Detach`, `Attach`, `Resync`, `HostEvent`)
+/// is open to every attached client.
+fn is_input_command(cmd: &SessionCommand) -> bool {
+    matches!(
+        cmd,
+        SessionCommand::Submit { .. }
+            | SessionCommand::SubmitPrepared { .. }
+            | SessionCommand::Steer { .. }
+            | SessionCommand::Cancel
+            | SessionCommand::Set { .. }
+            | SessionCommand::Compact { .. }
+            | SessionCommand::NewSession
+            | SessionCommand::EngineCommand { .. }
+            | SessionCommand::PluginCommand { .. }
+            | SessionCommand::Resume { .. }
+            | SessionCommand::KeepWarm { .. }
+            | SessionCommand::End {
+                reason: EndReason::ClientQuit
+            }
+    )
+}
+
+fn command_name(cmd: &SessionCommand) -> &'static str {
+    match cmd {
+        SessionCommand::Submit { .. } => "submit",
+        SessionCommand::SubmitPrepared { .. } => "submit_prepared",
+        SessionCommand::Steer { .. } => "steer",
+        SessionCommand::Cancel => "cancel",
+        SessionCommand::Answer { .. } => "answer",
+        SessionCommand::Set { .. } => "set",
+        SessionCommand::Compact { .. } => "compact",
+        SessionCommand::NewSession => "new_session",
+        SessionCommand::Save => "save",
+        SessionCommand::Query { .. } => "query",
+        SessionCommand::Attach { .. } => "attach",
+        SessionCommand::Detach { .. } => "detach",
+        SessionCommand::End { .. } => "end",
+        SessionCommand::Resync { .. } => "resync",
+        SessionCommand::EngineCommand { .. } => "engine_command",
+        SessionCommand::PluginCommand { .. } => "plugin_command",
+        SessionCommand::Resume { .. } => "resume",
+        SessionCommand::Checkpoint { .. } => "checkpoint",
+        SessionCommand::KeepWarm { .. } => "keep_warm",
+        SessionCommand::HostEvent(_) => "host_event",
+    }
+}
+
 pub struct SessionActor {
     pub(crate) id: SessionId,
     pub(crate) meta: SessionMeta,
@@ -184,12 +247,22 @@ pub struct SessionActor {
     pub(crate) cmd_rx: mpsc::Receiver<Addressed>,
     pub(crate) events: broadcast::Sender<Envelope>,
     pub(crate) view: Arc<arc_swap::ArcSwap<RuntimeView>>,
-    pub(crate) attached: HashMap<ClientId, ClientMeta>,
+    pub(crate) attached: HashMap<ClientId, AttachedClient>,
+    /// B1: the one client whose input commands are honoured (`None` = any
+    /// host-originated sender only).
+    pub(crate) input_owner: Option<ClientId>,
     pub(crate) next_client_id: u64,
     pub(crate) seq: u64,
     pub(crate) turn_replay: VecDeque<Envelope>,
     pub(crate) state: AttachState,
     pub(crate) background: BackgroundTasks,
+    /// B2: spawned compaction in flight (`busy` while `Some`).
+    pub(crate) compact: Option<CompactionJob>,
+    /// `await_extensions=false`: fires when process-level discovery is done;
+    /// the actor then emits `on_session_start` without having blocked boot.
+    pub(crate) ext_ready: Option<oneshot::Receiver<()>>,
+    /// 1 Hz `SubagentRows` cadence while a turn runs (`None` when idle).
+    pub(crate) subagent_tick: Option<tokio::time::Interval>,
     /// Mirrors `handle.lifecycle()` (B3 writes Parking/Parked).
     pub(crate) lifecycle: Arc<std::sync::atomic::AtomicU8>,
     /// Mirrors `handle.journal_id()` (B2 stores the successor id).
@@ -232,16 +305,34 @@ impl SessionActor {
 
         // C2: per-session on_session_start (keyed injection) once the
         // process-level discovery is known-finished. Never re-runs discovery.
-        if tokio::time::timeout(budgets::EXTENSIONS_READY_TIMEOUT, host.extensions_ready())
-            .await
-            .is_err()
-        {
-            tracing::warn!(
-                budget_secs = budgets::EXTENSIONS_READY_TIMEOUT_SECS,
-                "extensions_ready timed out — on_session_start may miss late extensions"
-            );
+        // `await_extensions=false` (TUI): a spawned waiter fires the
+        // `ext_ready` arm instead, so boot never blocks on discovery.
+        let mut ext_ready = None;
+        if cfg.await_extensions {
+            if tokio::time::timeout(budgets::EXTENSIONS_READY_TIMEOUT, host.extensions_ready())
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    budget_secs = budgets::EXTENSIONS_READY_TIMEOUT_SECS,
+                    "extensions_ready timed out — on_session_start may miss late extensions"
+                );
+            }
+            crate::extensions::loader::emit_session_start(runtime.hook_bus(), &sb.session.id)
+                .await;
+        } else {
+            let (tx, rx) = oneshot::channel();
+            let waiter_host = Arc::clone(host);
+            tokio::spawn(async move {
+                let _ = tokio::time::timeout(
+                    budgets::EXTENSIONS_READY_TIMEOUT,
+                    waiter_host.extensions_ready(),
+                )
+                .await;
+                let _ = tx.send(());
+            });
+            ext_ready = Some(rx);
         }
-        crate::extensions::loader::emit_session_start(runtime.hook_bus(), &sb.session.id).await;
 
         let id = SessionId::from(sb.session.id.clone());
         let meta = SessionMeta {
@@ -304,11 +395,15 @@ impl SessionActor {
             events,
             view,
             attached: HashMap::new(),
+            input_owner: None,
             next_client_id: 1,
             seq: 0,
             turn_replay: VecDeque::new(),
             state: AttachState::Detached { running: false },
             background,
+            compact: None,
+            ext_ready,
+            subagent_tick: None,
             lifecycle,
             journal_id,
         };
@@ -371,6 +466,26 @@ impl SessionActor {
         };
     }
 
+    /// `stream_handler.rs:264`: a turn OR a compaction blocks auto-turns.
+    pub(crate) fn busy(&self) -> bool {
+        self.streaming || self.compact.is_some()
+    }
+
+    /// `runtime.subagent_registry().display_rows()` → `SubagentRows`, only
+    /// when there is something to show (the TUI's reconcile is a no-op on
+    /// an empty registry).
+    pub(crate) fn publish_subagent_rows(&mut self) {
+        let rows = self
+            .runtime
+            .subagent_registry()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .display_rows();
+        if !rows.is_empty() {
+            self.emit(SessionEventWire::SubagentRows(rows));
+        }
+    }
+
     // ── turn start (dispatch.rs Submit tail / stream_handler.rs RunTurn) ──
 
     pub(crate) async fn start_turn(&mut self, trigger: TurnTrigger, user_text: Option<String>) {
@@ -400,6 +515,10 @@ impl SessionActor {
         self.stream = Some(stream);
         self.cancel = Some(ct);
         self.steer_tx = Some(s_tx);
+        let mut tick = tokio::time::interval(std::time::Duration::from_secs(1));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        tick.reset();
+        self.subagent_tick = Some(tick);
     }
 
     /// Every turn-end path (Done/Error/Cancel/stream EOF). Clears `turn_log`
@@ -410,6 +529,7 @@ impl SessionActor {
         self.cancel = None;
         self.steer_tx = None;
         self.streaming = false;
+        self.subagent_tick = None;
         self.turn_log.clear();
         self.update_attach_state();
     }
@@ -509,7 +629,7 @@ impl SessionActor {
     // ── event-queue wake (stream_handler.rs handle_event_queue_arm) ──────
 
     async fn on_queue_wake(&mut self) {
-        let busy = self.streaming;
+        let busy = self.busy();
         let drained = drain_event_queue(
             self.runtime.event_queue(),
             &mut self.conv.api_messages,
@@ -631,6 +751,7 @@ impl SessionActor {
             StreamEvent::Session(SessionEvent::Notice(_)) => {}
             StreamEvent::Session(SessionEvent::Done) => {
                 self.clear_stream();
+                self.publish_subagent_rows();
                 // Flush events that arrived during streaming into api_messages
                 let had_pending = !self.conv.pending_events.is_empty();
                 for formatted in self.conv.pending_events.drain(..) {
@@ -657,6 +778,7 @@ impl SessionActor {
             }
             StreamEvent::Session(SessionEvent::Error(_)) => {
                 self.clear_stream();
+                self.publish_subagent_rows();
                 // Remove only invalid messages appended by the ACTIVE turn.
                 crate::engine::stream::repair_history_after_failure(
                     &mut self.conv.api_messages,
@@ -963,21 +1085,55 @@ impl SessionActor {
             streaming: self.streaming,
             replay: self.turn_replay.iter().cloned().collect(),
             pending_prompts: self.pending_prompts.iter().map(|(p, _)| p.clone()).collect(),
-            clients: self.attached.iter().map(|(c, m)| (*c, m.kind)).collect(),
-            input_owner: None,
+            clients: self.attached.iter().map(|(c, a)| (*c, a.meta.kind)).collect(),
+            input_owner: self.input_owner,
         }
     }
 
+    /// B1 ownership: `Observe` never owns; `Mirror` owns iff nobody does
+    /// (else read-only + notice); `Takeover` steals with
+    /// `InputOwnerChanged{reason: Takeover}` to everyone (the old owner's
+    /// client renders the toast).
     fn attach(&mut self, client: ClientMeta, mode: AttachMode) {
         let cid = ClientId(self.next_client_id);
         self.next_client_id += 1;
         let kind = client.kind;
-        self.attached.insert(cid, client);
+        self.attached.insert(cid, AttachedClient { meta: client, mode });
         self.update_attach_state();
-        if mode != AttachMode::Mirror {
-            self.emit(SessionEventWire::SystemNotice(format!(
-                "attach mode {mode:?} not supported yet; using mirror"
-            )));
+        let mut owner_change: Option<(Option<ClientId>, OwnerChangeReason)> = None;
+        let mut notice: Option<String> = None;
+        match mode {
+            AttachMode::Observe => {}
+            AttachMode::Mirror => match self.input_owner {
+                None => owner_change = Some((None, OwnerChangeReason::Attach)),
+                Some(owner) => {
+                    let owner_kind = self
+                        .attached
+                        .get(&owner)
+                        .map(|a| format!("{:?}", a.meta.kind).to_lowercase())
+                        .unwrap_or_else(|| "?".into());
+                    notice = Some(format!(
+                        "input is owned by client #{} ({}); attach with --takeover to steal it",
+                        owner.0, owner_kind
+                    ));
+                }
+            },
+            AttachMode::Takeover => {
+                let reason = if self.input_owner.is_some() {
+                    OwnerChangeReason::Takeover
+                } else {
+                    OwnerChangeReason::Attach
+                };
+                owner_change = Some((self.input_owner, reason));
+            }
+        }
+        if let Some((from, reason)) = owner_change {
+            self.input_owner = Some(cid);
+            self.emit(SessionEventWire::InputOwnerChanged {
+                from,
+                to: Some(cid),
+                reason,
+            });
         }
         let snapshot = self.snapshot();
         self.emit(SessionEventWire::Attached {
@@ -985,24 +1141,100 @@ impl SessionActor {
             snapshot,
         });
         self.emit(SessionEventWire::ClientJoined { client: cid, kind });
+        if let Some(n) = notice {
+            self.emit(SessionEventWire::SystemNotice(n));
+        }
     }
 
     /// Never touches `stream`/`cancel`: the turn keeps running and its
-    /// events buffer in the broadcast (§8 detach-without-abort).
+    /// events buffer in the broadcast (§8 detach-without-abort). The owner
+    /// leaving passes input to the oldest attached non-`Observe` client.
     fn detach(&mut self, client: ClientId) {
-        if self.attached.remove(&client).is_some() {
-            self.update_attach_state();
-            self.emit(SessionEventWire::ClientLeft { client });
+        if self.attached.remove(&client).is_none() {
+            return;
+        }
+        self.update_attach_state();
+        self.emit(SessionEventWire::ClientLeft { client });
+        if self.input_owner == Some(client) {
+            let next = self
+                .attached
+                .iter()
+                .filter(|(_, a)| a.mode != AttachMode::Observe)
+                .map(|(c, _)| *c)
+                .min_by_key(|c| c.0);
+            self.input_owner = next;
+            self.emit(SessionEventWire::InputOwnerChanged {
+                from: Some(client),
+                to: next,
+                reason: OwnerChangeReason::OwnerDetached,
+            });
+        }
+    }
+
+    /// B1 (used by C3 reload): checkpoint the session without ending it —
+    /// cancel any turn (abort_context captured), abort compaction, answer
+    /// pending prompts `None`, save, close PTYs. Replies on
+    /// `CHECKPOINT_QUERY_ID` so `reload.rs` can await it per session.
+    pub(crate) async fn checkpoint(&mut self, reason: CheckpointReason) {
+        if self.streaming {
+            self.cancel_turn().await;
+        }
+        self.abort_compaction();
+        while let Some((pr, tx)) = self.pending_prompts.pop_front() {
+            let _ = tx.send(None);
+            self.emit(SessionEventWire::PromptResolved { prompt_id: pr.id });
+        }
+        if tokio::time::timeout(budgets::SAVE_TIMEOUT, self.save())
+            .await
+            .is_err()
+        {
+            tracing::warn!("checkpoint: save timed out");
+        }
+        let notice = match reason {
+            CheckpointReason::Reload => {
+                "daemon reloading — background shells/PTYs will be closed; the turn was checkpointed"
+            }
+            CheckpointReason::HostRequest => {
+                "checkpoint — background shells/PTYs closed; the turn was checkpointed"
+            }
+        };
+        self.emit(SessionEventWire::SystemNotice(notice.to_string()));
+        self.runtime.session_manager().shutdown_all();
+        self.emit(SessionEventWire::QueryResult {
+            id: super::wire::CHECKPOINT_QUERY_ID,
+            value: serde_json::json!({ "ok": true }),
+        });
+    }
+
+    /// B2 fills this in (abort the spawned task + `CompactionCancelled`).
+    pub(crate) fn abort_compaction(&mut self) {
+        if let Some(job) = self.compact.take() {
+            job.task.abort();
+            self.emit(SessionEventWire::CompactionCancelled);
         }
     }
 
     // ── command dispatch ─────────────────────────────────────────────────
 
-    /// `from` is carried for B1 (input ownership); today every sender is
-    /// honoured.
+    /// B1: a client-stamped input command from anyone but the owner is
+    /// `Refused` with no side effect; `from: None` (host) bypasses.
     async fn handle(&mut self, addressed: Addressed) -> std::ops::ControlFlow<EndReason> {
         use std::ops::ControlFlow;
-        let Addressed { from: _from, cmd } = addressed;
+        let Addressed { from, cmd } = addressed;
+        if let Some(c) = from {
+            if is_input_command(&cmd) && self.input_owner != Some(c) {
+                let reason = match self.input_owner {
+                    Some(o) => format!("input owned by client #{}", o.0),
+                    None => "input has no owner; attach with --takeover".to_string(),
+                };
+                self.emit(SessionEventWire::Refused {
+                    client: c,
+                    command: command_name(&cmd).to_string(),
+                    reason,
+                });
+                return ControlFlow::Continue(());
+            }
+        }
         match cmd {
             SessionCommand::Submit { text, .. } => self.submit(text).await,
             SessionCommand::Steer { text } => {
@@ -1053,9 +1285,7 @@ impl SessionActor {
             SessionCommand::Resume { .. } => self.emit(SessionEventWire::SystemNotice(
                 "resume: not implemented in this build".into(),
             )),
-            SessionCommand::Checkpoint { .. } => self.emit(SessionEventWire::SystemNotice(
-                "checkpoint: not implemented in this build".into(),
-            )),
+            SessionCommand::Checkpoint { reason } => self.checkpoint(reason).await,
             SessionCommand::KeepWarm { .. } => self.emit(SessionEventWire::SystemNotice(
                 "keep_warm: not implemented in this build".into(),
             )),
@@ -1085,6 +1315,7 @@ impl SessionActor {
         if self.streaming {
             self.cancel_turn().await;
         }
+        self.abort_compaction();
         // Outstanding prompts are cancelled (tool sees `None`).
         while let Some((pr, tx)) = self.pending_prompts.pop_front() {
             let _ = tx.send(None);
@@ -1161,6 +1392,24 @@ async fn next_stream_event(stream: &mut Option<ActiveStream>) -> Option<StreamEv
     }
 }
 
+async fn next_tick(tick: &mut Option<tokio::time::Interval>) {
+    match tick {
+        Some(t) => {
+            t.tick().await;
+        }
+        None => std::future::pending().await,
+    }
+}
+
+async fn ext_ready(rx: &mut Option<oneshot::Receiver<()>>) {
+    match rx {
+        Some(r) => {
+            let _ = r.await;
+        }
+        None => std::future::pending().await,
+    }
+}
+
 impl SessionTask {
     pub fn id(&self) -> &SessionId {
         self.0.id()
@@ -1183,6 +1432,13 @@ impl SessionTask {
                 },
                 Some(req) = actor.secret_prompt_rx.recv() => actor.on_prompt_request(req),
                 _ = queue.notified() => actor.on_queue_wake().await,
+                _ = next_tick(&mut actor.subagent_tick) => actor.publish_subagent_rows(),
+                _ = ext_ready(&mut actor.ext_ready) => {
+                    actor.ext_ready = None;
+                    let id = actor.conv.session.id.clone();
+                    crate::extensions::loader::emit_session_start(actor.runtime.hook_bus(), &id).await;
+                    actor.publish_view().await;
+                },
                 ev = next_stream_event(&mut actor.stream) => match ev {
                     Some(ev) => actor.on_stream_event(ev).await,
                     None => {

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -862,7 +862,7 @@ impl SessionActor {
     /// dispatch.rs Abort (:134-192) verbatim minus presentation, behind the
     /// TUI's `if streaming` guard (input.rs:350): a `Cancel` while idle is a
     /// no-op that only re-announces `Idle` — it must never touch
-    /// `abort_context`, save, or emit "aborted".
+    /// `abort_context`, save, or emit `Aborted`.
     pub(crate) async fn cancel_turn(&mut self) {
         if !self.streaming {
             if self.compact.is_some() {
@@ -912,12 +912,10 @@ impl SessionActor {
                 }
             }
         }
-        let abort_msg = if self.conv.abort_context.is_some() {
-            "aborted — context saved for next message"
-        } else {
-            "aborted"
-        };
-        self.emit(SessionEventWire::SystemNotice(abort_msg.to_string()));
+        // Typed event; clients render "aborted[ — context saved …]".
+        self.emit(SessionEventWire::Aborted {
+            context_saved: self.conv.abort_context.is_some(),
+        });
         self.save().await;
         self.emit_conversation();
         self.emit(SessionEventWire::Idle);
@@ -1774,8 +1772,8 @@ impl SessionActor {
             SessionCommand::Cancel => self.cancel_turn().await,
             SessionCommand::Answer { prompt_id, value } => self.answer(prompt_id, value),
             SessionCommand::Set { id, setting } => self.apply_setting(id, setting).await,
+            // `CompactionStarted` is the contract; no notice before it.
             SessionCommand::Compact { instructions } => {
-                self.emit(SessionEventWire::SystemNotice("compacting...".into()));
                 self.compact(instructions, "manual").await;
             }
             SessionCommand::NewSession => {
@@ -1783,10 +1781,9 @@ impl SessionActor {
                 self.runtime
                     .set_session_id(Some(self.conv.session.id.clone()));
                 self.journal_id.store(Arc::new(self.conv.session.id.clone()));
-                self.emit(SessionEventWire::SystemNotice(format!(
-                    "session cleared → {}",
-                    &self.conv.session.id[..8.min(self.conv.session.id.len())]
-                )));
+                self.emit(SessionEventWire::Cleared {
+                    session_id: self.conv.session.id.clone(),
+                });
                 self.emit_conversation();
             }
             SessionCommand::Save => self.save().await,

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -63,11 +63,11 @@ const TURN_REPLAY_CAP: usize = 4096;
 /// `start_turn` and holds the current turn only. The actor's content is
 /// the narrower, arguably correct one.
 #[derive(Default)]
-struct TurnLog {
+pub(crate) struct TurnLog {
     parts: Vec<TurnPart>,
 }
 
-enum TurnPart {
+pub(crate) enum TurnPart {
     Thinking(String),
     Text(String),
     ToolUse { name: String, input: String },
@@ -160,36 +160,40 @@ impl TurnLog {
 }
 
 pub struct SessionActor {
-    id: SessionId,
-    meta: SessionMeta,
-    config: SessionConfig,
+    pub(crate) id: SessionId,
+    pub(crate) meta: SessionMeta,
+    pub(crate) config: SessionConfig,
     /// THE runtime; `session_id` + `cwd` set by `create`.
-    runtime: Runtime,
-    conv: ConversationState,
+    pub(crate) runtime: Runtime,
+    pub(crate) conv: ConversationState,
     // ── turn machine: the run() loop locals + App fields ──
-    stream: Option<ActiveStream>,
-    cancel: Option<CancellationToken>,
-    steer_tx: Option<mpsc::UnboundedSender<String>>,
-    streaming: bool,
-    turn_baseline: usize,
-    consecutive_auto_turns: u32,
-    turn_log: TurnLog,
+    pub(crate) stream: Option<ActiveStream>,
+    pub(crate) cancel: Option<CancellationToken>,
+    pub(crate) steer_tx: Option<mpsc::UnboundedSender<String>>,
+    pub(crate) streaming: bool,
+    pub(crate) turn_baseline: usize,
+    pub(crate) consecutive_auto_turns: u32,
+    pub(crate) turn_log: TurnLog,
     // ── prompts ──
-    secret_prompt_handle: SecretPromptHandle,
-    secret_prompt_rx: mpsc::UnboundedReceiver<SecretPromptRequest>,
+    pub(crate) secret_prompt_handle: SecretPromptHandle,
+    pub(crate) secret_prompt_rx: mpsc::UnboundedReceiver<SecretPromptRequest>,
     /// Held across detach; replayed in `AttachSnapshot.pending_prompts`.
-    pending_prompts: VecDeque<(PromptRequest, oneshot::Sender<Option<String>>)>,
-    next_prompt_id: u64,
+    pub(crate) pending_prompts: VecDeque<(PromptRequest, oneshot::Sender<Option<String>>)>,
+    pub(crate) next_prompt_id: u64,
     // ── clients ──
-    cmd_rx: mpsc::Receiver<SessionCommand>,
-    events: broadcast::Sender<Envelope>,
-    view: Arc<arc_swap::ArcSwap<RuntimeView>>,
-    attached: HashMap<ClientId, ClientMeta>,
-    next_client_id: u64,
-    seq: u64,
-    turn_replay: VecDeque<Envelope>,
-    state: AttachState,
-    background: BackgroundTasks,
+    pub(crate) cmd_rx: mpsc::Receiver<Addressed>,
+    pub(crate) events: broadcast::Sender<Envelope>,
+    pub(crate) view: Arc<arc_swap::ArcSwap<RuntimeView>>,
+    pub(crate) attached: HashMap<ClientId, ClientMeta>,
+    pub(crate) next_client_id: u64,
+    pub(crate) seq: u64,
+    pub(crate) turn_replay: VecDeque<Envelope>,
+    pub(crate) state: AttachState,
+    pub(crate) background: BackgroundTasks,
+    /// Mirrors `handle.lifecycle()` (B3 writes Parking/Parked).
+    pub(crate) lifecycle: Arc<std::sync::atomic::AtomicU8>,
+    /// Mirrors `handle.journal_id()` (B2 stores the successor id).
+    pub(crate) journal_id: Arc<arc_swap::ArcSwap<String>>,
 }
 
 impl SessionActor {
@@ -223,6 +227,7 @@ impl SessionActor {
             &config,
             &sb.session,
             cfg.cwd.clone(),
+            crate::engine::setup::IndexRecord::Start,
         );
 
         // C2: per-session on_session_start (keyed injection) once the
@@ -248,6 +253,11 @@ impl SessionActor {
             continued: sb.continued,
             continue_info: sb.continue_info.as_ref().map(ContinueInfoWire::from),
             host_pid: std::process::id(),
+            lifecycle: SessionLifecycle::Live,
+            clients: 0,
+            input_owner: None,
+            awaiting_input: 0,
+            journal_id: sb.session.id.clone(),
         };
         let mut conv = if sb.continued {
             ConversationState::from_resumed(sb.session)
@@ -261,8 +271,16 @@ impl SessionActor {
         conv.abort_context = sb.abort_context;
 
         let view = RuntimeView::from_runtime(&runtime).await;
-        let (handle, SessionEndpoints { cmd_rx, events, view }) =
-            SessionHandle::new(meta.clone(), view);
+        let (
+            handle,
+            SessionEndpoints {
+                cmd_rx,
+                events,
+                view,
+                lifecycle,
+                journal_id,
+            },
+        ) = SessionHandle::new(meta.clone(), view);
         let (sp_tx, secret_prompt_rx) = mpsc::unbounded_channel();
 
         let actor = SessionActor {
@@ -291,6 +309,8 @@ impl SessionActor {
             turn_replay: VecDeque::new(),
             state: AttachState::Detached { running: false },
             background,
+            lifecycle,
+            journal_id,
         };
         Ok((handle, SessionTask(actor)))
     }
@@ -299,7 +319,7 @@ impl SessionActor {
 
     /// The ONLY seq++ site. Pushes to `turn_replay` while streaming, except
     /// prompt traffic (never replayed) and per-client replies.
-    fn emit(&mut self, event: SessionEventWire) {
+    pub(crate) fn emit(&mut self, event: SessionEventWire) {
         let replay = self.streaming
             && !matches!(
                 event,
@@ -325,23 +345,23 @@ impl SessionActor {
         let _ = self.events.send(env);
     }
 
-    fn emit_conversation(&mut self) {
+    pub(crate) fn emit_conversation(&mut self) {
         let snap = self.conv.snapshot(self.consecutive_auto_turns);
         self.emit(SessionEventWire::Conversation(snap));
     }
 
-    async fn publish_view(&mut self) {
+    pub(crate) async fn publish_view(&mut self) {
         let v = RuntimeView::from_runtime(&self.runtime).await;
         self.view.store(Arc::new(v));
     }
 
-    async fn save(&mut self) {
+    pub(crate) async fn save(&mut self) {
         if self.config.persist {
             self.conv.save().await;
         }
     }
 
-    fn update_attach_state(&mut self) {
+    pub(crate) fn update_attach_state(&mut self) {
         self.state = if self.attached.is_empty() {
             AttachState::Detached {
                 running: self.streaming,
@@ -353,7 +373,7 @@ impl SessionActor {
 
     // ── turn start (dispatch.rs Submit tail / stream_handler.rs RunTurn) ──
 
-    async fn start_turn(&mut self, trigger: TurnTrigger) {
+    pub(crate) async fn start_turn(&mut self, trigger: TurnTrigger, user_text: Option<String>) {
         let ct = CancellationToken::new();
         let (s_tx, s_rx) = mpsc::unbounded_channel::<String>();
         self.streaming = true;
@@ -364,6 +384,7 @@ impl SessionActor {
         self.emit(SessionEventWire::TurnStarted {
             turn_baseline: self.turn_baseline,
             trigger,
+            user_text,
         });
         // Blocks command processing during setup exactly like the TUI loop.
         let stream = self
@@ -384,7 +405,7 @@ impl SessionActor {
     /// Every turn-end path (Done/Error/Cancel/stream EOF). Clears `turn_log`
     /// too: a `Cancel` racing a `Done` must not scrape the finished turn into
     /// `abort_context`.
-    fn clear_stream(&mut self) {
+    pub(crate) fn clear_stream(&mut self) {
         self.stream = None;
         self.cancel = None;
         self.steer_tx = None;
@@ -394,7 +415,7 @@ impl SessionActor {
     }
 
     /// dispatch.rs Submit (:1231-1288) minus presentation.
-    async fn submit(&mut self, text: String) {
+    pub(crate) async fn submit(&mut self, text: String) {
         if self.streaming {
             // A Submit while streaming is what the TUI calls StreamingInput.
             self.steer(text);
@@ -413,11 +434,11 @@ impl SessionActor {
         self.conv.api_messages.push(std::sync::Arc::new(
             serde_json::json!({"role": "user", "content": api_content}),
         ));
-        self.start_turn(TurnTrigger::User).await;
+        self.start_turn(TurnTrigger::User, None).await;
     }
 
     /// dispatch.rs StreamingInput plain-text branch (:1369-1378).
-    fn steer(&mut self, text: String) {
+    pub(crate) fn steer(&mut self, text: String) {
         let delivered = self
             .steer_tx
             .as_ref()
@@ -434,7 +455,7 @@ impl SessionActor {
     /// TUI's `if streaming` guard (input.rs:350): a `Cancel` while idle is a
     /// no-op that only re-announces `Idle` — it must never touch
     /// `abort_context`, save, or emit "aborted".
-    async fn cancel_turn(&mut self) {
+    pub(crate) async fn cancel_turn(&mut self) {
         if !self.streaming {
             self.emit(SessionEventWire::Idle);
             return;
@@ -523,7 +544,7 @@ impl SessionActor {
                     tracing::warn!("handle_event_arm: RunTurn with active stream — skipping");
                 } else {
                     self.consecutive_auto_turns += 1;
-                    self.start_turn(TurnTrigger::EventAuto).await;
+                    self.start_turn(TurnTrigger::EventAuto, None).await;
                 }
             }
             WakeAction::Forward => {
@@ -660,6 +681,7 @@ impl SessionActor {
                 }
                 // Auto-send the queued message (user-authored — reset counter)
                 self.consecutive_auto_turns = 0;
+                let user_text = queued.clone();
                 let api_content = if let Some(ref ctx) = self.conv.abort_context {
                     let combined = format!("{}\n\n{}", ctx, queued);
                     self.conv.abort_context = None;
@@ -670,7 +692,7 @@ impl SessionActor {
                 self.conv.api_messages.push(std::sync::Arc::new(
                     serde_json::json!({"role": "user", "content": api_content}),
                 ));
-                self.start_turn(TurnTrigger::QueuedAuto).await;
+                self.start_turn(TurnTrigger::QueuedAuto, Some(user_text)).await;
             }
             After::AutoTriggerEvents => {
                 if self.config.auto_compact {
@@ -678,7 +700,7 @@ impl SessionActor {
                 }
                 // Central claim gate: allows turns 1-5, denies the 6th.
                 if claim_auto_turn(&mut self.consecutive_auto_turns) {
-                    self.start_turn(TurnTrigger::EventAuto).await;
+                    self.start_turn(TurnTrigger::EventAuto, None).await;
                 } else {
                     self.emit(SessionEventWire::AutoTurnCapReached { cap: AUTO_TURN_CAP });
                     self.emit(SessionEventWire::Idle);
@@ -702,7 +724,7 @@ impl SessionActor {
 
     /// chat.rs `/compact` + auto-compaction body (inline; the TUI's spawned
     /// compaction task is day 2).
-    async fn compact(&mut self, instructions: Option<String>, source: &str) {
+    pub(crate) async fn compact(&mut self, instructions: Option<String>, source: &str) {
         self.emit(SessionEventWire::SystemNotice(format!(
             "[{}]",
             preview_compaction_disclosure(&self.runtime, &self.conv.api_messages).render_line()
@@ -773,7 +795,7 @@ impl SessionActor {
 
     // ── settings / queries / engine commands ─────────────────────────────
 
-    async fn apply_setting(&mut self, setting: SessionSetting) {
+    pub(crate) async fn apply_setting(&mut self, id: u64, setting: SessionSetting) {
         let name = match &setting {
             SessionSetting::Model { .. } => "model",
             SessionSetting::ReasoningLevel { .. } => "reasoning_level",
@@ -789,11 +811,16 @@ impl SessionActor {
             SessionSetting::GrantWorkerModel { .. } => "grant_worker_model",
         };
         let rt = &mut self.runtime;
+        let mut clamp_wire = None;
         let result: std::result::Result<Option<String>, String> = match setting {
             SessionSetting::Model { model } => rt.try_set_model(model).map(|clamp| {
                 self.conv.session.model = rt.model().to_string();
                 clamp.map(|c| {
                     self.conv.session.thinking_level = rt.thinking_level().to_string();
+                    clamp_wire = Some(ReasoningClampWire {
+                        from: c.from.as_str().to_string(),
+                        to: c.to.as_str().to_string(),
+                    });
                     format!(
                         "thinking → {} (clamped from {}: not supported by {})",
                         c.to.as_str(),
@@ -855,14 +882,16 @@ impl SessionActor {
             Err(e) => (false, Some(e)),
         };
         self.emit(SessionEventWire::SettingChanged(SettingApplied {
+            id,
             setting: name.to_string(),
             ok,
             message,
             view,
+            clamp: clamp_wire,
         }));
     }
 
-    async fn query(&mut self, id: u64, query: SessionQuery) {
+    pub(crate) async fn query(&mut self, id: u64, query: SessionQuery) {
         let value = match query {
             SessionQuery::Status => serde_json::json!({
                 "session": self.conv.session.id,
@@ -913,59 +942,20 @@ impl SessionActor {
                     "should_compact": a.should_compact(),
                 })
             }
-        };
-        self.emit(SessionEventWire::QueryResult { id, value });
-    }
-
-    /// `engine::commands::handle_engine_command` on THE runtime; reply as a
-    /// `QueryResult` the client renders (chat.rs slash-command branch).
-    async fn engine_command(&mut self, id: u64, cmd: String, arg: String) {
-        use crate::engine::commands::{handle_engine_command, CommandResult};
-        let value = match handle_engine_command(&cmd, &arg, &mut self.runtime) {
-            None => serde_json::json!({ "kind": "unhandled" }),
-            Some(CommandResult::Quit) => serde_json::json!({ "kind": "quit" }),
-            Some(CommandResult::ModelChanged {
-                model,
-                reasoning_clamped,
-            }) => {
-                self.conv.session.model = self.runtime.model().to_string();
-                let mut text = format!("model → {}", model);
-                if let Some(clamp) = reasoning_clamped {
-                    self.conv.session.thinking_level = self.runtime.thinking_level().to_string();
-                    text.push_str(&format!(
-                        "\nthinking → {} (clamped from {}: not supported by {})",
-                        clamp.to.as_str(),
-                        clamp.from.as_str(),
-                        self.runtime.model()
-                    ));
+            SessionQuery::ContextReport => {
+                use crate::engine::commands::{context_command, CommandResult};
+                match context_command(&self.runtime, Some(&self.conv.api_messages)) {
+                    CommandResult::Output(text) => serde_json::json!({ "text": text }),
+                    other => serde_json::json!({ "unsupported": format!("{other:?}") }),
                 }
-                self.publish_view().await;
-                serde_json::json!({ "kind": "notice", "text": text })
             }
-            Some(CommandResult::ThinkingChanged { spec }) => {
-                self.conv.session.thinking_level = spec.config_value();
-                self.publish_view().await;
-                serde_json::json!({ "kind": "notice", "text": format!("thinking → {}", spec.level()) })
-            }
-            Some(CommandResult::Compact {
-                custom_instructions,
-            }) => {
-                self.emit(SessionEventWire::SystemNotice("compacting...".into()));
-                self.compact(custom_instructions, "manual").await;
-                serde_json::json!({ "kind": "none" })
-            }
-            Some(CommandResult::Error(e)) => serde_json::json!({ "kind": "error", "text": e }),
-            Some(CommandResult::Output(text)) => {
-                serde_json::json!({ "kind": "output", "text": text })
-            }
-            Some(_) => serde_json::json!({ "kind": "none" }),
         };
         self.emit(SessionEventWire::QueryResult { id, value });
     }
 
     // ── attach / detach ──────────────────────────────────────────────────
 
-    fn snapshot(&self) -> AttachSnapshot {
+    pub(crate) fn snapshot(&self) -> AttachSnapshot {
         AttachSnapshot {
             meta: self.meta.clone(),
             view: (**self.view.load()).clone(),
@@ -974,6 +964,7 @@ impl SessionActor {
             replay: self.turn_replay.iter().cloned().collect(),
             pending_prompts: self.pending_prompts.iter().map(|(p, _)| p.clone()).collect(),
             clients: self.attached.iter().map(|(c, m)| (*c, m.kind)).collect(),
+            input_owner: None,
         }
     }
 
@@ -1007,8 +998,11 @@ impl SessionActor {
 
     // ── command dispatch ─────────────────────────────────────────────────
 
-    async fn handle(&mut self, cmd: SessionCommand) -> std::ops::ControlFlow<EndReason> {
+    /// `from` is carried for B1 (input ownership); today every sender is
+    /// honoured.
+    async fn handle(&mut self, addressed: Addressed) -> std::ops::ControlFlow<EndReason> {
         use std::ops::ControlFlow;
+        let Addressed { from: _from, cmd } = addressed;
         match cmd {
             SessionCommand::Submit { text, .. } => self.submit(text).await,
             SessionCommand::Steer { text } => {
@@ -1020,7 +1014,7 @@ impl SessionActor {
             }
             SessionCommand::Cancel => self.cancel_turn().await,
             SessionCommand::Answer { prompt_id, value } => self.answer(prompt_id, value),
-            SessionCommand::Set(setting) => self.apply_setting(setting).await,
+            SessionCommand::Set { id, setting } => self.apply_setting(id, setting).await,
             SessionCommand::Compact { instructions } => {
                 self.emit(SessionEventWire::SystemNotice("compacting...".into()));
                 self.compact(instructions, "manual").await;
@@ -1046,6 +1040,24 @@ impl SessionActor {
             SessionCommand::Resync { .. } => self.emit(SessionEventWire::SystemNotice(
                 "resync not supported yet".into(),
             )),
+            // Phase-3 stubs: A3 (SubmitPrepared/PluginCommand/Resume), B1
+            // (Checkpoint), B3 (KeepWarm) fill these in.
+            SessionCommand::SubmitPrepared { .. } => self.emit(SessionEventWire::SystemNotice(
+                "submit_prepared: not implemented in this build".into(),
+            )),
+            SessionCommand::PluginCommand { id, .. } => self.emit(SessionEventWire::QueryResult {
+                id,
+                value: serde_json::json!({ "kind": "error", "text": "plugin_command: not implemented in this build" }),
+            }),
+            SessionCommand::Resume { .. } => self.emit(SessionEventWire::SystemNotice(
+                "resume: not implemented in this build".into(),
+            )),
+            SessionCommand::Checkpoint { .. } => self.emit(SessionEventWire::SystemNotice(
+                "checkpoint: not implemented in this build".into(),
+            )),
+            SessionCommand::KeepWarm { .. } => self.emit(SessionEventWire::SystemNotice(
+                "keep_warm: not implemented in this build".into(),
+            )),
             SessionCommand::HostEvent(ev) => match ev {
                 HostEvent::ExtensionNotification {
                     extension_id,
@@ -1065,6 +1077,10 @@ impl SessionActor {
     // ── teardown (tui/mod.rs:352-432 + chat.rs shutdown) ─────────────────
 
     async fn finish(&mut self, reason: EndReason) {
+        self.lifecycle.store(
+            SessionLifecycle::Ending as u8,
+            std::sync::atomic::Ordering::Release,
+        );
         if self.streaming {
             self.cancel_turn().await;
         }

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -159,6 +159,89 @@ impl TurnLog {
     }
 }
 
+/// A field that is `None` exactly while the session is `Parked` (B3).
+/// Derefs to the value so the turn machine reads `self.runtime` / `self.conv`
+/// unchanged; every command that needs them goes through `ensure_live()`
+/// first, so the panic path is a programming error, not a runtime state.
+pub(crate) struct Live<T>(Option<T>);
+
+impl<T> Live<T> {
+    pub(crate) fn new(v: T) -> Self {
+        Self(Some(v))
+    }
+    pub(crate) fn is_live(&self) -> bool {
+        self.0.is_some()
+    }
+    pub(crate) fn park_take(&mut self) -> Option<T> {
+        self.0.take()
+    }
+    pub(crate) fn unpark_set(&mut self, v: T) {
+        self.0 = Some(v);
+    }
+}
+
+impl<T> std::ops::Deref for Live<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.0.as_ref().expect("session is parked: runtime/conv unavailable")
+    }
+}
+
+impl<T> std::ops::DerefMut for Live<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.0.as_mut().expect("session is parked: runtime/conv unavailable")
+    }
+}
+
+/// `SYNAPS_DAEMON_PARK_GRACE_SECS`: `never` → `None` (Parked disabled);
+/// `n` → n seconds after the last detach once idle; default 60.
+pub fn park_grace() -> Option<std::time::Duration> {
+    match std::env::var("SYNAPS_DAEMON_PARK_GRACE_SECS") {
+        Ok(v) if v.trim().eq_ignore_ascii_case("never") => None,
+        Ok(v) => v
+            .trim()
+            .parse::<u64>()
+            .ok()
+            .map(std::time::Duration::from_secs)
+            .or(Some(DEFAULT_PARK_GRACE)),
+        Err(_) => Some(DEFAULT_PARK_GRACE),
+    }
+}
+
+pub const DEFAULT_PARK_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Non-persisted runtime knobs replayed after unpark (last-wins per
+/// variant). Model/reasoning/system prompt live in the journal already.
+fn replayable(setting: &SessionSetting) -> bool {
+    matches!(
+        setting,
+        SessionSetting::ContextWindow { .. }
+            | SessionSetting::CompactionModel { .. }
+            | SessionSetting::ApiRetries { .. }
+            | SessionSetting::SubagentTimeout { .. }
+            | SessionSetting::MaxToolOutput { .. }
+            | SessionSetting::BashTimeout { .. }
+            | SessionSetting::BashMaxTimeout { .. }
+            | SessionSetting::GrantWorkerModel { .. }
+    )
+}
+
+fn replay_setting(rt: &mut Runtime, setting: &SessionSetting) {
+    match setting {
+        SessionSetting::ContextWindow { tokens } => rt.set_context_window(*tokens),
+        SessionSetting::CompactionModel { model } => rt.set_compaction_model(model.clone()),
+        SessionSetting::ApiRetries { n } => rt.set_api_retries(*n),
+        SessionSetting::SubagentTimeout { secs } => rt.set_subagent_timeout(*secs),
+        SessionSetting::MaxToolOutput { bytes } => rt.set_max_tool_output(*bytes),
+        SessionSetting::BashTimeout { secs } => rt.set_bash_timeout(*secs),
+        SessionSetting::BashMaxTimeout { secs } => rt.set_bash_max_timeout(*secs),
+        SessionSetting::GrantWorkerModel { model } => {
+            let _ = rt.grant_worker_model(model);
+        }
+        _ => {}
+    }
+}
+
 /// One attached client: its meta + the mode it attached with (B1 ownership
 /// needs the mode to pick the next owner when the owner detaches).
 pub(crate) struct AttachedClient {
@@ -226,9 +309,22 @@ pub struct SessionActor {
     pub(crate) id: SessionId,
     pub(crate) meta: SessionMeta,
     pub(crate) config: SessionConfig,
-    /// THE runtime; `session_id` + `cwd` set by `create`.
-    pub(crate) runtime: Runtime,
-    pub(crate) conv: ConversationState,
+    /// THE runtime; `session_id` + `cwd` set by `create`. `None` ⇔ Parked.
+    pub(crate) runtime: Live<Runtime>,
+    /// `None` ⇔ Parked.
+    pub(crate) conv: Live<ConversationState>,
+    /// B3: unpark needs a fresh `foreground_runtime()`.
+    pub(crate) host: Arc<EngineHost>,
+    /// Kept across Park (`finish()` needs it without a Runtime).
+    pub(crate) hook_bus: Arc<crate::extensions::hooks::HookBus>,
+    /// Session-lifetime queue; `background` pushes into it, every Runtime
+    /// this actor builds is pointed at it (`Runtime::set_event_queue`).
+    pub(crate) event_queue: Arc<crate::events::EventQueue>,
+    /// Last-wins per variant; replayed after unpark (non-persisted knobs).
+    pub(crate) settings_replay: Vec<SessionSetting>,
+    pub(crate) keep_warm: bool,
+    /// Armed on last-detach-while-idle / idle-while-detached.
+    pub(crate) park_deadline: Option<tokio::time::Instant>,
     // ── turn machine: the run() loop locals + App fields ──
     pub(crate) stream: Option<ActiveStream>,
     pub(crate) cancel: Option<CancellationToken>,
@@ -362,6 +458,9 @@ impl SessionActor {
         conv.abort_context = sb.abort_context;
 
         let view = RuntimeView::from_runtime(&runtime).await;
+        let hook_bus = Arc::clone(runtime.hook_bus());
+        let event_queue = Arc::clone(runtime.event_queue());
+        let keep_warm = cfg.keep_warm;
         let (
             handle,
             SessionEndpoints {
@@ -378,8 +477,14 @@ impl SessionActor {
             id,
             meta,
             config: cfg,
-            runtime,
-            conv,
+            runtime: Live::new(runtime),
+            conv: Live::new(conv),
+            host: Arc::clone(host),
+            hook_bus,
+            event_queue,
+            settings_replay: Vec::new(),
+            keep_warm,
+            park_deadline: None,
             stream: None,
             cancel: None,
             steer_tx: None,
@@ -451,12 +556,17 @@ impl SessionActor {
     }
 
     pub(crate) async fn save(&mut self) {
-        if self.config.persist {
+        if self.config.persist && self.conv.is_live() {
             self.conv.save().await;
         }
     }
 
+    /// Recomputes `state` from clients/streaming and (re)arms or disarms the
+    /// park grace timer. A no-op while Parking/Parked.
     pub(crate) fn update_attach_state(&mut self) {
+        if matches!(self.state, AttachState::Parking | AttachState::Parked) {
+            return;
+        }
         self.state = if self.attached.is_empty() {
             AttachState::Detached {
                 running: self.streaming,
@@ -464,6 +574,158 @@ impl SessionActor {
         } else {
             AttachState::Attached(self.attached.len())
         };
+        self.rearm_park();
+    }
+
+    // ── Parked (B3) ──────────────────────────────────────────────────────
+
+    pub(crate) fn is_parked(&self) -> bool {
+        matches!(self.state, AttachState::Parked)
+    }
+
+    pub(crate) fn can_park(&self) -> bool {
+        self.attached.is_empty()
+            && !self.streaming
+            && self.compact.is_none()
+            && self.pending_prompts.is_empty()
+            && self.conv.is_live()
+            && self.conv.queued_message.is_none()
+            && !self.keep_warm
+            && self.config.persist
+            && !self.is_parked()
+    }
+
+    fn rearm_park(&mut self) {
+        if !self.can_park() {
+            self.park_deadline = None;
+            return;
+        }
+        match park_grace() {
+            Some(grace) => {
+                if self.park_deadline.is_none() {
+                    self.park_deadline = Some(tokio::time::Instant::now() + grace);
+                }
+            }
+            None => self.park_deadline = None,
+        }
+    }
+
+    fn set_lifecycle(&mut self, l: SessionLifecycle) {
+        self.lifecycle
+            .store(l as u8, std::sync::atomic::Ordering::Release);
+        self.emit(SessionEventWire::Lifecycle(l));
+    }
+
+    /// Save, close PTYs, drop `conv` THEN `runtime`. `background` (inbox
+    /// watcher + per-session UDS + registry) stays: `synaps send` keeps
+    /// resolving and its push into `event_queue` is the wake-up.
+    pub(crate) async fn park(&mut self) {
+        self.park_deadline = None;
+        if !self.can_park() {
+            return;
+        }
+        self.state = AttachState::Parking;
+        self.set_lifecycle(SessionLifecycle::Parking);
+        if tokio::time::timeout(budgets::SAVE_TIMEOUT, self.save())
+            .await
+            .is_err()
+        {
+            tracing::warn!(session = %self.id, "park: save timed out — staying live");
+            self.state = AttachState::Detached { running: false };
+            self.set_lifecycle(SessionLifecycle::Live);
+            return;
+        }
+        if self.runtime.session_manager().active_count() > 0 {
+            self.emit(SessionEventWire::SystemNotice(
+                "parked: background shells closed".into(),
+            ));
+        }
+        self.runtime.session_manager().shutdown_all();
+        self.turn_replay.clear();
+        // Drop order: conv first, then runtime — a panic between them can
+        // never leave a Runtime without state to save.
+        let conv = self.conv.park_take();
+        drop(conv);
+        let runtime = self.runtime.park_take();
+        drop(runtime);
+        self.state = AttachState::Parked;
+        self.set_lifecycle(SessionLifecycle::Parked);
+        tracing::info!(session = %self.id, "session parked");
+    }
+
+    /// Rebuild `runtime` + `conv` from the journal (`load_session_in_dir`
+    /// via `resolve_session_and_prompt`), replay non-persisted settings,
+    /// `finish_session_setup(IndexRecord::Skip)`. On error the session
+    /// stays Parked (nothing is half-built).
+    pub(crate) async fn unpark(&mut self) -> Result<()> {
+        let started = std::time::Instant::now();
+        let journal_id = (**self.journal_id.load()).clone();
+        let host = Arc::clone(&self.host);
+        let cfg = self.config.clone();
+        let queue = Arc::clone(&self.event_queue);
+        let replay = self.settings_replay.clone();
+        let build = async move {
+            let config: crate::SynapsConfig = (**host.config()).clone();
+            let mut runtime = host.foreground_runtime().await?;
+            runtime.set_event_queue(queue);
+            let sb = crate::engine::setup::resolve_session_and_prompt(
+                &mut runtime,
+                &Some(Some(journal_id)),
+                cfg.system.as_deref(),
+                cfg.prompt_manifest.as_deref(),
+            )?;
+            runtime.set_cwd(cfg.cwd.clone());
+            if let Some(ref m) = cfg.model_override {
+                runtime.set_model(m.clone());
+            }
+            crate::engine::setup::finish_session_setup(
+                &mut runtime,
+                &config,
+                &sb.session,
+                cfg.cwd.clone(),
+                crate::engine::setup::IndexRecord::Skip,
+            );
+            for s in &replay {
+                replay_setting(&mut runtime, s);
+            }
+            Ok::<_, crate::RuntimeError>((runtime, sb))
+        };
+        let (runtime, sb) = match tokio::time::timeout(budgets::UNPARK_TIMEOUT, build).await {
+            Ok(Ok(v)) => v,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                return Err(crate::RuntimeError::Session(format!(
+                    "unpark timed out after {}s",
+                    budgets::UNPARK_TIMEOUT_SECS
+                )))
+            }
+        };
+        let mut conv = ConversationState::from_resumed(sb.session);
+        conv.api_messages = sb.api_messages;
+        conv.total_input_tokens = sb.total_input_tokens;
+        conv.total_output_tokens = sb.total_output_tokens;
+        conv.session_cost = sb.session_cost;
+        conv.abort_context = sb.abort_context;
+        self.runtime.unpark_set(runtime);
+        self.conv.unpark_set(conv);
+        self.publish_view().await;
+        self.state = AttachState::Detached { running: false };
+        self.set_lifecycle(SessionLifecycle::Live);
+        self.update_attach_state();
+        tracing::info!(session = %self.id, ms = started.elapsed().as_millis() as u64, "session unparked");
+        Ok(())
+    }
+
+    /// Unpark if Parked. `Err` = still Parked; the caller reports it
+    /// (`Refused` to a client, `AttachRefused` to an attacher, a warning
+    /// for host wakes).
+    pub(crate) async fn ensure_live(&mut self) -> std::result::Result<(), String> {
+        if !self.is_parked() {
+            return Ok(());
+        }
+        self.unpark()
+            .await
+            .map_err(|e| format!("session parked and could not be restored: {e}"))
     }
 
     /// `stream_handler.rs:264`: a turn OR a compaction blocks auto-turns.
@@ -588,13 +850,15 @@ impl SessionActor {
             self.emit(SessionEventWire::Dequeued { text: q });
         }
         // Flush any events that arrived during streaming
-        for formatted in self.conv.pending_events.drain(..) {
-            self.conv
-                .api_messages
-                .push(std::sync::Arc::new(serde_json::json!({
-                    "role": "user",
-                    "content": formatted
-                })));
+        {
+            let conv: &mut ConversationState = &mut self.conv;
+            for formatted in conv.pending_events.drain(..) {
+                conv.api_messages
+                    .push(std::sync::Arc::new(serde_json::json!({
+                        "role": "user",
+                        "content": formatted
+                    })));
+            }
         }
         self.clear_stream();
         // Cancel all running reactive subagents; recover a poisoned guard
@@ -629,11 +893,21 @@ impl SessionActor {
     // ── event-queue wake (stream_handler.rs handle_event_queue_arm) ──────
 
     async fn on_queue_wake(&mut self) {
+        if self.is_parked() {
+            if self.event_queue.is_empty() {
+                return;
+            }
+            if let Err(e) = self.ensure_live().await {
+                tracing::warn!(session = %self.id, error = %e, "event wake could not unpark; events stay queued");
+                return;
+            }
+        }
         let busy = self.busy();
+        let conv: &mut ConversationState = &mut self.conv;
         let drained = drain_event_queue(
-            self.runtime.event_queue(),
-            &mut self.conv.api_messages,
-            &mut self.conv.pending_events,
+            &self.event_queue,
+            &mut conv.api_messages,
+            &mut conv.pending_events,
             busy,
             self.steer_tx.as_ref(),
         );
@@ -754,13 +1028,15 @@ impl SessionActor {
                 self.publish_subagent_rows();
                 // Flush events that arrived during streaming into api_messages
                 let had_pending = !self.conv.pending_events.is_empty();
-                for formatted in self.conv.pending_events.drain(..) {
-                    self.conv
-                        .api_messages
-                        .push(std::sync::Arc::new(serde_json::json!({
-                            "role": "user",
-                            "content": formatted
-                        })));
+                {
+                    let conv: &mut ConversationState = &mut self.conv;
+                    for formatted in conv.pending_events.drain(..) {
+                        conv.api_messages
+                            .push(std::sync::Arc::new(serde_json::json!({
+                                "role": "user",
+                                "content": formatted
+                            })));
+                    }
                 }
                 if let Some(queued) = self.conv.queued_message.take() {
                     after = After::AutoSendQueued(queued);
@@ -918,6 +1194,12 @@ impl SessionActor {
     // ── settings / queries / engine commands ─────────────────────────────
 
     pub(crate) async fn apply_setting(&mut self, id: u64, setting: SessionSetting) {
+        if replayable(&setting) {
+            let disc = std::mem::discriminant(&setting);
+            self.settings_replay
+                .retain(|s| std::mem::discriminant(s) != disc);
+            self.settings_replay.push(setting.clone());
+        }
         let name = match &setting {
             SessionSetting::Model { .. } => "model",
             SessionSetting::ReasoningLevel { .. } => "reasoning_level",
@@ -1014,10 +1296,32 @@ impl SessionActor {
     }
 
     pub(crate) async fn query(&mut self, id: u64, query: SessionQuery) {
+        // Status/View never wake a parked session (the idle probe must not).
+        if self.is_parked() {
+            let value = match query {
+                SessionQuery::Status => serde_json::json!({
+                    "session": (**self.journal_id.load()).clone(),
+                    "model": self.view.load().model,
+                    "lifecycle": SessionLifecycle::Parked,
+                    "streaming": false,
+                    "auto_turns": self.consecutive_auto_turns,
+                    "attached": 0,
+                    "pending_prompts": 0,
+                }),
+                SessionQuery::View => serde_json::to_value(&**self.view.load()).unwrap_or_default(),
+                _ => match self.ensure_live().await {
+                    Ok(()) => return Box::pin(self.query(id, query)).await,
+                    Err(e) => serde_json::json!({ "error": e }),
+                },
+            };
+            self.emit(SessionEventWire::QueryResult { id, value });
+            return;
+        }
         let value = match query {
             SessionQuery::Status => serde_json::json!({
                 "session": self.conv.session.id,
                 "model": self.runtime.model(),
+                "lifecycle": SessionLifecycle::from_u8(self.lifecycle.load(std::sync::atomic::Ordering::Acquire)),
                 "tokens": { "input": self.conv.total_input_tokens, "output": self.conv.total_output_tokens },
                 "cost": self.conv.session_cost,
                 "messages": self.conv.api_messages.len(),
@@ -1094,7 +1398,11 @@ impl SessionActor {
     /// (else read-only + notice); `Takeover` steals with
     /// `InputOwnerChanged{reason: Takeover}` to everyone (the old owner's
     /// client renders the toast).
-    fn attach(&mut self, client: ClientMeta, mode: AttachMode) {
+    async fn attach(&mut self, client: ClientMeta, mode: AttachMode) {
+        if let Err(e) = self.ensure_live().await {
+            self.emit(SessionEventWire::AttachRefused { message: e });
+            return;
+        }
         let cid = ClientId(self.next_client_id);
         self.next_client_id += 1;
         let kind = client.kind;
@@ -1235,6 +1543,47 @@ impl SessionActor {
                 return ControlFlow::Continue(());
             }
         }
+        // B3: anything that needs the runtime wakes a parked session first.
+        if self.is_parked() {
+            let needs_runtime = !matches!(
+                cmd,
+                SessionCommand::Attach { .. }
+                    | SessionCommand::Detach { .. }
+                    | SessionCommand::End { .. }
+                    | SessionCommand::Query { .. }
+                    | SessionCommand::Answer { .. }
+                    | SessionCommand::Save
+                    | SessionCommand::Cancel
+                    | SessionCommand::Checkpoint { .. }
+                    | SessionCommand::Resync { .. }
+                    | SessionCommand::HostEvent(_)
+            );
+            if matches!(cmd, SessionCommand::HostEvent(_)) {
+                return ControlFlow::Continue(()); // nobody attached, nothing to render
+            }
+            if matches!(cmd, SessionCommand::Save | SessionCommand::Cancel | SessionCommand::Checkpoint { .. }) {
+                if let SessionCommand::Checkpoint { .. } = cmd {
+                    self.emit(SessionEventWire::QueryResult {
+                        id: super::wire::CHECKPOINT_QUERY_ID,
+                        value: serde_json::json!({ "ok": true, "parked": true }),
+                    });
+                }
+                return ControlFlow::Continue(()); // already on disk / idle
+            }
+            if needs_runtime {
+                if let Err(e) = self.ensure_live().await {
+                    match from {
+                        Some(c) => self.emit(SessionEventWire::Refused {
+                            client: c,
+                            command: command_name(&cmd).to_string(),
+                            reason: e,
+                        }),
+                        None => self.emit(SessionEventWire::SystemNotice(e)),
+                    }
+                    return ControlFlow::Continue(());
+                }
+            }
+        }
         match cmd {
             SessionCommand::Submit { text, .. } => self.submit(text).await,
             SessionCommand::Steer { text } => {
@@ -1267,7 +1616,7 @@ impl SessionActor {
             SessionCommand::EngineCommand { id, name, arg } => {
                 self.engine_command(id, name, arg).await
             }
-            SessionCommand::Attach { client, mode } => self.attach(client, mode),
+            SessionCommand::Attach { client, mode } => self.attach(client, mode).await,
             SessionCommand::Detach { client } => self.detach(client),
             SessionCommand::End { reason } => return ControlFlow::Break(reason),
             SessionCommand::Resync { .. } => self.emit(SessionEventWire::SystemNotice(
@@ -1286,9 +1635,14 @@ impl SessionActor {
                 "resume: not implemented in this build".into(),
             )),
             SessionCommand::Checkpoint { reason } => self.checkpoint(reason).await,
-            SessionCommand::KeepWarm { .. } => self.emit(SessionEventWire::SystemNotice(
-                "keep_warm: not implemented in this build".into(),
-            )),
+            SessionCommand::KeepWarm { on } => {
+                self.keep_warm = on;
+                self.rearm_park();
+                self.emit(SessionEventWire::SystemNotice(format!(
+                    "keep-warm {}",
+                    if on { "on: this session will not be parked" } else { "off" }
+                )));
+            }
             SessionCommand::HostEvent(ev) => match ev {
                 HostEvent::ExtensionNotification {
                     extension_id,
@@ -1322,17 +1676,25 @@ impl SessionActor {
             self.emit(SessionEventWire::PromptResolved { prompt_id: pr.id });
         }
 
-        let session_id = self.conv.session.id.clone();
-        let api_messages = self.conv.api_messages.clone();
+        let parked = !self.conv.is_live();
+        let session_id = (**self.journal_id.load()).clone();
+        let api_messages = if parked {
+            None
+        } else {
+            Some(self.conv.api_messages.clone())
+        };
 
-        // STEP 1: save — own bounded budget, highest priority.
+        // STEP 1: save — own bounded budget, highest priority. A parked
+        // session is already on disk: end record only.
         let persist = self.config.persist;
         let save_fut = async {
             if persist {
-                self.conv.save().await;
+                if !parked {
+                    self.conv.save().await;
+                }
                 let mut index_record =
                     crate::core::session_index::SessionIndexRecord::end(&session_id);
-                index_record.turns = Some(api_messages.len());
+                index_record.turns = api_messages.as_ref().map(|m| m.len());
                 if let Err(err) = crate::core::session_index::append_record(&index_record) {
                     tracing::warn!("failed to append session end index record: {}", err);
                 }
@@ -1350,25 +1712,30 @@ impl SessionActor {
 
         // STEP 2 (C2): on_session_end — per session, concurrent, fail-open,
         // own budget; clears this session's keyed injection.
+        let hook_bus = Arc::clone(&self.hook_bus);
         crate::extensions::loader::emit_session_end(
-            self.runtime.hook_bus(),
+            &hook_bus,
             &session_id,
-            Some(api_messages),
+            api_messages,
             budgets::HOOKS_TIMEOUT,
         )
         .await;
 
-        // STEP 3: bounded observability flush.
-        if let Some(outcome) = self
-            .runtime
-            .shutdown_observability_async(crate::runtime::telemetry::DEFAULT_SHUTDOWN_FLUSH_TIMEOUT)
-            .await
-        {
-            if !outcome.is_flushed() {
-                tracing::warn!(
-                    stats = ?outcome.stats(),
-                    "observability flush timed out — detached worker keeps draining"
-                );
+        // STEP 3: bounded observability flush (live only).
+        if self.runtime.is_live() {
+            if let Some(outcome) = self
+                .runtime
+                .shutdown_observability_async(
+                    crate::runtime::telemetry::DEFAULT_SHUTDOWN_FLUSH_TIMEOUT,
+                )
+                .await
+            {
+                if !outcome.is_flushed() {
+                    tracing::warn!(
+                        stats = ?outcome.stats(),
+                        "observability flush timed out — detached worker keeps draining"
+                    );
+                }
             }
         }
 
@@ -1401,6 +1768,13 @@ async fn next_tick(tick: &mut Option<tokio::time::Interval>) {
     }
 }
 
+async fn park_timer(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(t) => tokio::time::sleep_until(t).await,
+        None => std::future::pending().await,
+    }
+}
+
 async fn ext_ready(rx: &mut Option<oneshot::Receiver<()>>) {
     match rx {
         Some(r) => {
@@ -1417,7 +1791,7 @@ impl SessionTask {
 
     /// Unbiased select (the TUI loop is unbiased too).
     pub async fn run(mut self) {
-        let queue = Arc::clone(self.0.runtime.event_queue());
+        let queue = Arc::clone(&self.0.event_queue);
         let reason = loop {
             let actor = &mut self.0;
             tokio::select! {
@@ -1433,11 +1807,15 @@ impl SessionTask {
                 Some(req) = actor.secret_prompt_rx.recv() => actor.on_prompt_request(req),
                 _ = queue.notified() => actor.on_queue_wake().await,
                 _ = next_tick(&mut actor.subagent_tick) => actor.publish_subagent_rows(),
+                _ = park_timer(actor.park_deadline) => actor.park().await,
                 _ = ext_ready(&mut actor.ext_ready) => {
                     actor.ext_ready = None;
-                    let id = actor.conv.session.id.clone();
-                    crate::extensions::loader::emit_session_start(actor.runtime.hook_bus(), &id).await;
-                    actor.publish_view().await;
+                    let id = (**actor.journal_id.load()).clone();
+                    let bus = Arc::clone(&actor.hook_bus);
+                    crate::extensions::loader::emit_session_start(&bus, &id).await;
+                    if actor.runtime.is_live() {
+                        actor.publish_view().await;
+                    }
                 },
                 ev = next_stream_event(&mut actor.stream) => match ev {
                     Some(ev) => actor.on_stream_event(ev).await,

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -661,6 +661,10 @@ impl SessionActor {
         drop(conv);
         let runtime = self.runtime.park_take();
         drop(runtime);
+        // Hand the freed pages back: jemalloc otherwise keeps them as
+        // dirty/muzzy for its decay window, and a parked session that
+        // still shows in RssAnon buys nothing.
+        crate::core::memstat::purge_arenas();
         self.state = AttachState::Parked;
         self.set_lifecycle(SessionLifecycle::Parked);
         tracing::info!(session = %self.id, "session parked");

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -211,11 +211,13 @@ pub fn park_grace() -> Option<std::time::Duration> {
 pub const DEFAULT_PARK_GRACE: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Non-persisted runtime knobs replayed after unpark (last-wins per
-/// variant). Model/reasoning/system prompt live in the journal already.
+/// variant). Model/reasoning live in the journal already; `/system` is
+/// runtime-only (never journaled) so it replays too (M7).
 fn replayable(setting: &SessionSetting) -> bool {
     matches!(
         setting,
-        SessionSetting::ContextWindow { .. }
+        SessionSetting::SystemPrompt { .. }
+            | SessionSetting::ContextWindow { .. }
             | SessionSetting::CompactionModel { .. }
             | SessionSetting::ApiRetries { .. }
             | SessionSetting::SubagentTimeout { .. }
@@ -228,6 +230,7 @@ fn replayable(setting: &SessionSetting) -> bool {
 
 fn replay_setting(rt: &mut Runtime, setting: &SessionSetting) {
     match setting {
+        SessionSetting::SystemPrompt { text } => rt.set_system_prompt(text.clone()),
         SessionSetting::ContextWindow { tokens } => rt.set_context_window(*tokens),
         SessionSetting::CompactionModel { model } => rt.set_compaction_model(model.clone()),
         SessionSetting::ApiRetries { n } => rt.set_api_retries(*n),
@@ -301,6 +304,7 @@ fn command_name(cmd: &SessionCommand) -> &'static str {
         SessionCommand::Resume { .. } => "resume",
         SessionCommand::Checkpoint { .. } => "checkpoint",
         SessionCommand::KeepWarm { .. } => "keep_warm",
+        SessionCommand::Park => "park",
         SessionCommand::HostEvent(_) => "host_event",
     }
 }
@@ -562,6 +566,21 @@ impl SessionActor {
     pub(crate) async fn save(&mut self) {
         if self.config.persist && self.conv.is_live() {
             self.conv.save().await;
+        }
+    }
+
+    /// C3: the checkpoint reply payload (`SessionReloadRecord`).
+    pub(crate) fn reload_record(&self) -> SessionReloadRecord {
+        let view = self.view.load();
+        SessionReloadRecord {
+            config: self.config.clone(),
+            keep_warm: self.keep_warm,
+            lifecycle: SessionLifecycle::from_u8(
+                self.lifecycle.load(std::sync::atomic::Ordering::Acquire),
+            ),
+            settings_replay: self.settings_replay.clone(),
+            model: view.model.clone(),
+            thinking_level: view.thinking_level.clone(),
         }
     }
 
@@ -1727,9 +1746,10 @@ impl SessionActor {
         };
         self.emit(SessionEventWire::SystemNotice(notice.to_string()));
         self.runtime.session_manager().shutdown_all();
+        let record = serde_json::to_value(self.reload_record()).unwrap_or_default();
         self.emit(SessionEventWire::QueryResult {
             id: super::wire::CHECKPOINT_QUERY_ID,
-            value: serde_json::json!({ "ok": true }),
+            value: serde_json::json!({ "ok": true, "record": record }),
         });
     }
 
@@ -1774,17 +1794,25 @@ impl SessionActor {
                     | SessionCommand::Save
                     | SessionCommand::Cancel
                     | SessionCommand::Checkpoint { .. }
+                    | SessionCommand::Park
                     | SessionCommand::Resync { .. }
                     | SessionCommand::HostEvent(_)
             );
             if matches!(cmd, SessionCommand::HostEvent(_)) {
                 return ControlFlow::Continue(()); // nobody attached, nothing to render
             }
-            if matches!(cmd, SessionCommand::Save | SessionCommand::Cancel | SessionCommand::Checkpoint { .. }) {
+            if matches!(
+                cmd,
+                SessionCommand::Save
+                    | SessionCommand::Cancel
+                    | SessionCommand::Park
+                    | SessionCommand::Checkpoint { .. }
+            ) {
                 if let SessionCommand::Checkpoint { .. } = cmd {
+                    let record = serde_json::to_value(self.reload_record()).unwrap_or_default();
                     self.emit(SessionEventWire::QueryResult {
                         id: super::wire::CHECKPOINT_QUERY_ID,
-                        value: serde_json::json!({ "ok": true, "parked": true }),
+                        value: serde_json::json!({ "ok": true, "parked": true, "record": record }),
                     });
                 }
                 return ControlFlow::Continue(()); // already on disk / idle
@@ -1853,6 +1881,7 @@ impl SessionActor {
                 "resume: not implemented in this build".into(),
             )),
             SessionCommand::Checkpoint { reason } => self.checkpoint(reason).await,
+            SessionCommand::Park => self.park().await,
             SessionCommand::KeepWarm { on } => {
                 self.keep_warm = on;
                 self.rearm_park();

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -596,16 +596,28 @@ impl SessionActor {
         matches!(self.state, AttachState::Parked)
     }
 
+    /// A session with nothing to save (`ConversationState::save` skips an
+    /// empty `api_messages`, so no journal ever exists) never parks: it
+    /// costs nothing warm and could not be unparked from disk (H2).
     pub(crate) fn can_park(&self) -> bool {
         self.attached.is_empty()
             && !self.streaming
             && self.compact.is_none()
             && self.pending_prompts.is_empty()
             && self.conv.is_live()
+            && !self.conv.api_messages.is_empty()
             && self.conv.queued_message.is_none()
             && !self.keep_warm
             && self.config.persist
             && !self.is_parked()
+    }
+
+    /// `<sessions>/<id>.json` — written by both persistence modes.
+    fn journal_exists(&self) -> bool {
+        let id = (**self.journal_id.load()).clone();
+        crate::config::resolve_write_path("sessions")
+            .join(format!("{id}.json"))
+            .is_file()
     }
 
     fn rearm_park(&mut self) {
@@ -648,6 +660,13 @@ impl SessionActor {
             self.set_lifecycle(SessionLifecycle::Live);
             return;
         }
+        if !self.journal_exists() {
+            // Never park what cannot be restored (H2).
+            tracing::warn!(session = %self.id, "park: no journal on disk — staying live");
+            self.state = AttachState::Detached { running: false };
+            self.set_lifecycle(SessionLifecycle::Live);
+            return;
+        }
         if self.runtime.session_manager().active_count() > 0 {
             self.emit(SessionEventWire::SystemNotice(
                 "parked: background shells closed".into(),
@@ -681,20 +700,44 @@ impl SessionActor {
         let cfg = self.config.clone();
         let queue = Arc::clone(&self.event_queue);
         let replay = self.settings_replay.clone();
+        let journal_present = self.journal_exists();
+        let view = self.view.load_full();
         let build = async move {
             let config: crate::SynapsConfig = (**host.config()).clone();
             let mut runtime = host.foreground_runtime().await?;
             runtime.set_event_queue(queue);
-            let sb = crate::engine::setup::resolve_session_and_prompt(
-                &mut runtime,
-                &Some(Some(journal_id)),
-                cfg.system.as_deref(),
-                cfg.prompt_manifest.as_deref(),
-            )?;
+            let mut sb = if journal_present {
+                crate::engine::setup::resolve_session_and_prompt(
+                    &mut runtime,
+                    &Some(Some(journal_id)),
+                    cfg.system.as_deref(),
+                    cfg.prompt_manifest.as_deref(),
+                )?
+            } else {
+                // The journal vanished under us (H2): rebuild an empty
+                // conversation under the SAME id with the last-published
+                // model/thinking rather than leaving a zombie Parked session.
+                tracing::warn!(
+                    session = %journal_id,
+                    "unpark: journal missing — restoring as a fresh conversation"
+                );
+                let mut sb = crate::engine::setup::resolve_session_and_prompt(
+                    &mut runtime,
+                    &None,
+                    cfg.system.as_deref(),
+                    cfg.prompt_manifest.as_deref(),
+                )?;
+                sb.session.id = journal_id.clone();
+                runtime.set_session_id(Some(journal_id));
+                sb
+            };
             runtime.set_cwd(cfg.cwd.clone());
-            if let Some(ref m) = cfg.model_override {
-                runtime.set_model(m.clone());
-            }
+            // The CURRENT model/thinking (the last published view), not
+            // `cfg.model_override` frozen at create: `/model` survives park.
+            runtime.set_model(view.model.clone());
+            let _ = runtime.restore_session_reasoning(&view.thinking_level);
+            sb.session.model = view.model.clone();
+            sb.session.thinking_level = runtime.thinking_level().to_string();
             crate::engine::setup::finish_session_setup(
                 &mut runtime,
                 &config,

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -262,11 +262,14 @@ pub(crate) struct CompactionJob {
 
 /// Commands that only the input owner may send (B1). Everything else
 /// (`Answer`, `Query`, `Save`, `Detach`, `Attach`, `Resync`, `HostEvent`)
-/// is open to every attached client.
+/// is open to every attached client. `Checkpoint` cancels the owner's turn
+/// and kills its PTYs, so it is owner-only from a client (M1); the daemon
+/// sends it `from: None`.
 fn is_input_command(cmd: &SessionCommand) -> bool {
     matches!(
         cmd,
-        SessionCommand::Submit { .. }
+        SessionCommand::Checkpoint { .. }
+            | SessionCommand::Submit { .. }
             | SessionCommand::SubmitPrepared { .. }
             | SessionCommand::Steer { .. }
             | SessionCommand::Cancel

--- a/crates/agent-engine/src/session/actor_cmds.rs
+++ b/crates/agent-engine/src/session/actor_cmds.rs
@@ -41,7 +41,6 @@ impl SessionActor {
             Some(CommandResult::Compact {
                 custom_instructions,
             }) => {
-                self.emit(SessionEventWire::SystemNotice("compacting...".into()));
                 self.compact(custom_instructions, "manual").await;
                 serde_json::json!({ "kind": "none" })
             }

--- a/crates/agent-engine/src/session/actor_cmds.rs
+++ b/crates/agent-engine/src/session/actor_cmds.rs
@@ -1,0 +1,56 @@
+//! `SessionActor` — command bodies that belong to the TUI port (A3):
+//! `engine_command` (moved verbatim from `actor.rs`), and — as A3 lands —
+//! `submit_prepared`, `plugin_command`, `resume`, `emit_subagent_rows`.
+//! Kept apart from `actor.rs` so the turn machine (B) and the command
+//! surface (A) never touch the same file.
+
+use super::actor::SessionActor;
+use super::types::*;
+
+impl SessionActor {
+    /// `engine::commands::handle_engine_command` on THE runtime; reply as a
+    /// `QueryResult` the client renders (chat.rs slash-command branch).
+    pub(crate) async fn engine_command(&mut self, id: u64, cmd: String, arg: String) {
+        use crate::engine::commands::{handle_engine_command, CommandResult};
+        let value = match handle_engine_command(&cmd, &arg, &mut self.runtime) {
+            None => serde_json::json!({ "kind": "unhandled" }),
+            Some(CommandResult::Quit) => serde_json::json!({ "kind": "quit" }),
+            Some(CommandResult::ModelChanged {
+                model,
+                reasoning_clamped,
+            }) => {
+                self.conv.session.model = self.runtime.model().to_string();
+                let mut text = format!("model → {}", model);
+                if let Some(clamp) = reasoning_clamped {
+                    self.conv.session.thinking_level = self.runtime.thinking_level().to_string();
+                    text.push_str(&format!(
+                        "\nthinking → {} (clamped from {}: not supported by {})",
+                        clamp.to.as_str(),
+                        clamp.from.as_str(),
+                        self.runtime.model()
+                    ));
+                }
+                self.publish_view().await;
+                serde_json::json!({ "kind": "notice", "text": text })
+            }
+            Some(CommandResult::ThinkingChanged { spec }) => {
+                self.conv.session.thinking_level = spec.config_value();
+                self.publish_view().await;
+                serde_json::json!({ "kind": "notice", "text": format!("thinking → {}", spec.level()) })
+            }
+            Some(CommandResult::Compact {
+                custom_instructions,
+            }) => {
+                self.emit(SessionEventWire::SystemNotice("compacting...".into()));
+                self.compact(custom_instructions, "manual").await;
+                serde_json::json!({ "kind": "none" })
+            }
+            Some(CommandResult::Error(e)) => serde_json::json!({ "kind": "error", "text": e }),
+            Some(CommandResult::Output(text)) => {
+                serde_json::json!({ "kind": "output", "text": text })
+            }
+            Some(_) => serde_json::json!({ "kind": "none" }),
+        };
+        self.emit(SessionEventWire::QueryResult { id, value });
+    }
+}

--- a/crates/agent-engine/src/session/budgets.rs
+++ b/crates/agent-engine/src/session/budgets.rs
@@ -18,3 +18,8 @@ pub const HOOKS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(HO
 pub const EXTENSIONS_READY_TIMEOUT_SECS: u64 = 30;
 pub const EXTENSIONS_READY_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(EXTENSIONS_READY_TIMEOUT_SECS);
+
+/// `SessionActor::unpark` bound (B3): journal load + runtime rebuild.
+/// Transports wait `ATTACH_TIMEOUT_PARKED` (25 s) for a parked attach.
+pub const UNPARK_TIMEOUT_SECS: u64 = 20;
+pub const UNPARK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(UNPARK_TIMEOUT_SECS);

--- a/crates/agent-engine/src/session/handle.rs
+++ b/crates/agent-engine/src/session/handle.rs
@@ -11,6 +11,14 @@ use tokio::sync::{broadcast, mpsc};
 
 use super::transport::TransportError;
 use super::types::{Addressed, ClientId, Envelope, SessionCommand, SessionId, SessionLifecycle, SessionMeta};
+
+/// Live client accounting published by the actor (B4 `sessions()` listing).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Presence {
+    pub clients: usize,
+    pub input_owner: Option<ClientId>,
+    pub awaiting_input: usize,
+}
 use super::view::RuntimeView;
 
 /// Bounded command queue depth (rpc `WRITER_CHAN_CAP` precedent).
@@ -39,6 +47,8 @@ pub struct SessionHandle {
     lifecycle: Arc<AtomicU8>,
     /// `conv.session.id` — changes on LinkedSuccessor compaction.
     journal_id: Arc<arc_swap::ArcSwap<String>>,
+    /// Clients / input owner / pending prompts, written by the actor.
+    presence: Arc<arc_swap::ArcSwap<Presence>>,
 }
 
 impl std::fmt::Debug for SessionHandle {
@@ -57,6 +67,7 @@ pub struct SessionEndpoints {
     pub view: Arc<arc_swap::ArcSwap<RuntimeView>>,
     pub lifecycle: Arc<AtomicU8>,
     pub journal_id: Arc<arc_swap::ArcSwap<String>>,
+    pub presence: Arc<arc_swap::ArcSwap<Presence>>,
 }
 
 impl SessionHandle {
@@ -68,6 +79,7 @@ impl SessionHandle {
         let view = Arc::new(arc_swap::ArcSwap::from_pointee(view));
         let lifecycle = Arc::new(AtomicU8::new(SessionLifecycle::Live as u8));
         let journal_id = Arc::new(arc_swap::ArcSwap::from_pointee(meta.id.0.clone()));
+        let presence = Arc::new(arc_swap::ArcSwap::from_pointee(Presence::default()));
         let handle = Self {
             id: meta.id.clone(),
             cmd_tx,
@@ -76,6 +88,7 @@ impl SessionHandle {
             view: Arc::clone(&view),
             lifecycle: Arc::clone(&lifecycle),
             journal_id: Arc::clone(&journal_id),
+            presence: Arc::clone(&presence),
         };
         (
             handle,
@@ -85,6 +98,7 @@ impl SessionHandle {
                 view,
                 lifecycle,
                 journal_id,
+                presence,
             },
         )
     }
@@ -118,6 +132,24 @@ impl SessionHandle {
     /// Current `conv.session.id` (= `id` until a LinkedSuccessor compaction).
     pub fn journal_id(&self) -> String {
         (**self.journal_id.load()).clone()
+    }
+
+    /// Clients / input owner / pending prompts as last published.
+    pub fn presence(&self) -> Presence {
+        **self.presence.load()
+    }
+
+    /// `meta()` with the live cells filled in (lifecycle, clients, owner,
+    /// awaiting_input, journal_id) — what listings show.
+    pub fn meta_live(&self) -> SessionMeta {
+        let mut m = (*self.meta).clone();
+        let p = self.presence();
+        m.lifecycle = self.lifecycle();
+        m.clients = p.clients;
+        m.input_owner = p.input_owner;
+        m.awaiting_input = p.awaiting_input;
+        m.journal_id = self.journal_id();
+        m
     }
 
     pub fn subscribe(&self) -> broadcast::Receiver<Envelope> {

--- a/crates/agent-engine/src/session/handle.rs
+++ b/crates/agent-engine/src/session/handle.rs
@@ -4,12 +4,13 @@
 //! `ClientTransport` is built on it. `echo_for_test` ships a stand-in actor
 //! so package B can build the wire before the real `SessionActor` exists.
 
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
 use tokio::sync::{broadcast, mpsc};
 
 use super::transport::TransportError;
-use super::types::{Envelope, SessionCommand, SessionId, SessionMeta};
+use super::types::{Addressed, ClientId, Envelope, SessionCommand, SessionId, SessionLifecycle, SessionMeta};
 use super::view::RuntimeView;
 
 /// Bounded command queue depth (rpc `WRITER_CHAN_CAP` precedent).
@@ -29,11 +30,15 @@ pub fn events_cap() -> usize {
 #[derive(Clone)]
 pub struct SessionHandle {
     pub id: SessionId,
-    cmd_tx: mpsc::Sender<SessionCommand>,
+    cmd_tx: mpsc::Sender<Addressed>,
     events: broadcast::Sender<Envelope>,
     meta: Arc<SessionMeta>,
     /// Sync, lock-free read of the last published RuntimeView (§2.7).
     view: Arc<arc_swap::ArcSwap<RuntimeView>>,
+    /// Written by the actor (Live/Parking/Parked/Ending).
+    lifecycle: Arc<AtomicU8>,
+    /// `conv.session.id` — changes on LinkedSuccessor compaction.
+    journal_id: Arc<arc_swap::ArcSwap<String>>,
 }
 
 impl std::fmt::Debug for SessionHandle {
@@ -47,9 +52,11 @@ impl std::fmt::Debug for SessionHandle {
 
 /// Actor-side ends of a session's channels, minted with the handle.
 pub struct SessionEndpoints {
-    pub cmd_rx: mpsc::Receiver<SessionCommand>,
+    pub cmd_rx: mpsc::Receiver<Addressed>,
     pub events: broadcast::Sender<Envelope>,
     pub view: Arc<arc_swap::ArcSwap<RuntimeView>>,
+    pub lifecycle: Arc<AtomicU8>,
+    pub journal_id: Arc<arc_swap::ArcSwap<String>>,
 }
 
 impl SessionHandle {
@@ -59,12 +66,16 @@ impl SessionHandle {
         let (cmd_tx, cmd_rx) = mpsc::channel(CMD_CHAN_CAP);
         let (events, _) = broadcast::channel(events_cap());
         let view = Arc::new(arc_swap::ArcSwap::from_pointee(view));
+        let lifecycle = Arc::new(AtomicU8::new(SessionLifecycle::Live as u8));
+        let journal_id = Arc::new(arc_swap::ArcSwap::from_pointee(meta.id.0.clone()));
         let handle = Self {
             id: meta.id.clone(),
             cmd_tx,
             events: events.clone(),
             meta: Arc::new(meta),
             view: Arc::clone(&view),
+            lifecycle: Arc::clone(&lifecycle),
+            journal_id: Arc::clone(&journal_id),
         };
         (
             handle,
@@ -72,18 +83,41 @@ impl SessionHandle {
                 cmd_rx,
                 events,
                 view,
+                lifecycle,
+                journal_id,
             },
         )
     }
 
-    /// Send a command. `Backpressure` when the queue is full (never drop
-    /// silently); `Closed` once the actor is gone.
+    /// Send a host-originated command (`from: None`). `Backpressure` when
+    /// the queue is full (never drop silently); `Closed` once the actor is
+    /// gone.
     pub async fn send(&self, cmd: SessionCommand) -> Result<(), TransportError> {
+        self.send_addressed(Addressed { from: None, cmd })
+    }
+
+    /// Send on behalf of an attached client (ownership is enforced by the
+    /// actor, B1).
+    pub async fn send_from(&self, from: ClientId, cmd: SessionCommand) -> Result<(), TransportError> {
+        self.send_addressed(Addressed { from: Some(from), cmd })
+    }
+
+    fn send_addressed(&self, cmd: Addressed) -> Result<(), TransportError> {
         match self.cmd_tx.try_send(cmd) {
             Ok(()) => Ok(()),
             Err(mpsc::error::TrySendError::Full(_)) => Err(TransportError::Backpressure),
             Err(mpsc::error::TrySendError::Closed(_)) => Err(TransportError::Closed),
         }
+    }
+
+    /// Park/unpark state as last written by the actor.
+    pub fn lifecycle(&self) -> SessionLifecycle {
+        SessionLifecycle::from_u8(self.lifecycle.load(Ordering::Acquire))
+    }
+
+    /// Current `conv.session.id` (= `id` until a LinkedSuccessor compaction).
+    pub fn journal_id(&self) -> String {
+        (**self.journal_id.load()).clone()
     }
 
     pub fn subscribe(&self) -> broadcast::Receiver<Envelope> {
@@ -140,6 +174,11 @@ pub mod echo {
             continued: false,
             continue_info: None,
             host_pid: std::process::id(),
+            lifecycle: SessionLifecycle::Live,
+            clients: 0,
+            input_owner: None,
+            awaiting_input: 0,
+            journal_id: id.0.clone(),
         }
     }
 
@@ -202,6 +241,7 @@ pub mod echo {
                 replay: Vec::new(),
                 pending_prompts: Vec::new(),
                 clients: self.clients.iter().map(|(c, m)| (*c, m.kind)).collect(),
+                input_owner: None,
             }
         }
 
@@ -237,6 +277,7 @@ pub mod echo {
                     self.emit(SessionEventWire::TurnStarted {
                         turn_baseline: baseline,
                         trigger: TurnTrigger::User,
+                        user_text: None,
                     });
                     self.emit(SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(
                         text.clone(),
@@ -276,17 +317,19 @@ pub mod echo {
                     };
                     self.emit(SessionEventWire::QueryResult { id, value });
                 }
-                SessionCommand::Set(setting) => {
+                SessionCommand::Set { id, setting } => {
                     let mut view = (**self.view.load()).clone();
                     if let SessionSetting::Model { model } = &setting {
                         view.model = model.clone();
                     }
                     self.view.store(Arc::new(view.clone()));
                     self.emit(SessionEventWire::SettingChanged(SettingApplied {
+                        id,
                         setting: "echo".into(),
                         ok: true,
                         message: None,
                         view,
+                        clamp: None,
                     }));
                 }
                 SessionCommand::End { reason } => {
@@ -311,7 +354,7 @@ pub mod echo {
             clients: HashMap::new(),
             conv: ConversationSnapshot::default(),
         };
-        while let Some(cmd) = ep.cmd_rx.recv().await {
+        while let Some(Addressed { cmd, .. }) = ep.cmd_rx.recv().await {
             if !echo.handle(cmd) {
                 break;
             }
@@ -406,9 +449,10 @@ mod tests {
         let mut rx = handle.subscribe();
         assert_eq!(handle.view().model, "echo");
         handle
-            .send(SessionCommand::Set(SessionSetting::Model {
-                model: "other".into(),
-            }))
+            .send(SessionCommand::Set {
+                id: 0,
+                setting: SessionSetting::Model { model: "other".into() },
+            })
             .await
             .unwrap();
         let e = next(&mut rx).await;

--- a/crates/agent-engine/src/session/handle.rs
+++ b/crates/agent-engine/src/session/handle.rs
@@ -392,7 +392,8 @@ mod tests {
             e0.event,
             SessionEventWire::TurnStarted {
                 turn_baseline: 0,
-                trigger: TurnTrigger::User
+                trigger: TurnTrigger::User,
+                user_text: None,
             }
         ));
         let e1 = next(&mut rx).await;

--- a/crates/agent-engine/src/session/mod.rs
+++ b/crates/agent-engine/src/session/mod.rs
@@ -7,6 +7,7 @@
 //! the daemon UDS. `agent-tui` must never be a dependency of anything here.
 
 pub mod actor;
+pub mod actor_cmds;
 pub mod budgets;
 pub mod handle;
 pub mod socket_transport;

--- a/crates/agent-engine/src/session/socket_transport.rs
+++ b/crates/agent-engine/src/session/socket_transport.rs
@@ -7,7 +7,7 @@
 //!
 //! Tracing here logs frame *types* only (`ClientFrame`'s redacting `Debug`).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -31,6 +31,9 @@ pub struct Connected {
     writer: mpsc::Sender<ClientFrame>,
     writer_task: tokio::task::JoinHandle<()>,
     pub welcome: Welcome,
+    /// Remembered for `reconnect`.
+    path: PathBuf,
+    hello: Hello,
 }
 
 pub struct Pong {
@@ -98,6 +101,7 @@ impl Connected {
         let mut reader = BufReader::new(r);
         let (writer, writer_task) = spawn_writer(w);
         let client_version = hello.protocol_version;
+        let hello_copy = hello.clone();
         writer
             .send(ClientFrame::Hello(hello))
             .await
@@ -110,7 +114,7 @@ impl Connected {
                 if welcome.protocol_version != client_version {
                     return Err(TransportError::Version { client: client_version, daemon: welcome.protocol_version });
                 }
-                Ok(Self { reader, writer, writer_task, welcome })
+                Ok(Self { reader, writer, writer_task, welcome, path: path.to_path_buf(), hello: hello_copy })
             }
             Some(DaemonFrame::Refused { reason: RefuseReason::Version { daemon_version, .. }, .. }) => {
                 Err(TransportError::Version { client: client_version, daemon: daemon_version })
@@ -181,6 +185,8 @@ pub struct SocketTransport {
     mode: AttachMode,
     input_owner: Option<ClientId>,
     ended: bool,
+    path: PathBuf,
+    hello: Hello,
     /// `Reloading` seen; the next EOF is a reload, not a death.
     reload_pending: Option<u64>,
     /// Why `next_event` returned `None` (`Reloading{generation}` after a
@@ -252,6 +258,8 @@ impl SocketTransport {
                 mode,
                 input_owner: snapshot.input_owner,
                 ended: false,
+                path: conn.path,
+                hello: conn.hello,
                 reload_pending: None,
                 last_error: None,
                 messages: snapshot.conversation.api_messages.clone(),
@@ -292,6 +300,30 @@ impl SocketTransport {
         let p = c.purge().await;
         c.bye().await;
         p
+    }
+
+    /// `Reload{..}` on a control connection. `Ok(generation)` once the daemon
+    /// answered `Bye{Reloading{generation}}` (it is about to exec);
+    /// `Refused{ReloadRefused}` / `Error` → `Err`.
+    pub async fn reload(path: &Path, now: bool, drain_secs: Option<u64>, exe: Option<PathBuf>) -> Result<u64, TransportError> {
+        let mut c = Connected::connect(path, Hello::new(ClientKind::Attach)).await?;
+        c.writer
+            .send(ClientFrame::Reload { now, drain_secs, exe })
+            .await
+            .map_err(|_| TransportError::Closed)?;
+        // Drain + checkpoint can take a while: wait up to drain + 60 s.
+        let budget = Duration::from_secs(drain_secs.unwrap_or(30) + 60);
+        let frame = tokio::time::timeout(budget, read_frame(&mut c.reader))
+            .await
+            .map_err(|_| TransportError::Protocol("reload reply timed out".into()))??;
+        match frame {
+            Some(DaemonFrame::Bye { reason: Some(ByeReason::Reloading { generation, .. }) }) => Ok(generation),
+            Some(DaemonFrame::Bye { .. }) => Err(TransportError::Protocol("daemon said bye without a reload reason".into())),
+            Some(DaemonFrame::Refused { reason: RefuseReason::ReloadRefused { why }, .. }) => Err(TransportError::Refused(why)),
+            Some(DaemonFrame::Refused { message, .. }) | Some(DaemonFrame::Error { message, .. }) => Err(TransportError::Refused(message)),
+            Some(other) => Err(TransportError::Protocol(format!("expected bye, got {other:?}"))),
+            None => Err(TransportError::Closed),
+        }
     }
 
     /// Detach cleanly: `Detach` + `Bye`. The turn keeps running in the daemon.
@@ -460,9 +492,54 @@ impl ClientTransport for SocketTransport {
         self.input_owner
     }
 
-    /// C3 fills the body (backoff, `Hello{reconnect_of}`, re-attach).
-    async fn reconnect(&mut self, _mode: AttachMode) -> Result<AttachSnapshot, TransportError> {
-        Err(TransportError::Unsupported("reconnect: not implemented in this build"))
+    /// C3: after `Reloading`/EOF — backoff 100 ms ×2 → cap 5 s, total ≤
+    /// `SYNAPS_TUI_ATTACH_RECONNECT_SECS` (60); `Hello{reconnect_of}` →
+    /// `Attach::Existing{alias-resolved id, mode}` where `mode = Takeover`
+    /// iff this client was the input owner (§2.7: two reconnecting mirrors
+    /// cannot both take over). On success `self` IS the new connection; the
+    /// returned snapshot is a full re-mirror.
+    async fn reconnect(&mut self, mode: AttachMode) -> Result<AttachSnapshot, TransportError> {
+        let was_owner = self.input_owner == Some(self.client);
+        let generation = self.reload_pending.unwrap_or(self.welcome.generation);
+        let mut hello = self.hello.clone();
+        hello.reconnect_of = Some(ClientReconnect {
+            previous_client: self.client,
+            session_id: self.session.clone(),
+            was_owner,
+            generation,
+        });
+        let mode = if was_owner { AttachMode::Takeover } else { mode };
+        let total = std::env::var("SYNAPS_TUI_ATTACH_RECONNECT_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .map(Duration::from_secs)
+            .unwrap_or(Duration::from_secs(60));
+        let deadline = tokio::time::Instant::now() + total;
+        let mut backoff = Duration::from_millis(100);
+        let mut last;
+        loop {
+            match Connected::connect(&self.path, hello.clone()).await {
+                Ok(conn) => {
+                    match Self::attach(conn, Attach::Existing { session_id: self.session.clone(), mode }).await {
+                        Ok((t, snap)) => {
+                            *self = t;
+                            return Ok(snap);
+                        }
+                        Err(TransportError::Refused(m)) => return Err(TransportError::Refused(m)),
+                        Err(e) => last = e,
+                    }
+                }
+                Err(TransportError::Version { client, daemon }) => {
+                    return Err(TransportError::Version { client, daemon })
+                }
+                Err(e) => last = e,
+            }
+            if tokio::time::Instant::now() + backoff > deadline {
+                return Err(last);
+            }
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(Duration::from_secs(5));
+        }
     }
 }
 
@@ -699,7 +776,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reloading_then_bye_sets_last_error_and_reconnect_is_a_stub() {
+    async fn reloading_then_bye_sets_last_error_and_reconnect_gives_up_on_a_dead_socket() {
         let (_d, path) = sock();
         let l = UnixListener::bind(&path).unwrap();
         let srv = tokio::spawn(fake_daemon(l, PROTOCOL_VERSION));
@@ -714,8 +791,12 @@ mod tests {
         assert!(matches!(e.event, SessionEventWire::Reloading { generation: 2, .. }));
         assert!(t.next_event().await.is_none());
         assert!(matches!(t.last_error(), Some(TransportError::Reloading { generation: 2 })));
-        assert!(matches!(t.reconnect(AttachMode::Observe).await, Err(TransportError::Unsupported(_))));
         srv.await.unwrap();
+        // Nobody listens any more: the backoff loop gives up at the budget.
+        std::env::set_var("SYNAPS_TUI_ATTACH_RECONNECT_SECS", "1");
+        let r = t.reconnect(AttachMode::Observe).await;
+        std::env::remove_var("SYNAPS_TUI_ATTACH_RECONNECT_SECS");
+        assert!(r.is_err());
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/session/socket_transport.rs
+++ b/crates/agent-engine/src/session/socket_transport.rs
@@ -17,7 +17,7 @@ use tokio::net::UnixStream;
 use tokio::sync::mpsc;
 
 use super::handle::CMD_CHAN_CAP;
-use super::transport::{ClientTransport, TransportError, ATTACH_TIMEOUT};
+use super::transport::{ClientTransport, TransportError, ATTACH_TIMEOUT, ATTACH_TIMEOUT_PARKED};
 use super::types::*;
 use super::view::RuntimeView;
 use super::wire::*;
@@ -147,7 +147,7 @@ impl Connected {
 
     pub async fn shutdown(&mut self, force: bool) -> Result<(), TransportError> {
         match self.request(ClientFrame::Shutdown { force }).await? {
-            DaemonFrame::Bye => Ok(()),
+            DaemonFrame::Bye { .. } => Ok(()),
             DaemonFrame::Error { message, .. } => Err(TransportError::Protocol(message)),
             other => Err(TransportError::Protocol(format!("expected bye, got {other:?}"))),
         }
@@ -169,7 +169,14 @@ pub struct SocketTransport {
     client: ClientId,
     view: Arc<arc_swap::ArcSwap<RuntimeView>>,
     pub welcome: Welcome,
+    mode: AttachMode,
+    input_owner: Option<ClientId>,
     ended: bool,
+    /// `Reloading` seen; the next EOF is a reload, not a death.
+    reload_pending: Option<u64>,
+    /// Why `next_event` returned `None` (`Reloading{generation}` after a
+    /// reload announcement) — the TUI branches to `reconnect` on it.
+    last_error: Option<TransportError>,
     /// Local `api_messages` mirror: seeded by `Attached`, updated by
     /// `Stream(MessageHistory)` and `QueryResult{DIGEST_RESYNC_QUERY_ID}`.
     /// `Conversation` arrives as a digest; the mirror fills it in.
@@ -184,20 +191,41 @@ impl SocketTransport {
         Connected::connect(path, hello).await
     }
 
-    /// Attach (existing or create) on a handshaken connection.
+    /// Attach (existing or create) on a handshaken connection. `AttachRefused`
+    /// and `DaemonFrame::Error` alike → `TransportError::Refused`. Waits
+    /// `ATTACH_TIMEOUT_PARKED` when the daemon lists the session as `Parked`.
     pub async fn attach(mut conn: Connected, attach: Attach) -> Result<(Self, AttachSnapshot), TransportError> {
+        let (mode, parked) = match &attach {
+            Attach::Existing { session_id, mode } => (
+                *mode,
+                conn.welcome
+                    .sessions
+                    .iter()
+                    .any(|m| &m.id == session_id && m.lifecycle == SessionLifecycle::Parked),
+            ),
+            Attach::Create { mode, .. } => (*mode, false),
+        };
         conn.writer
             .send(ClientFrame::Attach(attach))
             .await
             .map_err(|_| TransportError::Closed)?;
-        let frame = tokio::time::timeout(ATTACH_TIMEOUT, read_frame(&mut conn.reader))
-            .await
-            .map_err(|_| TransportError::Protocol("attach timed out".into()))??;
-        let attached = match frame {
-            Some(DaemonFrame::Attached(a)) => a,
-            Some(DaemonFrame::Error { message, .. }) => return Err(TransportError::Protocol(message)),
-            Some(other) => return Err(TransportError::Protocol(format!("expected attached, got {other:?}"))),
-            None => return Err(TransportError::Closed),
+        let budget = if parked { ATTACH_TIMEOUT_PARKED } else { ATTACH_TIMEOUT };
+        let deadline = tokio::time::Instant::now() + budget;
+        let attached = loop {
+            let frame = tokio::time::timeout_at(deadline, read_frame(&mut conn.reader))
+                .await
+                .map_err(|_| TransportError::Protocol("attach timed out".into()))??;
+            match frame {
+                Some(DaemonFrame::Attached(a)) => break a,
+                Some(DaemonFrame::Error { message, .. }) => return Err(TransportError::Refused(message)),
+                Some(DaemonFrame::Event(w)) => match w.event {
+                    WireSessionEvent::AttachRefused { message } => return Err(TransportError::Refused(message)),
+                    // Notices/lifecycle chatter may precede `Attached` (unpark).
+                    _ => continue,
+                },
+                Some(DaemonFrame::Bye { .. }) | None => return Err(TransportError::Closed),
+                Some(other) => return Err(TransportError::Protocol(format!("expected attached, got {other:?}"))),
+            }
         };
         let (client, snapshot) = attached.into_snapshot();
         let meta = snapshot.meta.clone();
@@ -212,12 +240,21 @@ impl SocketTransport {
                 client,
                 view,
                 welcome: conn.welcome,
+                mode,
+                input_owner: snapshot.input_owner,
                 ended: false,
+                reload_pending: None,
+                last_error: None,
                 messages: snapshot.conversation.api_messages.clone(),
                 pending_digest: None,
             },
             snapshot,
         ))
+    }
+
+    /// Why the last `next_event` returned `None` (if it was not a plain end).
+    pub fn last_error(&self) -> Option<&TransportError> {
+        self.last_error.as_ref()
     }
 
     // ── control fast path helpers (fresh connection each) ──
@@ -333,6 +370,12 @@ impl ClientTransport for SocketTransport {
         }
     }
 
+    /// The daemon's conn stamps `from` with this connection's client id, so
+    /// on the wire `send` and `send_from_self` are the same frame.
+    async fn send_from_self(&self, cmd: SessionCommand) -> Result<(), TransportError> {
+        self.send(cmd).await
+    }
+
     async fn next_event(&mut self) -> Option<Envelope> {
         if self.ended {
             return None;
@@ -346,13 +389,30 @@ impl ClientTransport for SocketTransport {
                             self.view.store(Arc::new(applied.view.clone()));
                         }
                         SessionEventWire::Ended { .. } => self.ended = true,
+                        SessionEventWire::InputOwnerChanged { to, .. } => self.input_owner = *to,
+                        SessionEventWire::Reloading { generation, .. } => {
+                            self.reload_pending = Some(*generation);
+                        }
                         _ => {}
                     }
                     return Some(env);
                 }
                 Ok(Some(DaemonFrame::Error { message, .. })) => return Some(self.notice(message)),
-                Ok(Some(DaemonFrame::Bye)) | Ok(None) => {
+                Ok(Some(DaemonFrame::Bye { reason })) => {
+                    if let Some(ByeReason::Reloading { generation, .. }) = reason {
+                        self.reload_pending = Some(generation);
+                    }
                     self.ended = true;
+                    if let Some(generation) = self.reload_pending {
+                        self.last_error = Some(TransportError::Reloading { generation });
+                    }
+                    return None;
+                }
+                Ok(None) => {
+                    self.ended = true;
+                    if let Some(generation) = self.reload_pending {
+                        self.last_error = Some(TransportError::Reloading { generation });
+                    }
                     return None;
                 }
                 Ok(Some(other)) => {
@@ -374,6 +434,19 @@ impl ClientTransport for SocketTransport {
 
     fn client_id(&self) -> ClientId {
         self.client
+    }
+
+    fn mode(&self) -> AttachMode {
+        self.mode
+    }
+
+    fn input_owner(&self) -> Option<ClientId> {
+        self.input_owner
+    }
+
+    /// C3 fills the body (backoff, `Hello{reconnect_of}`, re-attach).
+    async fn reconnect(&mut self, _mode: AttachMode) -> Result<AttachSnapshot, TransportError> {
+        Err(TransportError::Unsupported("reconnect: not implemented in this build"))
     }
 }
 
@@ -415,6 +488,7 @@ mod tests {
                         profile: None,
                         sessions: vec![],
                         progressive_tool_disclosure: true,
+                        generation: 1,
                     })
                 }
                 ClientFrame::Ping => DaemonFrame::Pong { pid: 1, uptime_s: 0, sessions: 0 },
@@ -428,6 +502,7 @@ mod tests {
                         replay: vec![],
                         pending_prompts: vec![],
                         clients: vec![],
+                        input_owner: Some(ClientId(7)),
                     },
                 )),
                 ClientFrame::Cmd { cmd: SessionCommand::Submit { text, .. }, .. } => {
@@ -439,7 +514,7 @@ mod tests {
                         event: SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(text))).into(),
                     })
                 }
-                ClientFrame::Cmd { cmd: SessionCommand::Set(_), .. } => {
+                ClientFrame::Cmd { cmd: SessionCommand::Set { id, .. }, .. } => {
                     seq += 1;
                     let mut view = crate::session::handle::echo::view_for();
                     view.model = "changed".into();
@@ -447,7 +522,43 @@ mod tests {
                         session_id: sid.clone(),
                         seq,
                         ts: chrono::Utc::now(),
-                        event: SessionEventWire::SettingChanged(SettingApplied { setting: "model".into(), ok: true, message: None, view }).into(),
+                        event: SessionEventWire::SettingChanged(SettingApplied {
+                            id,
+                            setting: "model".into(),
+                            ok: true,
+                            message: None,
+                            view,
+                            clamp: None,
+                        })
+                        .into(),
+                    })
+                }
+                // Checkpoint = "the daemon is about to reload": Reloading event, then Bye{Reloading}.
+                ClientFrame::Cmd { cmd: SessionCommand::Checkpoint { .. }, .. } => {
+                    seq += 1;
+                    let ev = DaemonFrame::Event(WireEnvelope {
+                        session_id: sid.clone(),
+                        seq,
+                        ts: chrono::Utc::now(),
+                        event: WireSessionEvent::Reloading { generation: 2, retry_after_ms: 500 },
+                    });
+                    w.write_all(encode_line(&ev).unwrap().as_bytes()).await.unwrap();
+                    let bye = DaemonFrame::Bye { reason: Some(ByeReason::Reloading { generation: 2, retry_after_ms: 500 }) };
+                    w.write_all(encode_line(&bye).unwrap().as_bytes()).await.unwrap();
+                    break;
+                }
+                // KeepWarm = ownership change notice.
+                ClientFrame::Cmd { cmd: SessionCommand::KeepWarm { .. }, .. } => {
+                    seq += 1;
+                    DaemonFrame::Event(WireEnvelope {
+                        session_id: sid.clone(),
+                        seq,
+                        ts: chrono::Utc::now(),
+                        event: WireSessionEvent::InputOwnerChanged {
+                            from: Some(ClientId(7)),
+                            to: Some(ClientId(9)),
+                            reason: OwnerChangeReason::Takeover,
+                        },
                     })
                 }
                 // Steer = "the daemon's history drifted": digest for [user:text] without a MessageHistory.
@@ -478,7 +589,7 @@ mod tests {
                     })
                 }
                 ClientFrame::Bye => {
-                    let _ = w.write_all(encode_line(&DaemonFrame::Bye).unwrap().as_bytes()).await;
+                    let _ = w.write_all(encode_line(&DaemonFrame::Bye { reason: None }).unwrap().as_bytes()).await;
                     break;
                 }
                 ClientFrame::Cmd { cmd: SessionCommand::Detach { .. }, .. } => continue,
@@ -507,6 +618,8 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(t.client_id(), ClientId(7));
+        assert_eq!(t.mode(), AttachMode::Mirror);
+        assert_eq!(t.input_owner(), Some(ClientId(7)));
         assert_eq!(snap.meta.id.as_str(), "fake-1");
         assert_eq!(t.session_id().as_str(), "fake-1");
         assert_eq!(t.view().model, "echo");
@@ -517,10 +630,16 @@ mod tests {
             SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(s))) => assert_eq!(s, "hello"),
             other => panic!("{other:?}"),
         }
-        t.send(SessionCommand::Set(SessionSetting::Model { model: "changed".into() })).await.unwrap();
+        t.send_from_self(SessionCommand::Set { id: 11, setting: SessionSetting::Model { model: "changed".into() } })
+            .await
+            .unwrap();
         let e = t.next_event().await.unwrap();
-        assert!(matches!(e.event, SessionEventWire::SettingChanged(_)));
+        assert!(matches!(e.event, SessionEventWire::SettingChanged(SettingApplied { id: 11, .. })));
         assert_eq!(t.view().model, "changed");
+        t.send(SessionCommand::KeepWarm { on: true }).await.unwrap();
+        let e = t.next_event().await.unwrap();
+        assert!(matches!(e.event, SessionEventWire::InputOwnerChanged { .. }));
+        assert_eq!(t.input_owner(), Some(ClientId(9)));
 
         // Error → SystemNotice; Bye → None.
         t.send(SessionCommand::Save).await.unwrap();
@@ -564,12 +683,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reloading_then_bye_sets_last_error_and_reconnect_is_a_stub() {
+        let (_d, path) = sock();
+        let l = UnixListener::bind(&path).unwrap();
+        let srv = tokio::spawn(fake_daemon(l, PROTOCOL_VERSION));
+        let conn = SocketTransport::connect(&path, Hello::new(ClientKind::Test)).await.unwrap();
+        let (mut t, _) = SocketTransport::attach(conn, Attach::Existing { session_id: "fake-1".into(), mode: AttachMode::Observe })
+            .await
+            .unwrap();
+        assert_eq!(t.mode(), AttachMode::Observe);
+        assert!(t.last_error().is_none());
+        t.send(SessionCommand::Checkpoint { reason: CheckpointReason::Reload }).await.unwrap();
+        let e = t.next_event().await.unwrap();
+        assert!(matches!(e.event, SessionEventWire::Reloading { generation: 2, .. }));
+        assert!(t.next_event().await.is_none());
+        assert!(matches!(t.last_error(), Some(TransportError::Reloading { generation: 2 })));
+        assert!(matches!(t.reconnect(AttachMode::Observe).await, Err(TransportError::Unsupported(_))));
+        srv.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn attach_error_frame_is_refused() {
+        let (_d, path) = sock();
+        let l = UnixListener::bind(&path).unwrap();
+        // A daemon that welcomes, then answers the Attach with an Error frame.
+        let srv = tokio::spawn(async move {
+            let (stream, _) = l.accept().await.unwrap();
+            let (r, mut w) = stream.into_split();
+            let mut reader = BufReader::new(r);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.unwrap();
+            let welcome = DaemonFrame::Welcome(Welcome {
+                protocol_version: PROTOCOL_VERSION,
+                daemon_version: "t".into(),
+                pid: 1,
+                profile: None,
+                sessions: vec![],
+                progressive_tool_disclosure: true,
+                generation: 1,
+            });
+            w.write_all(encode_line(&welcome).unwrap().as_bytes()).await.unwrap();
+            line.clear();
+            reader.read_line(&mut line).await.unwrap();
+            let err = DaemonFrame::Error { session_id: None, message: "unknown session".into() };
+            w.write_all(encode_line(&err).unwrap().as_bytes()).await.unwrap();
+        });
+        let conn = SocketTransport::connect(&path, Hello::new(ClientKind::Test)).await.unwrap();
+        let err = SocketTransport::attach(conn, Attach::Existing { session_id: "nope".into(), mode: AttachMode::Mirror })
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(err, TransportError::Refused(ref m) if m == "unknown session"), "{err}");
+        srv.await.unwrap();
+    }
+
+    #[tokio::test]
     async fn socket_transport_refuses_version_mismatch() {
         let (_d, path) = sock();
         let l = UnixListener::bind(&path).unwrap();
         let srv = tokio::spawn(fake_daemon(l, 99));
         let err = SocketTransport::connect(&path, Hello::new(ClientKind::Test)).await.err().unwrap();
-        assert!(matches!(err, TransportError::Version { client: 1, daemon: 99 }), "{err}");
+        assert!(matches!(err, TransportError::Version { client: PROTOCOL_VERSION, daemon: 99 }), "{err}");
         srv.await.unwrap();
     }
 

--- a/crates/agent-engine/src/session/socket_transport.rs
+++ b/crates/agent-engine/src/session/socket_transport.rs
@@ -145,6 +145,15 @@ impl Connected {
         }
     }
 
+    /// `Purge` → the daemon runs `memstat::purge_arenas()`; replies `Pong`.
+    pub async fn purge(&mut self) -> Result<Pong, TransportError> {
+        match self.request(ClientFrame::Purge).await? {
+            DaemonFrame::Pong { pid, uptime_s, sessions } => Ok(Pong { pid, uptime_s, sessions }),
+            DaemonFrame::Error { message, .. } => Err(TransportError::Protocol(message)),
+            other => Err(TransportError::Protocol(format!("expected pong, got {other:?}"))),
+        }
+    }
+
     pub async fn shutdown(&mut self, force: bool) -> Result<(), TransportError> {
         match self.request(ClientFrame::Shutdown { force }).await? {
             DaemonFrame::Bye { .. } => Ok(()),
@@ -276,6 +285,13 @@ impl SocketTransport {
     pub async fn shutdown(path: &Path, force: bool) -> Result<(), TransportError> {
         let mut c = Connected::connect(path, Hello::new(ClientKind::Attach)).await?;
         c.shutdown(force).await
+    }
+
+    pub async fn purge(path: &Path) -> Result<Pong, TransportError> {
+        let mut c = Connected::connect(path, Hello::new(ClientKind::Attach)).await?;
+        let p = c.purge().await;
+        c.bye().await;
+        p
     }
 
     /// Detach cleanly: `Detach` + `Bye`. The turn keeps running in the daemon.

--- a/crates/agent-engine/src/session/transport.rs
+++ b/crates/agent-engine/src/session/transport.rs
@@ -27,13 +27,28 @@ pub enum TransportError {
     Protocol(String),
     #[error("version: client {client} daemon {daemon}")]
     Version { client: u32, daemon: u32 },
+    /// The operation does not exist on this transport (e.g. `reconnect` on
+    /// `LocalTransport`).
+    #[error("unsupported: {0}")]
+    Unsupported(&'static str),
+    /// The daemon announced a reload and closed; `reconnect` applies.
+    #[error("daemon reloading (generation {generation})")]
+    Reloading { generation: u64 },
+    /// The daemon/actor refused the attach or command (`AttachRefused`,
+    /// `DaemonFrame::Error` during attach).
+    #[error("refused: {0}")]
+    Refused(String),
 }
 
 #[async_trait::async_trait]
 pub trait ClientTransport: Send {
     fn session_id(&self) -> &SessionId;
     fn meta(&self) -> &SessionMeta;
+    /// Host-originated send (`from: None`; bypasses input ownership).
     async fn send(&self, cmd: SessionCommand) -> Result<(), TransportError>;
+    /// Send stamped with this client's id (the TUI uses this; ownership is
+    /// enforced by the actor, B1).
+    async fn send_from_self(&self, cmd: SessionCommand) -> Result<(), TransportError>;
     /// Next envelope, or `None` when the session ended / socket closed.
     async fn next_event(&mut self) -> Option<Envelope>;
     /// Sync, cheap, never stale by more than one `SettingChanged`: what the
@@ -41,26 +56,46 @@ pub trait ClientTransport: Send {
     fn view(&self) -> Arc<RuntimeView>;
     /// Client id assigned at Attach (needed for Detach/Resync).
     fn client_id(&self) -> ClientId;
+    /// The mode this transport attached with.
+    fn mode(&self) -> AttachMode;
+    /// Current input owner — updated from `Attached` / `InputOwnerChanged`.
+    fn input_owner(&self) -> Option<ClientId>;
+    /// Socket only (Local returns `Err(Unsupported)`): after `Reloading`/EOF,
+    /// reconnect with backoff and re-attach with `mode` (C3/A4).
+    async fn reconnect(&mut self, mode: AttachMode) -> Result<AttachSnapshot, TransportError>;
 }
 
 /// Attach handshake budget.
 pub const ATTACH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+/// Attach budget when the listed lifecycle is `Parked` (unpark ≤ 20 s, B3).
+pub const ATTACH_TIMEOUT_PARKED: std::time::Duration = std::time::Duration::from_secs(25);
 
 pub struct LocalTransport {
     handle: SessionHandle,
     rx: broadcast::Receiver<Envelope>,
     client: ClientId,
     meta: SessionMeta,
+    mode: AttachMode,
+    input_owner: Option<ClientId>,
     /// Set after `Ended` (or actor gone): `next_event` returns `None` from then on.
     ended: bool,
 }
 
 impl LocalTransport {
-    /// Attach in-process: sends Attach, awaits the Attached envelope
-    /// (bounded 5 s), returns the transport + snapshot.
+    /// Attach in-process as a `Mirror` (= `attach_with(.., Mirror)`).
     pub async fn attach(
         handle: SessionHandle,
         meta: ClientMeta,
+    ) -> Result<(Self, AttachSnapshot), TransportError> {
+        Self::attach_with(handle, meta, AttachMode::Mirror).await
+    }
+
+    /// Attach in-process: sends Attach, awaits the Attached envelope
+    /// (bounded 5 s), returns the transport + snapshot.
+    pub async fn attach_with(
+        handle: SessionHandle,
+        meta: ClientMeta,
+        mode: AttachMode,
     ) -> Result<(Self, AttachSnapshot), TransportError> {
         // Subscribe BEFORE sending so the Attached reply cannot be missed.
         // `Attached` is broadcast; with one attach in flight per handle at a
@@ -69,18 +104,22 @@ impl LocalTransport {
         handle
             .send(SessionCommand::Attach {
                 client: meta,
-                mode: AttachMode::Mirror,
+                mode,
             })
             .await?;
 
         let wait = async {
             loop {
                 match rx.recv().await {
-                    Ok(env) => {
-                        if let SessionEventWire::Attached { client, snapshot } = env.event {
+                    Ok(env) => match env.event {
+                        SessionEventWire::Attached { client, snapshot } => {
                             return Ok((client, snapshot));
                         }
-                    }
+                        SessionEventWire::AttachRefused { message } => {
+                            return Err(TransportError::Refused(message));
+                        }
+                        _ => {}
+                    },
                     Err(broadcast::error::RecvError::Lagged(_)) => continue,
                     Err(broadcast::error::RecvError::Closed) => {
                         return Err(TransportError::Closed)
@@ -88,7 +127,12 @@ impl LocalTransport {
                 }
             }
         };
-        let (client, snapshot) = match tokio::time::timeout(ATTACH_TIMEOUT, wait).await {
+        let timeout = if handle.lifecycle() == super::types::SessionLifecycle::Parked {
+            ATTACH_TIMEOUT_PARKED
+        } else {
+            ATTACH_TIMEOUT
+        };
+        let (client, snapshot) = match tokio::time::timeout(timeout, wait).await {
             Ok(r) => r?,
             Err(_) => return Err(TransportError::Protocol("attach timed out".into())),
         };
@@ -99,6 +143,8 @@ impl LocalTransport {
                 rx,
                 client,
                 meta,
+                mode,
+                input_owner: snapshot.input_owner,
                 ended: false,
             },
             snapshot,
@@ -124,6 +170,10 @@ impl ClientTransport for LocalTransport {
         self.handle.send(cmd).await
     }
 
+    async fn send_from_self(&self, cmd: SessionCommand) -> Result<(), TransportError> {
+        self.handle.send_from(self.client, cmd).await
+    }
+
     async fn next_event(&mut self) -> Option<Envelope> {
         if self.ended {
             return None;
@@ -144,8 +194,10 @@ impl ClientTransport for LocalTransport {
         };
         match recv {
             Ok(env) => {
-                if matches!(env.event, SessionEventWire::Ended { .. }) {
-                    self.ended = true;
+                match &env.event {
+                    SessionEventWire::Ended { .. } => self.ended = true,
+                    SessionEventWire::InputOwnerChanged { to, .. } => self.input_owner = *to,
+                    _ => {}
                 }
                 Some(env)
             }
@@ -174,6 +226,18 @@ impl ClientTransport for LocalTransport {
 
     fn client_id(&self) -> ClientId {
         self.client
+    }
+
+    fn mode(&self) -> AttachMode {
+        self.mode
+    }
+
+    fn input_owner(&self) -> Option<ClientId> {
+        self.input_owner
+    }
+
+    async fn reconnect(&mut self, _mode: AttachMode) -> Result<AttachSnapshot, TransportError> {
+        Err(TransportError::Unsupported("reconnect: in-process transport"))
     }
 }
 
@@ -214,6 +278,9 @@ mod tests {
             .unwrap();
         assert_eq!(t.session_id().as_str(), "lt-1");
         assert_eq!(t.client_id(), ClientId(1));
+        assert_eq!(t.mode(), AttachMode::Mirror);
+        assert!(t.input_owner().is_none());
+        assert!(matches!(t.reconnect(AttachMode::Mirror).await, Err(TransportError::Unsupported(_))));
         assert_eq!(snap.meta.model, "echo");
         assert_eq!(t.view().model, "echo");
         assert!(snap.conversation.api_messages.is_empty());

--- a/crates/agent-engine/src/session/types.rs
+++ b/crates/agent-engine/src/session/types.rs
@@ -370,9 +370,28 @@ pub enum SessionCommand {
     Checkpoint { reason: CheckpointReason },
     /// (B3) pin/unpin (`--keep-warm`, `/keep-warm on|off`).
     KeepWarm { on: bool },
+    /// Host-only (never wire): park now if `can_park()` (reload rehydrates
+    /// a Parked session Parked). A no-op otherwise.
+    #[serde(skip)]
+    Park,
     /// Host→session (never wire): the actor re-emits as `SessionEventWire`.
     #[serde(skip)]
     HostEvent(HostEvent),
+}
+
+/// What `Checkpoint{Reload}` reports so `daemon reload` can rebuild the
+/// session as it IS (not as it was created): the actor's config, keep-warm
+/// pin, lifecycle, the non-persisted knobs (`settings_replay`, incl.
+/// `/system`), and the CURRENT model/thinking.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SessionReloadRecord {
+    pub config: SessionConfig,
+    pub keep_warm: bool,
+    pub lifecycle: SessionLifecycle,
+    #[serde(default)]
+    pub settings_replay: Vec<SessionSetting>,
+    pub model: String,
+    pub thinking_level: String,
 }
 
 impl std::fmt::Debug for SessionCommand {
@@ -411,6 +430,7 @@ impl std::fmt::Debug for SessionCommand {
             }
             Self::NewSession => f.write_str("NewSession"),
             Self::Save => f.write_str("Save"),
+            Self::Park => f.write_str("Park"),
             Self::Query { id, query } => {
                 f.debug_struct("Query").field("id", id).field("query", query).finish()
             }

--- a/crates/agent-engine/src/session/types.rs
+++ b/crates/agent-engine/src/session/types.rs
@@ -78,10 +78,40 @@ pub struct SessionConfig {
     /// The TUI does its own compaction; default `false`.
     #[serde(default)]
     pub auto_compact: bool,
+    /// Compaction transition policy: `InPlace` (default; chat, today's
+    /// actor) or `LinkedSuccessor` (the TUI's successor-session chain).
+    #[serde(default)]
+    pub compaction_policy: CompactionPolicyWire,
+    /// Block `create` on process-level extension discovery before emitting
+    /// `on_session_start` (chat/daemon). The TUI passes `false`: the actor
+    /// emits it from a spawned waiter so boot never blocks on discovery.
+    #[serde(default = "default_true")]
+    pub await_extensions: bool,
+    /// Never `Park` this session (`--keep-warm`). Default `false`.
+    #[serde(default)]
+    pub keep_warm: bool,
 }
 
 fn default_true() -> bool {
     true
+}
+
+/// Serializable mirror of `runtime::compaction::CompactionPolicy`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompactionPolicyWire {
+    #[default]
+    InPlace,
+    LinkedSuccessor,
+}
+
+impl From<CompactionPolicyWire> for crate::runtime::compaction::CompactionPolicy {
+    fn from(p: CompactionPolicyWire) -> Self {
+        match p {
+            CompactionPolicyWire::InPlace => Self::InPlace,
+            CompactionPolicyWire::LinkedSuccessor => Self::LinkedSuccessor,
+        }
+    }
 }
 
 impl Default for SessionConfig {
@@ -95,6 +125,9 @@ impl Default for SessionConfig {
             model_override: None,
             persist: true,
             auto_compact: false,
+            compaction_policy: CompactionPolicyWire::InPlace,
+            await_extensions: true,
+            keep_warm: false,
         }
     }
 }
@@ -129,6 +162,41 @@ pub struct SessionMeta {
     pub continue_info: Option<ContinueInfoWire>,
     /// Daemon pid (in-process: this process).
     pub host_pid: u32,
+    // ── filled at list time from the handle's cells (meta itself is frozen) ──
+    #[serde(default)]
+    pub lifecycle: SessionLifecycle,
+    #[serde(default)]
+    pub clients: usize,
+    #[serde(default)]
+    pub input_owner: Option<ClientId>,
+    #[serde(default)]
+    pub awaiting_input: usize,
+    /// `conv.session.id` — differs from `id` after a LinkedSuccessor compaction.
+    #[serde(default)]
+    pub journal_id: String,
+}
+
+/// Where a session is in its park/unpark life (`SessionHandle::lifecycle`).
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionLifecycle {
+    #[default]
+    Live = 0,
+    Parking = 1,
+    Parked = 2,
+    Ending = 3,
+}
+
+impl SessionLifecycle {
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            1 => Self::Parking,
+            2 => Self::Parked,
+            3 => Self::Ending,
+            _ => Self::Live,
+        }
+    }
 }
 
 /// Minted by the actor per Attach.
@@ -167,8 +235,8 @@ pub enum ClientKind {
     Test,
 }
 
-/// Today: Mirror only is honoured; Takeover/Observe parse and map to Mirror
-/// with a Notice.
+/// Attach mode. Ownership (B1): `Mirror` owns input iff nobody does,
+/// `Takeover` steals it, `Observe` never owns it.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AttachMode {
@@ -182,6 +250,10 @@ pub enum AttachMode {
 pub enum AttachState {
     Attached(usize),
     Detached { running: bool },
+    /// Save + PTY teardown in progress (B3).
+    Parking,
+    /// `runtime`/`conv` dropped; `background` alive; unpark on Attach/wake (B3).
+    Parked,
 }
 
 // ── prompts ───────────────────────────────────────────────────────────────────
@@ -220,8 +292,27 @@ pub struct PromptRequest {
 
 // ── commands, settings, queries ───────────────────────────────────────────────
 
+/// A command with its origin. `from: None` = host-originated (router,
+/// lifecycle, idle probe) and bypasses input ownership (B1).
+#[derive(Debug)]
+pub struct Addressed {
+    pub from: Option<ClientId>,
+    pub cmd: SessionCommand,
+}
+
+/// Why a `Checkpoint` was requested.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckpointReason {
+    Reload,
+    HostRequest,
+}
+
 /// The entire client→session control surface (SEAMS §5.2/§5.3).
-#[derive(Debug, Serialize, Deserialize)]
+///
+/// `Debug` is manual: `Submit`/`Steer`/`SubmitPrepared`/`Answer`/`Resume`
+/// print `<redacted>` (no lengths) so a command can be traced by *type*.
+#[derive(Serialize, Deserialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
 pub enum SessionCommand {
     /// User-authored prompt. Actor: reset auto-turn counter, fold
@@ -240,7 +331,8 @@ pub enum SessionCommand {
     /// Answer to a PromptRequest. `None` = cancelled.
     /// NEVER journaled, NEVER replayed, NEVER traced.
     Answer { prompt_id: u64, value: Option<String> },
-    Set(SessionSetting),
+    /// `id` is client-chosen and echoed in `SettingChanged.id`.
+    Set { id: u64, setting: SessionSetting },
     Compact { instructions: Option<String> },
     /// `/new`: ConversationState::clear.
     NewSession,
@@ -258,9 +350,100 @@ pub enum SessionCommand {
     /// /model /thinking /context /trace /memory /compact …). Reply =
     /// `QueryResult { id, value: {"kind": .., "text": ..} }`.
     EngineCommand { id: u64, name: String, arg: String },
+    /// (A3) dispatch.rs LoadSkill — pre-built tool_use/tool_result pair
+    /// (+ optional user text) then a turn. Does NOT fold abort_context and
+    /// does NOT reset consecutive_auto_turns.
+    SubmitPrepared {
+        messages: Vec<crate::SharedMessage>,
+        #[serde(default)]
+        user_text: Option<String>,
+    },
+    /// (A3) tools-backed (non-interactive) plugin command on THE runtime's
+    /// tool set. Reply = `QueryResult{id, {kind:"plugin_output", ..}}`.
+    PluginCommand { id: u64, plugin: String, name: String, arg: String },
+    /// (A3) `/resume`: save current, load `query`, restore model/reasoning/
+    /// system prompt, swap conversation. Reply = `Resumed{id, ..}`.
+    Resume { id: u64, query: String },
+    /// (B1, used by C3 reload) cancel any turn (abort_context captured),
+    /// abort compaction, save, close PTYs, emit Notice. Never ends the
+    /// session. Reply = `QueryResult{id: CHECKPOINT_QUERY_ID, {ok:true}}`.
+    Checkpoint { reason: CheckpointReason },
+    /// (B3) pin/unpin (`--keep-warm`, `/keep-warm on|off`).
+    KeepWarm { on: bool },
     /// Host→session (never wire): the actor re-emits as `SessionEventWire`.
     #[serde(skip)]
     HostEvent(HostEvent),
+}
+
+impl std::fmt::Debug for SessionCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Submit { attachments, .. } => f
+                .debug_struct("Submit")
+                .field("text", &format_args!("<redacted>"))
+                .field("attachments", &attachments.len())
+                .finish(),
+            Self::Steer { .. } => f
+                .debug_struct("Steer")
+                .field("text", &format_args!("<redacted>"))
+                .finish(),
+            Self::SubmitPrepared { .. } => f
+                .debug_struct("SubmitPrepared")
+                .field("messages", &format_args!("<redacted>"))
+                .field("user_text", &format_args!("<redacted>"))
+                .finish(),
+            Self::Answer { prompt_id, .. } => f
+                .debug_struct("Answer")
+                .field("prompt_id", prompt_id)
+                .field("value", &format_args!("<redacted>"))
+                .finish(),
+            Self::Resume { id, .. } => f
+                .debug_struct("Resume")
+                .field("id", id)
+                .field("query", &format_args!("<redacted>"))
+                .finish(),
+            Self::Cancel => f.write_str("Cancel"),
+            Self::Set { id, setting } => {
+                f.debug_struct("Set").field("id", id).field("setting", setting).finish()
+            }
+            Self::Compact { instructions } => {
+                f.debug_struct("Compact").field("instructions", instructions).finish()
+            }
+            Self::NewSession => f.write_str("NewSession"),
+            Self::Save => f.write_str("Save"),
+            Self::Query { id, query } => {
+                f.debug_struct("Query").field("id", id).field("query", query).finish()
+            }
+            Self::Attach { client, mode } => {
+                f.debug_struct("Attach").field("client", client).field("mode", mode).finish()
+            }
+            Self::Detach { client } => f.debug_struct("Detach").field("client", client).finish(),
+            Self::End { reason } => f.debug_struct("End").field("reason", reason).finish(),
+            Self::Resync { client, since_seq } => f
+                .debug_struct("Resync")
+                .field("client", client)
+                .field("since_seq", since_seq)
+                .finish(),
+            Self::EngineCommand { id, name, arg } => f
+                .debug_struct("EngineCommand")
+                .field("id", id)
+                .field("name", name)
+                .field("arg", arg)
+                .finish(),
+            Self::PluginCommand { id, plugin, name, arg } => f
+                .debug_struct("PluginCommand")
+                .field("id", id)
+                .field("plugin", plugin)
+                .field("name", name)
+                .field("arg", arg)
+                .finish(),
+            Self::Checkpoint { reason } => {
+                f.debug_struct("Checkpoint").field("reason", reason).finish()
+            }
+            Self::KeepWarm { on } => f.debug_struct("KeepWarm").field("on", on).finish(),
+            Self::HostEvent(ev) => f.debug_tuple("HostEvent").field(ev).finish(),
+        }
+    }
 }
 
 /// Host-originated events pushed into a session (C3 router, loader).
@@ -303,10 +486,23 @@ pub enum SessionSetting {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SettingApplied {
+    /// Correlates with `Set{id}`.
+    #[serde(default)]
+    pub id: u64,
     pub setting: String,
     pub ok: bool,
     pub message: Option<String>,
     pub view: RuntimeView,
+    /// `{from, to}` when a model change clamped the reasoning level, so the
+    /// TUI renders `reasoning_clamp_notice` byte-for-byte.
+    #[serde(default)]
+    pub clamp: Option<ReasoningClampWire>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReasoningClampWire {
+    pub from: String,
+    pub to: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -326,6 +522,8 @@ pub enum SessionQuery {
     View,
     /// assess_context
     ContextAssessment,
+    /// `engine::commands::context_command(runtime, Some(api_messages))` text.
+    ContextReport,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -347,9 +545,12 @@ pub enum EndReason {
 pub enum SessionEventWire {
     Stream(crate::StreamEvent),
     /// Actor bookkeeping the client needs to mirror `App` fields exactly.
+    /// `user_text` = the queued text on `QueuedAuto` (TUI pushes the User
+    /// card + scroll); `None` otherwise.
     TurnStarted {
         turn_baseline: usize,
         trigger: TurnTrigger,
+        user_text: Option<String>,
     },
     /// Emitted after every MessageHistory / Done / Error / Cancel / Compact so
     /// mirrors never diverge: the actor's api_messages IS the truth.
@@ -385,6 +586,58 @@ pub enum SessionEventWire {
     ClientJoined { client: ClientId, kind: ClientKind },
     ClientLeft { client: ClientId },
     Ended { reason: EndReason },
+    /// Cancel landed. TUI: drop_empty_thinking, push Error(abort_msg),
+    /// subagents.clear(), streaming=false.
+    Aborted { context_saved: bool },
+    /// `/clear`. TUI: transcript.clear, counters=0, "new session started".
+    Cleared { session_id: String },
+    /// (B2) `disclosure` = preview_compaction_disclosure().render_line().
+    CompactionStarted { source: String, disclosure: String },
+    CompactionApplied {
+        previous_session_id: String,
+        session_id: String,
+        chains_advanced: Vec<String>,
+        queued_restored: Option<String>,
+        msg_count: usize,
+    },
+    /// "compaction failed: {e}" vs "compaction task panicked: {e}".
+    CompactionFailed { message: String, panicked: bool },
+    CompactionCancelled,
+    /// `runtime.subagent_registry().display_rows()` — at Done/Error and at
+    /// 1 Hz while any row is non-terminal.
+    SubagentRows(Vec<crate::runtime::subagent::SubagentDisplayRow>),
+    /// `/resume` reply (`Resume{id}`).
+    Resumed {
+        id: u64,
+        old_id: String,
+        new_id: String,
+        via: Option<String>,
+        clamp_notice: Option<String>,
+    },
+    /// (B1) sent to the previous owner on takeover, and to everyone on any
+    /// owner change.
+    InputOwnerChanged {
+        from: Option<ClientId>,
+        to: Option<ClientId>,
+        reason: OwnerChangeReason,
+    },
+    /// (B1) a non-owner sent an input command. Only the sender renders it.
+    Refused { client: ClientId, command: String, reason: String },
+    /// (B3) targeted like `Attached`: the attach could not be honoured.
+    AttachRefused { message: String },
+    /// (B3) lifecycle transitions for mirrors and `sessions` listings.
+    Lifecycle(SessionLifecycle),
+    /// (C3) daemon is about to exec itself; clients reconnect.
+    Reloading { generation: u64, retry_after_ms: u64 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OwnerChangeReason {
+    Attach,
+    Takeover,
+    OwnerDetached,
+    Reload,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -419,6 +672,9 @@ pub struct ConversationTokens {
 /// counter). Clients MUST replace, never merge, on `Conversation(_)`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ConversationSnapshot {
+    /// The TUI's `App.session` mirror (never `api_messages`).
+    #[serde(default)]
+    pub header: SessionHeader,
     pub api_messages: Vec<crate::SharedMessage>,
     pub tokens: ConversationTokens,
     pub cost: f64,
@@ -426,6 +682,36 @@ pub struct ConversationSnapshot {
     pub queued_message: Option<String>,
     pub pending_events_len: usize,
     pub consecutive_auto_turns: u32,
+}
+
+/// `Session` minus `api_messages` and accounting: what a client mirrors.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionHeader {
+    pub id: String,
+    pub title: String,
+    pub name: Option<String>,
+    pub model: String,
+    pub thinking_level: String,
+    pub system_prompt: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub parent_session: Option<String>,
+}
+
+impl From<&crate::Session> for SessionHeader {
+    fn from(s: &crate::Session) -> Self {
+        Self {
+            id: s.id.clone(),
+            title: s.title.clone(),
+            name: s.name.clone(),
+            model: s.model.clone(),
+            thinking_level: s.thinking_level.clone(),
+            system_prompt: s.system_prompt.clone(),
+            created_at: s.created_at,
+            updated_at: s.updated_at,
+            parent_session: s.parent_session.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -439,6 +725,9 @@ pub struct AttachSnapshot {
     pub replay: Vec<Envelope>,
     pub pending_prompts: Vec<PromptRequest>,
     pub clients: Vec<(ClientId, ClientKind)>,
+    /// Who owns input right now (B1) — so a joiner knows immediately
+    /// whether its keystrokes will be honoured.
+    pub input_owner: Option<ClientId>,
 }
 
 /// `ReasoningLevel` has no serde impls in agent-core; go through its
@@ -481,20 +770,26 @@ mod tests {
 
     #[test]
     fn command_json_round_trip() {
-        let cmd = SessionCommand::Set(SessionSetting::ReasoningLevel {
-            level: agent_core::reasoning::ReasoningLevel::Ultra,
-        });
+        let cmd = SessionCommand::Set {
+            id: 7,
+            setting: SessionSetting::ReasoningLevel {
+                level: agent_core::reasoning::ReasoningLevel::Ultra,
+            },
+        };
         let json = serde_json::to_string(&cmd).unwrap();
         assert_eq!(
             json,
-            r#"{"cmd":"set","setting":"reasoning_level","level":"ultra"}"#
+            r#"{"cmd":"set","id":7,"setting":{"setting":"reasoning_level","level":"ultra"}}"#
         );
         let back: SessionCommand = serde_json::from_str(&json).unwrap();
         assert!(matches!(
             back,
-            SessionCommand::Set(SessionSetting::ReasoningLevel {
-                level: agent_core::reasoning::ReasoningLevel::Ultra
-            })
+            SessionCommand::Set {
+                id: 7,
+                setting: SessionSetting::ReasoningLevel {
+                    level: agent_core::reasoning::ReasoningLevel::Ultra
+                }
+            }
         ));
 
         let submit: SessionCommand = serde_json::from_str(r#"{"cmd":"submit","text":"hi"}"#).unwrap();
@@ -505,6 +800,72 @@ mod tests {
             }
             other => panic!("unexpected {other:?}"),
         }
+    }
+
+    #[test]
+    fn new_commands_round_trip() {
+        let cmds = vec![
+            SessionCommand::SubmitPrepared {
+                messages: vec![std::sync::Arc::new(serde_json::json!({"role":"user","content":"x"}))],
+                user_text: Some("t".into()),
+            },
+            SessionCommand::PluginCommand { id: 1, plugin: "p".into(), name: "n".into(), arg: "a".into() },
+            SessionCommand::Resume { id: 2, query: "q".into() },
+            SessionCommand::Checkpoint { reason: CheckpointReason::Reload },
+            SessionCommand::KeepWarm { on: true },
+            SessionCommand::Query { id: 3, query: SessionQuery::ContextReport },
+        ];
+        for cmd in cmds {
+            let json = serde_json::to_string(&cmd).unwrap();
+            let back: SessionCommand = serde_json::from_str(&json).unwrap();
+            assert_eq!(serde_json::to_string(&back).unwrap(), json);
+        }
+        let cp: SessionCommand = serde_json::from_str(r#"{"cmd":"checkpoint","reason":"host_request"}"#).unwrap();
+        assert!(matches!(cp, SessionCommand::Checkpoint { reason: CheckpointReason::HostRequest }));
+    }
+
+    #[test]
+    fn command_debug_redacts_bodies_without_lengths() {
+        let secret = "hunter2-very-secret";
+        let cmds = vec![
+            SessionCommand::Submit { text: secret.into(), attachments: vec![] },
+            SessionCommand::Steer { text: secret.into() },
+            SessionCommand::SubmitPrepared {
+                messages: vec![std::sync::Arc::new(serde_json::json!({"content": secret}))],
+                user_text: Some(secret.into()),
+            },
+            SessionCommand::Answer { prompt_id: 1, value: Some(secret.into()) },
+            SessionCommand::Resume { id: 1, query: secret.into() },
+        ];
+        for cmd in cmds {
+            let d = format!("{cmd:?}");
+            assert!(!d.contains(secret), "{d}");
+            assert!(d.contains("<redacted>"), "{d}");
+            assert!(!d.contains("chars"), "{d}");
+            assert!(!d.contains(&secret.len().to_string()), "{d}");
+        }
+        let d = format!("{:?}", SessionCommand::Set { id: 4, setting: SessionSetting::ReloadPrompt });
+        assert_eq!(d, "Set { id: 4, setting: ReloadPrompt }");
+    }
+
+    #[test]
+    fn session_config_new_fields_default() {
+        let cfg: SessionConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(cfg.compaction_policy, CompactionPolicyWire::InPlace);
+        assert!(cfg.await_extensions);
+        assert!(!cfg.keep_warm);
+        let cfg: SessionConfig =
+            serde_json::from_str(r#"{"compaction_policy":"linked_successor","await_extensions":false}"#).unwrap();
+        assert_eq!(cfg.compaction_policy, CompactionPolicyWire::LinkedSuccessor);
+        assert!(!cfg.await_extensions);
+    }
+
+    #[test]
+    fn session_lifecycle_u8_round_trip() {
+        for l in [SessionLifecycle::Live, SessionLifecycle::Parking, SessionLifecycle::Parked, SessionLifecycle::Ending] {
+            assert_eq!(SessionLifecycle::from_u8(l as u8), l);
+        }
+        assert_eq!(serde_json::to_string(&SessionLifecycle::Parked).unwrap(), r#""parked""#);
     }
 
     #[test]

--- a/crates/agent-engine/src/session/wire.rs
+++ b/crates/agent-engine/src/session/wire.rs
@@ -29,7 +29,10 @@ use super::view::RuntimeView;
 use crate::{AgentEvent, LlmEvent, SessionEvent, StreamEvent, TurnError, TurnOutcome};
 
 /// Separate from `RPC_PROTOCOL_VERSION`; bump on any non-additive change.
-pub const PROTOCOL_VERSION: u32 = 1;
+/// v2 (phase 3): `Set` became a struct variant, `Bye` gained a reason.
+/// Protocol stays exact-match; only *binary* versions compare directionally
+/// (reload, §2.8).
+pub const PROTOCOL_VERSION: u32 = 2;
 /// Exact-match policy today (`min == max == PROTOCOL_VERSION`).
 pub const PROTOCOL_MIN: u32 = PROTOCOL_VERSION;
 pub const PROTOCOL_MAX: u32 = PROTOCOL_VERSION;
@@ -47,6 +50,9 @@ pub const RESERVED_QUERY_ID_BASE: u64 = 1 << 63;
 pub const DIGEST_RESYNC_QUERY_ID: u64 = RESERVED_QUERY_ID_BASE;
 /// The daemon's idle monitor probes `Status` under this id.
 pub const IDLE_PROBE_QUERY_ID: u64 = RESERVED_QUERY_ID_BASE + 1;
+/// `Checkpoint` replies `QueryResult{id: CHECKPOINT_QUERY_ID, {ok:true}}`
+/// so `reload.rs` can await it per session.
+pub const CHECKPOINT_QUERY_ID: u64 = RESERVED_QUERY_ID_BASE + 2;
 
 /// The binary version the daemon/client report in the handshake.
 pub fn binary_version() -> String {
@@ -73,11 +79,26 @@ pub enum ClientFrame {
         session_id: SessionId,
         cmd: SessionCommand,
     },
+    /// Control fast path (no session): checkpoint every session, write
+    /// reload-state, execv self. Reply: `Reloading` to every attached
+    /// client, `Bye` to this one. (C3)
+    Reload {
+        #[serde(default)]
+        now: bool,
+        #[serde(default)]
+        drain_secs: Option<u64>,
+        #[serde(default)]
+        exe: Option<PathBuf>,
+    },
+    /// Control fast path: `memstat::purge_arenas()` in the daemon (bench
+    /// hygiene). Reply: `Pong`. (C2)
+    Purge,
     Bye,
 }
 
 impl std::fmt::Debug for ClientFrame {
-    /// Frame *types* only for anything that can carry user text or a secret.
+    /// Frame *types* only for anything that can carry user text or a secret
+    /// (`SessionCommand`'s own `Debug` redacts bodies without lengths).
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Hello(h) => f.debug_tuple("Hello").field(h).finish(),
@@ -86,32 +107,15 @@ impl std::fmt::Debug for ClientFrame {
             Self::Shutdown { force } => f.debug_struct("Shutdown").field("force", force).finish(),
             Self::Attach(a) => f.debug_tuple("Attach").field(a).finish(),
             Self::Cmd { session_id, cmd } => {
-                let cmd: &dyn std::fmt::Debug = match cmd {
-                    SessionCommand::Answer { prompt_id, value } => {
-                        return f
-                            .debug_struct("Cmd")
-                            .field("session_id", session_id)
-                            .field("cmd", &format_args!("Answer {{ prompt_id: {prompt_id}, value: <redacted {} chars> }}", value.as_ref().map_or(0, |v| v.chars().count())))
-                            .finish();
-                    }
-                    SessionCommand::Submit { text, attachments } => {
-                        return f
-                            .debug_struct("Cmd")
-                            .field("session_id", session_id)
-                            .field("cmd", &format_args!("Submit {{ text: <{} chars>, attachments: {} }}", text.chars().count(), attachments.len()))
-                            .finish();
-                    }
-                    SessionCommand::Steer { text } => {
-                        return f
-                            .debug_struct("Cmd")
-                            .field("session_id", session_id)
-                            .field("cmd", &format_args!("Steer {{ text: <{} chars> }}", text.chars().count()))
-                            .finish();
-                    }
-                    other => other,
-                };
                 f.debug_struct("Cmd").field("session_id", session_id).field("cmd", cmd).finish()
             }
+            Self::Reload { now, drain_secs, exe } => f
+                .debug_struct("Reload")
+                .field("now", now)
+                .field("drain_secs", drain_secs)
+                .field("exe", exe)
+                .finish(),
+            Self::Purge => f.write_str("Purge"),
             Self::Bye => f.write_str("Bye"),
         }
     }
@@ -123,6 +127,19 @@ pub struct Hello {
     pub client: ClientMeta,
     pub cwd: PathBuf,
     pub client_version: String,
+    /// Set when re-connecting after `Reloading`/EOF (C3/A4).
+    #[serde(default)]
+    pub reconnect_of: Option<ClientReconnect>,
+}
+
+/// Who this connection used to be, so the daemon can restore ownership by
+/// reconnect order + `was_owner`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientReconnect {
+    pub previous_client: ClientId,
+    pub session_id: SessionId,
+    pub was_owner: bool,
+    pub generation: u64,
 }
 
 impl Hello {
@@ -135,6 +152,7 @@ impl Hello {
             },
             cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")),
             client_version: binary_version(),
+            reconnect_of: None,
         }
     }
 }
@@ -185,7 +203,19 @@ pub enum DaemonFrame {
         session_id: Option<SessionId>,
         message: String,
     },
-    Bye,
+    /// `Some(Reloading{..})` before exec; `None` otherwise (today).
+    Bye {
+        #[serde(default)]
+        reason: Option<ByeReason>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "bye", rename_all = "snake_case")]
+pub enum ByeReason {
+    Reloading { generation: u64, retry_after_ms: u64 },
+    Shutdown,
+    Detached,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -200,6 +230,8 @@ pub enum RefuseReason {
     Busy,
     UnknownSession,
     Config,
+    /// `synaps daemon reload` version gate failed (C3).
+    ReloadRefused { why: String },
 }
 
 /// Auth-status *summary* only — never key material.
@@ -211,6 +243,13 @@ pub struct Welcome {
     pub profile: Option<String>,
     pub sessions: Vec<SessionMeta>,
     pub progressive_tool_disclosure: bool,
+    /// Reload counter (starts at 1).
+    #[serde(default = "one")]
+    pub generation: u64,
+}
+
+fn one() -> u64 {
+    1
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -254,6 +293,8 @@ pub struct AttachedWire {
     pub replay: Vec<WireEnvelope>,
     pub pending_prompts: Vec<PromptRequest>,
     pub clients: Vec<(ClientId, ClientKind)>,
+    #[serde(default)]
+    pub input_owner: Option<ClientId>,
 }
 
 impl AttachedWire {
@@ -267,6 +308,7 @@ impl AttachedWire {
             replay: s.replay.into_iter().map(Into::into).collect(),
             pending_prompts: s.pending_prompts,
             clients: s.clients,
+            input_owner: s.input_owner,
         }
     }
 
@@ -281,6 +323,7 @@ impl AttachedWire {
                 replay: self.replay.into_iter().map(Into::into).collect(),
                 pending_prompts: self.pending_prompts,
                 clients: self.clients,
+                input_owner: self.input_owner,
             },
         )
     }
@@ -293,6 +336,8 @@ impl AttachedWire {
 /// client can tell whether its local mirror is current.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ConversationDigest {
+    #[serde(default)]
+    pub header: SessionHeader,
     pub messages_len: usize,
     pub messages_hash: u64,
     pub tokens: ConversationTokens,
@@ -325,6 +370,7 @@ pub fn messages_hash(messages: &[crate::SharedMessage]) -> u64 {
 impl ConversationDigest {
     pub fn of(s: &ConversationSnapshot) -> Self {
         Self {
+            header: s.header.clone(),
             messages_len: s.api_messages.len(),
             messages_hash: messages_hash(&s.api_messages),
             tokens: s.tokens.clone(),
@@ -343,6 +389,7 @@ impl ConversationDigest {
     /// Rebuild a snapshot around `messages` (the caller's mirror).
     pub fn into_snapshot(self, api_messages: Vec<crate::SharedMessage>) -> ConversationSnapshot {
         ConversationSnapshot {
+            header: self.header,
             api_messages,
             tokens: self.tokens,
             cost: self.cost,
@@ -361,7 +408,12 @@ impl ConversationDigest {
 #[allow(clippy::large_enum_variant)] // mirrors SessionEventWire by design
 pub enum WireSessionEvent {
     Stream { event: WireStreamEvent },
-    TurnStarted { turn_baseline: usize, trigger: TurnTrigger },
+    TurnStarted {
+        turn_baseline: usize,
+        trigger: TurnTrigger,
+        #[serde(default)]
+        user_text: Option<String>,
+    },
     /// Digest only — see module docs.
     Conversation { digest: ConversationDigest },
     Prompt { request: PromptRequest },
@@ -380,6 +432,31 @@ pub enum WireSessionEvent {
     ClientJoined { client: ClientId, kind: ClientKind },
     ClientLeft { client: ClientId },
     Ended { reason: EndReason },
+    Aborted { context_saved: bool },
+    Cleared { session_id: String },
+    CompactionStarted { source: String, disclosure: String },
+    CompactionApplied {
+        previous_session_id: String,
+        session_id: String,
+        chains_advanced: Vec<String>,
+        queued_restored: Option<String>,
+        msg_count: usize,
+    },
+    CompactionFailed { message: String, panicked: bool },
+    CompactionCancelled,
+    SubagentRows { rows: Vec<crate::runtime::subagent::SubagentDisplayRow> },
+    Resumed {
+        id: u64,
+        old_id: String,
+        new_id: String,
+        via: Option<String>,
+        clamp_notice: Option<String>,
+    },
+    InputOwnerChanged { from: Option<ClientId>, to: Option<ClientId>, reason: OwnerChangeReason },
+    Refused { client: ClientId, command: String, reason: String },
+    AttachRefused { message: String },
+    Lifecycle { lifecycle: SessionLifecycle },
+    Reloading { generation: u64, retry_after_ms: u64 },
     /// Forward-compat: an additive variant from a newer daemon.
     #[serde(other)]
     Unknown,
@@ -600,7 +677,9 @@ impl From<SessionEventWire> for WireSessionEvent {
         use SessionEventWire as S;
         match e {
             S::Stream(ev) => Self::Stream { event: ev.into() },
-            S::TurnStarted { turn_baseline, trigger } => Self::TurnStarted { turn_baseline, trigger },
+            S::TurnStarted { turn_baseline, trigger, user_text } => {
+                Self::TurnStarted { turn_baseline, trigger, user_text }
+            }
             S::Conversation(snapshot) => Self::Conversation { digest: ConversationDigest::of(&snapshot) },
             S::Prompt(request) => Self::Prompt { request },
             S::PromptResolved { prompt_id } => Self::PromptResolved { prompt_id },
@@ -620,6 +699,23 @@ impl From<SessionEventWire> for WireSessionEvent {
             S::ClientJoined { client, kind } => Self::ClientJoined { client, kind },
             S::ClientLeft { client } => Self::ClientLeft { client },
             S::Ended { reason } => Self::Ended { reason },
+            S::Aborted { context_saved } => Self::Aborted { context_saved },
+            S::Cleared { session_id } => Self::Cleared { session_id },
+            S::CompactionStarted { source, disclosure } => Self::CompactionStarted { source, disclosure },
+            S::CompactionApplied { previous_session_id, session_id, chains_advanced, queued_restored, msg_count } => {
+                Self::CompactionApplied { previous_session_id, session_id, chains_advanced, queued_restored, msg_count }
+            }
+            S::CompactionFailed { message, panicked } => Self::CompactionFailed { message, panicked },
+            S::CompactionCancelled => Self::CompactionCancelled,
+            S::SubagentRows(rows) => Self::SubagentRows { rows },
+            S::Resumed { id, old_id, new_id, via, clamp_notice } => {
+                Self::Resumed { id, old_id, new_id, via, clamp_notice }
+            }
+            S::InputOwnerChanged { from, to, reason } => Self::InputOwnerChanged { from, to, reason },
+            S::Refused { client, command, reason } => Self::Refused { client, command, reason },
+            S::AttachRefused { message } => Self::AttachRefused { message },
+            S::Lifecycle(lifecycle) => Self::Lifecycle { lifecycle },
+            S::Reloading { generation, retry_after_ms } => Self::Reloading { generation, retry_after_ms },
         }
     }
 }
@@ -629,7 +725,9 @@ impl From<WireSessionEvent> for SessionEventWire {
         use WireSessionEvent as W;
         match e {
             W::Stream { event } => Self::Stream(event.into()),
-            W::TurnStarted { turn_baseline, trigger } => Self::TurnStarted { turn_baseline, trigger },
+            W::TurnStarted { turn_baseline, trigger, user_text } => {
+                Self::TurnStarted { turn_baseline, trigger, user_text }
+            }
             // Messages are not on the wire; `SocketTransport` fills them from
             // its mirror before handing the envelope up.
             W::Conversation { digest } => Self::Conversation(digest.into_snapshot(Vec::new())),
@@ -654,6 +752,23 @@ impl From<WireSessionEvent> for SessionEventWire {
             W::ClientJoined { client, kind } => Self::ClientJoined { client, kind },
             W::ClientLeft { client } => Self::ClientLeft { client },
             W::Ended { reason } => Self::Ended { reason },
+            W::Aborted { context_saved } => Self::Aborted { context_saved },
+            W::Cleared { session_id } => Self::Cleared { session_id },
+            W::CompactionStarted { source, disclosure } => Self::CompactionStarted { source, disclosure },
+            W::CompactionApplied { previous_session_id, session_id, chains_advanced, queued_restored, msg_count } => {
+                Self::CompactionApplied { previous_session_id, session_id, chains_advanced, queued_restored, msg_count }
+            }
+            W::CompactionFailed { message, panicked } => Self::CompactionFailed { message, panicked },
+            W::CompactionCancelled => Self::CompactionCancelled,
+            W::SubagentRows { rows } => Self::SubagentRows(rows),
+            W::Resumed { id, old_id, new_id, via, clamp_notice } => {
+                Self::Resumed { id, old_id, new_id, via, clamp_notice }
+            }
+            W::InputOwnerChanged { from, to, reason } => Self::InputOwnerChanged { from, to, reason },
+            W::Refused { client, command, reason } => Self::Refused { client, command, reason },
+            W::AttachRefused { message } => Self::AttachRefused { message },
+            W::Lifecycle { lifecycle } => Self::Lifecycle(lifecycle),
+            W::Reloading { generation, retry_after_ms } => Self::Reloading { generation, retry_after_ms },
             W::Unknown => Self::SystemNotice("unknown event from a newer daemon (ignored)".into()),
         }
     }
@@ -711,6 +826,17 @@ mod tests {
 
     fn conv() -> ConversationSnapshot {
         ConversationSnapshot {
+            header: SessionHeader {
+                id: "wire-1".into(),
+                title: "t".into(),
+                name: None,
+                model: "m".into(),
+                thinking_level: "off".into(),
+                system_prompt: Some("sys".into()),
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                parent_session: Some("p".into()),
+            },
             api_messages: vec![Arc::new(serde_json::json!({"role":"user","content":"hi"}))],
             tokens: ConversationTokens { input: 1, output: 2, cache_read: 3, cache_creation: 4 },
             cost: 0.5,
@@ -778,7 +904,8 @@ mod tests {
         };
         let mut v: Vec<S> = stream_fixtures().into_iter().map(S::Stream).collect();
         v.extend([
-            S::TurnStarted { turn_baseline: 4, trigger: TurnTrigger::EventAuto },
+            S::TurnStarted { turn_baseline: 4, trigger: TurnTrigger::EventAuto, user_text: None },
+            S::TurnStarted { turn_baseline: 5, trigger: TurnTrigger::QueuedAuto, user_text: Some("q".into()) },
             S::Conversation(conv()),
             S::Prompt(prompt()),
             S::PromptResolved { prompt_id: 3 },
@@ -790,7 +917,14 @@ mod tests {
             S::SystemNotice("sys".into()),
             S::LoaderProgress(loader),
             S::ExtensionNotification { extension_id: "e".into(), method: "widget.upsert".into(), params: serde_json::json!({"a":1}) },
-            S::SettingChanged(SettingApplied { setting: "model".into(), ok: true, message: None, view: view() }),
+            S::SettingChanged(SettingApplied {
+                id: 3,
+                setting: "model".into(),
+                ok: true,
+                message: None,
+                view: view(),
+                clamp: Some(ReasoningClampWire { from: "ultra".into(), to: "high".into() }),
+            }),
             S::QueryResult { id: 1, value: serde_json::json!([1, 2]) },
             S::Attached {
                 client: ClientId(2),
@@ -802,11 +936,38 @@ mod tests {
                     replay: vec![env(S::Stream(StreamEvent::Llm(LlmEvent::Text("partial".into()))))],
                     pending_prompts: vec![prompt()],
                     clients: vec![(ClientId(1), ClientKind::Tui)],
+                    input_owner: Some(ClientId(1)),
                 },
             },
             S::ClientJoined { client: ClientId(1), kind: ClientKind::Attach },
             S::ClientLeft { client: ClientId(1) },
             S::Ended { reason: EndReason::HostShutdown },
+            S::Aborted { context_saved: true },
+            S::Cleared { session_id: "new-1".into() },
+            S::CompactionStarted { source: "manual".into(), disclosure: "disc".into() },
+            S::CompactionApplied {
+                previous_session_id: "old".into(),
+                session_id: "new".into(),
+                chains_advanced: vec!["c1".into()],
+                queued_restored: Some("q".into()),
+                msg_count: 12,
+            },
+            S::CompactionFailed { message: "boom".into(), panicked: false },
+            S::CompactionCancelled,
+            S::SubagentRows(vec![crate::runtime::subagent::SubagentDisplayRow {
+                subagent_id: 1,
+                agent_name: "a".into(),
+                status: crate::runtime::subagent::SubagentStatus::Failed("x".into()),
+                cancel_requested: false,
+                elapsed_secs: 1.25,
+                finished_elapsed: Some(std::time::Duration::from_millis(1250)),
+            }]),
+            S::Resumed { id: 2, old_id: "o".into(), new_id: "n".into(), via: Some("name".into()), clamp_notice: None },
+            S::InputOwnerChanged { from: Some(ClientId(1)), to: Some(ClientId(2)), reason: OwnerChangeReason::Takeover },
+            S::Refused { client: ClientId(2), command: "submit".into(), reason: "input owned by client #1".into() },
+            S::AttachRefused { message: "parked".into() },
+            S::Lifecycle(SessionLifecycle::Parked),
+            S::Reloading { generation: 2, retry_after_ms: 500 },
         ]);
         v
     }
@@ -814,8 +975,8 @@ mod tests {
     #[test]
     fn wire_roundtrip_every_variant() {
         let all = fixtures();
-        // Every SessionEventWire variant (19) + every StreamEvent leaf (18; Stream counted once).
-        assert_eq!(all.len(), 18 + 18);
+        // Every non-Stream SessionEventWire variant (31; TurnStarted twice = 32) + every StreamEvent leaf (18).
+        assert_eq!(all.len(), 32 + 18);
         for ev in all {
             let is_conv = matches!(ev, SessionEventWire::Conversation(_));
             let e = env(ev);
@@ -873,6 +1034,11 @@ mod tests {
             ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::Answer { prompt_id: 1, value: Some("pw".into()) } },
             ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::EngineCommand { id: 4, name: "model".into(), arg: "x".into() } },
             ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::Query { id: 5, query: SessionQuery::Status } },
+            ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::Set { id: 6, setting: SessionSetting::ReloadPrompt } },
+            ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::Checkpoint { reason: CheckpointReason::Reload } },
+            ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::KeepWarm { on: true } },
+            ClientFrame::Reload { now: true, drain_secs: Some(3), exe: Some(PathBuf::from("/bin/synaps")) },
+            ClientFrame::Purge,
             ClientFrame::Bye,
         ];
         for f in frames {
@@ -882,14 +1048,16 @@ mod tests {
         }
         let frames = vec![
             DaemonFrame::Welcome(Welcome {
-                protocol_version: 1,
+                protocol_version: 2,
                 daemon_version: "0.9.0".into(),
                 pid: 1,
                 profile: None,
                 sessions: vec![meta()],
                 progressive_tool_disclosure: true,
+                generation: 1,
             }),
-            DaemonFrame::Refused { reason: RefuseReason::Version { daemon_version: 1, min: 1, max: 1 }, message: "no".into() },
+            DaemonFrame::Refused { reason: RefuseReason::Version { daemon_version: 2, min: 2, max: 2 }, message: "no".into() },
+            DaemonFrame::Refused { reason: RefuseReason::ReloadRefused { why: "older".into() }, message: "no".into() },
             DaemonFrame::Pong { pid: 1, uptime_s: 2, sessions: 0 },
             DaemonFrame::SessionList { sessions: vec![meta()] },
             DaemonFrame::Attached(AttachedWire::new(
@@ -902,11 +1070,14 @@ mod tests {
                     replay: vec![],
                     pending_prompts: vec![],
                     clients: vec![],
+                    input_owner: None,
                 },
             )),
             DaemonFrame::Event(env(SessionEventWire::SystemNotice("x".into())).into()),
             DaemonFrame::Error { session_id: None, message: "e".into() },
-            DaemonFrame::Bye,
+            DaemonFrame::Bye { reason: None },
+            DaemonFrame::Bye { reason: Some(ByeReason::Reloading { generation: 2, retry_after_ms: 500 }) },
+            DaemonFrame::Bye { reason: Some(ByeReason::Shutdown) },
         ];
         for f in frames {
             let line = encode_line(&f).unwrap();
@@ -922,6 +1093,15 @@ mod tests {
         assert_eq!(PROTOCOL_MIN, PROTOCOL_MAX);
         let json = serde_json::to_string(&ClientFrame::Hello(h)).unwrap();
         assert!(json.starts_with(r#"{"type":"hello""#));
+        assert_eq!(PROTOCOL_VERSION, 2);
+        // v1 frames (no `reconnect_of`, bare `bye`) still parse — the refusal is by version, not by shape.
+        let h: Hello = serde_json::from_str(
+            r#"{"protocol_version":1,"client":{"kind":"tui","terminal":null,"instance":"i"},"cwd":"/","client_version":"0"}"#,
+        )
+        .unwrap();
+        assert!(h.reconnect_of.is_none());
+        let b: DaemonFrame = serde_json::from_str(r#"{"type":"bye"}"#).unwrap();
+        assert!(matches!(b, DaemonFrame::Bye { reason: None }));
     }
 
     #[test]
@@ -941,7 +1121,11 @@ mod tests {
         let d = format!("{f:?}");
         assert!(!d.contains("private"), "{d}");
         let f = ClientFrame::Cmd { session_id: "s".into(), cmd: SessionCommand::Steer { text: "steer me".into() } };
-        assert!(!format!("{f:?}").contains("steer me"));
+        let d = format!("{f:?}");
+        assert!(!d.contains("steer me"));
+        // No lengths either: a char count is a side channel.
+        assert!(!d.contains("chars"), "{d}");
+        assert!(!d.contains('8'), "{d}");
     }
 
     #[test]
@@ -968,6 +1152,7 @@ mod tests {
             profile: Some("p".into()),
             sessions: vec![meta()],
             progressive_tool_disclosure: false,
+            generation: 1,
         })
         .unwrap()
         .to_lowercase();

--- a/crates/agent-engine/src/tools/secret_prompt.rs
+++ b/crates/agent-engine/src/tools/secret_prompt.rs
@@ -120,4 +120,44 @@ impl SecretPromptQueue {
         }
         self.activate_next();
     }
+
+    /// Drop the active prompt WITHOUT answering (the oneshot is dropped, not
+    /// sent): another client resolved it (`PromptResolved` for a prompt this
+    /// client did not answer). The next pending prompt activates.
+    pub fn dismiss(&mut self) {
+        if let Some(mut active) = self.active.take() {
+            active.buffer.clear();
+            drop(active.response_tx);
+        }
+        self.activate_next();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dismiss_drops_without_answering_and_activates_next() {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let rx = Arc::new(Mutex::new(rx));
+        let (tx1, mut rx1) = tokio::sync::oneshot::channel();
+        let (tx2, mut rx2) = tokio::sync::oneshot::channel();
+        tx.send(SecretPromptRequest { title: "a".into(), prompt: "p".into(), response_tx: tx1 }).unwrap();
+        tx.send(SecretPromptRequest { title: "b".into(), prompt: "p".into(), response_tx: tx2 }).unwrap();
+        let mut q = SecretPromptQueue::new();
+        q.poll_requests(&rx);
+        assert_eq!(q.active().unwrap().title, "a");
+        q.push_char('z');
+        q.dismiss();
+        // Dropped, never sent: the waiter sees a closed channel (== cancelled).
+        assert!(matches!(rx1.try_recv(), Err(tokio::sync::oneshot::error::TryRecvError::Closed)));
+        // The next prompt is active with a fresh buffer.
+        assert_eq!(q.active().unwrap().title, "b");
+        assert_eq!(q.active().unwrap().buffer, "");
+        q.push_char('x');
+        q.submit();
+        assert_eq!(rx2.try_recv().unwrap(), Some("x".to_string()));
+        assert!(!q.is_active());
+    }
 }

--- a/crates/agent-engine/tests/session_actor.rs
+++ b/crates/agent-engine/tests/session_actor.rs
@@ -427,9 +427,10 @@ async fn cancel_while_idle_is_a_noop() {
     a.send(submit("again")).await.unwrap();
     let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
     assert!(
-        !seen.iter().any(|e| matches!(&e.event,
-            SessionEventWire::SystemNotice(n) if n.starts_with("aborted"))),
-        "no abort notice"
+        !seen
+            .iter()
+            .any(|e| matches!(&e.event, SessionEventWire::Aborted { .. })),
+        "no Aborted event"
     );
     let conv = last_conversation(&seen);
     assert_eq!(conv.api_messages.len(), 4);

--- a/crates/agent-engine/tests/session_actor.rs
+++ b/crates/agent-engine/tests/session_actor.rs
@@ -312,15 +312,18 @@ async fn set_applies_and_publishes_view() {
     let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Test))
         .await
         .unwrap();
-    a.send(SessionCommand::Set(SessionSetting::ContextWindow {
-        tokens: Some(4242),
-    }))
+    a.send(SessionCommand::Set {
+        id: 42,
+        setting: SessionSetting::ContextWindow { tokens: Some(4242) },
+    })
     .await
     .unwrap();
     let seen = until(&mut a, |e| matches!(e, SessionEventWire::SettingChanged(_))).await;
     match &seen.last().unwrap().event {
         SessionEventWire::SettingChanged(s) => {
             assert!(s.ok);
+            assert_eq!(s.id, 42);
+            assert!(s.clamp.is_none());
             assert_eq!(s.setting, "context_window");
             assert_eq!(s.view.context_window, 4242);
         }

--- a/crates/agent-engine/tests/session_actor_common/mod.rs
+++ b/crates/agent-engine/tests/session_actor_common/mod.rs
@@ -1,0 +1,310 @@
+//! Shared harness for the `session_actor_*` integration tests: temp HOME,
+//! loopback Anthropic SSE stub, host/config helpers, event drains.
+#![allow(dead_code)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_engine::session::{
+    ClientTransport, EndReason, Envelope, LocalTransport, SessionCommand, SessionConfig,
+    SessionEventWire,
+};
+use agent_engine::{EngineHost, HostOpts};
+use axum::response::IntoResponse;
+
+pub const MODEL: &str = "claude-sonnet-4-5";
+
+pub const SSE_HI: &str = concat!(
+    "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"type\":\"message\",",
+    "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-5\",\"stop_reason\":null,",
+    "\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,",
+    "\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":0,",
+    "\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
+    "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",",
+    "\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":1,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}\n\n",
+    "data: {\"type\":\"message_stop\"}\n\n",
+);
+
+/// Started stream with one text delta and NO terminal event.
+pub const SSE_PREFIX: &str = concat!(
+    "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_01\",\"type\":\"message\",",
+    "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-5\",\"stop_reason\":null,",
+    "\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,",
+    "\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":0,",
+    "\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n",
+);
+
+/// Turn requesting the `prompt_fixture` tool; follow-up round serves SSE_HI.
+pub const SSE_PROMPT_TOOL_USE: &str = concat!(
+    "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_p1\",\"type\":\"message\",",
+    "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-5\",\"stop_reason\":null,",
+    "\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,",
+    "\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_prompt\",\"name\":\"prompt_fixture\"}}\n\n",
+    "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",",
+    "\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}\n\n",
+    "data: {\"type\":\"message_stop\"}\n\n",
+);
+
+pub struct Home {
+    pub dir: tempfile::TempDir,
+}
+
+impl Home {
+    pub fn new() -> Self {
+        let dir = tempfile::TempDir::new().unwrap();
+        let base = dir.path().join(".synaps-cli");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(base.join("config"), "").unwrap();
+        std::fs::write(
+            base.join("auth.json"),
+            "{\"anthropic\": {\"type\": \"oauth\", \"refresh\": \"r\", \"access\": \"synthetic-token\", \"expires\": 9999999999999}}",
+        )
+        .unwrap();
+        for k in ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"] {
+            std::env::remove_var(k);
+        }
+        std::env::set_var("HOME", dir.path());
+        std::env::set_var("SYNAPS_BASE_DIR", &base);
+        Self { dir }
+    }
+}
+
+/// `endless`: after the body, keep-alive comments forever (cancel fixture).
+pub async fn stub(body: &'static str, endless: bool) -> (String, Arc<AtomicUsize>) {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_c = Arc::clone(&hits);
+    let app = axum::Router::new().fallback(move || {
+        let hits = Arc::clone(&hits_c);
+        async move {
+            hits.fetch_add(1, Ordering::SeqCst);
+            if endless {
+                let stream = futures::stream::once(async move {
+                    Ok::<_, std::io::Error>(axum::body::Bytes::from(body))
+                })
+                .chain(futures::stream::unfold((), |()| async {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    Some((Ok(axum::body::Bytes::from(": keep-alive\n\n")), ()))
+                }));
+                axum::response::Response::builder()
+                    .status(200)
+                    .header("content-type", "text/event-stream")
+                    .body(axum::body::Body::from_stream(stream))
+                    .unwrap()
+            } else {
+                (
+                    axum::http::StatusCode::OK,
+                    [("content-type", "text/event-stream")],
+                    body.to_string(),
+                )
+                    .into_response()
+            }
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), hits)
+}
+
+use futures::StreamExt;
+
+/// Sequenced stub: hit `i` serves `bodies[min(i, len-1)]` (all terminal).
+pub async fn stub_seq(bodies: &'static [&'static str]) -> (String, Arc<AtomicUsize>) {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_c = Arc::clone(&hits);
+    let app = axum::Router::new().fallback(move || {
+        let hits = Arc::clone(&hits_c);
+        async move {
+            let i = hits.fetch_add(1, Ordering::SeqCst);
+            let body = bodies[i.min(bodies.len() - 1)];
+            (
+                axum::http::StatusCode::OK,
+                [("content-type", "text/event-stream")],
+                body.to_string(),
+            )
+                .into_response()
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), hits)
+}
+
+/// Stub whose response is delayed `delay` per hit (slow compaction fixture).
+pub async fn stub_slow(body: &'static str, delay: Duration) -> (String, Arc<AtomicUsize>) {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_c = Arc::clone(&hits);
+    let app = axum::Router::new().fallback(move || {
+        let hits = Arc::clone(&hits_c);
+        async move {
+            hits.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(delay).await;
+            (
+                axum::http::StatusCode::OK,
+                [("content-type", "text/event-stream")],
+                body.to_string(),
+            )
+                .into_response()
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), hits)
+}
+
+pub async fn host() -> Arc<EngineHost> {
+    EngineHost::boot(HostOpts {
+        profile: None,
+        no_extensions: true,
+    })
+    .await
+    .unwrap()
+}
+
+pub fn cfg() -> SessionConfig {
+    SessionConfig {
+        model_override: Some(MODEL.into()),
+        persist: false,
+        ..SessionConfig::default()
+    }
+}
+
+pub async fn next(t: &mut LocalTransport) -> Envelope {
+    tokio::time::timeout(Duration::from_secs(30), t.next_event())
+        .await
+        .expect("timely")
+        .expect("alive")
+}
+
+pub async fn until(
+    t: &mut LocalTransport,
+    pred: impl Fn(&SessionEventWire) -> bool,
+) -> Vec<Envelope> {
+    let mut out = Vec::new();
+    loop {
+        let env = next(t).await;
+        let done = pred(&env.event);
+        out.push(env);
+        if done {
+            return out;
+        }
+    }
+}
+
+/// Drain everything that arrives within `d` (no waiting for a terminal).
+pub async fn drain_for(t: &mut LocalTransport, d: Duration) -> Vec<Envelope> {
+    let mut out = Vec::new();
+    let deadline = tokio::time::Instant::now() + d;
+    loop {
+        let left = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if left.is_zero() {
+            return out;
+        }
+        match tokio::time::timeout(left, t.next_event()).await {
+            Ok(Some(env)) => out.push(env),
+            _ => return out,
+        }
+    }
+}
+
+pub fn submit(text: &str) -> SessionCommand {
+    SessionCommand::Submit {
+        text: text.into(),
+        attachments: vec![],
+    }
+}
+
+pub fn last_conversation(seen: &[Envelope]) -> agent_engine::session::ConversationSnapshot {
+    seen.iter()
+        .rev()
+        .find_map(|e| match &e.event {
+            SessionEventWire::Conversation(c) => Some(c.clone()),
+            _ => None,
+        })
+        .expect("a Conversation envelope")
+}
+
+pub async fn end(t: &mut LocalTransport) {
+    t.send(SessionCommand::End {
+        reason: EndReason::ClientQuit,
+    })
+    .await
+    .unwrap();
+    until(t, |e| matches!(e, SessionEventWire::Ended { .. })).await;
+}
+
+/// Builtin-origin tool that asks for a secret through the stream's
+/// `SecretPromptHandle` and reports only its length (never the value).
+pub struct PromptFixtureTool;
+
+#[async_trait::async_trait]
+impl agent_engine::Tool for PromptFixtureTool {
+    fn name(&self) -> &str {
+        "prompt_fixture"
+    }
+    fn description(&self) -> &str {
+        "prompts for a secret"
+    }
+    fn parameters(&self) -> agent_engine::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn origin(&self) -> agent_engine::tools::ToolOrigin {
+        agent_engine::tools::ToolOrigin::Builtin
+    }
+    async fn execute(
+        &self,
+        _params: agent_engine::Value,
+        ctx: agent_engine::ToolContext,
+    ) -> agent_engine::Result<String> {
+        let handle = ctx
+            .capabilities
+            .secret_prompt
+            .expect("actor passes its SecretPromptHandle to the stream");
+        Ok(match handle.prompt("Secret".into(), "enter secret".into()).await {
+            Some(v) => format!("answered:{}", v.len()),
+            None => "cancelled".to_string(),
+        })
+    }
+}
+
+pub async fn prompt_host() -> Arc<EngineHost> {
+    let host = host().await;
+    host.parts()
+        .tools
+        .write()
+        .await
+        .register(Arc::new(PromptFixtureTool));
+    host
+}
+
+pub fn prompt_id(env: &Envelope) -> Option<u64> {
+    match &env.event {
+        SessionEventWire::Prompt(p) => Some(p.id),
+        _ => None,
+    }
+}
+
+pub fn tool_results(snap: &agent_engine::session::ConversationSnapshot) -> Vec<String> {
+    snap.api_messages
+        .iter()
+        .filter_map(|m| m["content"].as_array())
+        .flat_map(|b| b.iter())
+        .filter(|b| b["type"] == "tool_result")
+        .map(|b| b["content"].as_str().unwrap_or("").to_string())
+        .collect()
+}

--- a/crates/agent-engine/tests/session_actor_common/mod.rs
+++ b/crates/agent-engine/tests/session_actor_common/mod.rs
@@ -123,13 +123,42 @@ use futures::StreamExt;
 
 /// Sequenced stub: hit `i` serves `bodies[min(i, len-1)]` (all terminal).
 pub async fn stub_seq(bodies: &'static [&'static str]) -> (String, Arc<AtomicUsize>) {
+    stub_seq_with(bodies, false).await
+}
+
+/// `stub_seq` whose LAST body is served endless (keep-alives forever).
+pub async fn stub_seq_endless_last(
+    bodies: &'static [&'static str],
+) -> (String, Arc<AtomicUsize>) {
+    stub_seq_with(bodies, true).await
+}
+
+async fn stub_seq_with(
+    bodies: &'static [&'static str],
+    endless_last: bool,
+) -> (String, Arc<AtomicUsize>) {
     let hits = Arc::new(AtomicUsize::new(0));
     let hits_c = Arc::clone(&hits);
     let app = axum::Router::new().fallback(move || {
         let hits = Arc::clone(&hits_c);
         async move {
             let i = hits.fetch_add(1, Ordering::SeqCst);
-            let body = bodies[i.min(bodies.len() - 1)];
+            let idx = i.min(bodies.len() - 1);
+            let body = bodies[idx];
+            if endless_last && idx == bodies.len() - 1 {
+                let stream = futures::stream::once(async move {
+                    Ok::<_, std::io::Error>(axum::body::Bytes::from(body))
+                })
+                .chain(futures::stream::unfold((), |()| async {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    Some((Ok(axum::body::Bytes::from(": keep-alive\n\n")), ()))
+                }));
+                return axum::response::Response::builder()
+                    .status(200)
+                    .header("content-type", "text/event-stream")
+                    .body(axum::body::Body::from_stream(stream))
+                    .unwrap();
+            }
             (
                 axum::http::StatusCode::OK,
                 [("content-type", "text/event-stream")],

--- a/crates/agent-engine/tests/session_actor_compaction.rs
+++ b/crates/agent-engine/tests/session_actor_compaction.rs
@@ -1,0 +1,307 @@
+//! B2 — spawned compaction (PLAN-phase3 §2.5, §4.2): Attach/Detach/Cancel/
+//! Query serviced while a compaction is in flight; Submit queued; Cancel
+//! aborts; LinkedSuccessor policy updates `journal_id` + the continue target;
+//! `SYNAPS_SESSION_COMPACT_INLINE=1` restores the #107 inline body.
+
+mod session_actor_common;
+use session_actor_common::*;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_engine::session::{
+    ClientKind, ClientMeta, ClientTransport, CompactionPolicyWire, LocalTransport,
+    SessionCommand, SessionConfig, SessionEventWire, SessionQuery,
+};
+use axum::response::IntoResponse;
+use serial_test::serial;
+
+/// Streaming turns (`"stream":true`) → SSE_HI; the non-streaming compaction
+/// call → a JSON summary after `delay`. Counts compaction hits.
+async fn stub_compact(delay: Duration) -> (String, Arc<AtomicUsize>) {
+    let compactions = Arc::new(AtomicUsize::new(0));
+    let c = Arc::clone(&compactions);
+    let app = axum::Router::new().fallback(move |body: String| {
+        let c = Arc::clone(&c);
+        async move {
+            if body.contains("\"stream\":true") {
+                return (
+                    axum::http::StatusCode::OK,
+                    [("content-type", "text/event-stream")],
+                    SSE_HI.to_string(),
+                )
+                    .into_response();
+            }
+            c.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(delay).await;
+            axum::Json(serde_json::json!({
+                "id": "msg_c", "type": "message", "role": "assistant",
+                "model": MODEL, "stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "SUMMARY: the user said hello a few times."}],
+                "usage": {"input_tokens": 50, "output_tokens": 10}
+            }))
+            .into_response()
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (format!("http://{addr}"), compactions)
+}
+
+/// 4+ messages so the engine has something to compact.
+async fn warm(t: &mut LocalTransport, turns: usize) {
+    for i in 0..turns {
+        t.send(submit(&format!("hello {i}"))).await.unwrap();
+        until(t, |e| matches!(e, SessionEventWire::Idle)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn compaction_does_not_block_attach_and_submit_is_queued_and_restored() {
+    let _h = Home::new();
+    let (url, compactions) = stub_compact(Duration::from_secs(2)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host
+        .create_session(SessionConfig {
+            persist: true,
+            ..cfg()
+        })
+        .await
+        .unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    warm(&mut a, 2).await;
+
+    a.send(SessionCommand::Compact { instructions: None }).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::CompactionStarted { .. })).await;
+    assert!(matches!(
+        &seen.last().unwrap().event,
+        SessionEventWire::CompactionStarted { source, disclosure } if source == "manual" && !disclosure.is_empty()
+    ));
+
+    // Serviced during compaction: Attach (with snapshot), Query, Detach.
+    let t0 = std::time::Instant::now();
+    let (mut b, snap) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
+        .await
+        .unwrap();
+    assert!(t0.elapsed() < Duration::from_millis(1500), "attach did not wait for compaction");
+    assert_eq!(snap.conversation.api_messages.len(), 4);
+    b.send(SessionCommand::Query {
+        id: 5,
+        query: SessionQuery::Status,
+    })
+    .await
+    .unwrap();
+    until(&mut b, |e| matches!(e, SessionEventWire::QueryResult { id: 5, .. })).await;
+    b.send(SessionCommand::Detach {
+        client: b.client_id(),
+    })
+    .await
+    .unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::ClientLeft { .. })).await;
+
+    // Submit during compaction → queued, not sent.
+    a.send(submit("while compacting")).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Steered { .. })).await;
+    assert!(matches!(
+        &seen.last().unwrap().event,
+        SessionEventWire::Steered { text, delivered: false } if text == "while compacting"
+    ));
+
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    let applied = seen
+        .iter()
+        .find_map(|e| match &e.event {
+            SessionEventWire::CompactionApplied {
+                previous_session_id,
+                session_id,
+                queued_restored,
+                msg_count,
+                ..
+            } => Some((
+                previous_session_id.clone(),
+                session_id.clone(),
+                queued_restored.clone(),
+                *msg_count,
+            )),
+            _ => None,
+        })
+        .expect("CompactionApplied");
+    assert_eq!(applied.0, handle.id.as_str());
+    assert_eq!(applied.1, handle.id.as_str(), "InPlace keeps the id");
+    assert_eq!(applied.2.as_deref(), Some("while compacting"));
+    assert_eq!(applied.3, 4);
+    assert_eq!(compactions.load(Ordering::SeqCst), 1);
+    let conv = last_conversation(&seen);
+    assert!(conv.queued_message.is_none());
+    assert!(conv.api_messages.len() < 4 + 1 || conv.api_messages.len() >= 2);
+    // The queued text rides the transition as the last user message; it is
+    // reported, never re-sent (loop_arms.rs:806-811).
+    assert!(!seen
+        .iter()
+        .any(|e| matches!(e.event, SessionEventWire::TurnStarted { .. })));
+    assert_eq!(
+        conv.api_messages.last().unwrap()["content"],
+        "while compacting"
+    );
+    end(&mut a).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn cancel_aborts_compaction_and_auto_turns_see_busy() {
+    let _h = Home::new();
+    let (url, _) = stub_compact(Duration::from_secs(5)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    warm(&mut a, 2).await;
+    let before = {
+        a.send(SessionCommand::Query {
+            id: 1,
+            query: SessionQuery::Messages,
+        })
+        .await
+        .unwrap();
+        let seen = until(&mut a, |e| matches!(e, SessionEventWire::QueryResult { id: 1, .. })).await;
+        match &seen.last().unwrap().event {
+            SessionEventWire::QueryResult { value, .. } => value.clone(),
+            _ => unreachable!(),
+        }
+    };
+
+    a.send(SessionCommand::Compact {
+        instructions: Some("short".into()),
+    })
+    .await
+    .unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::CompactionStarted { .. })).await;
+    a.send(submit("queued")).await.unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Steered { .. })).await;
+
+    let t0 = std::time::Instant::now();
+    a.send(SessionCommand::Cancel).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    assert!(t0.elapsed() < Duration::from_secs(2), "cancel does not wait for the job");
+    assert!(seen
+        .iter()
+        .any(|e| matches!(e.event, SessionEventWire::CompactionCancelled)));
+    assert!(seen.iter().any(|e| matches!(
+        &e.event,
+        SessionEventWire::Dequeued { text } if text == "queued"
+    )));
+    assert!(!seen
+        .iter()
+        .any(|e| matches!(e.event, SessionEventWire::CompactionApplied { .. })));
+    // Prior state intact.
+    a.send(SessionCommand::Query {
+        id: 2,
+        query: SessionQuery::Messages,
+    })
+    .await
+    .unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::QueryResult { id: 2, .. })).await;
+    match &seen.last().unwrap().event {
+        SessionEventWire::QueryResult { value, .. } => assert_eq!(value, &before),
+        _ => unreachable!(),
+    }
+    // Nothing lands later either.
+    let late = drain_for(&mut a, Duration::from_secs(1)).await;
+    assert!(!late.iter().any(|e| matches!(
+        e.event,
+        SessionEventWire::CompactionApplied { .. } | SessionEventWire::CompactionFailed { .. }
+    )));
+    end(&mut a).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn linked_successor_updates_journal_id_and_continue_target() {
+    let _h = Home::new();
+    let (url, _) = stub_compact(Duration::from_millis(200)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host
+        .create_session(SessionConfig {
+            persist: true,
+            compaction_policy: CompactionPolicyWire::LinkedSuccessor,
+            ..cfg()
+        })
+        .await
+        .unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    warm(&mut a, 2).await;
+    assert_eq!(handle.journal_id(), handle.id.as_str());
+
+    a.send(SessionCommand::Compact { instructions: None }).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    let (prev, new) = seen
+        .iter()
+        .find_map(|e| match &e.event {
+            SessionEventWire::CompactionApplied {
+                previous_session_id,
+                session_id,
+                ..
+            } => Some((previous_session_id.clone(), session_id.clone())),
+            _ => None,
+        })
+        .expect("CompactionApplied");
+    assert_eq!(prev, handle.id.as_str());
+    assert_ne!(new, prev, "LinkedSuccessor mints a successor");
+    assert_eq!(handle.journal_id(), new);
+    let conv = last_conversation(&seen);
+    assert_eq!(conv.header.id, new);
+    assert_eq!(conv.header.parent_session.as_deref(), Some(prev.as_str()));
+    assert_eq!(conv.tokens.input, 0, "counters reset on successor");
+    assert_eq!(conv.cost, 0.0);
+    // Successor on disk with the parent link; parent marks compacted_into.
+    let succ = agent_engine::core::session::Session::load(&new).expect("successor saved");
+    assert_eq!(succ.parent_session.as_deref(), Some(prev.as_str()));
+    let parent = agent_engine::core::session::Session::load(&prev).unwrap();
+    assert_eq!(parent.compacted_into.as_deref(), Some(new.as_str()));
+
+    // The next turn journals into the successor.
+    a.send(submit("after")).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    let n = last_conversation(&seen).api_messages.len();
+    end(&mut a).await;
+    let succ = agent_engine::core::session::Session::load(&new).unwrap();
+    assert_eq!(succ.api_messages.len(), n);
+    assert_eq!(host.sessions().len(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn compact_inline_kill_switch_restores_inline_notices() {
+    let _h = Home::new();
+    std::env::set_var("SYNAPS_SESSION_COMPACT_INLINE", "1");
+    let (url, _) = stub_compact(Duration::from_millis(100)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    warm(&mut a, 2).await;
+    a.send(SessionCommand::Compact { instructions: None }).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Conversation(_))).await;
+    std::env::remove_var("SYNAPS_SESSION_COMPACT_INLINE");
+    assert!(!seen
+        .iter()
+        .any(|e| matches!(e.event, SessionEventWire::CompactionStarted { .. })));
+    assert!(seen.iter().any(|e| matches!(
+        &e.event,
+        SessionEventWire::SystemNotice(n) if n.starts_with("[compacted → ~")
+    )));
+    end(&mut a).await;
+}

--- a/crates/agent-engine/tests/session_actor_compaction.rs
+++ b/crates/agent-engine/tests/session_actor_compaction.rs
@@ -305,3 +305,91 @@ async fn compact_inline_kill_switch_restores_inline_notices() {
     )));
     end(&mut a).await;
 }
+
+/// H1: the typed events are the contract — `/compact` (both the `Compact`
+/// command and the `/compact` engine command) produces exactly one
+/// `CompactionStarted`, one `CompactionApplied`, and no "compacting..."
+/// `SystemNotice` a client would double-render.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn compaction_emits_typed_events_exactly_once_and_no_notice() {
+    let _h = Home::new();
+    let (url, _) = stub_compact(Duration::from_millis(50)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host
+        .create_session(SessionConfig {
+            persist: true,
+            ..cfg()
+        })
+        .await
+        .unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    warm(&mut a, 2).await;
+
+    for via_engine_command in [false, true] {
+        if via_engine_command {
+            a.send(SessionCommand::EngineCommand {
+                id: 9,
+                name: "compact".into(),
+                arg: String::new(),
+            })
+            .await
+            .unwrap();
+        } else {
+            a.send(SessionCommand::Compact { instructions: None }).await.unwrap();
+        }
+        let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+        let started = seen
+            .iter()
+            .filter(|e| matches!(e.event, SessionEventWire::CompactionStarted { .. }))
+            .count();
+        let applied = seen
+            .iter()
+            .filter(|e| matches!(e.event, SessionEventWire::CompactionApplied { .. }))
+            .count();
+        assert_eq!(started, 1, "via_engine_command={via_engine_command}");
+        assert_eq!(applied, 1, "via_engine_command={via_engine_command}");
+        assert!(
+            !seen.iter().any(|e| matches!(
+                &e.event,
+                SessionEventWire::SystemNotice(n) if n.contains("compact")
+            )),
+            "no compaction SystemNotice: {:?}",
+            seen.iter().map(|e| &e.event).collect::<Vec<_>>()
+        );
+    }
+    end(&mut a).await;
+}
+
+/// `Cancel` mid-turn and `NewSession` emit the typed `Aborted` / `Cleared`
+/// events, never the legacy notice text.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn abort_and_clear_are_typed_events() {
+    let _h = Home::new();
+    let (url, _) = stub_compact(Duration::from_millis(50)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    warm(&mut a, 1).await;
+
+    a.send(SessionCommand::NewSession).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Conversation(_))).await;
+    assert_eq!(
+        seen.iter()
+            .filter(|e| matches!(e.event, SessionEventWire::Cleared { .. }))
+            .count(),
+        1
+    );
+    assert!(!seen.iter().any(|e| matches!(
+        &e.event,
+        SessionEventWire::SystemNotice(n) if n.contains("cleared") || n.starts_with("aborted")
+    )));
+    end(&mut a).await;
+}

--- a/crates/agent-engine/tests/session_actor_ownership.rs
+++ b/crates/agent-engine/tests/session_actor_ownership.rs
@@ -250,7 +250,7 @@ async fn checkpoint_cancels_turn_saves_closes_ptys_answers_prompts_none() {
     let _h = Home::new();
     // Round 1: shell_start; round 2+: an endless stream so Checkpoint has a
     // turn to cancel.
-    let (url, _) = stub_seq(&[SSE_SHELL_START, SSE_PREFIX]).await;
+    let (url, _) = stub_seq_endless_last(&[SSE_SHELL_START, SSE_PREFIX]).await;
     std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
     let host = host().await;
     let handle = host

--- a/crates/agent-engine/tests/session_actor_ownership.rs
+++ b/crates/agent-engine/tests/session_actor_ownership.rs
@@ -296,10 +296,9 @@ async fn checkpoint_cancels_turn_saves_closes_ptys_answers_prompts_none() {
         &e.event,
         SessionEventWire::SystemNotice(n) if n.contains("daemon reloading")
     )));
-    assert!(seen.iter().any(|e| matches!(
-        &e.event,
-        SessionEventWire::SystemNotice(n) if n.starts_with("aborted")
-    )));
+    assert!(seen
+        .iter()
+        .any(|e| matches!(&e.event, SessionEventWire::Aborted { .. })));
     let conv = last_conversation(&seen);
     assert!(
         conv.abort_context.as_deref().unwrap_or("").contains("[response]: hi"),

--- a/crates/agent-engine/tests/session_actor_ownership.rs
+++ b/crates/agent-engine/tests/session_actor_ownership.rs
@@ -320,3 +320,68 @@ async fn checkpoint_cancels_turn_saves_closes_ptys_answers_prompts_none() {
     assert!(saved.abort_context.is_some());
     end(&mut a).await;
 }
+
+/// M1: `Checkpoint` from a non-owner (an `--observe` mirror) is `Refused`
+/// with no side effect — the owner's turn keeps streaming. The host
+/// (`from: None`) still checkpoints.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn checkpoint_is_owner_only_from_clients() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_HI, true).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+    let (mut a, _) = attach(&handle, ClientKind::Tui, AttachMode::Mirror).await;
+    let (mut b, _) = attach(&handle, ClientKind::Attach, AttachMode::Observe).await;
+
+    a.send_from_self(submit("hello")).await.unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::TurnStarted { .. })).await;
+
+    b.send_from_self(SessionCommand::Checkpoint {
+        reason: CheckpointReason::HostRequest,
+    })
+    .await
+    .unwrap();
+    let seen = until(&mut b, |e| matches!(e, SessionEventWire::Refused { .. })).await;
+    match &seen.last().unwrap().event {
+        SessionEventWire::Refused { client, command, .. } => {
+            assert_eq!(*client, b.client_id());
+            assert_eq!(command, "checkpoint");
+        }
+        _ => unreachable!(),
+    }
+    assert!(!seen.iter().any(|e| matches!(
+        e.event,
+        SessionEventWire::Aborted { .. } | SessionEventWire::QueryResult { id: CHECKPOINT_QUERY_ID, .. }
+    )));
+    b.send_from_self(SessionCommand::Query {
+        id: 3,
+        query: SessionQuery::Status,
+    })
+    .await
+    .unwrap();
+    let seen = until(&mut b, |e| matches!(e, SessionEventWire::QueryResult { id: 3, .. })).await;
+    match &seen.last().unwrap().event {
+        SessionEventWire::QueryResult { value, .. } => {
+            assert_eq!(value["streaming"], true, "turn still running: {value}")
+        }
+        _ => unreachable!(),
+    }
+
+    // Host-originated checkpoint lands.
+    handle
+        .send(SessionCommand::Checkpoint {
+            reason: CheckpointReason::HostRequest,
+        })
+        .await
+        .unwrap();
+    let seen = until(&mut a, |e| {
+        matches!(e, SessionEventWire::QueryResult { id, .. } if *id == CHECKPOINT_QUERY_ID)
+    })
+    .await;
+    assert!(seen
+        .iter()
+        .any(|e| matches!(e.event, SessionEventWire::Aborted { .. })));
+    end(&mut a).await;
+}

--- a/crates/agent-engine/tests/session_actor_ownership.rs
+++ b/crates/agent-engine/tests/session_actor_ownership.rs
@@ -1,0 +1,323 @@
+//! B1 — input ownership (Mirror/Observe/Takeover), `Refused`,
+//! `InputOwnerChanged`, and `Checkpoint` (PLAN-phase3 §2.5, §5.3).
+
+mod session_actor_common;
+use session_actor_common::*;
+
+use std::time::Duration;
+
+use agent_engine::session::wire::CHECKPOINT_QUERY_ID;
+use agent_engine::session::{
+    AttachMode, CheckpointReason, ClientKind, ClientMeta, ClientTransport, LocalTransport,
+    OwnerChangeReason, SessionCommand, SessionEventWire, SessionQuery, SessionSetting,
+};
+use serial_test::serial;
+
+async fn attach(
+    handle: &agent_engine::session::SessionHandle,
+    kind: ClientKind,
+    mode: AttachMode,
+) -> (LocalTransport, agent_engine::session::AttachSnapshot) {
+    LocalTransport::attach_with(handle.clone(), ClientMeta::new(kind), mode)
+        .await
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn first_mirror_owns_second_mirror_is_read_only_with_notice() {
+    let _h = Home::new();
+    let (url, hits) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+
+    let (mut a, snap_a) = attach(&handle, ClientKind::Tui, AttachMode::Mirror).await;
+    assert_eq!(snap_a.input_owner, Some(a.client_id()));
+    assert_eq!(a.input_owner(), Some(a.client_id()));
+
+    let (mut b, snap_b) = attach(&handle, ClientKind::Attach, AttachMode::Mirror).await;
+    assert_eq!(snap_b.input_owner, Some(a.client_id()), "a keeps input");
+    let seen = until(&mut b, |e| matches!(e, SessionEventWire::SystemNotice(_))).await;
+    match &seen.last().unwrap().event {
+        SessionEventWire::SystemNotice(n) => {
+            assert!(n.contains("input is owned by client #1"), "{n}");
+            assert!(n.contains("--takeover"), "{n}");
+        }
+        _ => unreachable!(),
+    }
+
+    // b's Submit is refused with no side effect: no TurnStarted, no stub hit.
+    b.send_from_self(submit("hello")).await.unwrap();
+    let seen = until(&mut b, |e| matches!(e, SessionEventWire::Refused { .. })).await;
+    match &seen.last().unwrap().event {
+        SessionEventWire::Refused {
+            client,
+            command,
+            reason,
+        } => {
+            assert_eq!(*client, b.client_id());
+            assert_eq!(command, "submit");
+            assert!(reason.contains("client #1"), "{reason}");
+        }
+        _ => unreachable!(),
+    }
+    assert!(!seen
+        .iter()
+        .any(|e| matches!(e.event, SessionEventWire::TurnStarted { .. })));
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(hits.load(std::sync::atomic::Ordering::SeqCst), 0);
+
+    // a's Submit runs.
+    a.send_from_self(submit("hello")).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    assert!(seen
+        .iter()
+        .any(|e| matches!(e.event, SessionEventWire::TurnStarted { .. })));
+    assert_eq!(last_conversation(&seen).api_messages.len(), 2);
+    end(&mut a).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn observer_never_owns_and_answer_allowed_from_any_client() {
+    let _h = Home::new();
+    let (url, _) = stub_seq(&[SSE_PROMPT_TOOL_USE, SSE_HI]).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = prompt_host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+
+    // Observer first: still nobody owns.
+    let (mut o, snap_o) = attach(&handle, ClientKind::Attach, AttachMode::Observe).await;
+    assert_eq!(snap_o.input_owner, None);
+    o.send_from_self(submit("nope")).await.unwrap();
+    let seen = until(&mut o, |e| matches!(e, SessionEventWire::Refused { .. })).await;
+    assert!(matches!(
+        &seen.last().unwrap().event,
+        SessionEventWire::Refused { reason, .. } if reason.contains("no owner")
+    ));
+
+    // Mirror after an observer takes ownership.
+    let (mut a, snap_a) = attach(&handle, ClientKind::Tui, AttachMode::Mirror).await;
+    assert_eq!(snap_a.input_owner, Some(a.client_id()));
+    a.send_from_self(submit("go")).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Prompt(_))).await;
+    let pid = prompt_id(seen.last().unwrap()).unwrap();
+
+    // The observer may answer the prompt (SPEC §8).
+    until(&mut o, |e| matches!(e, SessionEventWire::Prompt(_))).await;
+    o.send_from_self(SessionCommand::Answer {
+        prompt_id: pid,
+        value: Some("s3cret".into()),
+    })
+    .await
+    .unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    assert_eq!(
+        tool_results(&last_conversation(&seen)),
+        vec!["answered:6".to_string()]
+    );
+    // Observer may query too.
+    o.send_from_self(SessionCommand::Query {
+        id: 9,
+        query: SessionQuery::Status,
+    })
+    .await
+    .unwrap();
+    until(&mut o, |e| matches!(e, SessionEventWire::QueryResult { id: 9, .. })).await;
+    end(&mut a).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn takeover_steals_and_notifies_previous_owner() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+
+    let (mut a, _) = attach(&handle, ClientKind::Tui, AttachMode::Mirror).await;
+    let (mut b, snap_b) = attach(&handle, ClientKind::Attach, AttachMode::Takeover).await;
+    assert_eq!(snap_b.input_owner, Some(b.client_id()));
+
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::InputOwnerChanged { .. })).await;
+    match &seen.last().unwrap().event {
+        SessionEventWire::InputOwnerChanged { from, to, reason } => {
+            assert_eq!(*from, Some(a.client_id()));
+            assert_eq!(*to, Some(b.client_id()));
+            assert_eq!(*reason, OwnerChangeReason::Takeover);
+        }
+        _ => unreachable!(),
+    }
+    assert_eq!(a.input_owner(), Some(b.client_id()));
+
+    a.send_from_self(submit("x")).await.unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Refused { .. })).await;
+    b.send_from_self(submit("y")).await.unwrap();
+    until(&mut b, |e| matches!(e, SessionEventWire::Idle)).await;
+
+    // Host-originated sends bypass ownership.
+    a.send(SessionCommand::Set {
+        id: 3,
+        setting: SessionSetting::ApiRetries { n: 1 },
+    })
+    .await
+    .unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::SettingChanged(s) if s.id == 3)).await;
+    end(&mut b).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn owner_detach_passes_to_oldest_non_observer() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(cfg()).await.unwrap();
+
+    let (mut a, _) = attach(&handle, ClientKind::Tui, AttachMode::Mirror).await;
+    let (mut o, _) = attach(&handle, ClientKind::Attach, AttachMode::Observe).await;
+    let (mut b, _) = attach(&handle, ClientKind::Attach, AttachMode::Mirror).await;
+    let (mut c, _) = attach(&handle, ClientKind::Attach, AttachMode::Mirror).await;
+
+    a.send_from_self(SessionCommand::Detach {
+        client: a.client_id(),
+    })
+    .await
+    .unwrap();
+    let seen = until(&mut b, |e| matches!(e, SessionEventWire::InputOwnerChanged { .. })).await;
+    match &seen.last().unwrap().event {
+        SessionEventWire::InputOwnerChanged { from, to, reason } => {
+            assert_eq!(*from, Some(a.client_id()));
+            assert_eq!(*to, Some(b.client_id()), "oldest non-observer, not o");
+            assert_eq!(*reason, OwnerChangeReason::OwnerDetached);
+        }
+        _ => unreachable!(),
+    }
+    until(&mut o, |e| matches!(e, SessionEventWire::InputOwnerChanged { .. })).await;
+    assert_eq!(o.input_owner(), Some(b.client_id()));
+    c.send_from_self(submit("x")).await.unwrap();
+    until(&mut c, |e| matches!(e, SessionEventWire::Refused { .. })).await;
+    b.send_from_self(submit("y")).await.unwrap();
+    until(&mut b, |e| matches!(e, SessionEventWire::Idle)).await;
+
+    // Everyone gone → owner None; the next attach owns again.
+    for t in [&mut b, &mut c, &mut o] {
+        t.send_from_self(SessionCommand::Detach {
+            client: t.client_id(),
+        })
+        .await
+        .unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let (mut d, snap_d) = attach(&handle, ClientKind::Attach, AttachMode::Mirror).await;
+    assert_eq!(snap_d.input_owner, Some(d.client_id()));
+    end(&mut d).await;
+}
+
+/// `shell_start sleep <marker>` then `Checkpoint`: the PTY child is gone, the
+/// stream is cancelled with abort context, the reply lands on
+/// `CHECKPOINT_QUERY_ID`, and the session is still alive.
+const SSE_SHELL_START: &str = concat!(
+    "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_s1\",\"type\":\"message\",",
+    "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-5\",\"stop_reason\":null,",
+    "\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,",
+    "\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_sh\",\"name\":\"shell_start\"}}\n\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":0,",
+    "\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"command\\\":\\\"sleep 271828\\\"}\"}}\n\n",
+    "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",",
+    "\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}\n\n",
+    "data: {\"type\":\"message_stop\"}\n\n",
+);
+
+fn marker_alive() -> bool {
+    std::process::Command::new("pgrep")
+        .args(["-f", "sleep 271828"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn checkpoint_cancels_turn_saves_closes_ptys_answers_prompts_none() {
+    let _h = Home::new();
+    // Round 1: shell_start; round 2+: an endless stream so Checkpoint has a
+    // turn to cancel.
+    let (url, _) = stub_seq(&[SSE_SHELL_START, SSE_PREFIX]).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host
+        .create_session(agent_engine::session::SessionConfig {
+            persist: true,
+            ..cfg()
+        })
+        .await
+        .unwrap();
+    let (mut a, _) = attach(&handle, ClientKind::Tui, AttachMode::Mirror).await;
+    a.send_from_self(submit("start a shell")).await.unwrap();
+    // Wait for the tool result (PTY spawned) then the second round's delta.
+    until(&mut a, |e| {
+        matches!(
+            e,
+            SessionEventWire::Stream(agent_engine::StreamEvent::Llm(
+                agent_engine::LlmEvent::ToolResult { .. }
+            ))
+        )
+    })
+    .await;
+    assert!(marker_alive(), "PTY child running");
+    until(&mut a, |e| {
+        matches!(
+            e,
+            SessionEventWire::Stream(agent_engine::StreamEvent::Llm(
+                agent_engine::LlmEvent::Text(_)
+            ))
+        )
+    })
+    .await;
+
+    a.send(SessionCommand::Checkpoint {
+        reason: CheckpointReason::Reload,
+    })
+    .await
+    .unwrap();
+    let seen = until(&mut a, |e| {
+        matches!(e, SessionEventWire::QueryResult { id, .. } if *id == CHECKPOINT_QUERY_ID)
+    })
+    .await;
+    assert!(seen.iter().any(|e| matches!(
+        &e.event,
+        SessionEventWire::SystemNotice(n) if n.contains("daemon reloading")
+    )));
+    assert!(seen.iter().any(|e| matches!(
+        &e.event,
+        SessionEventWire::SystemNotice(n) if n.starts_with("aborted")
+    )));
+    let conv = last_conversation(&seen);
+    assert!(
+        conv.abort_context.as_deref().unwrap_or("").contains("[response]: hi"),
+        "abort context captured: {:?}",
+        conv.abort_context
+    );
+    // PTY child killed (PtyHandle::drop) — allow the reap a moment.
+    let mut gone = false;
+    for _ in 0..20 {
+        if !marker_alive() {
+            gone = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(gone, "shell_start child survived Checkpoint");
+    assert!(handle.is_alive(), "checkpoint never ends the session");
+    let saved = agent_engine::core::session::Session::load(handle.id.as_str()).expect("saved");
+    assert!(saved.abort_context.is_some());
+    end(&mut a).await;
+}

--- a/crates/agent-engine/tests/session_actor_parked.rs
+++ b/crates/agent-engine/tests/session_actor_parked.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use agent_engine::session::{
     ClientKind, ClientMeta, ClientTransport, EndReason, LocalTransport, SessionCommand,
     SessionConfig, SessionEventWire, SessionHandle, SessionLifecycle, SessionQuery,
-    SessionSetting, TransportError, TurnTrigger,
+    SessionSetting, TurnTrigger,
 };
 use serial_test::serial;
 
@@ -317,9 +317,12 @@ async fn event_injection_wakes_parked_session_and_runs_turn() {
     handle.closed().await;
 }
 
+/// H2: a session whose journal vanished while Parked is NOT a zombie —
+/// `unpark` rebuilds an empty conversation under the same id (current
+/// model/thinking kept) and the attach succeeds.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
-async fn unpark_failure_yields_attach_refused_and_session_stays_parked() {
+async fn unpark_missing_journal_restores_fresh_conversation() {
     let _h = Home::new();
     let _g = Grace::set("0");
     let (url, _) = stub(SSE_HI, false).await;
@@ -338,43 +341,62 @@ async fn unpark_failure_yields_attach_refused_and_session_stays_parked() {
     assert!(agent_engine::core::session::Session::load(handle.id.as_str()).is_ok());
     agent_engine::core::session::delete_session_file(handle.id.as_str()).unwrap();
     assert!(agent_engine::core::session::Session::load(handle.id.as_str()).is_err());
-    let err = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
-        .await
-        .err()
-        .expect("attach refused");
-    match err {
-        TransportError::Refused(m) => assert!(m.contains("could not be restored"), "{m}"),
-        other => panic!("unexpected {other:?}"),
-    }
-    assert_eq!(handle.lifecycle(), SessionLifecycle::Parked, "stays Parked, not corrupted");
-    assert!(handle.is_alive());
-    assert_eq!(host.sessions().len(), 1, "still listed");
 
-    // End while parked: on_session_end + Ended, no save (file stays absent).
-    let mut watch = handle.subscribe();
+    let (mut b, snap) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
+        .await
+        .expect("attach restores a fresh conversation");
+    assert_eq!(handle.lifecycle(), SessionLifecycle::Live);
+    assert!(snap.conversation.api_messages.is_empty(), "fresh conversation");
+    assert_eq!(snap.conversation.header.id, handle.id.as_str(), "same session id");
+    assert_eq!(snap.view.model, MODEL);
+    assert_eq!(host.sessions().len(), 1);
+    // Turns work on the rebuilt conversation and the journal comes back.
+    b.send(submit("again")).await.unwrap();
+    let seen = until(&mut b, |e| matches!(e, SessionEventWire::Idle)).await;
+    assert_eq!(last_conversation(&seen).api_messages.len(), 2);
+    assert!(agent_engine::core::session::Session::load(handle.id.as_str()).is_ok());
+    end(&mut b).await;
+}
+
+/// H2: a session that never ran a turn has nothing on disk (`save` skips an
+/// empty conversation) → it must stay Live after the grace, not park into
+/// something that cannot be restored.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn empty_session_never_parks() {
+    let _h = Home::new();
+    let _g = Grace::set("0");
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(pcfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    detach(&mut a).await;
+    assert!(
+        !wait_lifecycle(&handle, SessionLifecycle::Parked, Duration::from_secs(2)).await,
+        "never-saved session must not park"
+    );
+    assert_eq!(handle.lifecycle(), SessionLifecycle::Live);
+    assert!(agent_engine::core::session::Session::load(handle.id.as_str()).is_err());
+
+    // Re-attach is a plain attach (no unpark); a turn then parks normally.
+    let (mut b, snap) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
+        .await
+        .unwrap();
+    assert!(snap.conversation.api_messages.is_empty());
+    b.send(submit("hi")).await.unwrap();
+    until(&mut b, |e| matches!(e, SessionEventWire::Idle)).await;
+    detach(&mut b).await;
+    assert!(wait_lifecycle(&handle, SessionLifecycle::Parked, Duration::from_secs(5)).await);
     handle
         .send(SessionCommand::End {
             reason: EndReason::HostShutdown,
         })
         .await
         .unwrap();
-    let mut ended = false;
-    while let Ok(env) = tokio::time::timeout(Duration::from_secs(10), watch.recv()).await {
-        if let Ok(env) = env {
-            if matches!(env.event, SessionEventWire::Ended { .. }) {
-                ended = true;
-                break;
-            }
-        } else {
-            break;
-        }
-    }
-    assert!(ended);
     handle.closed().await;
-    assert!(
-        agent_engine::core::session::Session::load(handle.id.as_str()).is_err(),
-        "end while parked never saves"
-    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/agent-engine/tests/session_actor_parked.rs
+++ b/crates/agent-engine/tests/session_actor_parked.rs
@@ -1,0 +1,436 @@
+//! B3 — `Parked` (PLAN-phase3 §2.5, §5.3): grace timer, guards, park/unpark,
+//! event wake, `AttachRefused`, lifecycle events, no duplicate index record.
+
+mod session_actor_common;
+use session_actor_common::*;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_engine::session::{
+    ClientKind, ClientMeta, ClientTransport, EndReason, LocalTransport, SessionCommand,
+    SessionConfig, SessionEventWire, SessionHandle, SessionLifecycle, SessionQuery,
+    SessionSetting, TransportError, TurnTrigger,
+};
+use serial_test::serial;
+
+fn pcfg() -> SessionConfig {
+    SessionConfig {
+        persist: true,
+        ..cfg()
+    }
+}
+
+struct Grace;
+impl Grace {
+    fn set(v: &str) -> Self {
+        std::env::set_var("SYNAPS_DAEMON_PARK_GRACE_SECS", v);
+        Self
+    }
+}
+impl Drop for Grace {
+    fn drop(&mut self) {
+        std::env::remove_var("SYNAPS_DAEMON_PARK_GRACE_SECS");
+    }
+}
+
+async fn detach(t: &mut LocalTransport) {
+    t.send(SessionCommand::Detach {
+        client: t.client_id(),
+    })
+    .await
+    .unwrap();
+    until(t, |e| matches!(e, SessionEventWire::ClientLeft { .. })).await;
+}
+
+/// Poll `handle.lifecycle()` until `want` (≤ `for_`), returning whether seen.
+async fn wait_lifecycle(handle: &SessionHandle, want: SessionLifecycle, for_: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + for_;
+    while tokio::time::Instant::now() < deadline {
+        if handle.lifecycle() == want {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    handle.lifecycle() == want
+}
+
+async fn status(t: &mut LocalTransport, id: u64) -> serde_json::Value {
+    t.send(SessionCommand::Query {
+        id,
+        query: SessionQuery::Status,
+    })
+    .await
+    .unwrap();
+    let seen = until(t, |e| matches!(e, SessionEventWire::QueryResult { id: i, .. } if *i == id)).await;
+    match &seen.last().unwrap().event {
+        SessionEventWire::QueryResult { value, .. } => value.clone(),
+        _ => unreachable!(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn parks_after_grace_when_detached_and_idle_and_attach_unparks() {
+    let _h = Home::new();
+    let _g = Grace::set("0");
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(pcfg()).await.unwrap();
+
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    // Non-persisted knob + an aborted turn so unpark has state to restore.
+    a.send(SessionCommand::Set {
+        id: 1,
+        setting: SessionSetting::ContextWindow {
+            tokens: Some(1_000_000),
+        },
+    })
+    .await
+    .unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::SettingChanged(_))).await;
+    a.send(submit("hello")).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    let before = last_conversation(&seen);
+    assert_eq!(before.api_messages.len(), 2);
+    let view_before = (*a.view()).clone();
+    assert_eq!(view_before.context_window, 1_000_000);
+
+    // A second subscriber watches lifecycle events land in order.
+    let mut watch = handle.subscribe();
+    detach(&mut a).await;
+    assert!(
+        wait_lifecycle(&handle, SessionLifecycle::Parked, Duration::from_secs(5)).await,
+        "grace 0 → parked"
+    );
+    let mut seq = Vec::new();
+    while let Ok(env) = watch.try_recv() {
+        if let SessionEventWire::Lifecycle(l) = env.event {
+            seq.push(l);
+        }
+    }
+    assert_eq!(seq, vec![SessionLifecycle::Parking, SessionLifecycle::Parked]);
+    assert!(handle.is_alive(), "actor task lives on while parked");
+    let reg = agent_engine::events::registry::find_session_registration(handle.id.as_str());
+    assert!(reg.is_some(), "per-session UDS still registered while parked");
+
+    // Attach → unpark: conversation, abort_context-free history, settings.
+    let (mut b, snap) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
+        .await
+        .unwrap();
+    assert_eq!(handle.lifecycle(), SessionLifecycle::Live);
+    assert_eq!(snap.conversation.api_messages, before.api_messages);
+    assert_eq!(snap.conversation.abort_context, before.abort_context);
+    assert_eq!(snap.view.context_window, 1_000_000, "settings replayed");
+    assert_eq!(snap.view.model, MODEL);
+    let st = status(&mut b, 7).await;
+    assert_eq!(st["lifecycle"], "live");
+    assert_eq!(st["messages"], 2);
+    // Turns work after unpark.
+    b.send(submit("again")).await.unwrap();
+    let seen = until(&mut b, |e| matches!(e, SessionEventWire::Idle)).await;
+    assert_eq!(last_conversation(&seen).api_messages.len(), 4);
+    end(&mut b).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn streaming_and_pending_prompt_block_park_until_done() {
+    let _h = Home::new();
+    let _g = Grace::set("0");
+    let (url, _) = stub_seq(&[SSE_PROMPT_TOOL_USE, SSE_HI]).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = prompt_host().await;
+    let handle = host.create_session(pcfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    a.send(submit("go")).await.unwrap();
+    let seen = until(&mut a, |e| matches!(e, SessionEventWire::Prompt(_))).await;
+    let pid = prompt_id(seen.last().unwrap()).unwrap();
+    detach(&mut a).await;
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    assert_eq!(
+        handle.lifecycle(),
+        SessionLifecycle::Live,
+        "pending prompt (and the running turn) block parking"
+    );
+
+    let (mut b, snap) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
+        .await
+        .unwrap();
+    assert!(snap.streaming);
+    assert_eq!(snap.pending_prompts.len(), 1);
+    b.send(SessionCommand::Answer {
+        prompt_id: pid,
+        value: Some("abc".into()),
+    })
+    .await
+    .unwrap();
+    until(&mut b, |e| matches!(e, SessionEventWire::Idle)).await;
+    detach(&mut b).await;
+    assert!(
+        wait_lifecycle(&handle, SessionLifecycle::Parked, Duration::from_secs(5)).await,
+        "answer → Done → detached+idle → parks"
+    );
+    handle
+        .send(SessionCommand::End {
+            reason: EndReason::HostShutdown,
+        })
+        .await
+        .unwrap();
+    handle.closed().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn keep_warm_never_parks_and_never_grace_disables() {
+    let _h = Home::new();
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    {
+        let _g = Grace::set("0");
+        let handle = host
+            .create_session(SessionConfig {
+                keep_warm: true,
+                ..pcfg()
+            })
+            .await
+            .unwrap();
+        let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+            .await
+            .unwrap();
+        a.send(submit("hi")).await.unwrap();
+        until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+        detach(&mut a).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert_eq!(handle.lifecycle(), SessionLifecycle::Live, "--keep-warm pins");
+
+        // /keep-warm off → parks; KeepWarm on while parked wakes + pins.
+        let (mut b, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+            .await
+            .unwrap();
+        b.send(SessionCommand::KeepWarm { on: false }).await.unwrap();
+        until(&mut b, |e| matches!(e, SessionEventWire::SystemNotice(n) if n.contains("keep-warm off"))).await;
+        detach(&mut b).await;
+        assert!(wait_lifecycle(&handle, SessionLifecycle::Parked, Duration::from_secs(5)).await);
+        handle.send(SessionCommand::KeepWarm { on: true }).await.unwrap();
+        assert!(wait_lifecycle(&handle, SessionLifecycle::Live, Duration::from_secs(5)).await);
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert_eq!(handle.lifecycle(), SessionLifecycle::Live);
+        handle
+            .send(SessionCommand::End {
+                reason: EndReason::HostShutdown,
+            })
+            .await
+            .unwrap();
+        handle.closed().await;
+    }
+    {
+        let _g = Grace::set("never");
+        let handle = host.create_session(pcfg()).await.unwrap();
+        let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+            .await
+            .unwrap();
+        a.send(submit("hi")).await.unwrap();
+        until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+        detach(&mut a).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert_eq!(handle.lifecycle(), SessionLifecycle::Live, "never = Parked disabled");
+        handle
+            .send(SessionCommand::End {
+                reason: EndReason::HostShutdown,
+            })
+            .await
+            .unwrap();
+        handle.closed().await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn event_injection_wakes_parked_session_and_runs_turn() {
+    use tokio::io::AsyncWriteExt;
+    let _h = Home::new();
+    let _g = Grace::set("0");
+    let (url, hits) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(pcfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    a.send(submit("hi")).await.unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    detach(&mut a).await;
+    assert!(wait_lifecycle(&handle, SessionLifecycle::Parked, Duration::from_secs(5)).await);
+    let hits_before = hits.load(std::sync::atomic::Ordering::SeqCst);
+
+    // `synaps send --session X`: the per-session UDS is still bound.
+    let mut watch = handle.subscribe();
+    let reg = agent_engine::events::registry::find_session_registration(handle.id.as_str())
+        .expect("registered while parked");
+    let event = agent_engine::events::types::Event::simple(
+        "test",
+        "wake up",
+        Some(agent_engine::events::types::Severity::High),
+    );
+    let mut c = tokio::net::UnixStream::connect(&reg.socket_path).await.unwrap();
+    c.write_all(&serde_json::to_vec(&event).unwrap()).await.unwrap();
+    c.shutdown().await.unwrap();
+
+    // Live again, an EventAuto turn ran, and it parked again afterwards.
+    let mut saw_live = false;
+    let mut saw_turn = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    while tokio::time::Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_secs(1), watch.recv()).await {
+            Ok(Ok(env)) => match env.event {
+                SessionEventWire::Lifecycle(SessionLifecycle::Live) => saw_live = true,
+                SessionEventWire::TurnStarted {
+                    trigger: TurnTrigger::EventAuto,
+                    ..
+                } => saw_turn = true,
+                SessionEventWire::Lifecycle(SessionLifecycle::Parked) if saw_turn => break,
+                _ => {}
+            },
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            _ => break,
+        }
+    }
+    assert!(saw_live, "unparked on event wake");
+    assert!(saw_turn, "EventAuto turn after wake");
+    assert!(hits.load(std::sync::atomic::Ordering::SeqCst) > hits_before);
+    assert!(wait_lifecycle(&handle, SessionLifecycle::Parked, Duration::from_secs(5)).await);
+    let saved = agent_engine::core::session::Session::load(handle.id.as_str()).unwrap();
+    assert_eq!(saved.api_messages.len(), 4, "hi/reply + event/reply on disk");
+    handle
+        .send(SessionCommand::End {
+            reason: EndReason::HostShutdown,
+        })
+        .await
+        .unwrap();
+    handle.closed().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn unpark_failure_yields_attach_refused_and_session_stays_parked() {
+    let _h = Home::new();
+    let _g = Grace::set("0");
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let handle = host.create_session(pcfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    a.send(submit("hi")).await.unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    detach(&mut a).await;
+    assert!(wait_lifecycle(&handle, SessionLifecycle::Parked, Duration::from_secs(5)).await);
+
+    // Journal gone → unpark cannot load it.
+    assert!(agent_engine::core::session::Session::load(handle.id.as_str()).is_ok());
+    agent_engine::core::session::delete_session_file(handle.id.as_str()).unwrap();
+    assert!(agent_engine::core::session::Session::load(handle.id.as_str()).is_err());
+    let err = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
+        .await
+        .err()
+        .expect("attach refused");
+    match err {
+        TransportError::Refused(m) => assert!(m.contains("could not be restored"), "{m}"),
+        other => panic!("unexpected {other:?}"),
+    }
+    assert_eq!(handle.lifecycle(), SessionLifecycle::Parked, "stays Parked, not corrupted");
+    assert!(handle.is_alive());
+    assert_eq!(host.sessions().len(), 1, "still listed");
+
+    // End while parked: on_session_end + Ended, no save (file stays absent).
+    let mut watch = handle.subscribe();
+    handle
+        .send(SessionCommand::End {
+            reason: EndReason::HostShutdown,
+        })
+        .await
+        .unwrap();
+    let mut ended = false;
+    while let Ok(env) = tokio::time::timeout(Duration::from_secs(10), watch.recv()).await {
+        if let Ok(env) = env {
+            if matches!(env.event, SessionEventWire::Ended { .. }) {
+                ended = true;
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+    assert!(ended);
+    handle.closed().await;
+    assert!(
+        agent_engine::core::session::Session::load(handle.id.as_str()).is_err(),
+        "end while parked never saves"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn no_duplicate_index_start_record_on_unpark_and_status_never_wakes() {
+    let _h = Home::new();
+    let _g = Grace::set("0");
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = Arc::clone(&host().await);
+    let handle = host.create_session(pcfg()).await.unwrap();
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    a.send(submit("hi")).await.unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    detach(&mut a).await;
+    assert!(wait_lifecycle(&handle, SessionLifecycle::Parked, Duration::from_secs(5)).await);
+
+    // The idle probe (Query{Status} from the host) answers without waking.
+    assert!(agent_engine::daemon::session_is_idle(&handle).await);
+    let mut rx = handle.subscribe();
+    handle
+        .send(SessionCommand::Query {
+            id: 42,
+            query: SessionQuery::Status,
+        })
+        .await
+        .unwrap();
+    let v = loop {
+        let env = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        if let SessionEventWire::QueryResult { id: 42, value } = env.event {
+            break value;
+        }
+    };
+    assert_eq!(v["lifecycle"], "parked");
+    assert_eq!(handle.lifecycle(), SessionLifecycle::Parked, "Status never wakes");
+
+    let starts = |id: &str| {
+        agent_engine::core::session_index::read_recent(10_000)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|r| {
+                r.session_id == id
+                    && r.event == agent_engine::core::session_index::SessionIndexEventKind::Start
+            })
+            .count()
+    };
+    assert_eq!(starts(handle.id.as_str()), 1);
+    let (mut b, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Attach))
+        .await
+        .unwrap();
+    assert_eq!(handle.lifecycle(), SessionLifecycle::Live);
+    assert_eq!(starts(handle.id.as_str()), 1, "unpark appends no START record");
+    end(&mut b).await;
+}

--- a/crates/agent-engine/tests/session_actor_parked.rs
+++ b/crates/agent-engine/tests/session_actor_parked.rs
@@ -434,3 +434,55 @@ async fn no_duplicate_index_start_record_on_unpark_and_status_never_wakes() {
     assert_eq!(starts(handle.id.as_str()), 1, "unpark appends no START record");
     end(&mut b).await;
 }
+
+/// B4: `--idle-exit` fires once every session is parked (REVIEW §5 retired):
+/// a real `Daemon` over the host map, one session, detach → park → the idle
+/// monitor requests shutdown without ever probing (waking) the actor.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn idle_exit_fires_once_all_sessions_parked() {
+    let _h = Home::new();
+    let _g = Grace::set("0");
+    let (url, _) = stub(SSE_HI, false).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host().await;
+    let run = tempfile::TempDir::new().unwrap();
+    let d = agent_engine::daemon::Daemon::start(
+        Arc::clone(&host),
+        agent_engine::daemon::DaemonOpts {
+            runtime_dir: Some(run.path().to_path_buf()),
+            idle_exit: Some(Duration::from_millis(300)),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let token = d.shutdown_token();
+
+    // One map: a session created on the host is what the daemon lists.
+    let handle = host.create_session(pcfg()).await.unwrap();
+    assert_eq!(d.state.live_sessions().len(), 1);
+    let (mut a, _) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Tui))
+        .await
+        .unwrap();
+    a.send(submit("hi")).await.unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Idle)).await;
+    let metas = d.state.session_metas();
+    assert_eq!(metas[0].clients, 1);
+    assert_eq!(metas[0].input_owner, Some(a.client_id()));
+    assert_eq!(metas[0].lifecycle, SessionLifecycle::Live);
+    assert_eq!(metas[0].journal_id, handle.id.as_str());
+    assert!(!token.is_cancelled(), "a client is attached: not idle");
+
+    detach(&mut a).await;
+    assert!(wait_lifecycle(&handle, SessionLifecycle::Parked, Duration::from_secs(5)).await);
+    assert_eq!(d.state.session_metas()[0].lifecycle, SessionLifecycle::Parked);
+    assert_eq!(d.state.session_metas()[0].clients, 0);
+    tokio::time::timeout(Duration::from_secs(10), token.cancelled())
+        .await
+        .expect("idle-exit fires with a parked session");
+    assert_eq!(handle.lifecycle(), SessionLifecycle::Parked, "the probe never woke it");
+    d.wait().await;
+    assert!(!handle.is_alive(), "shutdown_all ended the parked session");
+    assert_eq!(host.sessions().len(), 0);
+}

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -17,6 +17,11 @@ Protocol v1 (`crates/agent-engine/src/session/wire.rs`), daemon in `agent-engine
 | `SYNAPS_DAEMON_RELOAD_STATE` / `SYNAPS_DAEMON_LOCK_FD` | Internal: handed to the new image by `reload`; both scrubbed at start. `RELOAD_STATE` without `LOCK_FD` refuses to start (the flock is the liveness oracle). |
 | `synaps daemon purge` / `scripts/memprof/purge.sh` | jemalloc purge in the daemon before an RssAnon sample (C2). `SYNAPS_MEMPROF_PURGE=1` for attach clients is not wired yet (A4/C4 client diet). |
 | `SYNAPS_DAEMON_READY_FD` | Internal: write end of the ready pipe handed to a `--detach`ed child. Scrubbed from the env before accept. |
+| `SYNAPS_DAEMON_PARK_GRACE_SECS` (default 60; `never` disables) | B3: seconds after the last detach (idle, no prompts, no compaction, not keep-warm, journal on disk) before a session is **Parked** — `Runtime` + `ConversationState` dropped, restored from the journal on the next attach/turn/`synaps send`. A session that never ran a turn has no journal and never parks. |
+| `synaps attach --keep-warm` / `/keep-warm on\|off` / `SessionCommand::KeepWarm` | Pin: never park this session. Survives `daemon reload`. |
+| `synaps attach --observe` / `--takeover` | B1 attach modes: `--observe` never owns input (setters/`Submit` are `Refused`); `--takeover` steals ownership from the current owner (who is told via `InputOwnerChanged{Takeover}`); default `Mirror` owns input iff nobody does. |
+| `SYNAPS_SESSION_COMPACT_INLINE=1` | One-release kill-switch: run `/compact` and auto-compaction inline on the actor task (the #107 body — `Attach`/`Cancel` wait behind it) instead of the spawned job. Deleted in phase 4. |
+| `synaps daemon reload` / `stop` / `purge` from **any** same-uid client | Not a privilege boundary (0600 socket): a stray `synaps daemon reload` from any shell checkpoints every session and closes everyone's PTYs. `Checkpoint` over the wire is owner-only. |
 
 ## CLI
 
@@ -27,7 +32,7 @@ synaps daemon stop [--force]         # Shutdown{force} over the socket, wait for
 synaps daemon sessions [--json]
 synaps daemon purge                  # Purge frame → memstat::purge_arenas() in the daemon; reply Pong (bench hygiene, C2)
 synaps daemon reload [--now] [--drain-secs N] [--exe PATH] [--json]   # re-exec in place, same pid (C3; §Reload below)
-synaps attach [ID] [--create] [--continue NAME_OR_ID] [-s PROMPT]
+synaps attach [ID] [--create] [--continue NAME_OR_ID] [-s PROMPT] [--observe|--takeover] [--keep-warm]
 synaps --attach [ID]                 # today: notice + routes to `synaps attach` (daemon-attached TUI is day 2)
 ```
 
@@ -37,7 +42,9 @@ stderr tail). Measured on bella: ready in ~75 ms.
 
 `synaps attach` is a thin line client: stdin lines → `Submit` (or `Steer` while streaming);
 `/abort` → `Cancel`; `/detach`, `/quit` or **Ctrl-C → `Detach` + `Bye` — the turn keeps running**;
-`/model NAME`; `/cmd NAME [ARG]` (engine command); `/save`; `/new`; `/sessions` (status query).
+`/model NAME`; `/cmd NAME [ARG]` (engine command); `/save`; `/new`; `/sessions` (status query);
+`/keep-warm on|off`. Typed events render as `[aborted…]`, `[session cleared → id]`, `[compacting: …]`,
+`[compacted N messages]`, `[refused cmd: reason]`, `[input owner → …]`, `[session Parked]`.
 Prompts render as `[prompt #id] title: prompt > `; `Secret` prompts turn terminal echo off.
 With no ID: attaches to the single live session, creates one if none, lists if several.
 
@@ -128,9 +135,12 @@ C: bye | socket close = Detach (turn keeps running)
 - **Compaction is inline in the actor**: `Attach`/`Detach`/`Cancel` wait behind a running `compact()`;
   `SocketTransport::attach` gives up after `ATTACH_TIMEOUT` (5 s) with "attach timed out" — retry.
   Spawned compaction is day 2.
-- `daemon stop` while a turn is streaming cancels it **and captures an abort context** (`finish()` →
-  `cancel_turn()`), so the session is "aborted" on disk; the TUI's quit-mid-turn only cancels the token.
-  Defensible (the next `--continue` tells the model the previous answer was cut), documented here.
+- **Quit mid-turn saves an abort context — default path, every host.** `End{ClientQuit}` (chat's
+  stdin EOF / `/quit`, the in-process TUI's quit — never `synaps attach`, which only detaches) and `daemon stop` while a turn
+  is streaming run `finish()` → `cancel_turn()`: the turn is cancelled **and** the partial output is
+  captured as `abort_context` and saved, so the next `--continue` prepends `[ABORT CONTEXT…]` — where the
+  pre-actor TUI/chat only cancelled the token. Defensible (the model is told the previous answer was cut);
+  `/clear` or a fresh session discards it. Documented in `synaps chat /help` too.
 - Refuse-to-start (exit 3): flag unset; legacy MCP conflict (above); another daemon holds the lock.
 
 ## Reload (`synaps daemon reload`, phase 3 C3)
@@ -212,6 +222,10 @@ Honest list of behaviour changes on this branch with `SYNAPS_DAEMON` **unset**:
    finally has a writer), but it is a default-path change. `SYNAPS_MCP_CACHE_WRITEBACK=0` restores the
    old read-only behaviour.
 3. Hook events carry `session_id` (additive; `SYNAPS_HOOK_SESSION_ID=0`).
+4. **`synaps chat` renders typed events**: `/compact` prints `compacting...`, the disclosure line and
+   `[compacted → ~N tokens]` (one each — the actor emits `CompactionStarted/Applied/Failed/Cancelled`,
+   never a "compacting..." notice); `/abort`-equivalents render `Aborted{context_saved}`, `/clear` renders
+   `Cleared{session_id}`. Quit mid-turn saves an abort context (§Lifecycle above).
 
 ## Memory acceptance — `DAEMON=1 SYNAPS_DAEMON=1 scripts/memprof/bench-sessions.sh BIN 1 2 3`
 

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -163,15 +163,22 @@ Sequence (`daemon/reload.rs`, PLAN-phase3 §2.8), all on the requesting control 
 
 **Not preserved** (stated once): in-flight turns (checkpointed = cancelled with abort context), pending
 prompts (`None`), PTY/background shells (closed, announced before exec), `turn_replay`, un-persisted
-`TurnLog`, the prompt-manifest path, and non-persisted runtime settings until B3's `settings_replay`
-lands (only what the journal holds comes back: messages, model, thinking, system prompt, abort context).
-**Preserved**: every journal, session ids, cwd, keep-warm/parked state (recorded; honoured once B3 lands),
-input-owner *kind* (ownership itself is re-established by reconnect order + `was_owner`).
+`TurnLog`, input ownership (re-established by reconnect order + `was_owner`), the subagent registry.
+**Preserved** — each session's `Checkpoint{Reload}` reply carries a `SessionReloadRecord` that the new
+image rehydrates from: the journal and session id (same journal continued; `reload_aliases` only after a
+LinkedSuccessor compaction), the `SessionConfig` as created (cwd, `--system`, prompt manifest,
+compaction policy, auto-compact, persist), the keep-warm pin, the lifecycle (**a Parked session comes
+back Parked** — rehydrate creates it then sends the host-only `Park`), the non-persisted runtime knobs
+(`settings_replay`: `/context`, compaction model, API retries, subagent/bash timeouts, tool-output cap,
+worker grants, **`/system`**), and the **current** model/thinking (a `/model` change mid-session
+survives; the create-time `--model` override is not re-applied). A session that never ran a turn has no
+journal (`save` skips an empty conversation): it is recreated fresh under a new id and aliased.
 
 Tested against a **real** `synaps daemon --foreground` process (`tests/daemon_reload.rs`): same pid before
 and after, `generation` 1→2, flock held throughout, conversation identical after reconnect, client is
 owner again, second turn works; older `--exe` refused with the daemon still serving; a turn in flight is
-checkpointed and its abort context comes back from the journal.
+checkpointed and its abort context comes back from the journal; `/model` + `/context` + `/system` +
+keep-warm + a Parked session survive (`reload_preserves_model_keep_warm_settings_and_parked`).
 
 ## cwd caveats (risk §6.1)
 

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -12,6 +12,7 @@ Protocol v1 (`crates/agent-engine/src/session/wire.rs`), daemon in `agent-engine
 | `SYNAPS_DAEMON_ALLOW_LEGACY_MCP=1` | Allow start with `progressive_tool_disclosure=false` **and** MCP servers configured (legacy `McpTool` connections would be shared across sessions). Same as `--allow-legacy-mcp`. |
 | `SYNAPS_RUNTIME_DIR` | Where the socket/lock/json/pid live (default `~/.synaps-cli/run`, 0700). |
 | `SYNAPS_SESSION_EVENTS_CAP` | Per-session broadcast capacity (default 1024). A slow client gets `SystemNotice("event stream lagged; n dropped")`. |
+| `synaps daemon purge` / `scripts/memprof/purge.sh` | jemalloc purge in the daemon before an RssAnon sample (C2). `SYNAPS_MEMPROF_PURGE=1` for attach clients is not wired yet (A4/C4 client diet). |
 | `SYNAPS_DAEMON_READY_FD` | Internal: write end of the ready pipe handed to a `--detach`ed child. Scrubbed from the env before accept. |
 
 ## CLI
@@ -21,6 +22,7 @@ synaps daemon [--foreground|--detach] [--socket PATH] [--idle-exit SECS] [--allo
 synaps daemon status [--json]        # daemon.json + flock probe + Ping → state/pid/uptime/sessions (exit 1 if not answering)
 synaps daemon stop [--force]         # Shutdown{force} over the socket, wait for the flock; --force escalates SIGTERM (10 s) → SIGKILL (+5 s)
 synaps daemon sessions [--json]
+synaps daemon purge                  # Purge frame → memstat::purge_arenas() in the daemon; reply Pong (bench hygiene, C2)
 synaps attach [ID] [--create] [--continue NAME_OR_ID] [-s PROMPT]
 synaps --attach [ID]                 # today: notice + routes to `synaps attach` (daemon-attached TUI is day 2)
 ```
@@ -115,11 +117,10 @@ C: bye | socket close = Detach (turn keeps running)
   through the normal `End{HostShutdown}` path (saved to `sessions/<id>.json`; `synaps attach --continue`
   brings them back). Tested: `idle_exit_counts_clientless_idle_sessions_and_never_a_running_turn`.
 - **Extension notification router** (`extensions::notify_router`) is spawned by `run_foreground` after
-  discovery: every sidecar's `widget.*` frames fan out to **every** live session as
-  `ExtensionNotification`. Frames carry no session id, so **widgets are daemon-global under
-  `SYNAPS_DAEMON=1`** (a widget upsert from work in session A shows in session B's client). Per-session
-  routing needs `params.session_id` from the extension contract — day 2; `heartbeat`/`jawz-widget` are
-  last-writer-wins until then (`docs/extensions/session-id.md`).
+  discovery: a sidecar's `widget.*` frame goes to the session named by `params.session_id` (dropped with
+  a `debug!` if that session is not live), or to **every** live session when the frame carries none
+  (daemon-global — the pre-phase-3 behaviour). Plugin contract: `docs/extensions/session-id.md`;
+  `heartbeat`/`jawz-widget` stay last-writer-wins until their own repos adopt it.
 - **Compaction is inline in the actor**: `Attach`/`Detach`/`Cancel` wait behind a running `compact()`;
   `SocketTransport::attach` gives up after `ATTACH_TIMEOUT` (5 s) with "attach timed out" — retry.
   Spawned compaction is day 2.

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -152,7 +152,12 @@ Sequence (`daemon/reload.rs`, PLAN-phase3 §2.8), all on the requesting control 
 5. **Exec**: `daemon.json` rewritten (`generation+1`, same pid), sidecars stopped (≤ 5 s), the flock fd made
    inheritable (`SYNAPS_DAEMON_LOCK_FD`), `execv(exe, original argv)`. The listener is CLOEXEC (asserted in
    `listener::bind`) — closed at exec; the new image rebinds. **Exec failure**: `daemon.json`/reload-state
-   restored, `reloading` cleared, old image keeps serving (sessions checkpointed but alive).
+   restored, `reloading` cleared, the reload-announce token re-armed (new connections are served again),
+   extension discovery re-spawned (the sidecars were stopped for the exec — bounded 10 s like boot), old
+   image keeps serving (sessions checkpointed but alive; the requester already got `Bye{Reloading}` and
+   reconnects to the same generation). `--exe` is validated **before** the probe: canonical path, regular
+   file, executable, owned by our uid or root, not group/world-writable; then `--print-version` must parse
+   and pass the gate. Tested: `exe_validation_refuses_and_exec_failure_keeps_serving`.
 6. **New image**: `Daemon::start` sees `SYNAPS_DAEMON_RELOAD_STATE` → `DaemonLock::adopt(fd)` (same open file
    description = same flock, no gap), no `reap_stale`, rehydrates every recorded session
    (`create_session(continue_session = journal_id)`) **before** accepting; `reload_aliases` maps old→new

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -12,6 +12,9 @@ Protocol v1 (`crates/agent-engine/src/session/wire.rs`), daemon in `agent-engine
 | `SYNAPS_DAEMON_ALLOW_LEGACY_MCP=1` | Allow start with `progressive_tool_disclosure=false` **and** MCP servers configured (legacy `McpTool` connections would be shared across sessions). Same as `--allow-legacy-mcp`. |
 | `SYNAPS_RUNTIME_DIR` | Where the socket/lock/json/pid live (default `~/.synaps-cli/run`, 0700). |
 | `SYNAPS_SESSION_EVENTS_CAP` | Per-session broadcast capacity (default 1024). A slow client gets `SystemNotice("event stream lagged; n dropped")`. |
+| `synaps daemon reload [--now] [--drain-secs N] [--exe PATH]` / `SYNAPS_DAEMON_RELOAD_DRAIN_SECS` (default 30) | Re-exec the daemon in place (C3). `--now` = drain 0. `--exe` overrides (and records) the binary. |
+| `SYNAPS_TUI_ATTACH_RECONNECT_SECS` (default 60) | Total `SocketTransport::reconnect` budget after `Reloading`/EOF (backoff 100 ms ×2, cap 5 s). |
+| `SYNAPS_DAEMON_RELOAD_STATE` / `SYNAPS_DAEMON_LOCK_FD` | Internal: handed to the new image by `reload`; both scrubbed at start. `RELOAD_STATE` without `LOCK_FD` refuses to start (the flock is the liveness oracle). |
 | `synaps daemon purge` / `scripts/memprof/purge.sh` | jemalloc purge in the daemon before an RssAnon sample (C2). `SYNAPS_MEMPROF_PURGE=1` for attach clients is not wired yet (A4/C4 client diet). |
 | `SYNAPS_DAEMON_READY_FD` | Internal: write end of the ready pipe handed to a `--detach`ed child. Scrubbed from the env before accept. |
 
@@ -23,6 +26,7 @@ synaps daemon status [--json]        # daemon.json + flock probe + Ping → stat
 synaps daemon stop [--force]         # Shutdown{force} over the socket, wait for the flock; --force escalates SIGTERM (10 s) → SIGKILL (+5 s)
 synaps daemon sessions [--json]
 synaps daemon purge                  # Purge frame → memstat::purge_arenas() in the daemon; reply Pong (bench hygiene, C2)
+synaps daemon reload [--now] [--drain-secs N] [--exe PATH] [--json]   # re-exec in place, same pid (C3; §Reload below)
 synaps attach [ID] [--create] [--continue NAME_OR_ID] [-s PROMPT]
 synaps --attach [ID]                 # today: notice + routes to `synaps attach` (daemon-attached TUI is day 2)
 ```
@@ -128,6 +132,46 @@ C: bye | socket close = Detach (turn keeps running)
   `cancel_turn()`), so the session is "aborted" on disk; the TUI's quit-mid-turn only cancels the token.
   Defensible (the next `--continue` tells the model the previous answer was cut), documented here.
 - Refuse-to-start (exit 3): flag unset; legacy MCP conflict (above); another daemon holds the lock.
+
+## Reload (`synaps daemon reload`, phase 3 C3)
+
+Sequence (`daemon/reload.rs`, PLAN-phase3 §2.8), all on the requesting control connection:
+
+1. **Version gate** before anything is disturbed: `<exe> daemon --print-version` (hidden flag, 5 s) must
+   succeed, speak protocol ≥ ours, and be **newer or equal** by semver (`RefuseReason::ReloadRefused{why}`
+   otherwise; equal allows same-version rebuilds). `exe` = `daemon.json.exe` (argv[0] canonicalised at
+   first start — not `/proc/self/exe`, which reads "(deleted)" after an in-place rebuild) or `--exe`.
+2. **Drain**: `Attach::Create` → `Refused{Busy}`, `Submit`/`SubmitPrepared`/`Compact` → `Error("daemon
+   reloading; retry in a moment")`; wait ≤ `--drain-secs` for every session to be idle; then
+   `Checkpoint{Reload}` every session concurrently (≤ `SAVE_TIMEOUT`+1 s each): cancel with abort context,
+   answer prompts `None`, save, close PTYs, notice.
+3. **reload-state** `daemon[-P].reload.json` (0600): generation, per-session `{id, journal_id, config
+   (continue_session = journal_id, cwd, model), keep_warm, lifecycle}`.
+4. **Announce**: every other connection gets `Event(Reloading{generation, retry_after_ms: 500})` +
+   `Bye{Reloading}` (forwarders drain the checkpoint's events first); the requester gets `Bye{Reloading}`.
+5. **Exec**: `daemon.json` rewritten (`generation+1`, same pid), sidecars stopped (≤ 5 s), the flock fd made
+   inheritable (`SYNAPS_DAEMON_LOCK_FD`), `execv(exe, original argv)`. The listener is CLOEXEC (asserted in
+   `listener::bind`) — closed at exec; the new image rebinds. **Exec failure**: `daemon.json`/reload-state
+   restored, `reloading` cleared, old image keeps serving (sessions checkpointed but alive).
+6. **New image**: `Daemon::start` sees `SYNAPS_DAEMON_RELOAD_STATE` → `DaemonLock::adopt(fd)` (same open file
+   description = same flock, no gap), no `reap_stale`, rehydrates every recorded session
+   (`create_session(continue_session = journal_id)`) **before** accepting; `reload_aliases` maps old→new
+   ids for one generation (they differ only after a LinkedSuccessor compaction).
+7. **Clients**: `SocketTransport::next_event` returns `None` with `last_error = Reloading{generation}`;
+   `reconnect(mode)` backs off, sends `Hello{reconnect_of}` and `Attach::Existing{id, Takeover iff
+   was_owner else mode}` — two reconnecting mirrors cannot both take over.
+
+**Not preserved** (stated once): in-flight turns (checkpointed = cancelled with abort context), pending
+prompts (`None`), PTY/background shells (closed, announced before exec), `turn_replay`, un-persisted
+`TurnLog`, the prompt-manifest path, and non-persisted runtime settings until B3's `settings_replay`
+lands (only what the journal holds comes back: messages, model, thinking, system prompt, abort context).
+**Preserved**: every journal, session ids, cwd, keep-warm/parked state (recorded; honoured once B3 lands),
+input-owner *kind* (ownership itself is re-established by reconnect order + `was_owner`).
+
+Tested against a **real** `synaps daemon --foreground` process (`tests/daemon_reload.rs`): same pid before
+and after, `generation` 1→2, flock held throughout, conversation identical after reconnect, client is
+owner again, second turn works; older `--exe` refused with the daemon still serving; a turn in flight is
+checkpointed and its abort context comes back from the journal.
 
 ## cwd caveats (risk §6.1)
 

--- a/docs/extensions/session-id.md
+++ b/docs/extensions/session-id.md
@@ -33,10 +33,11 @@ extension that ignores `session_id` sees the same shape it always did.
 ## Why: one sidecar, many sessions
 
 In daemon mode one extension process serves every session in the daemon.
-The reverse direction is fanned out too: `synaps daemon` runs the
-notification router (`extensions::notify_router`), which delivers every
-sidecar's `widget.*` frames to **every** live session — widgets are
-daemon-global under `SYNAPS_DAEMON=1` until frames carry `params.session_id`.
+The reverse direction is routed too: `synaps daemon` runs the
+notification router (`extensions::notify_router`), which delivers a
+sidecar's `widget.*` frame to the session named by `params.session_id`
+when the frame carries one, and to **every** live session when it does
+not (daemon-global; the pre-phase-3 behaviour). See "Plugin contract" below.
 "Last tool call"-style state keyed on nothing is now keyed on the wrong thing:
 two sessions interleave their hooks on the same stdin. Key per-session state
 on `params.session_id`, and treat `null` as "no session (worker)".
@@ -44,6 +45,36 @@ on `params.session_id`, and treat `null` as "no session (worker)".
 The in-tree helper is `HookEvent::with_session(Option<&str>)`; the runtime
 emitters `emit_before_tool_call` / `emit_after_tool_call` take a trailing
 `session_id: Option<&str>`.
+
+## Plugin contract (daemon-mode phase 3, C2)
+
+The runtime side is done: hooks carry `session_id`; the router keys
+`widget.*` frames on `params.session_id`. A plugin that wants correct
+behaviour with more than one live session must:
+
+1. **Key its state on `session_id`.** One entry per session, created on
+   the first hook that names the session, removed on `on_session_end`
+   for that id. Treat `session_id == null` as "no session (worker /
+   extension-originated tool call)" — never fold it into a session entry.
+2. **Address outbound notifications.** Put `"session_id": "<id>"` in the
+   `params` of every `widget.upsert` / `widget.dismiss` (and any future
+   session-scoped notification). A frame without it is delivered to every
+   session — acceptable only for genuinely global UI.
+3. **Address injected events.** `synaps send --session <id>` (never
+   `--broadcast`) for anything that is a reply to one session's activity.
+   A parked session (phase-3 B3) is woken by an injected event, so a
+   periodic global beat wakes every parked session; key beats per session
+   and respect the park grace (`SYNAPS_DAEMON_PARK_GRACE_SECS`).
+
+Concretely, for the two in-tree plugins that have state today:
+
+| Plugin | Today | Contract |
+|---|---|---|
+| `heartbeat` (`~/.synaps-cli/plugins/heartbeat/main.py:76-105,150-183`) | one global `STATE["session_id"]`, captured from any hook; `fire_beat(--session\|--broadcast)` | `STATE: dict[session_id → {last_activity, beats, …}]`; capture per hook; `fire_beat --session <id>` per entry; delete the entry on `on_session_end`; `idle_threshold_sec ≥` park grace |
+| `jawz-widget` (`~/.synaps-cli/plugins/jawz-widget/main.py:110-126`) | one global `st.mode` | `modes: dict[session_id → mode]`; every `widget.upsert` carries `params.session_id` (the widget then shows in the session that produced it, not in every client) |
+
+Those plugin edits live in their own repos (`~/.synaps-cli/plugins`) and are
+a follow-up PR there; nothing in this repo depends on them landing.
 
 ## In-tree plugin audit (2026-09, jade 16 / bella 2)
 

--- a/scripts/memprof/bench-sessions.sh
+++ b/scripts/memprof/bench-sessions.sh
@@ -138,7 +138,7 @@ run_once_parked() { # N i -> prints "live_anon_kb parked_anon_kb dprocs_live dpr
   } > "$out"
   local live_anon live_procs
   live_anon=$(awk '/^-- live daemon tree RssAnon/{f=1} f&&/^TREE_ANON/{print $2; exit}' "$out")
-  live_procs=$(awk '/^-- live daemon tree RssAnon/{f=1} f&&/^pid=/{c++} /^TREE_ANON/{print c; exit}' "$out")
+  live_procs=$(awk '/^-- live daemon tree RssAnon/{f=1} f&&/^pid=/{c++} f&&/^TREE_ANON/{print c; exit}' "$out")
   # Detach every client (kill its tmux session) → grace → parked.
   for s in $(seq 1 "$n"); do tmux -L bench kill-session -t "s$s" 2>/dev/null; done
   sleep $((PARK_GRACE + 2)); purge
@@ -148,7 +148,7 @@ run_once_parked() { # N i -> prints "live_anon_kb parked_anon_kb dprocs_live dpr
   } >> "$out"
   local parked_anon parked_procs
   parked_anon=$(awk '/^-- parked daemon tree RssAnon/{f=1} f&&/^TREE_ANON/{print $2; exit}' "$out")
-  parked_procs=$(awk '/^-- parked daemon tree RssAnon/{f=1} f&&/^pid=/{c++} /^TREE_ANON/{print c; exit}' "$out")
+  parked_procs=$(awk '/^-- parked daemon tree RssAnon/{f=1} f&&/^pid=/{c++} f&&/^TREE_ANON/{print c; exit}' "$out")
   # Unpark latency: one fresh attach to a parked session.
   local attach_ms
   attach_ms=$("$HERE/launch.sh" "u1" "$BIN" attach "${ids[0]}" | sed -E 's/.*ready after ([0-9]+) ms.*/\1/')

--- a/scripts/memprof/bench-sessions.sh
+++ b/scripts/memprof/bench-sessions.sh
@@ -20,6 +20,16 @@
 # idle session). Requires SYNAPS_DAEMON=1 (exported here). Sessions are REAL
 # SessionActors.
 #
+# DAEMON=1 PARKED=1 mode (PLAN-phase3 §5.5): every session is created from a
+# FIXTURE_MSGS_MB (default 2) MB fixture journal (make-fixture-session.sh) via
+# `synaps attach --continue <fixture> --create`; the daemon runs with
+# SYNAPS_DAEMON_PARK_GRACE_SECS=$PARK_GRACE (default 5). Samples the daemon
+# tree RssAnon with N clients attached (live), then kills every client, waits
+# PARK_GRACE+2 s, purges, and samples again (parked). Columns: live_anon,
+# live_marginal, parked_anon, parked_marginal, ratio, attach_ms (a fresh
+# attach to a parked session = unpark latency). Gates: parked_marginal
+# <= 1.0 MB and <= 0.25 x live_marginal; daemon procs constant.
+#
 # Never touches tmux servers other than `-L bench`. No root needed.
 set -u
 HERE=$(cd "$(dirname "$0")" && pwd)
@@ -29,6 +39,9 @@ REPEAT=${REPEAT:-3}
 SETTLE=${SETTLE:-12}
 TAG=$(basename "$BIN")
 DAEMON=${DAEMON:-0}
+PARKED=${PARKED:-0}
+PARK_GRACE=${PARK_GRACE:-5}
+FIXTURE_MSGS_MB=${FIXTURE_MSGS_MB:-2}
 [ "$DAEMON" = 1 ] && export SYNAPS_DAEMON=1
 
 median() { sort -n | awk '{a[NR]=$1} END{ if (NR==0) print "n/a"; else if (NR%2) print a[(NR+1)/2]; else print (a[NR/2]+a[NR/2+1])/2 }'; }
@@ -98,6 +111,54 @@ run_once_daemon() { # N i -> prints "pss_kb daemon_pss_kb procs_beyond_daemon st
   echo "$pss $dpss $((procs-dprocs)) $dprocs ${starts[0]:-0} ${danon:-0} $out"
 }
 
+purge() { "$BIN" daemon purge >/dev/null 2>&1 || true; sleep 1; }
+
+run_once_parked() { # N i -> prints "live_anon_kb parked_anon_kb dprocs_live dprocs_parked attach_ms out"
+  local n=$1 i=$2 out=/tmp/memprof-$TAG-parked-N$n-r$i.txt
+  tmux -L bench kill-server 2>/dev/null; sleep 1
+  "$BIN" daemon stop >/dev/null 2>&1
+  local ids=() s
+  for s in $(seq 1 "$n"); do
+    local id="memprof-fix-$s-$i-$$"
+    "$HERE/make-fixture-session.sh" "$id" "$FIXTURE_MSGS_MB" >/dev/null
+    ids+=("$id")
+  done
+  tmux -L bench new -d -s d -x 120 -y 40 "exec env SYNAPS_DAEMON_PARK_GRACE_SECS=$PARK_GRACE $BIN daemon --foreground"
+  for _ in $(seq 1 500); do sleep 0.02; "$BIN" daemon status --json 2>/dev/null | grep -q '"ok":true' && break; done
+  local dpid; dpid=$(tmux -L bench list-panes -t d -F '#{pane_pid}')
+  for s in $(seq 1 "$n"); do
+    "$HERE/launch.sh" "s$s" "$BIN" attach --continue "${ids[$((s-1))]}" --create >/dev/null
+    sleep 0.3
+  done
+  sleep "$SETTLE"; purge
+  {
+    echo "== $BIN PARKED N=$n run=$i fixture_mb=$FIXTURE_MSGS_MB grace=$PARK_GRACE"
+    echo "-- live daemon tree RssAnon"; tree_anon "$dpid"
+    "$BIN" daemon status --json 2>/dev/null
+  } > "$out"
+  local live_anon live_procs
+  live_anon=$(awk '/^-- live daemon tree RssAnon/{f=1} f&&/^TREE_ANON/{print $2; exit}' "$out")
+  live_procs=$(awk '/^-- live daemon tree RssAnon/{f=1} f&&/^pid=/{c++} /^TREE_ANON/{print c; exit}' "$out")
+  # Detach every client (kill its tmux session) → grace → parked.
+  for s in $(seq 1 "$n"); do tmux -L bench kill-session -t "s$s" 2>/dev/null; done
+  sleep $((PARK_GRACE + 2)); purge
+  {
+    echo "-- parked daemon tree RssAnon"; tree_anon "$dpid"
+    "$BIN" daemon status --json 2>/dev/null
+  } >> "$out"
+  local parked_anon parked_procs
+  parked_anon=$(awk '/^-- parked daemon tree RssAnon/{f=1} f&&/^TREE_ANON/{print $2; exit}' "$out")
+  parked_procs=$(awk '/^-- parked daemon tree RssAnon/{f=1} f&&/^pid=/{c++} /^TREE_ANON/{print c; exit}' "$out")
+  # Unpark latency: one fresh attach to a parked session.
+  local attach_ms
+  attach_ms=$("$HERE/launch.sh" "u1" "$BIN" attach "${ids[0]}" | sed -E 's/.*ready after ([0-9]+) ms.*/\1/')
+  echo "-- attach_to_parked_ms=$attach_ms" >> "$out"
+  "$BIN" daemon stop >/dev/null 2>&1
+  tmux -L bench kill-server 2>/dev/null
+  for id in "${ids[@]}"; do rm -f "${SYNAPS_BASE_DIR:-$HOME/.synaps-cli}/sessions/$id".json*; done
+  echo "${live_anon:-0} ${parked_anon:-0} ${live_procs:-0} ${parked_procs:-0} ${attach_ms:-0} $out"
+}
+
 # Sum RssAnon (kB) over PID and all descendants; prints per-pid lines + TREE_ANON <kB>.
 tree_anon() {
   local root=$1 tot=0
@@ -110,6 +171,29 @@ tree_anon() {
   done
   echo "TREE_ANON $tot"
 }
+
+if [ "$DAEMON" = 1 ] && [ "$PARKED" = 1 ]; then
+  echo "binary=$BIN repeat=$REPEAT settle=${SETTLE}s mode=DAEMON+PARKED fixture_mb=$FIXTURE_MSGS_MB grace=${PARK_GRACE}s"
+  printf "%-4s %-12s %-14s %-12s %-16s %-8s %-12s %-10s\n" N "live_anon_MB" "live_marginal" "parked_anon" "parked_marginal" "ratio" "daemon_procs" "attach_ms(med)"
+  prev_live=""; prev_parked=""
+  for n in $NS; do
+    L=(); PK=(); DP=(); S=()
+    for i in $(seq 1 "$REPEAT"); do
+      read -r live parked lprocs pprocs ams out < <(run_once_parked "$n" "$i")
+      L+=("$live"); PK+=("$parked"); DP+=("$lprocs/$pprocs"); S+=("$ams")
+    done
+    l_med=$(printf '%s\n' "${L[@]}" | median)
+    p_med=$(printf '%s\n' "${PK[@]}" | median)
+    s_med=$(printf '%s\n' "${S[@]}" | median)
+    lmarg=$( [ -n "$prev_live" ] && awk -v a="$l_med" -v b="$prev_live" 'BEGIN{printf "%.2f", (a-b)/1024}' || echo "-" )
+    pmarg=$( [ -n "$prev_parked" ] && awk -v a="$p_med" -v b="$prev_parked" 'BEGIN{printf "%.2f", (a-b)/1024}' || echo "-" )
+    ratio=$( [ -n "$prev_live" ] && awk -v a="$p_med" -v b="$prev_parked" -v c="$l_med" -v d="$prev_live" 'BEGIN{ if (c-d>0) printf "%.2f", (a-b)/(c-d); else print "n/a" }' || echo "-" )
+    printf "%-4s %-12.1f %-14s %-12.1f %-16s %-8s %-12s %-10s\n" "$n" "$(awk -v k="$l_med" 'BEGIN{print k/1024}')" "$lmarg" "$(awk -v k="$p_med" 'BEGIN{print k/1024}')" "$pmarg" "$ratio" "${DP[0]}" "$s_med"
+    prev_live=$l_med; prev_parked=$p_med
+  done
+  echo "gates (§5.5): parked_marginal <= 1.0 MB; parked_marginal <= 0.25 x live_marginal; daemon_procs constant; attach_ms to a parked session <= 500 ms (informational above)"
+  exit 0
+fi
 
 if [ "$DAEMON" = 1 ]; then
   echo "binary=$BIN repeat=$REPEAT settle=${SETTLE}s mode=DAEMON"

--- a/scripts/memprof/make-fixture-session.sh
+++ b/scripts/memprof/make-fixture-session.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# make-fixture-session.sh ID [MB] — write a legacy-snapshot session file with
+# ~MB megabytes of api_messages (tool_result blobs) into the active sessions
+# dir, so a bench can `synaps attach --continue ID --create` a session that
+# actually carries state (PLAN-phase3 §5.5: an empty session is not what
+# Parked buys back).
+#
+# env: SYNAPS_BASE_DIR (default ~/.synaps-cli), FIXTURE_MODEL (default
+# claude-sonnet-4-5). Prints the file path.
+set -eu
+ID=${1:?usage: make-fixture-session.sh ID [MB]}
+MB=${2:-2}
+BASE=${SYNAPS_BASE_DIR:-$HOME/.synaps-cli}
+MODEL=${FIXTURE_MODEL:-claude-sonnet-4-5}
+DIR=$BASE/sessions
+mkdir -p "$DIR"; chmod 700 "$DIR"
+OUT=$DIR/$ID.json
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+python3 - "$OUT" "$ID" "$MB" "$MODEL" "$NOW" <<'PY'
+import json, sys
+out, sid, mb, model, now = sys.argv[1], sys.argv[2], float(sys.argv[3]), sys.argv[4], sys.argv[5]
+target = int(mb * 1024 * 1024)
+blob = ("lorem ipsum tool output line %05d\n" % 0) * 32   # ~1 KiB per result
+msgs, size, i = [], 0, 0
+while size < target:
+    tu = {"role": "assistant", "content": [{"type": "tool_use", "id": f"toolu_{i}", "name": "bash",
+          "input": {"command": f"echo {i}"}}]}
+    tr = {"role": "user", "content": [{"type": "tool_result", "tool_use_id": f"toolu_{i}",
+          "content": blob.replace("00000", "%05d" % i)}]}
+    msgs += [tu, tr]
+    size += len(json.dumps(tu)) + len(json.dumps(tr))
+    i += 1
+msgs.insert(0, {"role": "user", "content": "run the fixture"})
+msgs.append({"role": "assistant", "content": [{"type": "text", "text": "done"}]})
+sess = {
+    "id": sid, "title": "memprof fixture", "model": model, "thinking_level": "medium",
+    "system_prompt": None, "created_at": now, "updated_at": now,
+    "total_input_tokens": 0, "total_output_tokens": 0, "session_cost": 0.0,
+    "message_count": len(msgs), "api_messages": msgs,
+}
+with open(out, "w") as f:
+    json.dump(sess, f)
+print(out)
+PY
+chmod 600 "$OUT"

--- a/scripts/memprof/purge.sh
+++ b/scripts/memprof/purge.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Purge-before-sample helper (PLAN-phase3 C2). Run right before `mem.sh` /
+# RssAnon sampling so the daemon (and, with SYNAPS_MEMPROF_PURGE=1, the
+# attach clients on their next tick) return jemalloc dirty pages first.
+#
+#   scripts/memprof/purge.sh [BIN] [PROFILE]
+#
+# BIN defaults to $BIN or `synaps`; PROFILE is passed as `--profile`.
+# Exit 0 whether or not a daemon is running (bench scripts call it
+# unconditionally); prints the daemon's reply on success.
+#
+# bench-sessions.sh (B's file) can opt in with `PURGE=1` by calling this
+# script before its sample block; nothing here touches that script.
+set -u
+BIN="${1:-${BIN:-synaps}}"
+PROFILE="${2:-}"
+args=()
+[ -n "$PROFILE" ] && args+=(--profile "$PROFILE")
+if ! SYNAPS_DAEMON=1 "$BIN" "${args[@]}" daemon status --json >/dev/null 2>&1; then
+  echo "purge: no daemon running" >&2
+  exit 0
+fi
+SYNAPS_DAEMON=1 "$BIN" "${args[@]}" daemon purge
+# jemalloc's purge is asynchronous with respect to /proc accounting; give
+# the kernel a beat before the caller samples.
+sleep 0.5

--- a/src/cmd/attach.rs
+++ b/src/cmd/attach.rs
@@ -28,6 +28,29 @@ pub(crate) struct AttachArgs {
     /// System prompt for a created session.
     #[arg(long = "system", short = 's')]
     pub system: Option<String>,
+    /// Read-only mirror: never owns input (B1).
+    #[arg(long, conflicts_with = "takeover")]
+    pub observe: bool,
+    /// Steal input ownership from the current owner (B1).
+    #[arg(long)]
+    pub takeover: bool,
+    /// Never park this session (B3); also sent to an existing session.
+    #[arg(long = "keep-warm")]
+    pub keep_warm: bool,
+}
+
+impl AttachArgs {
+    /// `--observe` → `Observe`, `--takeover` → `Takeover`, else `Mirror`
+    /// (owner iff nobody owns input yet).
+    pub(crate) fn attach_mode(&self) -> AttachMode {
+        if self.observe {
+            AttachMode::Observe
+        } else if self.takeover {
+            AttachMode::Takeover
+        } else {
+            AttachMode::Mirror
+        }
+    }
 }
 
 struct Client {
@@ -91,20 +114,25 @@ impl Client {
             | SessionEventWire::LoaderProgress(_)
             | SessionEventWire::ExtensionNotification { .. }
             | SessionEventWire::Attached { .. } => {}
-            // Phase-3 envelopes: rendered by C4/A4; ignored by the line client today.
-            SessionEventWire::Aborted { .. }
-            | SessionEventWire::Cleared { .. }
-            | SessionEventWire::CompactionStarted { .. }
-            | SessionEventWire::CompactionApplied { .. }
-            | SessionEventWire::CompactionFailed { .. }
-            | SessionEventWire::CompactionCancelled
-            | SessionEventWire::SubagentRows(_)
-            | SessionEventWire::Resumed { .. }
-            | SessionEventWire::InputOwnerChanged { .. }
-            | SessionEventWire::Refused { .. }
-            | SessionEventWire::AttachRefused { .. }
-            | SessionEventWire::Lifecycle(_)
-            | SessionEventWire::Reloading { .. } => {}
+            SessionEventWire::Aborted { context_saved } => {
+                self.streaming = false;
+                self.out(if *context_saved { "[aborted — context saved for next message]\n" } else { "[aborted]\n" })
+            }
+            SessionEventWire::Cleared { session_id } => {
+                self.out(&format!("[session cleared → {}]\n", &session_id[..8.min(session_id.len())]))
+            }
+            SessionEventWire::CompactionStarted { disclosure, .. } => self.out(&format!("[compacting: {disclosure}]\n")),
+            SessionEventWire::CompactionApplied { msg_count, .. } => self.out(&format!("[compacted {msg_count} messages]\n")),
+            SessionEventWire::CompactionFailed { message, .. } => self.out(&format!("[compaction failed: {message}]\n")),
+            SessionEventWire::CompactionCancelled => self.out("[compaction cancelled]\n"),
+            SessionEventWire::InputOwnerChanged { to, reason, .. } => {
+                self.out(&format!("[input owner → {} ({reason:?})]\n", to.map(|c| format!("client #{}", c.0)).unwrap_or_else(|| "nobody".into())))
+            }
+            SessionEventWire::Refused { command, reason, .. } => self.out(&format!("[refused {command}: {reason}]\n")),
+            SessionEventWire::AttachRefused { message } => self.out(&format!("[attach refused: {message}]\n")),
+            SessionEventWire::Lifecycle(l) => self.out(&format!("[session {l:?}]\n")),
+            SessionEventWire::Reloading { generation, .. } => self.out(&format!("[daemon reloading → generation {generation}]\n")),
+            SessionEventWire::SubagentRows(_) | SessionEventWire::Resumed { .. } => {}
         }
     }
 
@@ -136,7 +164,10 @@ impl Client {
             "/new" => {
                 let _ = self.t.send(SessionCommand::NewSession).await;
             }
-            "/help" => self.out("/detach /abort /save /new /sessions /model NAME /cmd NAME [ARG]\n"),
+            "/help" => self.out("/detach /abort /save /new /sessions /model NAME /cmd NAME [ARG] /keep-warm on|off\n"),
+            "/keep-warm on" | "/keep-warm off" => {
+                let _ = self.t.send(SessionCommand::KeepWarm { on: line.ends_with("on") }).await;
+            }
             _ if line.starts_with("/cmd ") => {
                 let rest = line["/cmd ".len()..].trim();
                 let (name, arg) = rest.split_once(' ').unwrap_or((rest, ""));
@@ -196,25 +227,27 @@ pub(crate) async fn run(profile: Option<String>, args: AttachArgs) -> anyhow::Re
         eprintln!("[notice] daemon binary {} differs from client {} (same protocol)", conn.welcome.daemon_version, binary_version());
     }
 
+    let mode = args.attach_mode();
     let attach = if args.create || args.continue_session.is_some() {
         Attach::Create {
             config: SessionConfig {
                 continue_session: args.continue_session.clone().map(Some),
                 system: args.system.clone(),
                 cwd: Some(std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"))),
+                keep_warm: args.keep_warm,
                 ..Default::default()
             },
-            mode: AttachMode::Mirror,
+            mode,
         }
     } else if let Some(id) = &args.id {
         let id = resolve_id(&conn.welcome.sessions, id).unwrap_or_else(|| SessionId::from(id.as_str()));
-        Attach::Existing { session_id: id, mode: AttachMode::Mirror }
+        Attach::Existing { session_id: id, mode }
     } else if conn.welcome.sessions.len() == 1 {
-        Attach::Existing { session_id: conn.welcome.sessions[0].id.clone(), mode: AttachMode::Mirror }
+        Attach::Existing { session_id: conn.welcome.sessions[0].id.clone(), mode }
     } else if conn.welcome.sessions.is_empty() {
         Attach::Create {
-            config: SessionConfig { cwd: std::env::current_dir().ok(), ..Default::default() },
-            mode: AttachMode::Mirror,
+            config: SessionConfig { cwd: std::env::current_dir().ok(), keep_warm: args.keep_warm, ..Default::default() },
+            mode,
         }
     } else {
         eprintln!("several sessions; pick one:");
@@ -224,8 +257,12 @@ pub(crate) async fn run(profile: Option<String>, args: AttachArgs) -> anyhow::Re
         std::process::exit(1);
     };
 
+    let existing = matches!(attach, Attach::Existing { .. });
     let (t, snap) = SocketTransport::attach(conn, attach).await.map_err(|e| anyhow::anyhow!("attach: {e}"))?;
     let mut c = Client { t, streaming: snap.streaming, pending: snap.pending_prompts.clone(), stdout: std::io::stdout() };
+    if args.keep_warm && existing {
+        let _ = c.t.send(SessionCommand::KeepWarm { on: true }).await;
+    }
     // "○ ready" is the marker scripts/memprof/launch.sh polls for.
     c.out(&format!(
         "[attached {} as client #{}  model={}  messages={}{}] ○ ready\n",
@@ -284,4 +321,30 @@ fn resolve_id(sessions: &[SessionMeta], q: &str) -> Option<SessionId> {
         .find(|m| m.id.as_str() == q || m.name.as_deref() == Some(q))
         .or_else(|| sessions.iter().find(|m| m.id.as_str().starts_with(q)))
         .map(|m| m.id.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct Cli {
+        #[command(flatten)]
+        args: AttachArgs,
+    }
+
+    #[test]
+    fn flags_plumb_to_attach_mode() {
+        let a = Cli::parse_from(["attach"]).args;
+        assert_eq!(a.attach_mode(), AttachMode::Mirror);
+        assert!(!a.keep_warm);
+        let a = Cli::parse_from(["attach", "--observe"]).args;
+        assert_eq!(a.attach_mode(), AttachMode::Observe);
+        let a = Cli::parse_from(["attach", "abc", "--takeover", "--keep-warm"]).args;
+        assert_eq!(a.attach_mode(), AttachMode::Takeover);
+        assert!(a.keep_warm);
+        assert_eq!(a.id.as_deref(), Some("abc"));
+        assert!(Cli::try_parse_from(["attach", "--observe", "--takeover"]).is_err());
+    }
 }

--- a/src/cmd/attach.rs
+++ b/src/cmd/attach.rs
@@ -91,6 +91,20 @@ impl Client {
             | SessionEventWire::LoaderProgress(_)
             | SessionEventWire::ExtensionNotification { .. }
             | SessionEventWire::Attached { .. } => {}
+            // Phase-3 envelopes: rendered by C4/A4; ignored by the line client today.
+            SessionEventWire::Aborted { .. }
+            | SessionEventWire::Cleared { .. }
+            | SessionEventWire::CompactionStarted { .. }
+            | SessionEventWire::CompactionApplied { .. }
+            | SessionEventWire::CompactionFailed { .. }
+            | SessionEventWire::CompactionCancelled
+            | SessionEventWire::SubagentRows(_)
+            | SessionEventWire::Resumed { .. }
+            | SessionEventWire::InputOwnerChanged { .. }
+            | SessionEventWire::Refused { .. }
+            | SessionEventWire::AttachRefused { .. }
+            | SessionEventWire::Lifecycle(_)
+            | SessionEventWire::Reloading { .. } => {}
         }
     }
 
@@ -133,7 +147,7 @@ impl Client {
             }
             _ if line.starts_with("/model ") => {
                 let model = line["/model ".len()..].trim().to_string();
-                let _ = self.t.send(SessionCommand::Set(SessionSetting::Model { model })).await;
+                let _ = self.t.send(SessionCommand::Set { id: 0, setting: SessionSetting::Model { model } }).await;
             }
             text => {
                 let cmd = if self.streaming {

--- a/src/cmd/chat.rs
+++ b/src/cmd/chat.rs
@@ -905,7 +905,9 @@ mod actor {
             .await
             .map_err(|e| synaps_cli::RuntimeError::Session(e.to_string()))?;
         if let Some(p) = agent_prompt {
-            let _ = t.send(SessionCommand::Set(SessionSetting::SystemPrompt { text: p })).await;
+            let _ = t
+                .send(SessionCommand::Set { id: 0, setting: SessionSetting::SystemPrompt { text: p } })
+                .await;
         }
 
         let session_id = snap.meta.id.as_str().to_string();

--- a/src/cmd/chat.rs
+++ b/src/cmd/chat.rs
@@ -762,6 +762,19 @@ mod actor {
                     );
                 }
                 SessionEventWire::SystemNotice(text) => eprintln!("\x1b[2m{}\x1b[0m", text),
+                // B2: spawned compaction reports through typed events.
+                SessionEventWire::CompactionStarted { disclosure, .. } => {
+                    eprintln!("\x1b[2m[{}]\x1b[0m", disclosure)
+                }
+                SessionEventWire::CompactionApplied { msg_count, .. } => {
+                    eprintln!("\x1b[2m[compacted {} messages]\x1b[0m", msg_count)
+                }
+                SessionEventWire::CompactionFailed { message, .. } => {
+                    eprintln!("\x1b[2m[compaction failed: {}]\x1b[0m", message)
+                }
+                SessionEventWire::CompactionCancelled => {
+                    eprintln!("\x1b[2m[compaction cancelled]\x1b[0m")
+                }
                 SessionEventWire::Ended { .. } => self.ended = true,
                 _ => {}
             }

--- a/src/cmd/chat.rs
+++ b/src/cmd/chat.rs
@@ -1107,6 +1107,7 @@ mod actor {
                         }
                         "help" => {
                             eprintln!("commands: /model /thinking /compact /clear /sessions /status /quit");
+                            eprintln!("quitting (or EOF) mid-turn cancels the turn and saves an abort context for the next --continue");
                         }
                         _ => eprintln!("unknown command: /{} (try /help)", cmd),
                     },

--- a/src/cmd/chat.rs
+++ b/src/cmd/chat.rs
@@ -712,6 +712,10 @@ mod actor {
     use synaps_cli::{AgentEvent, LlmEvent, SessionEvent, StreamEvent};
     use tokio::io::{AsyncBufReadExt, BufReader as TokioBufReader};
 
+    /// Reserved query id for the post-compaction token readout (user
+    /// queries start at 1 and count up).
+    const COMPACT_TOKENS_QUERY: u64 = u64::MAX - 1;
+
     struct Render {
         is_tty: bool,
         in_thinking: bool,
@@ -762,12 +766,38 @@ mod actor {
                     );
                 }
                 SessionEventWire::SystemNotice(text) => eprintln!("\x1b[2m{}\x1b[0m", text),
-                // B2: spawned compaction reports through typed events.
+                SessionEventWire::Aborted { context_saved } => eprintln!(
+                    "\x1b[2m{}\x1b[0m",
+                    if context_saved {
+                        "aborted — context saved for next message"
+                    } else {
+                        "aborted"
+                    }
+                ),
+                SessionEventWire::Cleared { session_id } => eprintln!(
+                    "session cleared → {}",
+                    &session_id[..8.min(session_id.len())]
+                ),
+                // B2: spawned compaction reports through typed events — each
+                // rendered exactly once (the inline loop's three lines).
                 SessionEventWire::CompactionStarted { disclosure, .. } => {
-                    eprintln!("\x1b[2m[{}]\x1b[0m", disclosure)
+                    eprintln!("compacting...");
+                    eprintln!("{}", disclosure);
                 }
-                SessionEventWire::CompactionApplied { msg_count, .. } => {
-                    eprintln!("\x1b[2m[compacted {} messages]\x1b[0m", msg_count)
+                SessionEventWire::CompactionApplied { .. } => {
+                    // `compacted → ~N tokens` needs the post-apply assessment.
+                    let _ = transport
+                        .send(SessionCommand::Query {
+                            id: COMPACT_TOKENS_QUERY,
+                            query: SessionQuery::ContextAssessment,
+                        })
+                        .await;
+                }
+                SessionEventWire::QueryResult { id, value } if id == COMPACT_TOKENS_QUERY => {
+                    eprintln!(
+                        "\x1b[2m[compacted → ~{} tokens]\x1b[0m",
+                        value["used_tokens"].as_u64().unwrap_or(0)
+                    )
                 }
                 SessionEventWire::CompactionFailed { message, .. } => {
                     eprintln!("\x1b[2m[compaction failed: {}]\x1b[0m", message)

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -1,4 +1,5 @@
-//! `synaps daemon {start,status,stop,sessions}` (PLAN-phase2 §2.11, B4).
+//! `synaps daemon {start,status,stop,sessions,purge}` (PLAN-phase2 §2.11, B4;
+//! phase 3 C2 `purge`).
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -53,6 +54,9 @@ pub(crate) enum DaemonAction {
         #[arg(long)]
         json: bool,
     },
+    /// Ask the daemon to return jemalloc dirty pages to the OS (bench hygiene:
+    /// run before sampling RssAnon).
+    Purge,
 }
 
 fn opts_from(profile: Option<String>, a: &StartArgs) -> DaemonOpts {
@@ -82,7 +86,18 @@ pub(crate) async fn run(profile: Option<String>, args: DaemonArgs) -> anyhow::Re
         Some(DaemonAction::Status { json }) => status(profile, json).await,
         Some(DaemonAction::Stop { force }) => stop(profile, force).await,
         Some(DaemonAction::Sessions { json }) => sessions(profile, json).await,
+        Some(DaemonAction::Purge) => purge(profile).await,
     }
+}
+
+async fn purge(profile: Option<String>) -> anyhow::Result<()> {
+    let paths = registry::daemon_paths(profile.as_deref());
+    if !registry::is_alive(&paths) {
+        anyhow::bail!("daemon not running");
+    }
+    let pong = SocketTransport::purge(&paths.sock).await.map_err(|e| anyhow::anyhow!("{e}"))?;
+    println!("purged (pid {}, sessions {})", pong.pid, pong.sessions);
+    Ok(())
 }
 
 async fn start(profile: Option<String>, a: StartArgs) -> anyhow::Result<()> {

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -33,6 +33,10 @@ pub(crate) struct StartArgs {
     /// Allow legacy (non-progressive) MCP with servers configured.
     #[arg(long)]
     pub allow_legacy_mcp: bool,
+    /// Print `{"binary_version","protocol_version"}` and exit 0 (the reload
+    /// version gate probes the NEW binary with this).
+    #[arg(long, hide = true)]
+    pub print_version: bool,
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -57,6 +61,22 @@ pub(crate) enum DaemonAction {
     /// Ask the daemon to return jemalloc dirty pages to the OS (bench hygiene:
     /// run before sampling RssAnon).
     Purge,
+    /// Re-exec the daemon in place (same pid): checkpoint every session,
+    /// exec the (newer-or-equal) binary, rehydrate, clients reconnect.
+    Reload {
+        /// Skip the drain wait (in-flight turns are checkpointed immediately).
+        #[arg(long)]
+        now: bool,
+        /// Seconds to wait for turns to finish before checkpointing
+        /// (default SYNAPS_DAEMON_RELOAD_DRAIN_SECS or 30).
+        #[arg(long, value_name = "N")]
+        drain_secs: Option<u64>,
+        /// Binary to exec (default: the one recorded in daemon.json).
+        #[arg(long, value_name = "PATH")]
+        exe: Option<PathBuf>,
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 fn opts_from(profile: Option<String>, a: &StartArgs) -> DaemonOpts {
@@ -87,6 +107,74 @@ pub(crate) async fn run(profile: Option<String>, args: DaemonArgs) -> anyhow::Re
         Some(DaemonAction::Stop { force }) => stop(profile, force).await,
         Some(DaemonAction::Sessions { json }) => sessions(profile, json).await,
         Some(DaemonAction::Purge) => purge(profile).await,
+        Some(DaemonAction::Reload { now, drain_secs, exe, json }) => reload(profile, now, drain_secs, exe, json).await,
+    }
+}
+
+async fn reload(
+    profile: Option<String>,
+    now: bool,
+    drain_secs: Option<u64>,
+    exe: Option<PathBuf>,
+    json: bool,
+) -> anyhow::Result<()> {
+    let paths = registry::daemon_paths(profile.as_deref());
+    if !registry::is_alive(&paths) {
+        anyhow::bail!("daemon not running");
+    }
+    let before = registry::read_daemon_json(&paths);
+    let exe = exe.map(|p| p.canonicalize().unwrap_or(p));
+    let outcome = SocketTransport::reload(&paths.sock, now, drain_secs, exe).await;
+    match outcome {
+        Ok(gen) => {
+            // Wait for the new image to answer (≤ 15 s).
+            let t0 = std::time::Instant::now();
+            let mut pong = None;
+            while t0.elapsed() < Duration::from_secs(15) {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                if let Ok(p) = SocketTransport::ping(&paths.sock).await {
+                    pong = Some(p);
+                    break;
+                }
+            }
+            let after = registry::read_daemon_json(&paths);
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "ok": pong.is_some(),
+                        "pid": pong.as_ref().map(|p| p.pid),
+                        "generation": after.as_ref().map(|i| i.generation),
+                        "announced_generation": gen,
+                        "sessions": pong.as_ref().map(|p| p.sessions),
+                        "exe": after.as_ref().and_then(|i| i.exe.clone()),
+                        "previous_version": before.as_ref().map(|i| i.daemon_version.clone()),
+                        "version": after.as_ref().map(|i| i.daemon_version.clone()),
+                    })
+                );
+            } else if let Some(p) = &pong {
+                println!(
+                    "reloaded (pid {}, generation {}, sessions {})",
+                    p.pid,
+                    after.as_ref().map_or(gen, |i| i.generation),
+                    p.sessions
+                );
+            } else {
+                anyhow::bail!("reload announced (generation {gen}) but the daemon did not answer within 15 s");
+            }
+            if pong.is_none() {
+                std::process::exit(1);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if json {
+                println!("{}", serde_json::json!({"ok": false, "error": e.to_string()}));
+            } else {
+                eprintln!("reload refused: {e}");
+            }
+            std::process::exit(EXIT_REFUSED);
+        }
     }
 }
 
@@ -101,6 +189,10 @@ async fn purge(profile: Option<String>) -> anyhow::Result<()> {
 }
 
 async fn start(profile: Option<String>, a: StartArgs) -> anyhow::Result<()> {
+    if a.print_version {
+        println!("{}", serde_json::to_string(&daemon::reload::PrintVersion::current())?);
+        return Ok(());
+    }
     if let Err(code) = require_enabled("synaps daemon") {
         std::process::exit(code);
     }

--- a/src/cmd/daemon.rs
+++ b/src/cmd/daemon.rs
@@ -316,12 +316,16 @@ async fn sessions(profile: Option<String>, json: bool) -> anyhow::Result<()> {
     } else {
         for m in list {
             println!(
-                "{}  model={}  cwd={}  created={}{}",
+                "{}  {:?}  clients={}  owner={}  model={}  cwd={}  created={}{}{}",
                 m.id,
+                m.lifecycle,
+                m.clients,
+                m.input_owner.map_or("-".into(), |c| format!("#{}", c.0)),
                 m.model,
                 m.cwd.as_deref().map_or("-".into(), |p| p.display().to_string()),
                 m.created_at.format("%H:%M:%S"),
-                m.name.as_deref().map_or(String::new(), |n| format!("  name={n}"))
+                m.name.as_deref().map_or(String::new(), |n| format!("  name={n}")),
+                if m.journal_id != m.id.as_str() { format!("  journal={}", m.journal_id) } else { String::new() }
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,6 +368,7 @@ async fn async_main() -> anyhow::Result<()> {
                         create: false,
                         continue_session: cli.continue_session.flatten(),
                         system: cli.system,
+                        ..Default::default()
                     },
                 )
                 .await?;

--- a/tests/daemon_handshake.rs
+++ b/tests/daemon_handshake.rs
@@ -126,7 +126,7 @@ async fn handshake_refuses_version_mismatch_and_protocol_violations() {
     c.send(&ClientFrame::Sessions).await;
     assert!(matches!(c.recv().await, Some(DaemonFrame::SessionList { .. })));
     c.send(&ClientFrame::Bye).await;
-    assert!(matches!(c.recv().await, Some(DaemonFrame::Bye)));
+    assert!(matches!(c.recv().await, Some(DaemonFrame::Bye { .. })));
 
     d.shutdown_token().cancel();
     d.wait().await;

--- a/tests/daemon_no_tui_dep.rs
+++ b/tests/daemon_no_tui_dep.rs
@@ -46,19 +46,29 @@ fn daemon_no_tui_dep() {
     assert!(!seen.contains("synaps-tui"), "synaps-engine reaches synaps-tui: {seen:?}");
 }
 
-/// Source-grep guard (risk §6.5): the daemon and socket transport never
-/// trace an `Answer` body.
+fn rs_files(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    for e in std::fs::read_dir(dir).unwrap() {
+        let p = e.unwrap().path();
+        if p.is_dir() {
+            out.extend(rs_files(&p));
+        } else if p.extension().is_some_and(|x| x == "rs") {
+            out.push(p);
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Source-grep guard (risk §6.5, PLAN-phase3 C2): nothing under
+/// `crates/agent-engine/src/{session,daemon}/**` traces an `Answer` body or
+/// a prompt value.
 #[test]
 fn daemon_never_traces_answer_bodies() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/agent-engine/src");
-    let files = [
-        root.join("daemon/mod.rs"),
-        root.join("daemon/conn.rs"),
-        root.join("daemon/listener.rs"),
-        root.join("daemon/lifecycle.rs"),
-        root.join("daemon/registry.rs"),
-        root.join("session/socket_transport.rs"),
-    ];
+    let mut files = rs_files(&root.join("daemon"));
+    files.extend(rs_files(&root.join("session")));
+    assert!(files.len() >= 12, "expected the daemon + session trees: {files:?}");
     for f in files {
         let src = std::fs::read_to_string(&f).unwrap();
         for (i, line) in src.lines().enumerate() {
@@ -66,6 +76,62 @@ fn daemon_never_traces_answer_bodies() {
                 let l = line.to_ascii_lowercase();
                 assert!(!l.contains("answer") && !l.contains("value"), "{}:{}: {line}", f.display(), i + 1);
             }
+        }
+    }
+}
+
+/// PLAN-phase3 §2.2 / Appendix A: `SessionCommand` has a MANUAL `Debug`
+/// (bodies redacted, no lengths) and no derive; `ClientFrame` likewise; no
+/// `chars().count()` in either Debug impl (a length is a side channel).
+#[test]
+fn session_command_debug_is_manual_and_lengthless() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/agent-engine/src/session");
+    let types = std::fs::read_to_string(root.join("types.rs")).unwrap();
+    let wire = std::fs::read_to_string(root.join("wire.rs")).unwrap();
+
+    assert_eq!(
+        types.matches("impl std::fmt::Debug for SessionCommand").count(),
+        1,
+        "SessionCommand needs exactly one manual Debug impl"
+    );
+    // No `#[derive(..Debug..)]` directly above `pub enum SessionCommand`.
+    let lines: Vec<&str> = types.lines().collect();
+    let at = lines
+        .iter()
+        .position(|l| l.starts_with("pub enum SessionCommand"))
+        .expect("pub enum SessionCommand");
+    let mut k = at;
+    while k > 0 {
+        k -= 1;
+        let l = lines[k].trim();
+        if l.starts_with("#[") {
+            assert!(!l.contains("derive(") || !l.contains("Debug"), "types.rs:{}: {l}", k + 1);
+            continue;
+        }
+        if l.starts_with("///") || l.starts_with("//") {
+            continue;
+        }
+        break;
+    }
+    assert_eq!(types.matches("impl std::fmt::Debug for ClientFrame").count(), 0);
+    assert_eq!(wire.matches("impl std::fmt::Debug for ClientFrame").count(), 1);
+
+    for (name, src) in [("types.rs", &types), ("wire.rs", &wire)] {
+        for (i, line) in src.lines().enumerate() {
+            assert!(!line.contains("chars().count()"), "{name}:{}: {line}", i + 1);
+        }
+    }
+    // The redaction marker exists and the redacted variants carry no length.
+    let dbg_start = types.find("impl std::fmt::Debug for SessionCommand").unwrap();
+    let dbg = &types[dbg_start..];
+    let dbg_end = dbg.find("\n}\n").map(|e| e + 3).unwrap_or(dbg.len());
+    let dbg = &dbg[..dbg_end];
+    assert!(dbg.contains("<redacted>"), "SessionCommand Debug redacts bodies");
+    // `attachments.len()` is a count of attachments (P3-0 design), not a
+    // body length; any other `.len()` inside the impl is a side channel.
+    for (i, line) in dbg.lines().enumerate() {
+        if line.contains(".len()") {
+            assert!(line.contains("attachments.len()"), "SessionCommand Debug line {}: {line}", i + 1);
         }
     }
 }

--- a/tests/daemon_reload.rs
+++ b/tests/daemon_reload.rs
@@ -330,7 +330,7 @@ async fn reload_preserves_model_keep_warm_settings_and_parked() {
 
     // A: model/context/system survived.
     let conn = SocketTransport::connect(&d.paths.sock, Hello::new(ClientKind::Test)).await.unwrap();
-    let (mut a2, snap) = SocketTransport::attach(conn, Attach::Existing { session_id: a_id.clone(), mode: AttachMode::Mirror }).await.unwrap();
+    let (a2, snap) = SocketTransport::attach(conn, Attach::Existing { session_id: a_id.clone(), mode: AttachMode::Mirror }).await.unwrap();
     assert_eq!(snap.view.model, "claude-opus-4-6", "/model survived reload");
     assert_eq!(snap.view.context_window, 1_000_000, "settings_replay survived reload");
     assert_eq!(snap.view.system_prompt.as_deref(), Some("reload-me"), "/system survived reload");
@@ -339,7 +339,7 @@ async fn reload_preserves_model_keep_warm_settings_and_parked() {
 
     // B: attach unparks with its history.
     let conn = SocketTransport::connect(&d.paths.sock, Hello::new(ClientKind::Test)).await.unwrap();
-    let (mut b2, snap) = SocketTransport::attach(conn, Attach::Existing { session_id: b_id.clone(), mode: AttachMode::Mirror }).await.unwrap();
+    let (b2, snap) = SocketTransport::attach(conn, Attach::Existing { session_id: b_id.clone(), mode: AttachMode::Mirror }).await.unwrap();
     assert_eq!(snap.conversation.api_messages.len(), 2, "parked session's history survived reload");
     b2.detach().await;
 

--- a/tests/daemon_reload.rs
+++ b/tests/daemon_reload.rs
@@ -45,11 +45,16 @@ fn bin() -> &'static str {
 /// Spawn `synaps daemon --foreground` under the guard's HOME with the stub
 /// provider; wait for the socket to answer Ping (≤ 20 s).
 async fn spawn_daemon(guard: &HomeGuard, url: &str) -> DaemonProc {
+    spawn_daemon_env(guard, url, &[]).await
+}
+
+async fn spawn_daemon_env(guard: &HomeGuard, url: &str, extra: &[(&str, &str)]) -> DaemonProc {
     let run = guard.base_dir().join("run");
     std::fs::create_dir_all(&run).unwrap();
     let paths = registry::daemon_paths_in(&run, None);
     let child = Command::new(bin())
         .args(["daemon", "--foreground"])
+        .envs(extra.iter().copied())
         .env("HOME", guard.home.path())
         .env("SYNAPS_BASE_DIR", guard.base_dir())
         .env("SYNAPS_RUNTIME_DIR", &run)
@@ -247,5 +252,96 @@ async fn reload_with_turn_in_flight_checkpoints_and_saves_abort_context() {
     assert_eq!(snap.conversation.api_messages.len(), 1, "the interrupted assistant turn is not in the history");
 
     t.detach().await;
+    SocketTransport::shutdown(&d.paths.sock, true).await.unwrap();
+}
+
+/// Wait until `sessions` lists `sid` with `want` (≤ `for_`).
+async fn wait_listed_lifecycle(paths: &registry::DaemonPaths, sid: &SessionId, want: SessionLifecycle, for_: Duration) -> bool {
+    let t0 = std::time::Instant::now();
+    loop {
+        let metas = SocketTransport::sessions(&paths.sock).await.unwrap_or_default();
+        if metas.iter().any(|m| &m.id == sid && m.lifecycle == want) {
+            return true;
+        }
+        if t0.elapsed() > for_ {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// H3 (§5.4 `reload_preserves_parked_and_keep_warm`): reload-state carries
+/// the session as it IS — `/model` mid-session, a keep-warm pin, a
+/// non-persisted knob (`/context`), and a Parked session comes back Parked.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn reload_preserves_model_keep_warm_settings_and_parked() {
+    let guard = HomeGuard::new();
+    let (url, _hits, _) = spawn_stub(Script::Sse(ANTHROPIC_SSE)).await;
+    let d = spawn_daemon_env(&guard, &url, &[("SYNAPS_DAEMON_PARK_GRACE_SECS", "0")]).await;
+    let pid_before = d.child.id();
+
+    // Session A: turn, /model, /context, keep-warm → stays Live (pinned).
+    let (mut a, snap) = attach_create(&d.paths, guard.home.path()).await;
+    assert_eq!(snap.view.model, "claude-sonnet-4-5");
+    let a_id = a.session_id().clone();
+    one_turn(&mut a, "hello").await;
+    a.send_from_self(SessionCommand::Set { id: 1, setting: SessionSetting::Model { model: "claude-opus-4-6".into() } }).await.unwrap();
+    a.send_from_self(SessionCommand::Set { id: 2, setting: SessionSetting::ContextWindow { tokens: Some(1_000_000) } }).await.unwrap();
+    a.send_from_self(SessionCommand::Set { id: 3, setting: SessionSetting::SystemPrompt { text: "reload-me".into() } }).await.unwrap();
+    a.send_from_self(SessionCommand::KeepWarm { on: true }).await.unwrap();
+    let mut seen = 0;
+    while seen < 3 {
+        let env = tokio::time::timeout(Duration::from_secs(10), a.next_event()).await.unwrap().unwrap();
+        if let SessionEventWire::SettingChanged(_) = env.event {
+            seen += 1;
+        }
+    }
+    a.detach().await;
+
+    // Session B: one turn, detach → parks (grace 0).
+    let (mut b, _) = attach_create(&d.paths, guard.home.path()).await;
+    let b_id = b.session_id().clone();
+    one_turn(&mut b, "park me").await;
+    b.detach().await;
+    assert!(wait_listed_lifecycle(&d.paths, &b_id, SessionLifecycle::Parked, Duration::from_secs(10)).await, "B parks");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(wait_listed_lifecycle(&d.paths, &a_id, SessionLifecycle::Live, Duration::from_secs(1)).await, "A pinned stays Live");
+
+    let gen = SocketTransport::reload(&d.paths.sock, true, None, None).await.expect("reload accepted");
+    assert_eq!(gen, 2);
+    let t0 = std::time::Instant::now();
+    loop {
+        if registry::read_daemon_json(&d.paths).is_some_and(|i| i.generation == 2)
+            && SocketTransport::ping(&d.paths.sock).await.is_ok()
+        {
+            break;
+        }
+        assert!(t0.elapsed() < Duration::from_secs(20), "new image never answered");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_eq!(registry::read_daemon_json(&d.paths).unwrap().pid, pid_before);
+
+    // B came back Parked; A came back Live with the pin.
+    assert!(wait_listed_lifecycle(&d.paths, &b_id, SessionLifecycle::Parked, Duration::from_secs(10)).await, "B rehydrated Parked");
+    assert!(wait_listed_lifecycle(&d.paths, &a_id, SessionLifecycle::Live, Duration::from_secs(1)).await, "A rehydrated Live");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(wait_listed_lifecycle(&d.paths, &a_id, SessionLifecycle::Live, Duration::from_secs(1)).await, "A keep-warm survived (not parked after grace)");
+
+    // A: model/context/system survived.
+    let conn = SocketTransport::connect(&d.paths.sock, Hello::new(ClientKind::Test)).await.unwrap();
+    let (mut a2, snap) = SocketTransport::attach(conn, Attach::Existing { session_id: a_id.clone(), mode: AttachMode::Mirror }).await.unwrap();
+    assert_eq!(snap.view.model, "claude-opus-4-6", "/model survived reload");
+    assert_eq!(snap.view.context_window, 1_000_000, "settings_replay survived reload");
+    assert_eq!(snap.view.system_prompt.as_deref(), Some("reload-me"), "/system survived reload");
+    assert_eq!(snap.conversation.api_messages.len(), 2);
+    a2.detach().await;
+
+    // B: attach unparks with its history.
+    let conn = SocketTransport::connect(&d.paths.sock, Hello::new(ClientKind::Test)).await.unwrap();
+    let (mut b2, snap) = SocketTransport::attach(conn, Attach::Existing { session_id: b_id.clone(), mode: AttachMode::Mirror }).await.unwrap();
+    assert_eq!(snap.conversation.api_messages.len(), 2, "parked session's history survived reload");
+    b2.detach().await;
+
     SocketTransport::shutdown(&d.paths.sock, true).await.unwrap();
 }

--- a/tests/daemon_reload.rs
+++ b/tests/daemon_reload.rs
@@ -227,12 +227,15 @@ async fn reload_with_turn_in_flight_checkpoints_and_saves_abort_context() {
     // abort context itself is asserted from the reconnect snapshot, i.e.
     // from the journal), then Reloading, then EOF.
     let mut notices = Vec::new();
+    let mut aborted = false;
     while let Some(env) = tokio::time::timeout(Duration::from_secs(10), t.next_event()).await.expect("announce") {
-        if let SessionEventWire::SystemNotice(n) = env.event {
-            notices.push(n);
+        match env.event {
+            SessionEventWire::SystemNotice(n) => notices.push(n),
+            SessionEventWire::Aborted { .. } => aborted = true,
+            _ => {}
         }
     }
-    assert!(notices.iter().any(|n| n.starts_with("aborted")), "{notices:?}");
+    assert!(aborted, "typed Aborted expected; notices: {notices:?}");
     assert!(notices.iter().any(|n| n.contains("daemon reloading")), "{notices:?}");
 
     let snap = tokio::time::timeout(Duration::from_secs(15), t.reconnect(AttachMode::Mirror)).await.unwrap().expect("reconnected");

--- a/tests/daemon_reload.rs
+++ b/tests/daemon_reload.rs
@@ -345,3 +345,83 @@ async fn reload_preserves_model_keep_warm_settings_and_parked() {
 
     SocketTransport::shutdown(&d.paths.sock, true).await.unwrap();
 }
+
+/// A script that answers `--print-version` with OUR version (passes the
+/// gate) and then strips its own exec bit, so the `execv` that follows
+/// fails with EACCES: the one way past `validate_exe` + the probe.
+fn self_disarming_binary(dir: &Path) -> PathBuf {
+    let p = dir.join("synaps-disarm");
+    let pv = serde_json::to_string(&agent_engine::daemon::reload::PrintVersion::current()).unwrap();
+    std::fs::write(
+        &p,
+        format!("#!/bin/sh\nif [ \"$2\" = \"--print-version\" ]; then echo '{pv}'; chmod 644 \"$0\"; exit 0; fi\nexit 1\n"),
+    )
+    .unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    p
+}
+
+/// M4 + M8: `--exe` is validated up front (non-executable / world-writable
+/// / missing → refused, nothing disturbed); an `execv` that fails AFTER the
+/// gate leaves the old image serving — generation unchanged, reload-state
+/// gone, `reloading` cleared (a second reload is accepted), a turn works.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn exe_validation_refuses_and_exec_failure_keeps_serving() {
+    use std::os::unix::fs::PermissionsExt;
+    let guard = HomeGuard::new();
+    let (url, _hits, _) = spawn_stub(Script::Sse(ANTHROPIC_SSE)).await;
+    let d = spawn_daemon(&guard, &url).await;
+    let pid = d.child.id();
+    let (mut t, _) = attach_create(&d.paths, guard.home.path()).await;
+    one_turn(&mut t, "before").await;
+
+    // Refused up front: missing, non-executable, world-writable.
+    let missing = guard.home.path().join("does-not-exist");
+    let r = SocketTransport::reload(&d.paths.sock, true, None, Some(missing)).await;
+    assert!(matches!(r, Err(TransportError::Refused(ref m)) if m.contains("does-not-exist")), "{r:?}");
+    let noexec = fake_older_binary(guard.home.path());
+    std::fs::set_permissions(&noexec, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let r = SocketTransport::reload(&d.paths.sock, true, None, Some(noexec.clone())).await;
+    assert!(matches!(r, Err(TransportError::Refused(ref m)) if m.contains("not executable")), "{r:?}");
+    std::fs::set_permissions(&noexec, std::fs::Permissions::from_mode(0o777)).unwrap();
+    let r = SocketTransport::reload(&d.paths.sock, true, None, Some(noexec)).await;
+    assert!(matches!(r, Err(TransportError::Refused(ref m)) if m.contains("writable")), "{r:?}");
+    assert_eq!(registry::read_daemon_json(&d.paths).unwrap().generation, 1);
+
+    // Past the gate: the requester is told Bye{Reloading} BEFORE the exec
+    // (the reply is Ok(2)); the exec then fails and the old image keeps
+    // serving — generation restored, reload-state removed, socket alive.
+    let disarm = self_disarming_binary(guard.home.path());
+    let r = SocketTransport::reload(&d.paths.sock, true, None, Some(disarm)).await;
+    assert!(matches!(r, Ok(2)), "{r:?}");
+    let t0 = std::time::Instant::now();
+    loop {
+        let info = registry::read_daemon_json(&d.paths).unwrap();
+        if info.generation == 1
+            && !agent_engine::daemon::reload::reload_state_path(&d.paths).exists()
+            && SocketTransport::ping(&d.paths.sock).await.is_ok()
+        {
+            assert_eq!(info.pid, pid);
+            break;
+        }
+        assert!(t0.elapsed() < Duration::from_secs(30), "old image did not recover: {info:?}");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    assert!(registry::is_alive(&d.paths));
+
+    // The session was checkpointed (Aborted-free: it was idle) but is alive;
+    // the mirror reconnects and a turn works.
+    let snap = tokio::time::timeout(Duration::from_secs(15), t.reconnect(AttachMode::Mirror)).await.unwrap().expect("reconnected");
+    assert_eq!(snap.conversation.api_messages.len(), 2);
+    let after = one_turn(&mut t, "after").await;
+    assert_eq!(after.len(), 4);
+    // `reloading` cleared: a second (refused) reload is judged on its merits.
+    let old = fake_older_binary(guard.home.path());
+    let r = SocketTransport::reload(&d.paths.sock, true, None, Some(old)).await;
+    assert!(matches!(r, Err(TransportError::Refused(ref m)) if m.contains("older")), "{r:?}");
+
+    t.detach().await;
+    SocketTransport::shutdown(&d.paths.sock, true).await.unwrap();
+}

--- a/tests/daemon_reload.rs
+++ b/tests/daemon_reload.rs
@@ -1,0 +1,248 @@
+//! C3 — `synaps daemon reload` against a REAL daemon process (PLAN-phase3
+//! §5.4): the `synaps` binary is spawned as `daemon --foreground`, a client
+//! attaches over the socket and runs one scripted turn, `Reload{now}` is
+//! sent on a control connection, the client sees `Reloading` + EOF and
+//! `reconnect`s; the pid is unchanged, `daemon.json.generation == 2`, the
+//! flock is still held, the conversation survived, a second turn works.
+//! Plus: an OLDER binary (a shell script faking `--print-version`) is
+//! refused up front and the daemon keeps serving.
+//!
+//! Unix only (execv + flock).
+
+#![cfg(unix)]
+
+#[path = "support/phase2/mod.rs"]
+#[allow(dead_code)]
+mod phase2;
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use agent_engine::daemon::registry;
+use agent_engine::session::socket_transport::SocketTransport;
+use agent_engine::session::wire::*;
+use agent_engine::session::*;
+use phase2::*;
+use serial_test::serial;
+
+struct DaemonProc {
+    child: Child,
+    paths: registry::DaemonPaths,
+}
+
+impl Drop for DaemonProc {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_synaps")
+}
+
+/// Spawn `synaps daemon --foreground` under the guard's HOME with the stub
+/// provider; wait for the socket to answer Ping (≤ 20 s).
+async fn spawn_daemon(guard: &HomeGuard, url: &str) -> DaemonProc {
+    let run = guard.base_dir().join("run");
+    std::fs::create_dir_all(&run).unwrap();
+    let paths = registry::daemon_paths_in(&run, None);
+    let child = Command::new(bin())
+        .args(["daemon", "--foreground"])
+        .env("HOME", guard.home.path())
+        .env("SYNAPS_BASE_DIR", guard.base_dir())
+        .env("SYNAPS_RUNTIME_DIR", &run)
+        .env("SYNAPS_DAEMON", "1")
+        .env("SYNAPS_ANTHROPIC_BASE_URL", url)
+        .env("SYNAPS_NO_BOOT_FX", "1")
+        .env_remove("SYNAPS_DAEMON_RELOAD_STATE")
+        .env_remove("SYNAPS_DAEMON_LOCK_FD")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn daemon");
+    let d = DaemonProc { child, paths };
+    let t0 = std::time::Instant::now();
+    loop {
+        if SocketTransport::ping(&d.paths.sock).await.is_ok() {
+            break;
+        }
+        assert!(t0.elapsed() < Duration::from_secs(20), "daemon never answered");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    d
+}
+
+async fn attach_create(paths: &registry::DaemonPaths, cwd: &Path) -> (SocketTransport, AttachSnapshot) {
+    let conn = SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Test)).await.unwrap();
+    SocketTransport::attach(
+        conn,
+        Attach::Create {
+            config: SessionConfig {
+                cwd: Some(cwd.to_path_buf()),
+                model_override: Some("claude-sonnet-4-5".into()),
+                ..Default::default()
+            },
+            mode: AttachMode::Mirror,
+        },
+    )
+    .await
+    .unwrap()
+}
+
+async fn one_turn(t: &mut SocketTransport, text: &str) -> Vec<agent_engine::SharedMessage> {
+    t.send_from_self(SessionCommand::Submit { text: text.into(), attachments: vec![] }).await.unwrap();
+    let mut msgs = None;
+    loop {
+        let env = tokio::time::timeout(Duration::from_secs(20), t.next_event()).await.expect("turn hung").expect("alive");
+        match env.event {
+            SessionEventWire::Conversation(c) => msgs = Some(c.api_messages),
+            SessionEventWire::Idle => break,
+            SessionEventWire::Refused { reason, .. } => panic!("refused: {reason}"),
+            _ => {}
+        }
+    }
+    msgs.expect("conversation after the turn")
+}
+
+fn fake_older_binary(dir: &Path) -> PathBuf {
+    let p = dir.join("synaps-old");
+    std::fs::write(
+        &p,
+        "#!/bin/sh\nif [ \"$2\" = \"--print-version\" ]; then echo '{\"binary_version\":\"0.0.1\",\"protocol_version\":2}'; exit 0; fi\nexit 1\n",
+    )
+    .unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    p
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn reload_keeps_pid_sessions_and_reconnects_clients() {
+    let guard = HomeGuard::new();
+    let (url, _hits, _) = spawn_stub(Script::Sse(ANTHROPIC_SSE)).await;
+    let d = spawn_daemon(&guard, &url).await;
+    let pid_before = d.child.id();
+    let info = registry::read_daemon_json(&d.paths).expect("daemon.json");
+    assert_eq!(info.pid, pid_before);
+    assert_eq!(info.generation, 1);
+    assert_eq!(info.exe.as_deref().map(|p| p.canonicalize().unwrap()), Some(Path::new(bin()).canonicalize().unwrap()));
+
+    let (mut t, snap) = attach_create(&d.paths, guard.home.path()).await;
+    assert_eq!(t.welcome.generation, 1);
+    assert_eq!(snap.input_owner, Some(t.client_id()), "first mirror owns");
+    let sid = t.session_id().clone();
+    let before = one_turn(&mut t, "hello before reload").await;
+    assert_eq!(before.len(), 2, "user + assistant");
+
+    // Older binary → refused up front; the daemon keeps serving.
+    let old = fake_older_binary(guard.home.path());
+    let r = SocketTransport::reload(&d.paths.sock, true, None, Some(old)).await;
+    assert!(matches!(r, Err(TransportError::Refused(ref m)) if m.contains("older")), "{r:?}");
+    assert!(registry::is_alive(&d.paths));
+    assert_eq!(registry::read_daemon_json(&d.paths).unwrap().generation, 1);
+    assert!(SocketTransport::ping(&d.paths.sock).await.is_ok());
+
+    // Real reload to the same binary (equal version = allowed).
+    let gen = SocketTransport::reload(&d.paths.sock, true, None, None).await.expect("reload accepted");
+    assert_eq!(gen, 2);
+
+    // The attached client sees Reloading, then EOF flagged as a reload.
+    let mut saw_reloading = false;
+    loop {
+        match tokio::time::timeout(Duration::from_secs(10), t.next_event()).await.expect("announce") {
+            Some(env) => {
+                if let SessionEventWire::Reloading { generation, retry_after_ms } = env.event {
+                    assert_eq!(generation, 2);
+                    assert!(retry_after_ms > 0);
+                    saw_reloading = true;
+                }
+            }
+            None => break,
+        }
+    }
+    assert!(saw_reloading);
+    assert!(matches!(t.last_error(), Some(TransportError::Reloading { generation: 2 })));
+
+    // Reconnect (backoff) → same session, same history, owner again.
+    let snap = tokio::time::timeout(Duration::from_secs(15), t.reconnect(AttachMode::Mirror))
+        .await
+        .expect("reconnect budget")
+        .expect("reconnected");
+    assert_eq!(t.welcome.generation, 2);
+    assert_eq!(t.welcome.pid, pid_before, "same pid after execv");
+    assert_eq!(t.session_id(), &sid, "session id survives (same journal)");
+    assert_eq!(
+        serde_json::to_string(&snap.conversation.api_messages).unwrap(),
+        serde_json::to_string(&before).unwrap(),
+        "conversation survived the reload"
+    );
+    assert_eq!(snap.input_owner, Some(t.client_id()), "was_owner → Takeover → owner again");
+
+    let info = registry::read_daemon_json(&d.paths).unwrap();
+    assert_eq!(info.pid, pid_before);
+    assert_eq!(info.generation, 2);
+    assert!(registry::is_alive(&d.paths), "flock adopted, never released");
+    assert!(!agent_engine::daemon::reload::reload_state_path(&d.paths).exists(), "reload-state consumed");
+
+    let after = one_turn(&mut t, "hello after reload").await;
+    assert_eq!(after.len(), 4);
+
+    t.detach().await;
+    SocketTransport::shutdown(&d.paths.sock, false).await.unwrap();
+    let t0 = std::time::Instant::now();
+    while registry::is_alive(&d.paths) && t0.elapsed() < Duration::from_secs(10) {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(!registry::is_alive(&d.paths));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn reload_with_turn_in_flight_checkpoints_and_saves_abort_context() {
+    let guard = HomeGuard::new();
+    let (url, _hits, _) = spawn_stub(Script::Endless(ANTHROPIC_SSE_PREFIX)).await;
+    let d = spawn_daemon(&guard, &url).await;
+    let pid_before = d.child.id();
+
+    let (mut t, _snap) = attach_create(&d.paths, guard.home.path()).await;
+    let sid = t.session_id().clone();
+    t.send_from_self(SessionCommand::Submit { text: "never finishes".into(), attachments: vec![] }).await.unwrap();
+    // Wait for the partial text so the checkpoint has something to fold.
+    loop {
+        let env = tokio::time::timeout(Duration::from_secs(20), t.next_event()).await.unwrap().unwrap();
+        if matches!(env.event, SessionEventWire::Stream(agent_engine::StreamEvent::Llm(agent_engine::LlmEvent::Text(_)))) {
+            break;
+        }
+    }
+
+    let gen = SocketTransport::reload(&d.paths.sock, true, None, None).await.expect("reload accepted");
+    assert_eq!(gen, 2);
+    // Checkpoint before the announce: the client sees the abort notice
+    // (the `Conversation` that follows arrives as a digest the mirror must
+    // re-query, and the connection is gone before the answer — so the
+    // abort context itself is asserted from the reconnect snapshot, i.e.
+    // from the journal), then Reloading, then EOF.
+    let mut notices = Vec::new();
+    while let Some(env) = tokio::time::timeout(Duration::from_secs(10), t.next_event()).await.expect("announce") {
+        if let SessionEventWire::SystemNotice(n) = env.event {
+            notices.push(n);
+        }
+    }
+    assert!(notices.iter().any(|n| n.starts_with("aborted")), "{notices:?}");
+    assert!(notices.iter().any(|n| n.contains("daemon reloading")), "{notices:?}");
+
+    let snap = tokio::time::timeout(Duration::from_secs(15), t.reconnect(AttachMode::Mirror)).await.unwrap().expect("reconnected");
+    assert_eq!(t.welcome.pid, pid_before);
+    assert_eq!(t.session_id(), &sid);
+    assert!(!snap.streaming, "the turn was checkpointed, not resumed");
+    let ctx = snap.conversation.abort_context.clone().expect("abort context came back from the journal");
+    assert!(ctx.contains("[response]: partial"), "{ctx}");
+    assert_eq!(snap.conversation.api_messages.len(), 1, "the interrupted assistant turn is not in the history");
+
+    t.detach().await;
+    SocketTransport::shutdown(&d.paths.sock, true).await.unwrap();
+}

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -392,3 +392,19 @@ async fn idle_exit_counts_clientless_idle_sessions_and_never_a_running_turn() {
     tokio::time::timeout(Duration::from_secs(5), d.wait()).await.expect("idle-exit fired with a live idle session");
     assert!(!paths.sock.exists());
 }
+
+/// C2: `Purge` is a control fast path — answered with `Pong`, no session
+/// allocated.
+#[tokio::test]
+#[serial]
+async fn purge_frame_answers_pong() {
+    let guard = HomeGuard::new();
+    let run = guard.base_dir().join("run");
+    let d = start(&run).await;
+    let paths = d.paths.clone();
+    let pong = SocketTransport::purge(&paths.sock).await.unwrap();
+    assert_eq!(pong.pid, std::process::id());
+    assert_eq!(pong.sessions, 0);
+    assert!(d.state.live_sessions().is_empty());
+    d.state.request_shutdown(false);
+}

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -134,7 +134,7 @@ async fn socket_roundtrip_real_uds() {
         .await
         .err()
         .unwrap();
-    assert!(matches!(err, TransportError::Protocol(ref m) if m.contains("unknown session")), "{err}");
+    assert!(matches!(err, TransportError::Refused(ref m) if m.contains("unknown session")), "{err}");
 
     // shutdown over the socket: sessions ended, files unlinked, lock released
     SocketTransport::shutdown(&paths.sock, false).await.unwrap();

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -344,8 +344,9 @@ async fn idle_exit_counts_clientless_idle_sessions_and_never_a_running_turn() {
     let s2 = Arc::clone(&streaming);
     let actor = tokio::spawn(async move {
         while let Some(cmd) = ep.cmd_rx.recv().await {
-            if let SessionCommand::Query { id, query: SessionQuery::Status } = cmd {
+            if let SessionCommand::Query { id, query: SessionQuery::Status } = cmd.cmd {
                 assert_eq!(id, IDLE_PROBE_QUERY_ID);
+                assert!(cmd.from.is_none(), "idle probe is host-originated");
                 let value = serde_json::json!({ "streaming": s2.load(std::sync::atomic::Ordering::SeqCst), "pending_prompts": 0 });
                 let _ = events.send(Envelope { session_id: sid.clone(), seq: 0, ts: chrono::Utc::now(), event: SessionEventWire::QueryResult { id, value } });
             }

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -305,6 +305,8 @@ async fn stale_socket_reaped_and_second_daemon_refused() {
             profile: None,
             started_at: chrono::Utc::now(),
             socket: paths.sock.to_string_lossy().into_owned(),
+            exe: None,
+            generation: 1,
         },
     )
     .unwrap();

--- a/tests/daemon_socket.rs
+++ b/tests/daemon_socket.rs
@@ -222,8 +222,9 @@ async fn attach_to_session_with_history_over_1mib() {
 }
 
 /// §4 MED: a client may only send the user-facing subset; `Detach` only for
-/// its own id; `End`/`Attach`/`Resync` are refused with an `Error` frame and
-/// the session stays alive for everyone else.
+/// its own id; `End{host reason}`/`Attach`/`Resync` are refused with an
+/// `Error` frame and the session stays alive for everyone else
+/// (`End{ClientQuit}` passes the conn since C4 — ownership is the actor's).
 #[tokio::test]
 #[serial]
 async fn client_commands_are_whitelisted() {
@@ -259,7 +260,7 @@ async fn client_commands_are_whitelisted() {
     }
     b.send(SessionCommand::Detach { client: other }).await.unwrap();
     assert!(refused(&mut b).await.contains("not your client id"));
-    b.send(SessionCommand::End { reason: EndReason::ClientQuit }).await.unwrap();
+    b.send(SessionCommand::End { reason: EndReason::HostShutdown }).await.unwrap();
     assert!(refused(&mut b).await.contains("end:"));
     b.send(SessionCommand::Attach { client: ClientMeta::new(ClientKind::Test), mode: AttachMode::Mirror }).await.unwrap();
     assert!(refused(&mut b).await.contains("attach:"));

--- a/tests/daemon_takeover.rs
+++ b/tests/daemon_takeover.rs
@@ -1,0 +1,123 @@
+//! C4 — attach modes over the wire against the REAL actor: a second
+//! `Mirror` is read-only (its `Submit` is `Refused`), `Takeover` steals
+//! ownership and the previous owner sees `InputOwnerChanged`; an owner may
+//! `End{ClientQuit}` its session; `Observe` never owns.
+
+#[path = "support/phase2/mod.rs"]
+#[allow(dead_code)]
+mod phase2;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_engine::daemon::{Daemon, DaemonOpts};
+use agent_engine::session::socket_transport::SocketTransport;
+use agent_engine::session::wire::*;
+use agent_engine::session::*;
+use agent_engine::{EngineHost, HostOpts};
+use phase2::*;
+use serial_test::serial;
+
+async fn start(runtime_dir: &std::path::Path) -> Daemon {
+    let host: Arc<EngineHost> =
+        EngineHost::boot_and_install(HostOpts { profile: None, no_extensions: true }).await.expect("host boot");
+    Daemon::start(host, DaemonOpts { runtime_dir: Some(runtime_dir.to_path_buf()), ..Default::default() })
+        .await
+        .expect("daemon start")
+}
+
+async fn until(t: &mut SocketTransport, pred: impl Fn(&SessionEventWire) -> bool) -> SessionEventWire {
+    loop {
+        let env = tokio::time::timeout(Duration::from_secs(10), t.next_event()).await.expect("timely").expect("open");
+        if pred(&env.event) {
+            return env.event;
+        }
+    }
+}
+
+async fn attach(paths: &agent_engine::daemon::registry::DaemonPaths, kind: ClientKind, a: Attach) -> (SocketTransport, AttachSnapshot) {
+    let conn = SocketTransport::connect(&paths.sock, Hello::new(kind)).await.unwrap();
+    SocketTransport::attach(conn, a).await.unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn mirror_is_read_only_takeover_steals_owner_may_end() {
+    let guard = HomeGuard::new();
+    let (url, _hits, _) = spawn_stub(Script::Sse(ANTHROPIC_SSE)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let run = guard.base_dir().join("run");
+    let d = start(&run).await;
+    let paths = d.paths.clone();
+
+    let (mut a, snap) = attach(
+        &paths,
+        ClientKind::Tui,
+        Attach::Create {
+            config: SessionConfig { cwd: Some(guard.home.path().to_path_buf()), model_override: Some("claude-sonnet-4-5".into()), persist: false, ..Default::default() },
+            mode: AttachMode::Mirror,
+        },
+    )
+    .await;
+    assert_eq!(snap.input_owner, Some(a.client_id()), "first mirror owns");
+    let sid = a.session_id().clone();
+
+    // Second mirror: read-only.
+    let (mut b, snap_b) = attach(&paths, ClientKind::Attach, Attach::Existing { session_id: sid.clone(), mode: AttachMode::Mirror }).await;
+    assert_eq!(snap_b.input_owner, Some(a.client_id()));
+    b.send_from_self(SessionCommand::Submit { text: "from b".into(), attachments: vec![] }).await.unwrap();
+    let r = until(&mut b, |e| matches!(e, SessionEventWire::Refused { .. })).await;
+    let SessionEventWire::Refused { client, command, reason } = r else { unreachable!() };
+    assert_eq!(client, b.client_id());
+    assert_eq!(command, "submit");
+    assert!(reason.contains("owned by"), "{reason}");
+
+    // Observer: never owns, refused too.
+    let (mut o, snap_o) = attach(&paths, ClientKind::Attach, Attach::Existing { session_id: sid.clone(), mode: AttachMode::Observe }).await;
+    assert_eq!(snap_o.input_owner, Some(a.client_id()));
+    o.send_from_self(SessionCommand::Steer { text: "x".into() }).await.unwrap();
+    until(&mut o, |e| matches!(e, SessionEventWire::Refused { .. })).await;
+
+    // Takeover: c steals; a is told; a's next Submit is refused; c's works.
+    let (mut c, snap_c) = attach(&paths, ClientKind::Attach, Attach::Existing { session_id: sid.clone(), mode: AttachMode::Takeover }).await;
+    assert_eq!(snap_c.input_owner, Some(c.client_id()));
+    let ev = until(&mut a, |e| matches!(e, SessionEventWire::InputOwnerChanged { .. })).await;
+    let SessionEventWire::InputOwnerChanged { from, to, reason } = ev else { unreachable!() };
+    assert_eq!(from, Some(a.client_id()));
+    assert_eq!(to, Some(c.client_id()));
+    assert_eq!(reason, OwnerChangeReason::Takeover);
+    assert_eq!(a.input_owner(), Some(c.client_id()));
+    a.send_from_self(SessionCommand::Submit { text: "from a".into(), attachments: vec![] }).await.unwrap();
+    until(&mut a, |e| matches!(e, SessionEventWire::Refused { .. })).await;
+    c.send_from_self(SessionCommand::Submit { text: "from c".into(), attachments: vec![] }).await.unwrap();
+    until(&mut c, |e| matches!(e, SessionEventWire::TurnStarted { .. })).await;
+    until(&mut c, |e| matches!(e, SessionEventWire::Idle)).await;
+
+    // Listing carries lifecycle + journal id (owner/clients come with B4's cells).
+    let list = SocketTransport::sessions(&paths.sock).await.unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0].lifecycle, SessionLifecycle::Live);
+    assert_eq!(list[0].journal_id, sid.as_str());
+
+    // Non-owner End is refused by the actor; owner End ends for everyone.
+    b.send_from_self(SessionCommand::End { reason: EndReason::ClientQuit }).await.unwrap();
+    until(&mut b, |e| matches!(e, SessionEventWire::Refused { command, .. } if command == "end")).await;
+    assert_eq!(d.state.live_sessions().len(), 1, "session survives a non-owner End");
+    c.send_from_self(SessionCommand::End { reason: EndReason::ClientQuit }).await.unwrap();
+    // `Ended` then `Bye`/EOF; the conn may close before the forwarder got
+    // `Ended` out (pre-existing race, daemon_socket.rs:148 tolerates it too).
+    for t in [&mut a, &mut b, &mut c, &mut o] {
+        loop {
+            match tokio::time::timeout(Duration::from_secs(10), t.next_event()).await.expect("timely") {
+                Some(env) if matches!(env.event, SessionEventWire::Ended { .. }) => break,
+                Some(_) => continue,
+                None => break,
+            }
+        }
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(d.state.live_sessions().len(), 0);
+
+    d.shutdown_token().cancel();
+    d.wait().await;
+}

--- a/tests/session_actor_differential.rs
+++ b/tests/session_actor_differential.rs
@@ -3,25 +3,67 @@
 //! today's inline engine halves) and through `EngineHost::create_session` +
 //! `LocalTransport`; the `StreamEvent` sequences, the final `api_messages`
 //! and the auto-turn counters must be identical.
+//!
+//! Phase 3 (C1): `support/reference_reactor_ext.rs` (also frozen, own sha)
+//! adds Abort, the secret-prompt handle, save counting and usage — read
+//! its header for the list of what the oracle STILL cannot assert. The
+//! scenario table:
+//!
+//! | scenario                          | asserted                                                                 | not asserted                                   |
+//! |-----------------------------------|--------------------------------------------------------------------------|------------------------------------------------|
+//! | plain_turn (frozen)               | StreamEvent seq, api_messages, auto-turn counters                        | saves                                          |
+//! | error_repairs_history (frozen)    | same + repair                                                            | saves                                          |
+//! | event_injection_idle_… (frozen)   | same + cap notices, real UDS                                             | saves                                          |
+//! | tool_loop                         | seq incl. ToolUse/ToolResult/MessageHistory, api_messages, cost/tokens,  |                                                |
+//! |                                   | save count (oracle logical == sampled(oracle) == sampled(actor)), file   |                                                |
+//! |                                   | fields (api_messages/abort_context/tokens/cost)                          |                                                |
+//! | steer_mid_stream                  | Steer lands mid-stream (paced SSE) → SteeringDelivered position, 2nd     | delivered=false / auto-send (unreachable       |
+//! |                                   | round, api_messages, saves                                               | deterministically — ext header #2)             |
+//! | event_injection_busy_steered      | inject via real UDS mid-stream → Steered disposition, api_messages, saves| Buffered disposition (ext header #3)           |
+//! | cancel_captures_abort_context     | abort_context text equal, save at abort, Dequeued of a queued steer,     | partial ToolResultDelta fold (ext header #1)   |
+//! |                                   | next Submit's request body (fold) equal, file abort_context equal        |                                                |
+//! | secret_prompt_roundtrip           | Some(handle) on both sides; tool result equal; actor replay to a 2nd     |                                                |
+//! |                                   | client carries no Answer/value; saves                                    |                                                |
+//!
+//! `queue_while_busy_then_autosend` from PLAN §5.2 is NOT here: see ext
+//! header #2 — the `delivered == false` branch cannot be reached
+//! deterministically on either side.
 
 #[path = "support/phase2/mod.rs"]
 mod support;
 #[path = "support/reference_reactor.rs"]
 mod reference_reactor;
+#[path = "support/reference_reactor_ext.rs"]
+mod reference_reactor_ext;
 
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use agent_engine::session::{
     ClientKind, ClientMeta, ClientTransport, EndReason, LocalTransport, SessionCommand,
-    SessionConfig, SessionEventWire,
+    SessionConfig, SessionEventWire, SessionHandle,
 };
 use agent_engine::{EngineHost, HostOpts};
 use reference_reactor::ReferenceReactor;
+use reference_reactor_ext::ReferenceReactorExt;
 use serial_test::serial;
 use support::*;
-use synaps_cli::{SessionEvent, StreamEvent};
+use synaps_cli::{LlmEvent, SessionEvent, StreamEvent};
 
 const MODEL: &str = "claude-sonnet-4-5";
+
+/// `// FROZEN` (C1): the extension oracle is pinned like the base file.
+#[test]
+fn reference_reactor_ext_is_frozen() {
+    use sha2::{Digest, Sha256};
+    let src = include_str!("support/reference_reactor_ext.rs");
+    let hex = format!("{:x}", Sha256::digest(src.as_bytes()));
+    assert_eq!(
+        hex, "99543baeaf5c22e576647c26d6fc3a76b48825335c3c41547a68c8e0d7014a2d",
+        "tests/support/reference_reactor_ext.rs is a frozen oracle — do not edit"
+    );
+}
 
 /// `// FROZEN`: the oracle never changes after A5.
 #[test]
@@ -52,32 +94,48 @@ async fn oracle(host: &Arc<EngineHost>) -> ReferenceReactor {
 
 struct ActorRun {
     t: LocalTransport,
+    handle: SessionHandle,
     seen: Vec<String>,
     api_messages: Vec<synaps_cli::SharedMessage>,
     consecutive_auto_turns: u32,
     conversations_after_terminal: usize,
     cap_notices: u32,
+    abort_context: Option<String>,
+    cost: f64,
+    tokens: (u64, u64),
+    steered: Vec<bool>,
+    dequeued: Vec<String>,
 }
 
 async fn actor(host: &Arc<EngineHost>) -> ActorRun {
+    actor_with(host, false).await
+}
+
+async fn actor_with(host: &Arc<EngineHost>, persist: bool) -> ActorRun {
     let handle = host
         .create_session(SessionConfig {
             model_override: Some(MODEL.into()),
-            persist: false,
+            persist,
             ..SessionConfig::default()
         })
         .await
         .expect("create_session");
-    let (t, _snap) = LocalTransport::attach(handle, ClientMeta::new(ClientKind::Test))
+    let (t, _snap) = LocalTransport::attach(handle.clone(), ClientMeta::new(ClientKind::Test))
         .await
         .unwrap();
     ActorRun {
         t,
+        handle,
         seen: Vec::new(),
         api_messages: Vec::new(),
         consecutive_auto_turns: 0,
         conversations_after_terminal: 0,
         cap_notices: 0,
+        abort_context: None,
+        cost: 0.0,
+        tokens: (0, 0),
+        steered: Vec::new(),
+        dequeued: Vec::new(),
     }
 }
 
@@ -107,15 +165,68 @@ impl ActorRun {
                         self.conversations_after_terminal += 1;
                         expect_conv = false;
                     }
-                    self.api_messages = c.api_messages;
-                    self.consecutive_auto_turns = c.consecutive_auto_turns;
+                    self.absorb(c);
                 }
                 SessionEventWire::AutoTurnCapReached { .. } => self.cap_notices += 1,
+                SessionEventWire::Steered { delivered, .. } => self.steered.push(delivered),
+                SessionEventWire::Dequeued { text } => self.dequeued.push(text),
                 SessionEventWire::Idle => break,
                 SessionEventWire::Ended { .. } => panic!("ended early"),
                 _ => {}
             }
         }
+    }
+
+    fn absorb(&mut self, c: agent_engine::session::ConversationSnapshot) {
+        self.api_messages = c.api_messages;
+        self.consecutive_auto_turns = c.consecutive_auto_turns;
+        self.abort_context = c.abort_context;
+        self.cost = c.cost;
+        self.tokens = (c.tokens.input, c.tokens.output);
+    }
+
+    /// Pump (recording like `drive_to_idle`) until `pred` matches an
+    /// envelope; returns the matching event.
+    async fn until(
+        &mut self,
+        pred: impl Fn(&SessionEventWire) -> bool,
+    ) -> SessionEventWire {
+        loop {
+            let env = tokio::time::timeout(Duration::from_secs(30), self.t.next_event())
+                .await
+                .expect("actor hung")
+                .expect("actor alive");
+            let hit = pred(&env.event);
+            match &env.event {
+                SessionEventWire::Stream(ev) => self.seen.push(format!("{:?}", ev)),
+                SessionEventWire::Conversation(c) => self.absorb(c.clone()),
+                SessionEventWire::Steered { delivered, .. } => self.steered.push(*delivered),
+                SessionEventWire::Dequeued { text } => self.dequeued.push(text.clone()),
+                SessionEventWire::AutoTurnCapReached { .. } => self.cap_notices += 1,
+                SessionEventWire::Ended { .. } => panic!("ended early"),
+                _ => {}
+            }
+            if hit {
+                return env.event;
+            }
+        }
+    }
+
+    async fn submit(&mut self, text: &str) {
+        self.t
+            .send(SessionCommand::Submit {
+                text: text.into(),
+                attachments: vec![],
+            })
+            .await
+            .unwrap();
+    }
+
+    fn journal_path(&self, guard: &HomeGuard) -> std::path::PathBuf {
+        guard
+            .base_dir()
+            .join("sessions")
+            .join(format!("{}.json", self.handle.journal_id()))
     }
 
     async fn end(mut self) {
@@ -289,5 +400,480 @@ async fn event_injection_idle_autoturn_until_cap() {
     assert_eq!(o.consecutive_auto_turns, 5);
     assert_eq!(o.cap_notices, 1);
     assert_same(&o, &a);
+    a.end().await;
+}
+
+// ═══ C1: ext-oracle scenarios ════════════════════════════════════════════════
+
+async fn oracle_ext(host: &Arc<EngineHost>) -> ReferenceReactorExt {
+    let mut rt = host.foreground_runtime().await.unwrap();
+    rt.set_model(MODEL.to_string());
+    let session = synaps_cli::Session::new(rt.model(), rt.thinking_level(), rt.system_prompt());
+    ReferenceReactorExt::new(ReferenceReactor::new(rt), session)
+}
+
+fn oracle_journal_path(o: &ReferenceReactorExt, guard: &HomeGuard) -> std::path::PathBuf {
+    guard
+        .base_dir()
+        .join("sessions")
+        .join(format!("{}.json", o.session.id))
+}
+
+/// Save counter from OUTSIDE the process under test: `Session::save` goes
+/// through `write_atomic_private` (tmp + rename), so every save gives
+/// `sessions/<id>.json` a fresh inode. A spinning thread samples the inode
+/// far faster than a save can complete (JSON serialise + spawn_blocking
+/// round-trip); the oracle's logical counter is compared against this
+/// sampler on the oracle's own file in every scenario, so a sampler miss
+/// shows up as an oracle self-mismatch, not as a false actor pass.
+struct SaveSampler {
+    stop: Arc<AtomicBool>,
+    inodes: Arc<Mutex<Vec<u64>>>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl SaveSampler {
+    fn watch(path: std::path::PathBuf) -> Self {
+        use std::os::unix::fs::MetadataExt;
+        let stop = Arc::new(AtomicBool::new(false));
+        let inodes: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+        let (s, i) = (Arc::clone(&stop), Arc::clone(&inodes));
+        let thread = std::thread::spawn(move || {
+            let mut last = 0u64;
+            while !s.load(Ordering::Relaxed) {
+                if let Ok(m) = std::fs::metadata(&path) {
+                    let ino = m.ino();
+                    if ino != last {
+                        last = ino;
+                        i.lock().unwrap().push(ino);
+                    }
+                }
+                std::thread::yield_now();
+            }
+        });
+        Self {
+            stop,
+            inodes,
+            thread: Some(thread),
+        }
+    }
+
+    fn count(&self) -> usize {
+        self.inodes.lock().unwrap().len()
+    }
+}
+
+impl Drop for SaveSampler {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(t) = self.thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+/// The journal fields both sides write (id/title/timestamps/model differ by
+/// construction — the actor's `Session` is created before `model_override`
+/// is applied, the oracle's after — and are excluded).
+fn journal_fields(path: &std::path::Path) -> serde_json::Value {
+    let v: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(path).expect("journal exists")).unwrap();
+    serde_json::json!({
+        "api_messages": v["api_messages"],
+        "abort_context": v["abort_context"],
+        "total_input_tokens": v["total_input_tokens"],
+        "total_output_tokens": v["total_output_tokens"],
+        "session_cost": v["session_cost"],
+        "message_count": v["message_count"],
+    })
+}
+
+fn assert_same_ext(o: &ReferenceReactorExt, a: &ActorRun) {
+    assert_same(&o.r, a);
+    assert_eq!(o.r.abort_context, a.abort_context, "abort_context differs");
+    assert_eq!(o.session_cost, a.cost, "session cost differs");
+    assert_eq!(
+        (o.total_input_tokens, o.total_output_tokens),
+        a.tokens,
+        "token totals differ"
+    );
+}
+
+fn assert_saves(
+    o: &ReferenceReactorExt,
+    o_s: &SaveSampler,
+    a_s: &SaveSampler,
+    o_path: &std::path::Path,
+    a_path: &std::path::Path,
+) {
+    // Let the last rename land before reading.
+    std::thread::sleep(Duration::from_millis(50));
+    assert_eq!(
+        o.saves,
+        o_s.count(),
+        "sampler self-check: oracle logical saves != sampled saves"
+    );
+    assert_eq!(o_s.count(), a_s.count(), "save count differs (oracle vs actor)");
+    if o.saves > 0 {
+        assert_eq!(
+            journal_fields(o_path),
+            journal_fields(a_path),
+            "journal fields differ"
+        );
+    }
+}
+
+fn sse_tool_call(name: &str, id: &str) -> &'static str {
+    Box::leak(
+        format!(
+            concat!(
+                "data: {{\"type\":\"message_start\",\"message\":{{\"id\":\"msg_d1\",\"type\":\"message\",",
+                "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-5\",\"stop_reason\":null,",
+                "\"stop_sequence\":null,\"usage\":{{\"input_tokens\":10,\"output_tokens\":0,",
+                "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}}}}\n\n",
+                "data: {{\"type\":\"content_block_start\",\"index\":0,",
+                "\"content_block\":{{\"type\":\"tool_use\",\"id\":\"{id}\",\"name\":\"{name}\"}}}}\n\n",
+                "data: {{\"type\":\"content_block_stop\",\"index\":0}}\n\n",
+                "data: {{\"type\":\"message_delta\",\"delta\":{{\"stop_reason\":\"tool_use\",",
+                "\"stop_sequence\":null}},\"usage\":{{\"input_tokens\":10,\"output_tokens\":5,",
+                "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}}\n\n",
+                "data: {{\"type\":\"message_stop\"}}\n\n",
+            ),
+            id = id,
+            name = name,
+        )
+        .into_boxed_str(),
+    )
+}
+
+/// Deterministic builtin tool: constant result, no environment reads.
+struct EchoFixtureTool;
+
+#[async_trait::async_trait]
+impl agent_engine::Tool for EchoFixtureTool {
+    fn name(&self) -> &str {
+        "echo_fixture"
+    }
+    fn description(&self) -> &str {
+        "constant"
+    }
+    fn parameters(&self) -> agent_engine::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn origin(&self) -> agent_engine::tools::ToolOrigin {
+        agent_engine::tools::ToolOrigin::Builtin
+    }
+    async fn execute(
+        &self,
+        _params: agent_engine::Value,
+        _ctx: agent_engine::ToolContext,
+    ) -> agent_engine::Result<String> {
+        Ok("fixture-ok".to_string())
+    }
+}
+
+/// Prompts through the stream's `SecretPromptHandle`; reports the length
+/// only (mirrors `session_actor.rs::PromptFixtureTool`).
+struct PromptFixtureTool;
+
+#[async_trait::async_trait]
+impl agent_engine::Tool for PromptFixtureTool {
+    fn name(&self) -> &str {
+        "prompt_fixture"
+    }
+    fn description(&self) -> &str {
+        "prompts"
+    }
+    fn parameters(&self) -> agent_engine::Value {
+        serde_json::json!({"type": "object"})
+    }
+    fn origin(&self) -> agent_engine::tools::ToolOrigin {
+        agent_engine::tools::ToolOrigin::Builtin
+    }
+    async fn execute(
+        &self,
+        _params: agent_engine::Value,
+        ctx: agent_engine::ToolContext,
+    ) -> agent_engine::Result<String> {
+        let handle = ctx
+            .capabilities
+            .secret_prompt
+            .expect("both sides pass Some(handle) to the stream");
+        Ok(match handle.prompt("Secret".into(), "enter secret".into()).await {
+            Some(v) => format!("answered:{}", v.len()),
+            None => "cancelled".to_string(),
+        })
+    }
+}
+
+async fn host_with_tools() -> Arc<EngineHost> {
+    let host = host().await;
+    {
+        let mut tools = host.parts().tools.write().await;
+        tools.register(Arc::new(EchoFixtureTool));
+        tools.register(Arc::new(PromptFixtureTool));
+    }
+    host
+}
+
+/// Oracle-side `until(is_text)`: drive (with full bookkeeping) until the
+/// first `Text` delta.
+async fn pump_until_text(o: &mut ReferenceReactorExt) {
+    o.drive_until(None, |ev| matches!(ev, StreamEvent::Llm(LlmEvent::Text(_))))
+        .await;
+    assert!(o.r.streaming, "stream still live after the first Text");
+}
+
+fn is_text(ev: &SessionEventWire) -> bool {
+    matches!(ev, SessionEventWire::Stream(StreamEvent::Llm(LlmEvent::Text(_))))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn tool_loop() {
+    let guard = HomeGuard::new();
+    let tool = sse_tool_call("echo_fixture", "toolu_diff1");
+    let bodies: &'static [&'static str] =
+        Box::leak(Box::new([tool, ANTHROPIC_SSE, tool, ANTHROPIC_SSE]));
+    let (url, _hits, _) = spawn_stub(Script::SeqSse(bodies)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host_with_tools().await;
+
+    let mut o = oracle_ext(&host).await;
+    let o_path = oracle_journal_path(&o, &guard);
+    let o_s = SaveSampler::watch(o_path.clone());
+    o.submit("call the tool".into()).await;
+    o.drive_to_idle(None).await;
+
+    let mut a = actor_with(&host, true).await;
+    let a_path = a.journal_path(&guard);
+    let a_s = SaveSampler::watch(a_path.clone());
+    a.submit("call the tool").await;
+    a.drive_to_idle().await;
+
+    let histories = o.r.seen.iter().filter(|s| s.contains("MessageHistory")).count();
+    assert!(histories >= 1, "tool loop must publish MessageHistory");
+    assert!(o.r.seen.iter().any(|s| s.contains("ToolResult")));
+    assert_same_ext(&o, &a);
+    assert!(
+        a.api_messages.iter().any(|m| m.to_string().contains("fixture-ok")),
+        "tool result reached the history"
+    );
+    assert_saves(&o, &o_s, &a_s, &o_path, &a_path);
+    assert_eq!(o.saves, histories, "one save per MessageHistory (stream_handler.rs:77)");
+    a.end().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn steer_mid_stream() {
+    let guard = HomeGuard::new();
+    let (url, hits, _) = spawn_stub(Script::Paced {
+        body: ANTHROPIC_SSE,
+        frame_delay: Duration::from_millis(100),
+    })
+    .await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host_with_tools().await;
+
+    // Oracle: submit, pump until the first Text, steer, drive to idle.
+    let mut o = oracle_ext(&host).await;
+    let o_path = oracle_journal_path(&o, &guard);
+    let o_s = SaveSampler::watch(o_path.clone());
+    o.submit("start".into()).await;
+    pump_until_text(&mut o).await;
+    assert!(o.steer("redirect".into()), "steer delivered while streaming");
+    o.drive_to_idle(None).await;
+    let oracle_hits = hits.load(Ordering::SeqCst);
+    assert_eq!(oracle_hits, 2, "steer forces a second provider round");
+
+    let mut a = actor_with(&host, true).await;
+    let a_path = a.journal_path(&guard);
+    let a_s = SaveSampler::watch(a_path.clone());
+    a.submit("start").await;
+    a.until(is_text).await;
+    a.t.send(SessionCommand::Steer {
+        text: "redirect".into(),
+    })
+    .await
+    .unwrap();
+    a.drive_to_idle().await;
+    assert_eq!(hits.load(Ordering::SeqCst), 4);
+    assert_eq!(a.steered, vec![true]);
+
+    let delivered_at = |seen: &[String]| seen.iter().position(|s| s.contains("SteeringDelivered"));
+    assert!(delivered_at(&o.r.seen).is_some());
+    assert_eq!(delivered_at(&o.r.seen), delivered_at(&a.seen));
+    assert_same_ext(&o, &a);
+    assert!(a.api_messages.iter().any(|m| m["content"] == "redirect"));
+    assert_saves(&o, &o_s, &a_s, &o_path, &a_path);
+    a.end().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn event_injection_busy_steered() {
+    let guard = HomeGuard::new();
+    let (url, hits, _) = spawn_stub(Script::Paced {
+        body: ANTHROPIC_SSE,
+        frame_delay: Duration::from_millis(100),
+    })
+    .await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host_with_tools().await;
+
+    let mut o = oracle_ext(&host).await;
+    let o_path = oracle_journal_path(&o, &guard);
+    let o_s = SaveSampler::watch(o_path.clone());
+    o.submit("start".into()).await;
+    pump_until_text(&mut o).await;
+    o.r.runtime.event_queue().push(fixed_event(0)).unwrap();
+    o.on_queue_wake().await;
+    assert!(o.r.pending_events.is_empty(), "live steer channel ⇒ Steered, not Buffered");
+    o.drive_to_idle(None).await;
+    assert_eq!(hits.load(Ordering::SeqCst), 2);
+
+    let mut a = actor_with(&host, true).await;
+    let a_path = a.journal_path(&guard);
+    let a_s = SaveSampler::watch(a_path.clone());
+    let sid = a.t.session_id().as_str().to_string();
+    a.submit("start").await;
+    a.until(is_text).await;
+    inject(&sid, &fixed_event(0)).await;
+    a.until(|e| matches!(e, SessionEventWire::External(_))).await;
+    a.drive_to_idle().await;
+    assert_eq!(hits.load(Ordering::SeqCst), 4);
+
+    assert_same_ext(&o, &a);
+    assert!(
+        a.api_messages
+            .iter()
+            .any(|m| m["content"].as_str().is_some_and(|c| c.contains("event 0")))
+    );
+    assert_saves(&o, &o_s, &a_s, &o_path, &a_path);
+    a.end().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn cancel_captures_abort_context() {
+    let guard = HomeGuard::new();
+    let (url, _hits, bodies) = spawn_stub(Script::Endless(ANTHROPIC_SSE_PREFIX)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host_with_tools().await;
+
+    // Oracle: submit, see "partial", queue a steer, abort, then submit again
+    // (fold) and abort that too (the stub never finishes a turn).
+    let mut o = oracle_ext(&host).await;
+    let o_path = oracle_journal_path(&o, &guard);
+    let o_s = SaveSampler::watch(o_path.clone());
+    o.submit("first".into()).await;
+    pump_until_text(&mut o).await;
+    o.steer("queued-then-dropped".into());
+    let dequeued = o.abort().await;
+    assert_eq!(dequeued.as_deref(), Some("queued-then-dropped"));
+    let o_ctx = o.r.abort_context.clone().expect("oracle captured context");
+    assert!(o_ctx.contains("[response]: partial"), "{o_ctx}");
+    o.submit("second".into()).await;
+    pump_until_text(&mut o).await;
+    o.abort().await;
+
+    let mut a = actor_with(&host, true).await;
+    let a_path = a.journal_path(&guard);
+    let a_s = SaveSampler::watch(a_path.clone());
+    a.submit("first").await;
+    a.until(is_text).await;
+    a.t.send(SessionCommand::Steer {
+        text: "queued-then-dropped".into(),
+    })
+    .await
+    .unwrap();
+    a.t.send(SessionCommand::Cancel).await.unwrap();
+    a.until(|e| matches!(e, SessionEventWire::Idle)).await;
+    assert_eq!(a.dequeued, vec!["queued-then-dropped".to_string()]);
+    assert_eq!(a.abort_context.as_deref(), Some(o_ctx.as_str()));
+    a.submit("second").await;
+    a.until(is_text).await;
+    a.t.send(SessionCommand::Cancel).await.unwrap();
+    a.until(|e| matches!(e, SessionEventWire::Idle)).await;
+
+    // Both saw exactly the prefix events per turn (Endless never terminates).
+    assert_eq!(normalise(&o.r.seen), normalise(&a.seen));
+    assert_eq!(o.r.abort_context, a.abort_context, "second abort context");
+    // The fold: the second request's messages (captured at the stub) are
+    // identical — oracle = hit 1, actor = hit 3.
+    let bodies = bodies.lock().unwrap();
+    assert_eq!(bodies.len(), 4);
+    let msgs = |i: usize| -> serde_json::Value {
+        serde_json::from_slice::<serde_json::Value>(&bodies[i]).unwrap()["messages"].clone()
+    };
+    assert_eq!(msgs(1), msgs(3), "abort-context fold differs");
+    assert!(msgs(1)[0].to_string().contains("[ABORT CONTEXT"), "{}", msgs(1)[0]);
+    assert_eq!(o.r.api_messages.len(), a.api_messages.len());
+    assert_eq!(msgs_json(&o.r.api_messages), msgs_json(&a.api_messages));
+    assert_saves(&o, &o_s, &a_s, &o_path, &a_path);
+    assert_eq!(o.saves, 2, "one save per abort (dispatch.rs:191)");
+    a.end().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn secret_prompt_roundtrip() {
+    let guard = HomeGuard::new();
+    let tool = sse_tool_call("prompt_fixture", "toolu_diffp");
+    let bodies: &'static [&'static str] =
+        Box::leak(Box::new([tool, ANTHROPIC_SSE, tool, ANTHROPIC_SSE]));
+    let (url, _hits, _) = spawn_stub(Script::SeqSse(bodies)).await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+    let host = host_with_tools().await;
+
+    let mut o = oracle_ext(&host).await;
+    let o_path = oracle_journal_path(&o, &guard);
+    let o_s = SaveSampler::watch(o_path.clone());
+    o.submit("go".into()).await;
+    o.drive_to_idle(Some("s3cret".into())).await;
+
+    let mut a = actor_with(&host, true).await;
+    let a_path = a.journal_path(&guard);
+    let a_s = SaveSampler::watch(a_path.clone());
+    a.submit("go").await;
+    let prompt = a.until(|e| matches!(e, SessionEventWire::Prompt(_))).await;
+    let SessionEventWire::Prompt(p) = prompt else {
+        unreachable!()
+    };
+    // A second client attaching mid-prompt sees the prompt in
+    // `pending_prompts`, never in the replay, and never the answer.
+    let (mut b, snap) = LocalTransport::attach(a.handle.clone(), ClientMeta::new(ClientKind::Attach))
+        .await
+        .unwrap();
+    assert_eq!(snap.pending_prompts.len(), 1);
+    assert!(!snap.replay.iter().any(|e| matches!(e.event, SessionEventWire::Prompt(_))));
+    a.t.send(SessionCommand::Answer {
+        prompt_id: p.id,
+        value: Some("s3cret".into()),
+    })
+    .await
+    .unwrap();
+    a.drive_to_idle().await;
+    let mut b_seen = Vec::new();
+    loop {
+        let env = tokio::time::timeout(Duration::from_secs(5), b.next_event())
+            .await
+            .expect("b hung")
+            .expect("alive");
+        let s = format!("{:?}", env.event);
+        let idle = matches!(env.event, SessionEventWire::Idle);
+        b_seen.push(s);
+        if idle {
+            break;
+        }
+    }
+    assert!(
+        !b_seen.iter().any(|s| s.contains("s3cret") || s.contains("Answer")),
+        "second client never sees the answer: {b_seen:?}"
+    );
+    assert!(a.seen.iter().any(|s| s.contains("answered:6")));
+    assert_same_ext(&o, &a);
+    assert_saves(&o, &o_s, &a_s, &o_path, &a_path);
     a.end().await;
 }

--- a/tests/support/phase2/mod.rs
+++ b/tests/support/phase2/mod.rs
@@ -171,6 +171,13 @@ pub enum Script {
     /// SSE bodies answered per arrival order; the last body repeats for any
     /// further hits (tool-loop fixtures: tool-use turn, then continuation).
     SeqSse(&'static [&'static str]),
+    /// `body` split on the SSE frame boundary (`\n\n`), each frame preceded
+    /// by `frame_delay` — a deterministic mid-stream window for steer /
+    /// event-injection differential scenarios.
+    Paced {
+        body: &'static str,
+        frame_delay: Duration,
+    },
     /// Delay headers, then a comment first byte, then the model events, with
     /// each SSE frame fragmented into small chunks.
     Timed {
@@ -257,6 +264,23 @@ fn scripted_response(script: &Script, hit: usize, req_body: &[u8]) -> Response {
                     tokio::task::yield_now().await;
                     Some((Ok(frame), i + 1))
                 }
+            });
+            Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "text/event-stream")
+                .body(Body::from_stream(stream))
+                .unwrap()
+        }
+        Script::Paced { body, frame_delay } => {
+            let frames: Vec<Bytes> = body
+                .split_inclusive("\n\n")
+                .map(|f| Bytes::copy_from_slice(f.as_bytes()))
+                .collect();
+            let delay = *frame_delay;
+            let stream = futures::stream::unfold((0usize, frames), move |(i, frames)| async move {
+                let frame = frames.get(i).cloned()?;
+                tokio::time::sleep(delay).await;
+                Some((Ok::<_, std::convert::Infallible>(frame), (i + 1, frames)))
             });
             Response::builder()
                 .status(StatusCode::OK)

--- a/tests/support/reference_reactor_ext.rs
+++ b/tests/support/reference_reactor_ext.rs
@@ -1,0 +1,456 @@
+//! FROZEN reference reactor EXTENSION — the oracle half that
+//! `support/reference_reactor.rs` deliberately left out (its header forbids
+//! editing it, so this file wraps it instead of patching it).
+//!
+//! Re-derived (NOT verbatim — same caveat as the base file: same author,
+//! same reading; a shared misreading passes) from these inline TUI sites
+//! @ f0ee1e62:
+//!   - `dispatch.rs:134-192`       Abort (engine half: cancel token,
+//!                                 abort_context capture, dequeue, flush
+//!                                 pending events, save, streaming=false)
+//!   - `app.rs:644-683`            capture_abort_context (format strings)
+//!   - `app.rs:460-474`            save_session (the three call sites:
+//!                                 stream_handler.rs:77 MessageHistory,
+//!                                 dispatch.rs:191 Abort,
+//!                                 stream_handler.rs:203 AutoTriggerEvents)
+//!   - `app.rs:476-…`              add_usage (stream_handler.rs:142-161)
+//!   - `run_setup.rs:188-199`      secret-prompt channel: the 4th argument
+//!                                 of `run_stream_with_messages` is
+//!                                 `Some(handle)` here (the base file passes
+//!                                 `None`; the actor passes `Some`).
+//!
+//! `start_stream`, `submit` and `drive_to_idle` are copied from the base
+//! file and extended at the cited sites; `steer` and `on_queue_wake`
+//! delegate to it (the RunTurn branch of `on_queue_wake` therefore still
+//! starts a stream WITHOUT the prompt handle — no scenario below prompts
+//! from an event-triggered turn).
+//!
+//! What this extension STILL cannot assert — read before trusting a green
+//! run:
+//!   1. `abort_context` for a turn whose tool result was only partially
+//!      streamed (`ToolResultDelta`): the TUI folds from its transcript
+//!      (`app.rs:651`), this oracle folds from a `TurnLog`-shaped list
+//!      built from the same events the actor's `TurnLog` sees. Identical
+//!      construction on both sides ⇒ a shared misreading is invisible.
+//!   2. Steer/queue with a DEAD steering channel (`delivered == false` →
+//!      Done → auto-send of `queued_message`): the runtime holds the
+//!      receiver for the whole turn, so from the outside `delivered` is
+//!      always `true` while streaming; the `false` case is a scheduling
+//!      race (stream task finished, terminal event not yet consumed) that
+//!      cannot be scripted deterministically on either side. The base
+//!      file's `steer()` sets `queued_message`; only the Cancel→Dequeued
+//!      path is exercised here.
+//!   3. Event injection with disposition `Buffered` — same reason as (2):
+//!      while the stream is live, `drain_event_queue` steers. Only the
+//!      `Steered` disposition is differential-tested.
+//!   4. Compaction (inline in the actor at this commit; `Runtime::clone`
+//!      latch semantics) — phase-4 scenario.
+//!   5. Save COUNT on the actor side is observed from outside (inode
+//!      sampling of `sessions/<id>.json`, see the test file); the oracle's
+//!      logical counter is compared against the same sampler on its own
+//!      file in every scenario so a sampler miss would show up as an
+//!      oracle self-mismatch first.
+//!   6. Anything presentational (Layer 2/3 of PLAN-phase3 §5.1).
+//!
+//! NEVER edit the code below this header — `session_actor_differential.rs`
+//! pins this file's sha256.
+
+#![allow(dead_code)]
+
+use futures::StreamExt;
+use synaps_cli::engine::reactor::claim_auto_turn;
+use synaps_cli::tools::{SecretPromptHandle, SecretPromptRequest};
+use synaps_cli::{AgentEvent, CancellationToken, LlmEvent, Session, SessionEvent, StreamEvent};
+
+use super::reference_reactor::ReferenceReactor;
+
+/// The TUI transcript's abort-fold source, reduced to what
+/// `capture_abort_context` reads (app.rs:644-683).
+pub enum Part {
+    Thinking(String),
+    Text(String),
+    ToolUse { name: String, input: String },
+    ToolResult { tool_id: String, content: String },
+}
+
+pub struct ReferenceReactorExt {
+    pub r: ReferenceReactor,
+    pub session: Session,
+    pub prompt_handle: SecretPromptHandle,
+    pub prompt_rx: tokio::sync::mpsc::UnboundedReceiver<SecretPromptRequest>,
+    /// Logical save count — incremented at the three TUI call sites.
+    pub saves: usize,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub total_cache_read_tokens: u64,
+    pub total_cache_creation_tokens: u64,
+    pub session_cost: f64,
+    pub parts: Vec<Part>,
+}
+
+impl ReferenceReactorExt {
+    pub fn new(r: ReferenceReactor, session: Session) -> Self {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        Self {
+            r,
+            session,
+            prompt_handle: SecretPromptHandle::new(tx),
+            prompt_rx: rx,
+            saves: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            total_cache_read_tokens: 0,
+            total_cache_creation_tokens: 0,
+            session_cost: 0.0,
+            parts: Vec::new(),
+        }
+    }
+
+    /// app.rs:460-474
+    pub async fn save_session(&mut self) {
+        if self.r.api_messages.is_empty() {
+            return;
+        }
+        self.saves += 1;
+        self.session.api_messages = self.r.api_messages.clone();
+        self.session.total_input_tokens = self.total_input_tokens;
+        self.session.total_output_tokens = self.total_output_tokens;
+        self.session.session_cost = self.session_cost;
+        self.session.abort_context = self.r.abort_context.clone();
+        self.session.updated_at = chrono::Utc::now();
+        self.session.auto_title();
+        if let Err(e) = self.session.save().await {
+            eprintln!("[ERROR] Failed to save session: {}", e);
+        }
+    }
+
+    /// app.rs add_usage (stream_handler.rs:142-161 caller).
+    #[allow(clippy::too_many_arguments)]
+    fn add_usage(
+        &mut self,
+        input_tokens: u64,
+        output_tokens: u64,
+        cache_read: u64,
+        cache_creation: u64,
+        cache_creation_5m: Option<u64>,
+        cache_creation_1h: Option<u64>,
+        model: &str,
+    ) {
+        self.total_input_tokens += input_tokens;
+        self.total_output_tokens += output_tokens;
+        self.total_cache_read_tokens += cache_read;
+        self.total_cache_creation_tokens += cache_creation;
+        self.session_cost += synaps_cli::pricing::calculate_cost_optional_split(
+            model,
+            input_tokens,
+            output_tokens,
+            cache_read,
+            cache_creation,
+            cache_creation_5m,
+            cache_creation_1h,
+        );
+    }
+
+    /// Base `start_stream` with `Some(prompt_handle)` as the 4th argument
+    /// (run_setup.rs:188-199 + dispatch.rs:1262-1270).
+    async fn start_stream(&mut self) {
+        let ct = CancellationToken::new();
+        let (s_tx, s_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        self.r.streaming = true;
+        self.r.turn_baseline = self.r.api_messages.len();
+        self.parts.clear();
+        self.r.stream = Some(
+            self.r
+                .runtime
+                .run_stream_with_messages(
+                    self.r.api_messages.clone(),
+                    ct.clone(),
+                    Some(s_rx),
+                    Some(self.prompt_handle.clone()),
+                    false,
+                )
+                .await,
+        );
+        self.r.cancel = Some(ct);
+        self.r.steer_tx = Some(s_tx);
+    }
+
+    /// dispatch.rs:1231-1288
+    pub async fn submit(&mut self, input: String) {
+        self.r.consecutive_auto_turns = 0;
+        let api_content = if let Some(ref ctx) = self.r.abort_context {
+            let combined = format!("{}\n\n{}", ctx, input);
+            self.r.abort_context = None;
+            combined
+        } else {
+            input
+        };
+        self.r.api_messages.push(std::sync::Arc::new(
+            serde_json::json!({"role": "user", "content": api_content}),
+        ));
+        self.start_stream().await;
+    }
+
+    /// dispatch.rs:1369-1378 (delegated).
+    pub fn steer(&mut self, input: String) -> bool {
+        self.r.steer(input)
+    }
+
+    /// stream_handler.rs:256-391 (delegated; see header for the RunTurn
+    /// caveat).
+    pub async fn on_queue_wake(&mut self) {
+        self.r.on_queue_wake().await
+    }
+
+    /// app.rs:644-683 `capture_abort_context`.
+    fn capture_abort_context(&self) -> Option<String> {
+        let mut parts: Vec<String> = Vec::new();
+        for p in &self.parts {
+            match p {
+                Part::Thinking(t) if !t.is_empty() => {
+                    let preview: String = t.chars().take(500).collect();
+                    parts.push(format!("[thinking]: {}", preview));
+                }
+                Part::Text(t) if !t.is_empty() => {
+                    parts.push(format!("[response]: {}", t));
+                }
+                Part::ToolUse { name, input } => {
+                    let input_preview: String = input.chars().take(200).collect();
+                    parts.push(format!("[tool_use]: {} — {}", name, input_preview));
+                }
+                Part::ToolResult { content, .. } if !content.is_empty() => {
+                    let preview: String = content.chars().take(300).collect();
+                    parts.push(format!("[tool_result]: {}", preview));
+                }
+                _ => {}
+            }
+        }
+        if parts.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "[ABORT CONTEXT — your previous response was interrupted. Here's what you completed before the abort:]\n\n{}\n\n[END ABORT CONTEXT — continue from where you left off or adjust based on the user's new message]",
+            parts.join("\n")
+        ))
+    }
+
+    /// dispatch.rs:134-192 Abort, engine half. Returns the dequeued
+    /// message, if any (dispatch.rs:147-150 presentation input).
+    pub async fn abort(&mut self) -> Option<String> {
+        if !self.r.streaming {
+            return None;
+        }
+        if let Some(ref ct) = self.r.cancel {
+            ct.cancel();
+        }
+        self.r.abort_context = self.capture_abort_context();
+        let dequeued = self.r.queued_message.take();
+        for formatted in self.r.pending_events.drain(..) {
+            self.r
+                .api_messages
+                .push(std::sync::Arc::new(serde_json::json!({
+                    "role": "user",
+                    "content": formatted
+                })));
+        }
+        self.r.stream = None;
+        self.r.cancel = None;
+        self.r.steer_tx = None;
+        self.r.streaming = false;
+        // subagent cancellation (dispatch.rs:164-178) has no observable
+        // effect without subagents; omitted.
+        self.save_session().await; // dispatch.rs:191
+        dequeued
+    }
+
+    /// Base `drive_to_idle` + `parts` (transcript fold source), usage,
+    /// and the two in-stream save sites. A secret prompt raised by a tool
+    /// mid-turn is answered with `prompt_answer` (the input pane's submit,
+    /// engine half: `response_tx.send`).
+    pub async fn drive_to_idle(&mut self, prompt_answer: Option<String>) {
+        self.drive_until(prompt_answer, |_| false).await;
+    }
+
+    /// `drive_to_idle` that returns early once `stop(&event)` matches
+    /// (after applying that event) — the oracle-side "pump until the first
+    /// Text delta, then steer/abort" for the mid-stream scenarios.
+    pub async fn drive_until(
+        &mut self,
+        prompt_answer: Option<String>,
+        stop: impl Fn(&StreamEvent) -> bool,
+    ) {
+        while self.r.stream.is_some() {
+            let event = loop {
+                let stream = self.r.stream.as_mut().unwrap();
+                tokio::select! {
+                    ev = stream.next() => break ev,
+                    Some(req) = self.prompt_rx.recv() => {
+                        let _ = req.response_tx.send(prompt_answer.clone());
+                    }
+                }
+            };
+            let Some(event) = event else {
+                self.r.stream = None;
+                self.r.streaming = false;
+                break;
+            };
+            self.r.seen.push(format!("{:?}", event));
+            let stop_here = stop(&event);
+            enum Action {
+                Continue,
+                AutoSendQueued(String),
+                AutoTriggerEvents,
+            }
+            let mut action = Action::Continue;
+            match event {
+                StreamEvent::Llm(LlmEvent::Thinking(t)) => {
+                    if let Some(Part::Thinking(s)) = self.parts.last_mut() {
+                        s.push_str(&t);
+                    } else {
+                        self.parts.push(Part::Thinking(t));
+                    }
+                }
+                StreamEvent::Llm(LlmEvent::Text(t)) => {
+                    if let Some(Part::Text(s)) = self.parts.last_mut() {
+                        s.push_str(&t);
+                    } else {
+                        self.parts.push(Part::Text(t));
+                    }
+                }
+                StreamEvent::Llm(LlmEvent::ToolUse {
+                    tool_name, input, ..
+                }) => self.parts.push(Part::ToolUse {
+                    name: tool_name,
+                    input: serde_json::to_string(&input).unwrap_or_default(),
+                }),
+                StreamEvent::Llm(LlmEvent::ToolResultDelta { tool_id, delta }) => {
+                    match self.parts.iter_mut().rev().find_map(|p| match p {
+                        Part::ToolResult { tool_id: id, content } if *id == tool_id => {
+                            Some(content)
+                        }
+                        _ => None,
+                    }) {
+                        Some(c) => c.push_str(&delta),
+                        None => self.parts.push(Part::ToolResult {
+                            tool_id,
+                            content: delta,
+                        }),
+                    }
+                }
+                StreamEvent::Llm(LlmEvent::ToolResult { tool_id, result }) => {
+                    match self.parts.iter_mut().rev().find_map(|p| match p {
+                        Part::ToolResult { tool_id: id, content } if *id == tool_id => {
+                            Some(content)
+                        }
+                        _ => None,
+                    }) {
+                        Some(c) => *c = result,
+                        None => self.parts.push(Part::ToolResult {
+                            tool_id,
+                            content: result,
+                        }),
+                    }
+                }
+                StreamEvent::Llm(_) => {}
+                StreamEvent::Session(SessionEvent::MessageHistory(history)) => {
+                    self.r.api_messages = history;
+                    self.save_session().await; // stream_handler.rs:77
+                }
+                StreamEvent::Session(SessionEvent::Usage {
+                    input_tokens,
+                    output_tokens,
+                    cache_read_input_tokens,
+                    cache_creation_input_tokens,
+                    cache_creation_5m,
+                    cache_creation_1h,
+                    model,
+                }) => {
+                    let model_for_pricing = model
+                        .as_deref()
+                        .unwrap_or(self.r.runtime.model())
+                        .to_string();
+                    self.add_usage(
+                        input_tokens,
+                        output_tokens,
+                        cache_read_input_tokens,
+                        cache_creation_input_tokens,
+                        cache_creation_5m,
+                        cache_creation_1h,
+                        &model_for_pricing,
+                    );
+                }
+                StreamEvent::Agent(AgentEvent::SteeringDelivered { message }) => {
+                    if self.r.queued_message.as_ref() == Some(&message) {
+                        self.r.queued_message = None;
+                    }
+                }
+                StreamEvent::Agent(_) => {}
+                StreamEvent::Session(SessionEvent::Notice(_)) => {}
+                StreamEvent::Session(SessionEvent::Done) => {
+                    self.r.streaming = false;
+                    let had_pending = !self.r.pending_events.is_empty();
+                    for formatted in self.r.pending_events.drain(..) {
+                        self.r
+                            .api_messages
+                            .push(std::sync::Arc::new(serde_json::json!({
+                                "role": "user",
+                                "content": formatted
+                            })));
+                    }
+                    if let Some(queued) = self.r.queued_message.take() {
+                        action = Action::AutoSendQueued(queued);
+                    } else if had_pending {
+                        self.save_session().await; // stream_handler.rs:203
+                        action = Action::AutoTriggerEvents;
+                    }
+                }
+                StreamEvent::Session(SessionEvent::Error(_)) => {
+                    self.r.streaming = false;
+                    synaps_cli::engine::stream::repair_history_after_failure(
+                        &mut self.r.api_messages,
+                        self.r.turn_baseline,
+                    );
+                }
+            }
+            match action {
+                Action::Continue => {
+                    if !self.r.streaming {
+                        self.r.stream = None;
+                        self.r.cancel = None;
+                        self.r.steer_tx = None;
+                    }
+                }
+                Action::AutoSendQueued(queued) => {
+                    drop(self.r.stream.take());
+                    drop(self.r.cancel.take());
+                    drop(self.r.steer_tx.take());
+                    self.r.consecutive_auto_turns = 0;
+                    let api_content = if let Some(ref ctx) = self.r.abort_context {
+                        let combined = format!("{}\n\n{}", ctx, queued);
+                        self.r.abort_context = None;
+                        combined
+                    } else {
+                        queued
+                    };
+                    self.r.api_messages.push(std::sync::Arc::new(
+                        serde_json::json!({"role": "user", "content": api_content}),
+                    ));
+                    self.start_stream().await;
+                }
+                Action::AutoTriggerEvents => {
+                    drop(self.r.stream.take());
+                    drop(self.r.cancel.take());
+                    drop(self.r.steer_tx.take());
+                    if claim_auto_turn(&mut self.r.consecutive_auto_turns) {
+                        self.start_stream().await;
+                    } else {
+                        self.r.cap_notices += 1;
+                    }
+                }
+            }
+            if stop_here {
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Stacked on #107 (feat/daemon-mode) ← #105.** Merge those first; base is `feat/daemon-mode`. Engine + daemon + tests + docs only — **the in-process TUI is untouched** on this branch (that's #109). Everything daemon-side stays behind `SYNAPS_DAEMON=1`.

## What
- **Protocol v2** (directional: newer daemon only). `Addressed` commands stamp the sender; **input ownership** — Mirror/Observe/Takeover attach modes, non-owner input → `Refused` with zero side effect, owner-detach hands off to the oldest non-observer, `InputOwnerChanged` broadcast. `Checkpoint` owner-only.
- **`Parked`**: a detached idle session drops its `Runtime` + `ConversationState` after a grace period (`SYNAPS_DAEMON_PARK_GRACE_SECS`, default 60; `--keep-warm`/`/keep-warm` pins); metadata + journal + event queue survive so `synaps send` **wakes** it; pending prompts block parking; never-saved sessions never park; unpark on a missing journal rebuilds a fresh conversation under the same id; unpark applies the *current* model/thinking; `AttachRefused` on failure leaves the session Parked, not corrupted. Attach-to-parked: 47–69 ms.
- **Spawned compaction**: Attach/Detach/Cancel/Query serviced during a compaction; Submit queued; Cancel aborts it; typed `CompactionStarted/Applied/Failed/Cancelled` (no notice text — clients render once). `SYNAPS_SESSION_COMPACT_INLINE=1` restores inline. `busy` now includes compaction (a divergence #107 shipped, fixed).
- **`synaps daemon reload`**: validates `--exe` (regular, executable, ours-or-root, not group/world-writable, `--print-version` newer), drains, `Checkpoint{Reload}` every session (returns a `SessionReloadRecord`: config, keep_warm, lifecycle, settings_replay incl. `/system`, current model/thinking), notices clients that background bash/PTYs die, writes reload-state, `execv` **same pid** with the adopted flock + CLOEXEC listener, rehydrates before accepting (Parked come back Parked), clients get `Bye{Reloading}` → reconnect with backoff → `Attach{takeover iff was_owner}`. **On exec failure the daemon keeps serving** (state restored, announce re-armed, discovery re-spawned). Tested against a real daemon process.
- **One session map** (`EngineHost` owns it; `DaemonState` delegates). Typed `Aborted`/`Cleared` events. `Purge` frame + `synaps daemon purge`. Notification router routes by `params.session_id`. `synaps attach --observe|--takeover|--keep-warm`.
- **Differential**: 3 → 10 scenarios against the frozen reference reactor (tool loop, steer mid-stream, event injection mid-stream, cancel captures abort context, secret prompt round-trip, …) with **save counts** inode-sampled from outside and cross-checked. Two scenarios declared unscriptable (need a scheduling race) — stated in the header.
- Fixed a leak: every dropped `Runtime` left a 30 s shell-reaper ticker running.

## Evidence
- `cargo test --workspace --no-fail-fast` on bella: **3950 passed / 0 failed / 21 ignored, EXIT=0**. New: 27 actor tests (`session_actor_{ownership,parked,compaction}.rs`), `daemon_reload.rs` (pid same, gen 1→2, owner reclaimed, `/model`+keep-warm+Parked survive, exec-failure recovery), `daemon_takeover.rs`, differential 10/10.
- Parked bench (bella, 2 MB fixture journal): parked/live ratio **0.23–0.25** (gate ≤ 0.25 ✓), attach-to-parked ≤ 69 ms (gate 500 ✓), absolute parked marginal 1.9–2.5 MB vs a 1 MB gate — allocator noise; `synaps daemon purge` + longer settle needed to pin it; recorded honestly in `docs/daemon-mode.md`.
- Reviewed (static, 12-point) as part of the full phase-3 tree: NO-SHIP 6/10 as one PR → split; all engine-side must-fix items closed with tests. Known pre-existing flake `e_opens_expanded_provider_browser` (#344) is order-dependent and fails on the base tree too.

## Not here
The in-process TUI on the actor + `synaps --attach` running the real TUI → **#109** (the default-path change, carried by a reference-binary differential). Plugin-side `session_id` keying for `heartbeat`/`jawz-widget` → their repos. Attach-client diet, bench purge-before-sample as a gate → later.

Design trail: `~/Jawz/workspace/daemon-mode/{PLAN-phase3,REVIEW-phase3-shady}.md`. Refs #343.