### PR TITLE
feat(tui): in-process TUI runs on SessionActor; synaps --attach runs the real TUI over the daemon socket (phase 3 TUI — the default-path change)

### DIFF
--- a/crates/agent-engine/src/daemon/mod.rs
+++ b/crates/agent-engine/src/daemon/mod.rs
@@ -12,11 +12,12 @@ pub mod listener;
 pub mod registry;
 pub mod reload;
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use tokio_util::sync::CancellationToken;

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -684,7 +684,8 @@ fn build_http_client(read_timeout: Duration) -> reqwest::Result<Client> {
 
 /// The process-global HTTP client for `EngineHost` (same builder as
 /// `Runtime::new`).
-pub(crate) fn build_host_http_client() -> Result<Client> {
+/// The host's HTTP client builder (also used by the attach-TUI client, A4).
+pub fn build_host_http_client() -> Result<Client> {
     build_http_client(HTTP_READ_TIMEOUT)
         .map_err(|e| RuntimeError::Config(format!("Failed to build HTTP client: {}", e)))
 }

--- a/crates/agent-engine/src/session/actor.rs
+++ b/crates/agent-engine/src/session/actor.rs
@@ -1041,18 +1041,19 @@ impl SessionActor {
             SessionCommand::Resync { .. } => self.emit(SessionEventWire::SystemNotice(
                 "resync not supported yet".into(),
             )),
-            // Phase-3 stubs: A3 (SubmitPrepared/PluginCommand/Resume), B1
-            // (Checkpoint), B3 (KeepWarm) fill these in.
-            SessionCommand::SubmitPrepared { .. } => self.emit(SessionEventWire::SystemNotice(
-                "submit_prepared: not implemented in this build".into(),
-            )),
-            SessionCommand::PluginCommand { id, .. } => self.emit(SessionEventWire::QueryResult {
+            // A3 bodies live in actor_cmds.rs; B1 (Checkpoint), B3 (KeepWarm)
+            // fill in the rest.
+            SessionCommand::SubmitPrepared {
+                messages,
+                user_text,
+            } => self.submit_prepared(messages, user_text).await,
+            SessionCommand::PluginCommand {
                 id,
-                value: serde_json::json!({ "kind": "error", "text": "plugin_command: not implemented in this build" }),
-            }),
-            SessionCommand::Resume { .. } => self.emit(SessionEventWire::SystemNotice(
-                "resume: not implemented in this build".into(),
-            )),
+                plugin,
+                name,
+                arg,
+            } => self.plugin_command(id, plugin, name, arg).await,
+            SessionCommand::Resume { id, query } => self.resume(id, query).await,
             SessionCommand::Checkpoint { .. } => self.emit(SessionEventWire::SystemNotice(
                 "checkpoint: not implemented in this build".into(),
             )),

--- a/crates/agent-engine/src/session/actor_cmds.rs
+++ b/crates/agent-engine/src/session/actor_cmds.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use super::actor::SessionActor;
+use super::actor::{Live, SessionActor};
 use super::types::*;
 
 /// `/compact [instructions]` as the engine parses it (no runtime mutation).
@@ -246,7 +246,7 @@ impl SessionActor {
         } else {
             None
         };
-        self.conv = crate::engine::session::ConversationState::from_resumed(session);
+        self.conv = Live::new(crate::engine::session::ConversationState::from_resumed(session));
         if clamp_notice.is_some() {
             // Keep the session file in sync with the clamped runtime.
             self.conv.session.thinking_level = self.runtime.thinking_level().to_string();

--- a/crates/agent-engine/src/session/actor_cmds.rs
+++ b/crates/agent-engine/src/session/actor_cmds.rs
@@ -1,56 +1,330 @@
 //! `SessionActor` — command bodies that belong to the TUI port (A3):
-//! `engine_command` (moved verbatim from `actor.rs`), and — as A3 lands —
-//! `submit_prepared`, `plugin_command`, `resume`, `emit_subagent_rows`.
-//! Kept apart from `actor.rs` so the turn machine (B) and the command
-//! surface (A) never touch the same file.
+//! `engine_command` (structured reply), `submit_prepared`, `plugin_command`,
+//! `resume`, `session_name`, `emit_subagent_rows`. Kept apart from
+//! `actor.rs` so the turn machine (B) and the command surface (A) never
+//! touch the same file.
+
+use std::sync::Arc;
 
 use super::actor::SessionActor;
 use super::types::*;
 
+/// `/compact [instructions]` as the engine parses it (no runtime mutation).
+fn compact_request(cmd: &str, arg: &str) -> Option<crate::engine::commands::CommandResult> {
+    match crate::engine::commands::evaluate_engine_command(cmd, arg) {
+        Some(r @ crate::engine::commands::CommandResult::Compact { .. }) => Some(r),
+        _ => None,
+    }
+}
+
+/// `handle_engine_command` on `runtime` + the `QueryResult` value clients
+/// render. Returns `(value, view_changed)`. Shared by the actor and the
+/// TUI's `ScriptedTransport` so both answer identically.
+pub fn engine_command_reply(
+    cmd: &str,
+    arg: &str,
+    runtime: &mut crate::Runtime,
+    session: &mut crate::Session,
+) -> (serde_json::Value, bool) {
+    use crate::engine::commands::{handle_engine_command, CommandResult};
+    match handle_engine_command(cmd, arg, runtime) {
+        None => (serde_json::json!({ "kind": "unhandled" }), false),
+        Some(CommandResult::Quit) => (serde_json::json!({ "kind": "quit" }), false),
+        Some(CommandResult::ModelChanged {
+            model,
+            reasoning_clamped,
+        }) => {
+            session.model = runtime.model().to_string();
+            let mut text = format!("model → {}", model);
+            let mut clamp = serde_json::Value::Null;
+            if let Some(c) = reasoning_clamped {
+                session.thinking_level = runtime.thinking_level().to_string();
+                text.push_str(&format!(
+                    "\nthinking → {} (clamped from {}: not supported by {})",
+                    c.to.as_str(),
+                    c.from.as_str(),
+                    runtime.model()
+                ));
+                clamp = serde_json::json!({ "from": c.from.as_str(), "to": c.to.as_str() });
+            }
+            (
+                serde_json::json!({
+                    "kind": "notice",
+                    "event": "model_changed",
+                    "text": text,
+                    "model": runtime.model(),
+                    "clamp": clamp,
+                }),
+                true,
+            )
+        }
+        Some(CommandResult::ThinkingChanged { spec }) => {
+            session.thinking_level = spec.config_value();
+            (
+                serde_json::json!({
+                    "kind": "notice",
+                    "event": "thinking_changed",
+                    "text": format!("thinking → {}", spec.level()),
+                    "level": spec.level().to_string(),
+                    "config_value": spec.config_value(),
+                }),
+                true,
+            )
+        }
+        Some(CommandResult::Compact { .. }) => (serde_json::json!({ "kind": "none" }), false),
+        Some(CommandResult::Error(e)) => (serde_json::json!({ "kind": "error", "text": e }), false),
+        Some(CommandResult::Output(text)) => {
+            (serde_json::json!({ "kind": "output", "text": text }), false)
+        }
+        Some(_) => (serde_json::json!({ "kind": "none" }), false),
+    }
+}
+
 impl SessionActor {
     /// `engine::commands::handle_engine_command` on THE runtime; reply as a
-    /// `QueryResult` the client renders (chat.rs slash-command branch).
+    /// `QueryResult` the client renders. `kind`/`text` are what chat.rs
+    /// reads (`notice`/`error`/`output`/`quit`/`unhandled`); the TUI reads
+    /// the structured extras (`event`, `model`, `clamp`, `level`,
+    /// `config_value`) to render its own lines byte-for-byte.
     pub(crate) async fn engine_command(&mut self, id: u64, cmd: String, arg: String) {
-        use crate::engine::commands::{handle_engine_command, CommandResult};
-        let value = match handle_engine_command(&cmd, &arg, &mut self.runtime) {
-            None => serde_json::json!({ "kind": "unhandled" }),
-            Some(CommandResult::Quit) => serde_json::json!({ "kind": "quit" }),
-            Some(CommandResult::ModelChanged {
-                model,
-                reasoning_clamped,
-            }) => {
-                self.conv.session.model = self.runtime.model().to_string();
-                let mut text = format!("model → {}", model);
-                if let Some(clamp) = reasoning_clamped {
-                    self.conv.session.thinking_level = self.runtime.thinking_level().to_string();
-                    text.push_str(&format!(
-                        "\nthinking → {} (clamped from {}: not supported by {})",
-                        clamp.to.as_str(),
-                        clamp.from.as_str(),
-                        self.runtime.model()
-                    ));
-                }
-                self.publish_view().await;
-                serde_json::json!({ "kind": "notice", "text": text })
+        use crate::engine::commands::CommandResult;
+        // TUI-only commands that need the actor's session (it owns the
+        // journal): `saveas` names/unnames + force-saves.
+        if cmd == "saveas" {
+            let value = self.session_name(&arg).await;
+            self.emit(SessionEventWire::QueryResult { id, value });
+            return;
+        }
+        let (value, view_changed) =
+            engine_command_reply(&cmd, &arg, &mut self.runtime, &mut self.conv.session);
+        if view_changed {
+            self.publish_view().await;
+        }
+        if let Some(CommandResult::Compact {
+            custom_instructions,
+        }) = compact_request(&cmd, &arg)
+        {
+            self.emit(SessionEventWire::SystemNotice("compacting...".into()));
+            self.compact(custom_instructions, "manual").await;
+        }
+        self.emit(SessionEventWire::QueryResult { id, value });
+    }
+
+    /// `/saveas <name>` | `/saveas` (clear). Force-saves even with no
+    /// messages — persist the name change (commands.rs `saveas` arm).
+    async fn session_name(&mut self, arg: &str) -> serde_json::Value {
+        let trimmed = arg.trim();
+        if trimmed.is_empty() {
+            self.conv.session.clear_name();
+            let _ = self.conv.session.save().await;
+            self.emit_conversation();
+            return serde_json::json!({
+                "kind": "output", "text": "session name cleared", "name": serde_json::Value::Null,
+            });
+        }
+        match self.conv.session.set_name(trimmed) {
+            Ok(()) => {
+                let _ = self.conv.session.save().await;
+                self.emit_conversation();
+                serde_json::json!({
+                    "kind": "output",
+                    "text": format!("session named '{}'", trimmed),
+                    "name": trimmed,
+                })
             }
-            Some(CommandResult::ThinkingChanged { spec }) => {
-                self.conv.session.thinking_level = spec.config_value();
-                self.publish_view().await;
-                serde_json::json!({ "kind": "notice", "text": format!("thinking → {}", spec.level()) })
-            }
-            Some(CommandResult::Compact {
-                custom_instructions,
-            }) => {
-                self.emit(SessionEventWire::SystemNotice("compacting...".into()));
-                self.compact(custom_instructions, "manual").await;
-                serde_json::json!({ "kind": "none" })
-            }
-            Some(CommandResult::Error(e)) => serde_json::json!({ "kind": "error", "text": e }),
-            Some(CommandResult::Output(text)) => {
-                serde_json::json!({ "kind": "output", "text": text })
-            }
-            Some(_) => serde_json::json!({ "kind": "none" }),
+            Err(e) => serde_json::json!({ "kind": "error", "text": e.to_string() }),
+        }
+    }
+
+    /// dispatch.rs LoadSkill (:330-360): pre-built tool_use/tool_result pair
+    /// (+ optional user text) then a turn. Does NOT fold `abort_context` and
+    /// does NOT reset `consecutive_auto_turns`.
+    pub(crate) async fn submit_prepared(
+        &mut self,
+        messages: Vec<crate::SharedMessage>,
+        user_text: Option<String>,
+    ) {
+        if self.streaming {
+            self.emit(SessionEventWire::SystemNotice(
+                "cannot load a skill while streaming".into(),
+            ));
+            return;
+        }
+        self.conv.api_messages.extend(messages);
+        if let Some(text) = user_text {
+            self.conv
+                .api_messages
+                .push(Arc::new(serde_json::json!({"role": "user", "content": text})));
+        }
+        self.start_turn(TurnTrigger::PluginCommand, None).await;
+    }
+
+    /// commands.rs:123-158: tools-backed (non-interactive) plugin command on
+    /// THE runtime's tool set. Reply `{kind:"plugin_output", status, stdout,
+    /// stderr}` or `{kind:"error", text}`.
+    pub(crate) async fn plugin_command(&mut self, id: u64, plugin: String, name: String, arg: String) {
+        let value = match Self::find_plugin_command(&plugin, &name) {
+            None => serde_json::json!({
+                "kind": "error",
+                "text": format!("unknown plugin command /{plugin}:{name}"),
+            }),
+            Some(cmd) => match crate::skills::commands::execute_plugin_command_with_tools(
+                &cmd,
+                &arg,
+                self.runtime.tools_shared(),
+            )
+            .await
+            {
+                Ok(output) => serde_json::json!({
+                    "kind": "plugin_output",
+                    "status": output.status,
+                    "stdout": output.stdout,
+                    "stderr": output.stderr,
+                }),
+                Err(e) => serde_json::json!({ "kind": "error", "text": e.to_string() }),
+            },
         };
         self.emit(SessionEventWire::QueryResult { id, value });
+    }
+
+    fn find_plugin_command(
+        plugin: &str,
+        name: &str,
+    ) -> Option<Arc<crate::skills::registry::RegisteredPluginCommand>> {
+        let host = crate::host::EngineHost::current()?;
+        match host.command_registry().resolve(&format!("{plugin}:{name}")) {
+            crate::skills::registry::Resolution::PluginCommand(c) => Some(c),
+            _ => None,
+        }
+    }
+
+    /// commands.rs:647-693 `/resume`: save current, load `query`, restore
+    /// model/reasoning/system prompt, swap conversation. Reply `Resumed{id}`
+    /// then `Conversation`; error → `QueryResult{id, {kind:"error", text}}`.
+    pub(crate) async fn resume(&mut self, id: u64, query: String) {
+        if self.streaming {
+            self.emit(SessionEventWire::QueryResult {
+                id,
+                value: serde_json::json!({ "kind": "error", "text": "cannot resume while streaming" }),
+            });
+            return;
+        }
+        let session = match crate::resolve_session(&query) {
+            Ok(s) => s,
+            Err(e) => {
+                self.emit(SessionEventWire::QueryResult {
+                    id,
+                    value: serde_json::json!({ "kind": "error", "text": e.to_string() }),
+                });
+                return;
+            }
+        };
+        self.runtime.set_model(session.model.clone());
+        // A resumed session owns its saved choice. Preserve that explicit
+        // provenance across later model switches.
+        let clamp_notice = self
+            .runtime
+            .restore_session_reasoning(&session.thinking_level)
+            .map(|clamp| {
+                format!(
+                    "thinking → {} (clamped from {}: not supported by {})",
+                    clamp.to.as_str(),
+                    clamp.from.as_str(),
+                    self.runtime.model()
+                )
+            });
+        if let Some(ref sp) = session.system_prompt {
+            self.runtime.set_system_prompt(sp.clone());
+        }
+        self.save().await;
+        let old_id = self.conv.session.id.clone();
+        let new_id = session.id.clone();
+        let via = if crate::chain::load_chain(&query).is_ok() {
+            Some(format!("chain '{}'", query))
+        } else if crate::find_session_by_name(&query).is_ok() {
+            Some(format!("name '{}'", query))
+        } else {
+            None
+        };
+        self.conv = crate::engine::session::ConversationState::from_resumed(session);
+        if clamp_notice.is_some() {
+            // Keep the session file in sync with the clamped runtime.
+            self.conv.session.thinking_level = self.runtime.thinking_level().to_string();
+        }
+        self.consecutive_auto_turns = 0;
+        self.runtime.set_session_id(Some(new_id.clone()));
+        self.journal_id.store(Arc::new(new_id.clone()));
+        self.publish_view().await;
+        self.emit(SessionEventWire::Resumed {
+            id,
+            old_id,
+            new_id,
+            via,
+            clamp_notice,
+        });
+        self.emit_conversation();
+    }
+
+    /// `runtime.subagent_registry().display_rows()` → `SubagentRows`
+    /// (called at Done/Error and from the 1 Hz arm B adds).
+    #[allow(dead_code)]
+    pub(crate) fn emit_subagent_rows(&mut self) {
+        let rows = self
+            .runtime
+            .subagent_registry()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .display_rows();
+        self.emit(SessionEventWire::SubagentRows(rows));
+    }
+
+    /// Any non-terminal subagent row (drives the 1 Hz arm).
+    #[allow(dead_code)]
+    pub(crate) fn has_live_subagents(&self) -> bool {
+        self.runtime
+            .subagent_registry()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .display_rows()
+            .iter()
+            .any(|r| matches!(r.status, crate::runtime::subagent::SubagentStatus::Running))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! `/resume`'s reasoning restore is the runtime's `restore_session_reasoning`
+    //! + the clamp line above; pin the two behaviours the TUI tests pinned.
+    use crate::Runtime;
+
+    #[tokio::test]
+    async fn restore_session_reasoning_keeps_explicit_provenance() {
+        let mut runtime = Runtime::new().await.unwrap();
+        runtime.set_model("openai-codex/gpt-5.6-sol".to_string());
+        let clamp = runtime.restore_session_reasoning("ultra");
+        assert!(clamp.is_none());
+        assert_eq!(
+            runtime.reasoning_level(),
+            agent_core::reasoning::ReasoningLevel::Ultra
+        );
+        assert!(runtime.is_reasoning_explicit());
+        runtime.set_model("openai-codex/gpt-5.6-terra".to_string());
+        assert_eq!(
+            runtime.reasoning_level(),
+            agent_core::reasoning::ReasoningLevel::Ultra
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_session_reasoning_clamps_unsupported_level() {
+        let mut runtime = Runtime::new().await.unwrap();
+        runtime.set_model("xai-auth/grok-4.6".to_string());
+        let clamp = runtime.restore_session_reasoning("xhigh");
+        assert!(clamp.is_some());
+        assert_eq!(
+            runtime.reasoning_level(),
+            agent_core::reasoning::ReasoningLevel::High
+        );
+        assert!(runtime.is_reasoning_explicit());
     }
 }

--- a/crates/agent-tui/Cargo.toml
+++ b/crates/agent-tui/Cargo.toml
@@ -34,6 +34,7 @@ uuid         = { version = "1.0", features = ["v4"] }
 # Error handling
 thiserror    = "1.0"
 anyhow       = "1.0"
+reqwest      = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls-webpki-roots", "rustls-tls-native-roots"] }
 
 # TUI render crates
 ratatui       = "0.30"

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -125,10 +125,6 @@ pub(crate) struct App {
     /// Counter for unique subagent IDs within a session
     /// Saved context from an aborted response — injected into the next user message
     pub(crate) abort_context: Option<String>,
-    /// Dedupe key of the last `Aborted`/`Cleared` rendered since the last
-    /// `TurnStarted` — the actor's `SystemNotice` text and its typed event
-    /// may BOTH arrive (shim + typed); only one line is rendered.
-    pub(crate) shim_seen: Option<String>,
     /// Message queued while streaming — auto-sent when current response finishes
     pub(crate) queued_message: Option<String>,
     /// Tracks paste state: snapshot of input before first paste, and total pasted char count
@@ -360,7 +356,6 @@ impl App {
             },
             subagents: Vec::new(),
             abort_context: None,
-            shim_seen: None,
             queued_message: None,
             input_before_paste: None,
             pasted_char_count: 0,

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -125,6 +125,10 @@ pub(crate) struct App {
     /// Counter for unique subagent IDs within a session
     /// Saved context from an aborted response — injected into the next user message
     pub(crate) abort_context: Option<String>,
+    /// Dedupe key of the last `Aborted`/`Cleared` rendered since the last
+    /// `TurnStarted` — the actor's `SystemNotice` text and its typed event
+    /// may BOTH arrive (shim + typed); only one line is rendered.
+    pub(crate) shim_seen: Option<String>,
     /// Message queued while streaming — auto-sent when current response finishes
     pub(crate) queued_message: Option<String>,
     /// Tracks paste state: snapshot of input before first paste, and total pasted char count
@@ -356,6 +360,7 @@ impl App {
             },
             subagents: Vec::new(),
             abort_context: None,
+            shim_seen: None,
             queued_message: None,
             input_before_paste: None,
             pasted_char_count: 0,

--- a/crates/agent-tui/src/tui/app.rs
+++ b/crates/agent-tui/src/tui/app.rs
@@ -1,6 +1,46 @@
 use synaps_cli::pricing::calculate_cost_optional_split;
 use synaps_cli::Session;
 
+/// `SessionHeader` → the `Session` the TUI mirrors (`App.session`). Never
+/// carries `api_messages` — the actor owns the journal.
+pub(crate) fn session_from_header(h: &agent_engine::session::SessionHeader) -> Session {
+    let mut s = Session::new(&h.model, &h.thinking_level, h.system_prompt.as_deref());
+    apply_header(&mut s, h);
+    s
+}
+
+/// `SessionEventWire::CompactionApplied` fields, parked until the
+/// successor `Conversation` lands.
+pub(crate) struct CompactionApplied {
+    pub previous_session_id: String,
+    /// The successor id (also carried by the following `Conversation`).
+    #[allow(dead_code)]
+    pub session_id: String,
+    pub chains_advanced: Vec<String>,
+    pub queued_restored: Option<String>,
+    pub msg_count: usize,
+}
+
+/// `SessionEventWire::Resumed` fields, parked until the `Conversation`.
+pub(crate) struct ResumePending {
+    pub old_id: String,
+    pub new_id: String,
+    pub via: Option<String>,
+    pub clamp_notice: Option<String>,
+}
+
+pub(crate) fn apply_header(s: &mut Session, h: &agent_engine::session::SessionHeader) {
+    s.id = h.id.clone();
+    s.title = h.title.clone();
+    s.name = h.name.clone();
+    s.model = h.model.clone();
+    s.thinking_level = h.thinking_level.clone();
+    s.system_prompt = h.system_prompt.clone();
+    s.created_at = h.created_at;
+    s.updated_at = h.updated_at;
+    s.parent_session = h.parent_session.clone();
+}
+
 // Type re-export shims from slice (a). Kept this release — deleting is churn
 // for no gain. One-release grace per design §5(f).
 // TODO(P9-followup): drop re-exports; callers should import from transcript directly.
@@ -119,17 +159,24 @@ pub(crate) struct App {
     /// arm; `is_active()` is mirrored by `modal_stack.contains(SecretPrompt)`
     /// via `reconcile_secret_prompt` (asserted by `debug_assert_stack_sync`).
     pub(crate) secret_prompts: synaps_cli::tools::SecretPromptQueue,
-    /// Background compaction task — polled in the event loop so /compact doesn't block.
-    pub(crate) compact_task: Option<
-        tokio::task::JoinHandle<
-            Result<
-                synaps_cli::runtime::compaction::CompactionOutcome,
-                synaps_cli::error::RuntimeError,
-            >,
-        >,
-    >,
-    /// Events buffered during streaming — injected into api_messages after stream completes
-    pub(crate) pending_events: Vec<String>,
+    /// Compaction in flight on the actor (`CompactionStarted` … `Applied`/
+    /// `Failed`/`Cancelled`). Client-side guard for `/compact` and Submit.
+    pub(crate) compacting: bool,
+    /// Mirror of the actor's buffered-during-streaming event count
+    /// (`ConversationSnapshot.pending_events_len`).
+    pub(crate) pending_events_len: usize,
+    /// Last `SubagentRows` from the actor — the tick arm reconciles the HUD
+    /// from this cache at the same 1 Hz cadence the registry read had.
+    pub(crate) subagent_rows: Vec<synaps_cli::tools::SubagentDisplayRow>,
+    /// `CompactionApplied` waiting for the `Conversation` that carries the
+    /// successor's messages (then the "✓ compacted …" lines are pushed).
+    pub(crate) compaction_applied: Option<CompactionApplied>,
+    /// `Resumed` reply waiting for the `Conversation` that carries the
+    /// resumed session's messages (then the "switched from …" line).
+    pub(crate) resume_pending: Option<ResumePending>,
+    /// The last Submit text until `TurnStarted`/`Refused` (§6 #9: a refused
+    /// Submit gives the editor its text back).
+    pub(crate) last_submitted: Option<String>,
     /// Consecutive auto-triggered model turns since the last real user send.
     /// Incremented by the event-reactor wake path; reset on Submit / queued user message.
     /// When this reaches AUTO_TURN_CAP the reactor parks and shows a system message.
@@ -325,8 +372,12 @@ impl App {
             // P7.8: folded off the `run()` local; production wires the mpsc
             // channel separately (mod.rs). Starts empty (no active prompt).
             secret_prompts: synaps_cli::tools::SecretPromptQueue::new(),
-            compact_task: None,
-            pending_events: Vec::new(),
+            compacting: false,
+            pending_events_len: 0,
+            subagent_rows: Vec::new(),
+            compaction_applied: None,
+            resume_pending: None,
+            last_submitted: None,
             consecutive_auto_turns: 0,
             model_health: std::collections::HashMap::new(),
             catalog_overrides: std::collections::BTreeMap::new(),
@@ -457,20 +508,22 @@ impl App {
     /// Calculate the number of visual lines the input needs, given an inner width.
     /// Returns (total_lines, cursor_row, cursor_col) for layout and cursor placement.
     ///
-    pub(crate) async fn save_session(&mut self) {
-        if self.api_messages.is_empty() {
-            return;
-        }
-        self.session.api_messages = self.api_messages.clone();
-        self.session.total_input_tokens = self.total_input_tokens;
-        self.session.total_output_tokens = self.total_output_tokens;
-        self.session.session_cost = self.session_cost;
-        self.session.abort_context = self.abort_context.clone();
-        self.session.updated_at = chrono::Utc::now();
-        self.session.auto_title();
-        if let Err(e) = self.session.save().await {
-            eprintln!("\x1b[31m[ERROR] Failed to save session: {}\x1b[0m", e);
-        }
+    /// Replace the conversation mirrors from a `Conversation(_)` envelope
+    /// (PLAN-phase3 §2.4: replace, never merge). Per-turn `input_tokens`/
+    /// `output_tokens`, the TTL-split cache counters and `api_call_count`
+    /// are client-side per-turn state and stay as `Stream(Usage)` left them.
+    pub(crate) fn apply_conversation(&mut self, conv: &agent_engine::session::ConversationSnapshot) {
+        self.api_messages = conv.api_messages.clone();
+        self.total_input_tokens = conv.tokens.input;
+        self.total_output_tokens = conv.tokens.output;
+        self.total_cache_read_tokens = conv.tokens.cache_read;
+        self.total_cache_creation_tokens = conv.tokens.cache_creation;
+        self.session_cost = conv.cost;
+        self.abort_context = conv.abort_context.clone();
+        self.queued_message = conv.queued_message.clone();
+        self.pending_events_len = conv.pending_events_len;
+        self.consecutive_auto_turns = conv.consecutive_auto_turns;
+        apply_header(&mut self.session, &conv.header);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -636,51 +689,6 @@ impl App {
     pub(crate) fn on_tool_result(&mut self, tool_id: String, result: String) {
         self.transcript.on_tool_result(tool_id, result);
         self.needs_redraw = true;
-    }
-
-    /// Capture all assistant output since the last user message as abort context.
-    /// This gets injected into the next user message so the model knows what it
-    /// was doing before the abort.
-    pub(crate) fn capture_abort_context(&mut self) {
-        let mut parts: Vec<String> = Vec::new();
-
-        // Walk backwards from the end to find content since last user message
-        for tmsg in self.transcript.messages().iter().rev() {
-            match &tmsg.msg {
-                ChatMessage::User(_) => break, // stop at the last user message
-                ChatMessage::Thinking(t) if !t.is_empty() => {
-                    // Truncate thinking to avoid bloating context
-                    let preview: String = t.chars().take(500).collect();
-                    parts.push(format!("[thinking]: {}", preview));
-                }
-                ChatMessage::Text(t) if !t.is_empty() => {
-                    parts.push(format!("[response]: {}", t));
-                }
-                ChatMessage::ToolUse {
-                    tool_name, input, ..
-                } => {
-                    // Truncate input to keep context lean
-                    let input_preview: String = input.chars().take(200).collect();
-                    parts.push(format!("[tool_use]: {} — {}", tool_name, input_preview));
-                }
-                ChatMessage::ToolResult { content, .. } if !content.is_empty() => {
-                    let preview: String = content.chars().take(300).collect();
-                    parts.push(format!("[tool_result]: {}", preview));
-                }
-                _ => {}
-            }
-        }
-
-        if parts.is_empty() {
-            self.abort_context = None;
-            return;
-        }
-
-        parts.reverse(); // chronological order
-        self.abort_context = Some(format!(
-            "[ABORT CONTEXT — your previous response was interrupted. Here's what you completed before the abort:]\n\n{}\n\n[END ABORT CONTEXT — continue from where you left off or adjust based on the user's new message]",
-            parts.join("\n")
-        ));
     }
 
     pub(crate) fn history_up(&mut self) {

--- a/crates/agent-tui/src/tui/attach.rs
+++ b/crates/agent-tui/src/tui/attach.rs
@@ -1,0 +1,186 @@
+//! `synaps --attach [ID] [--observe|--takeover] [--keep-warm]` — the TUI
+//! over `SocketTransport` (PLAN-phase3 A4). Client diet: no `EngineHost`,
+//! no `Runtime`, no `ExtensionManager`, no MCP, no skills index — config,
+//! builtin commands, keybinds, the render thread and the event stream only.
+//! Plugin commands / interactive plugin commands are not available over the
+//! socket yet (`Query{Commands}` is phase 4).
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use agent_engine::session::socket_transport::SocketTransport;
+use agent_engine::session::wire::{Attach, Hello};
+use agent_engine::session::{
+    AttachMode, ClientKind, ClientTransport, CompactionPolicyWire, SessionCommand, SessionConfig,
+    SessionId, TransportError,
+};
+use synaps_cli::skills::registry::CommandRegistry;
+use synaps_cli::skills::BUILTIN_COMMANDS;
+use synaps_cli::Result;
+
+use super::app::ChatMessage;
+use super::run_setup::{app_from_snapshot, finish_setup, TransportMode};
+
+/// What to attach to.
+pub struct AttachOpts {
+    pub profile: Option<String>,
+    /// Session id (prefix ok); `None` = the only live session, else create.
+    pub id: Option<String>,
+    /// Create by continuing a saved session (name or id).
+    pub continue_session: Option<String>,
+    pub system: Option<String>,
+    pub prompt_manifest: Option<PathBuf>,
+    pub mode: AttachMode,
+    pub keep_warm: bool,
+}
+
+/// `SYNAPS_ATTACH_MODE=mirror|observe|takeover` default, overridden by flags.
+pub fn attach_mode(observe: bool, takeover: bool) -> AttachMode {
+    if takeover {
+        return AttachMode::Takeover;
+    }
+    if observe {
+        return AttachMode::Observe;
+    }
+    match std::env::var("SYNAPS_ATTACH_MODE").ok().as_deref() {
+        Some("observe") => AttachMode::Observe,
+        Some("takeover") => AttachMode::Takeover,
+        _ => AttachMode::Mirror,
+    }
+}
+
+fn cfg_err(e: impl std::fmt::Display) -> synaps_cli::RuntimeError {
+    synaps_cli::RuntimeError::Config(e.to_string())
+}
+
+pub async fn run_attached(opts: AttachOpts) -> Result<()> {
+    let paths = agent_engine::daemon::registry::daemon_paths(opts.profile.as_deref());
+    if !agent_engine::daemon::registry::is_alive(&paths) {
+        return Err(cfg_err(
+            "daemon not running (start it with `synaps daemon --detach`)",
+        ));
+    }
+    let conn = match SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Tui)).await {
+        Ok(c) => c,
+        Err(TransportError::Version { client, daemon }) => {
+            return Err(cfg_err(format!(
+                "protocol version mismatch (client {client}, daemon {daemon}); restart or reload the daemon with this binary"
+            )))
+        }
+        Err(e) => return Err(cfg_err(format!("connect: {e}"))),
+    };
+
+    let cwd = std::env::current_dir().ok();
+    let create = |continue_session: Option<Option<String>>| Attach::Create {
+        config: SessionConfig {
+            continue_session,
+            system: opts.system.clone(),
+            prompt_manifest: opts.prompt_manifest.clone(),
+            cwd: cwd.clone(),
+            compaction_policy: CompactionPolicyWire::LinkedSuccessor,
+            await_extensions: true,
+            keep_warm: opts.keep_warm,
+            ..Default::default()
+        },
+        mode: opts.mode,
+    };
+    let attach = if let Some(c) = &opts.continue_session {
+        create(Some(Some(c.clone())))
+    } else if let Some(id) = &opts.id {
+        let sid = conn
+            .welcome
+            .sessions
+            .iter()
+            .find(|m| m.id.as_str() == id || m.id.as_str().starts_with(id.as_str()))
+            .map(|m| m.id.clone())
+            .unwrap_or_else(|| SessionId::from(id.as_str()));
+        Attach::Existing {
+            session_id: sid,
+            mode: opts.mode,
+        }
+    } else if conn.welcome.sessions.len() == 1 {
+        Attach::Existing {
+            session_id: conn.welcome.sessions[0].id.clone(),
+            mode: opts.mode,
+        }
+    } else if conn.welcome.sessions.is_empty() {
+        create(None)
+    } else {
+        let mut lines = vec!["several sessions; pick one with --attach <ID>:".to_string()];
+        for m in &conn.welcome.sessions {
+            lines.push(format!("  {}  model={}  clients={}", m.id, m.model, m.clients));
+        }
+        return Err(cfg_err(lines.join("\n")));
+    };
+
+    let (transport, snapshot) = SocketTransport::attach(conn, attach)
+        .await
+        .map_err(|e| cfg_err(format!("attach: {e}")))?;
+
+    // ── Client diet: config + builtin commands + keybinds, nothing else ──
+    let config = synaps_cli::load_config();
+    let registry = Arc::new(CommandRegistry::new(BUILTIN_COMMANDS, Vec::new()));
+    let mut keybinds = synaps_cli::skills::keybinds::KeybindRegistry::new();
+    if !config.keybinds.is_empty() {
+        keybinds.register_user(&config.keybinds);
+    }
+    let keybind_registry = Arc::new(std::sync::RwLock::new(keybinds));
+    let system_prompt_path = synaps_cli::config::resolve_read_path("system.md");
+    let http = agent_engine::runtime::build_host_http_client()?;
+
+    let mut app = app_from_snapshot(&snapshot);
+    for w in &config.warnings {
+        app.push_msg(ChatMessage::System(format!("⚠ config: {}", w)));
+    }
+    app.push_msg(ChatMessage::System(format!(
+        "attached to {} as client #{} ({:?}){}",
+        snapshot.meta.id,
+        transport.client_id().0,
+        transport.mode(),
+        match snapshot.input_owner {
+            Some(owner) if owner != transport.client_id() =>
+                format!(" — input is owned by client #{}", owner.0),
+            _ => String::new(),
+        }
+    )));
+    // Mid-turn attach: rebuild the partial turn from the replay ring, then
+    // the actor's pending prompts.
+    let replay = snapshot.replay.clone();
+    let pending = snapshot.pending_prompts.clone();
+    app.streaming = snapshot.streaming;
+
+    let mut ctx = finish_setup(
+        app,
+        Box::new(transport),
+        http,
+        TransportMode::Socket,
+        config,
+        registry,
+        keybind_registry,
+        system_prompt_path,
+        None,
+    )
+    .await?;
+    // No extension host in this process: the loader arm never runs.
+    ctx.app.extension_loader_running = false;
+    for env in replay {
+        // Presentation only; a render handle is not needed for correctness.
+        let _ = super::stream_handler::handle_session_event_arm(
+            env,
+            &mut ctx.app,
+            &mut ctx.link,
+            &ctx.registry,
+            &ctx.render_handle,
+            &mut ctx.prompt_bridge,
+            None,
+        )
+        .await;
+    }
+    for pr in pending {
+        ctx.prompt_bridge.on_prompt(pr);
+    }
+    if opts.keep_warm {
+        let _ = ctx.link.send(SessionCommand::KeepWarm { on: true }).await;
+    }
+    super::run_loop(ctx).await
+}

--- a/crates/agent-tui/src/tui/attach.rs
+++ b/crates/agent-tui/src/tui/attach.rs
@@ -53,12 +53,30 @@ fn cfg_err(e: impl std::fmt::Display) -> synaps_cli::RuntimeError {
     synaps_cli::RuntimeError::Config(e.to_string())
 }
 
+/// What `--attach` prints when there is no daemon to attach to: says so,
+/// and how to start one (profile-aware).
+pub fn daemon_not_running_message(profile: Option<&str>, detail: Option<&str>) -> String {
+    let start = match profile {
+        Some(p) => format!("synaps --profile {p} daemon --detach"),
+        None => "synaps daemon --detach".to_string(),
+    };
+    let why = detail.map(|d| format!(" ({d})")).unwrap_or_default();
+    format!(
+        "no daemon is running{why} — nothing to attach to.\n\
+         start one with:  {start}\n\
+         or run in the foreground:  {}\n\
+         then re-run `synaps --attach` (SYNAPS_DAEMON=1).",
+        start.replace("--detach", "--foreground")
+    )
+}
+
 pub async fn run_attached(opts: AttachOpts) -> Result<()> {
     let paths = agent_engine::daemon::registry::daemon_paths(opts.profile.as_deref());
     if !agent_engine::daemon::registry::is_alive(&paths) {
-        return Err(cfg_err(
-            "daemon not running (start it with `synaps daemon --detach`)",
-        ));
+        return Err(cfg_err(daemon_not_running_message(
+            opts.profile.as_deref(),
+            None,
+        )));
     }
     let conn = match SocketTransport::connect(&paths.sock, Hello::new(ClientKind::Tui)).await {
         Ok(c) => c,
@@ -66,6 +84,14 @@ pub async fn run_attached(opts: AttachOpts) -> Result<()> {
             return Err(cfg_err(format!(
                 "protocol version mismatch (client {client}, daemon {daemon}); restart or reload the daemon with this binary"
             )))
+        }
+        Err(TransportError::Io(e)) => {
+            // Lock held but the socket is gone/refusing: the daemon is dead
+            // or still booting — same advice, with the cause.
+            return Err(cfg_err(daemon_not_running_message(
+                opts.profile.as_deref(),
+                Some(&format!("{}: {e}", paths.sock.display())),
+            )));
         }
         Err(e) => return Err(cfg_err(format!("connect: {e}"))),
     };
@@ -183,4 +209,26 @@ pub async fn run_attached(opts: AttachOpts) -> Result<()> {
         let _ = ctx.link.send(SessionCommand::KeepWarm { on: true }).await;
     }
     super::run_loop(ctx).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_running_message_says_so_and_how_to_start() {
+        let m = daemon_not_running_message(None, None);
+        assert!(m.starts_with("no daemon is running"), "{m}");
+        assert!(m.contains("synaps daemon --detach"), "{m}");
+        assert!(m.contains("synaps daemon --foreground"), "{m}");
+        let m = daemon_not_running_message(Some("work"), Some("connection refused"));
+        assert!(m.contains("(connection refused)"), "{m}");
+        assert!(m.contains("synaps --profile work daemon --detach"), "{m}");
+    }
+
+    #[test]
+    fn attach_mode_flags_override_env() {
+        assert_eq!(attach_mode(false, true), AttachMode::Takeover);
+        assert_eq!(attach_mode(true, false), AttachMode::Observe);
+    }
 }

--- a/crates/agent-tui/src/tui/commands.rs
+++ b/crates/agent-tui/src/tui/commands.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use chrono;
-use synaps_cli::{list_recent_sessions, resolve_session, Runtime, Session};
+use synaps_cli::list_recent_sessions;
 
 use super::app::{App, ChatMessage};
 use synaps_cli::extensions::commands::CommandOutputEvent;
@@ -123,34 +123,38 @@ pub enum ExtensionsMemoryAction {
 pub(super) async fn execute_command_action(
     action: CommandAction,
     app: &mut App,
-    runtime: &Runtime,
+    link: &mut super::session_link::SessionLink,
 ) {
     if let CommandAction::PluginCommand { command, arg } = action {
-        match synaps_cli::skills::commands::execute_plugin_command_with_tools(
-            &command,
-            &arg,
-            runtime.tools_shared(),
-        )
-        .await
+        // Tools-backed plugin command runs on THE runtime's tool set
+        // (actor_cmds::plugin_command); reply = {status, stdout, stderr}.
+        match link
+            .plugin_command(&command.plugin, &command.name, &arg)
+            .await
         {
-            Ok(output) => {
+            Ok(value) if value["kind"] == "plugin_output" => {
+                let status = value["status"]
+                    .as_i64()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "signal".to_string());
+                let stdout = value["stdout"].as_str().unwrap_or("");
+                let stderr = value["stderr"].as_str().unwrap_or("");
                 let mut lines = vec![format!(
                     "plugin command /{}:{} exited with {}",
-                    command.plugin,
-                    command.name,
-                    output
-                        .status
-                        .map(|c| c.to_string())
-                        .unwrap_or_else(|| "signal".to_string())
+                    command.plugin, command.name, status
                 )];
-                if !output.stdout.trim().is_empty() {
-                    lines.push(format!("stdout:\n{}", output.stdout.trim_end()));
+                if !stdout.trim().is_empty() {
+                    lines.push(format!("stdout:\n{}", stdout.trim_end()));
                 }
-                if !output.stderr.trim().is_empty() {
-                    lines.push(format!("stderr:\n{}", output.stderr.trim_end()));
+                if !stderr.trim().is_empty() {
+                    lines.push(format!("stderr:\n{}", stderr.trim_end()));
                 }
                 app.push_msg(ChatMessage::System(lines.join("\n")));
             }
+            Ok(value) => app.push_msg(ChatMessage::Error(format!(
+                "plugin command failed: {}",
+                value["text"].as_str().unwrap_or("unknown error")
+            ))),
             Err(e) => app.push_msg(ChatMessage::Error(format!("plugin command failed: {}", e))),
         }
     }
@@ -325,27 +329,12 @@ pub(super) fn resolve_prefix(raw: &str, commands: &[String]) -> String {
     raw.to_string()
 }
 
-/// Re-apply a saved session's reasoning level as explicit, clamped to the
-/// current model. Returns a notice when the saved level was clamped.
-fn restore_session_reasoning(runtime: &mut Runtime, thinking_level: &str) -> Option<String> {
-    runtime
-        .restore_session_reasoning(thinking_level)
-        .map(|clamp| {
-            format!(
-                "thinking → {} (clamped from {}: not supported by {})",
-                clamp.to.as_str(),
-                clamp.from.as_str(),
-                runtime.model()
-            )
-        })
-}
-
 /// Handle a slash command when NOT streaming.
 pub(super) async fn handle_command(
     cmd: &str,
     arg: &str,
     app: &mut App,
-    runtime: &mut Runtime,
+    link: &mut super::session_link::SessionLink,
     system_prompt_path: &Path,
     registry: &std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
     keybind_registry: &synaps_cli::skills::keybinds::KeybindRegistry,
@@ -396,14 +385,18 @@ pub(super) async fn handle_command(
     // not own session messages, so the surface passes them in. Must run
     // before the generic engine intercept (which has no history access).
     if cmd == "context" {
-        match synaps_cli::engine::commands::context_command(runtime, Some(&app.api_messages)) {
-            synaps_cli::engine::commands::CommandResult::Output(text) => {
-                app.push_msg(ChatMessage::System(text));
+        match link
+            .query(agent_engine::session::SessionQuery::ContextReport)
+            .await
+        {
+            Ok(value) => {
+                if let Some(text) = value["text"].as_str() {
+                    app.push_msg(ChatMessage::System(text.to_string()));
+                } else if let Some(e) = value["error"].as_str() {
+                    app.push_msg(ChatMessage::Error(e.to_string()));
+                }
             }
-            synaps_cli::engine::commands::CommandResult::Error(e) => {
-                app.push_msg(ChatMessage::Error(e));
-            }
-            _ => {}
+            Err(e) => app.push_msg(ChatMessage::Error(e)),
         }
         return CommandAction::None;
     }
@@ -419,17 +412,39 @@ pub(super) async fn handle_command(
     } else {
         cmd
     };
-    if let Some(result) = synaps_cli::engine::commands::handle_engine_command(cmd, arg, runtime) {
-        use synaps_cli::engine::commands::{
-            persist_to_config, thinking_config_value, CommandResult,
+    // `/compact` keeps the TUI's own guards + `SessionCommand::Compact`
+    // (dispatch.rs Compact arm) instead of the actor's chat-style path.
+    if let Some(synaps_cli::engine::commands::CommandResult::Compact {
+        custom_instructions,
+    }) = synaps_cli::engine::commands::evaluate_engine_command(cmd, arg)
+    {
+        return CommandAction::Compact {
+            custom_instructions,
         };
-        return match result {
-            CommandResult::Quit => CommandAction::Quit,
-            CommandResult::ModelChanged {
-                reasoning_clamped, ..
-            } => {
-                // Use the runtime's cleaned model string, not the raw arg.
-                let applied = runtime.model().to_string();
+    }
+    if synaps_cli::engine::commands::evaluate_engine_command(cmd, arg).is_some()
+        || matches!(cmd, "context" | "trace" | "memory")
+    {
+        use synaps_cli::engine::commands::persist_to_config;
+        let value = match link.engine_command(cmd, arg).await {
+            Ok(v) => v,
+            Err(e) => {
+                app.push_msg(ChatMessage::Error(e));
+                return CommandAction::None;
+            }
+        };
+        let text = |v: &serde_json::Value| v["text"].as_str().unwrap_or("").to_string();
+        // `event` carries the structured kind (model_changed/thinking_changed)
+        // alongside the chat-facing `kind`/`text`.
+        let key = value["event"]
+            .as_str()
+            .or_else(|| value["kind"].as_str())
+            .unwrap_or("none");
+        return match key {
+            "quit" => CommandAction::Quit,
+            "model_changed" => {
+                // The runtime's cleaned model string, not the raw arg.
+                let applied = value["model"].as_str().unwrap_or("").to_string();
                 app.session.model = applied.clone();
                 let status = persist_to_config("model", &applied);
                 app.push_msg(ChatMessage::System(format!(
@@ -437,35 +452,41 @@ pub(super) async fn handle_command(
                     applied, status
                 )));
                 // Session-only: the user's configured thinking value stays theirs.
-                if let Some(clamp) = reasoning_clamped {
-                    app.session.thinking_level = runtime.thinking_level().to_string();
-                    app.push_msg(ChatMessage::System(reasoning_clamp_notice(
-                        &clamp, &applied,
+                if let (Some(from), Some(to)) = (
+                    value["clamp"]["from"].as_str(),
+                    value["clamp"]["to"].as_str(),
+                ) {
+                    app.session.thinking_level = to.to_string();
+                    app.push_msg(ChatMessage::System(reasoning_clamp_notice_wire(
+                        &agent_engine::session::ReasoningClampWire {
+                            from: from.to_string(),
+                            to: to.to_string(),
+                        },
+                        &applied,
                     )));
                 }
                 CommandAction::None
             }
-            CommandResult::ThinkingChanged { spec } => {
-                app.session.thinking_level = thinking_config_value(spec);
-                let status = persist_to_config("thinking", &thinking_config_value(spec));
+            "thinking_changed" => {
+                let config_value = value["config_value"].as_str().unwrap_or("").to_string();
+                let level = value["level"].as_str().unwrap_or("").to_string();
+                app.session.thinking_level = config_value.clone();
+                let status = persist_to_config("thinking", &config_value);
                 app.push_msg(ChatMessage::System(format!(
                     "thinking set to: {} {}",
-                    spec.level(),
-                    status,
+                    level, status,
                 )));
                 CommandAction::None
             }
-            CommandResult::Compact {
-                custom_instructions,
-            } => CommandAction::Compact {
-                custom_instructions,
+            "compact" => CommandAction::Compact {
+                custom_instructions: value["instructions"].as_str().map(str::to_string),
             },
-            CommandResult::Error(e) => {
-                app.push_msg(ChatMessage::Error(e));
+            "error" => {
+                app.push_msg(ChatMessage::Error(text(&value)));
                 CommandAction::None
             }
-            CommandResult::Output(text) => {
-                app.push_msg(ChatMessage::System(text));
+            "output" => {
+                app.push_msg(ChatMessage::System(text(&value)));
                 CommandAction::None
             }
             _ => CommandAction::None,
@@ -474,15 +495,19 @@ pub(super) async fn handle_command(
 
     match cmd {
         "prompt" => match arg.trim() {
-            "reload" | "apply" => match runtime.reload_prompt() {
-                Ok(generation) => app.push_msg(ChatMessage::System(format!(
-                    "prompt applied (generation {generation})"
+            "reload" | "apply" => match link
+                .set_checked(agent_engine::session::SessionSetting::ReloadPrompt)
+                .await
+            {
+                Ok(applied) => app.push_msg(ChatMessage::System(format!(
+                    "prompt applied (generation {})",
+                    applied.view.prompt_generation
                 ))),
                 Err(error) => app.push_msg(ChatMessage::Error(format!(
                     "prompt reload rejected: {error}"
                 ))),
             },
-            "status" | "" => match runtime.prompt_inspection_json() {
+            "status" | "" => match link.view().prompt_inspection.clone() {
                 Some(status) => app.push_msg(ChatMessage::System(status)),
                 None => app.push_msg(ChatMessage::Error("no prompt manifest is active".into())),
             },
@@ -491,23 +516,14 @@ pub(super) async fn handle_command(
             )),
         },
         "clear" => {
-            app.save_session().await;
-            app.transcript.clear();
-            app.invalidate();
-            app.api_messages.clear();
-            app.total_input_tokens = 0;
-            app.total_output_tokens = 0;
-            app.total_cache_read_tokens = 0;
-            app.total_cache_creation_tokens = 0;
-            app.session_cost = 0.0;
-            app.input_tokens = 0;
-            app.output_tokens = 0;
-            app.session = Session::new(
-                runtime.model(),
-                runtime.thinking_level(),
-                runtime.system_prompt(),
-            );
-            app.push_msg(ChatMessage::System("new session started".to_string()));
+            // The actor saves + clears; presentation on `Cleared` +
+            // `Conversation` (stream_handler).
+            if let Err(e) = link
+                .send(agent_engine::session::SessionCommand::NewSession)
+                .await
+            {
+                app.push_msg(ChatMessage::Error(format!("clear failed: {e}")));
+            }
         }
         "model" | "models" => {
             // Non-empty args are intercepted by handle_engine_command above
@@ -526,7 +542,10 @@ pub(super) async fn handle_command(
                 ));
             } else if arg == "save" {
                 let _ = std::fs::create_dir_all(synaps_cli::config::get_active_config_dir());
-                match std::fs::write(system_prompt_path, runtime.system_prompt().unwrap_or("")) {
+                match std::fs::write(
+                    system_prompt_path,
+                    link.view().system_prompt.as_deref().unwrap_or(""),
+                ) {
                     Ok(_) => app.push_msg(ChatMessage::System(format!(
                         "saved to {}",
                         system_prompt_path.display()
@@ -534,11 +553,24 @@ pub(super) async fn handle_command(
                     Err(e) => app.push_msg(ChatMessage::Error(format!("failed to save: {}", e))),
                 }
             } else if arg == "show" {
-                let prompt = runtime.system_prompt().unwrap_or("(none)");
-                app.push_msg(ChatMessage::System(prompt.to_string()));
+                let prompt = link
+                    .view()
+                    .system_prompt
+                    .clone()
+                    .unwrap_or_else(|| "(none)".to_string());
+                app.push_msg(ChatMessage::System(prompt));
             } else {
-                runtime.set_system_prompt(arg.to_string());
-                app.push_msg(ChatMessage::System("system prompt updated".to_string()));
+                match link
+                    .set_checked(agent_engine::session::SessionSetting::SystemPrompt {
+                        text: arg.to_string(),
+                    })
+                    .await
+                {
+                    Ok(_) => {
+                        app.push_msg(ChatMessage::System("system prompt updated".to_string()))
+                    }
+                    Err(e) => app.push_msg(ChatMessage::Error(e)),
+                }
             }
         }
         "thinking" => {
@@ -546,8 +578,8 @@ pub(super) async fn handle_command(
             // (set + persist); only the empty-arg status case reaches here.
             app.push_msg(ChatMessage::System(format!(
                 "thinking: {} ({})",
-                runtime.thinking_level(),
-                runtime.thinking_budget()
+                link.view().thinking_level,
+                link.view().thinking_budget
             )));
         }
         "context" => {
@@ -559,7 +591,7 @@ pub(super) async fn handle_command(
                 "" => {
                     app.push_msg(ChatMessage::System(format!(
                         "context window: {} tokens",
-                        runtime.context_window()
+                        link.view().context_window
                     )));
                     None
                 }
@@ -571,8 +603,18 @@ pub(super) async fn handle_command(
                 }
             };
             if let Some(window) = window {
-                runtime.set_context_window(window);
-                app.last_turn_context_window = runtime.context_window();
+                match link
+                    .set_checked(agent_engine::session::SessionSetting::ContextWindow {
+                        tokens: window,
+                    })
+                    .await
+                {
+                    Ok(applied) => app.last_turn_context_window = applied.view.context_window,
+                    Err(e) => {
+                        app.push_msg(ChatMessage::Error(e));
+                        return CommandAction::None;
+                    }
+                }
                 let canonical = arg.to_ascii_lowercase();
                 let status =
                     synaps_cli::engine::commands::persist_to_config("context_window", &canonical);
@@ -650,43 +692,20 @@ pub(super) async fn handle_command(
                     "usage: /resume <name_or_id>".to_string(),
                 ));
             } else {
-                match resolve_session(arg) {
-                    Ok(session) => {
-                        runtime.set_model(session.model.clone());
-                        // A resumed session owns its saved choice. Preserve that
-                        // explicit provenance across later model switches.
-                        let clamp_notice =
-                            restore_session_reasoning(runtime, &session.thinking_level);
-                        if let Some(ref sp) = session.system_prompt {
-                            runtime.set_system_prompt(sp.clone());
-                        }
-                        app.save_session().await;
-                        let old_id = app.session.id.clone();
+                // The actor saves the current session, loads the target,
+                // restores model/reasoning/system prompt and swaps the
+                // conversation (actor_cmds::resume); the `Conversation`
+                // that follows carries the new messages + header.
+                match link.resume(arg).await {
+                    Ok(reply) => {
                         app.transcript.clear();
                         app.invalidate();
-                        app.api_messages = session.api_messages.clone();
-                        app.total_input_tokens = session.total_input_tokens;
-                        app.total_output_tokens = session.total_output_tokens;
-                        app.session_cost = session.session_cost;
-                        super::rebuild_display_messages(&session.api_messages, app);
-                        let new_id = session.id.clone();
-                        app.session = session;
-                        if let Some(notice) = clamp_notice {
-                            // Keep the session file in sync with the clamped runtime.
-                            app.session.thinking_level = runtime.thinking_level().to_string();
-                            app.push_msg(ChatMessage::System(notice));
-                        }
-                        let via = if synaps_cli::chain::load_chain(arg).is_ok() {
-                            format!(" (via chain '{}')", arg)
-                        } else if synaps_cli::session::find_session_by_name(arg).is_ok() {
-                            format!(" (via name '{}')", arg)
-                        } else {
-                            String::new()
-                        };
-                        app.push_msg(ChatMessage::System(format!(
-                            "switched from {} to {}{}",
-                            old_id, new_id, via
-                        )));
+                        app.resume_pending = Some(super::app::ResumePending {
+                            old_id: reply.old_id,
+                            new_id: reply.new_id,
+                            via: reply.via,
+                            clamp_notice: reply.clamp_notice,
+                        });
                     }
                     Err(e) => {
                         app.push_msg(ChatMessage::Error(format!("failed to load session: {}", e)));
@@ -695,25 +714,27 @@ pub(super) async fn handle_command(
             }
         }
         "saveas" => {
+            // Naming lives on the actor's session (it owns the journal):
+            // `EngineCommand{saveas}` → actor_cmds sets/clears the name and
+            // force-saves; reply text is rendered as before.
             let trimmed = arg.trim();
-            if trimmed.is_empty() {
-                app.session.clear_name();
-                // Force save even with no messages — persist the name change
-                let _ = app.session.save().await;
-                app.push_msg(ChatMessage::System("session name cleared".into()));
-            } else {
-                match app.session.set_name(trimmed) {
-                    Ok(()) => {
-                        // Force save even with no messages — persist the name change
-                        let _ = app.session.save().await;
-                        app.push_msg(ChatMessage::System(format!("session named '{}'", trimmed)));
+            match link.engine_command("saveas", trimmed).await {
+                Ok(value) => match value["kind"].as_str() {
+                    Some("output") => {
+                        app.session.name = value["name"].as_str().map(str::to_string);
+                        app.push_msg(ChatMessage::System(
+                            value["text"].as_str().unwrap_or("").to_string(),
+                        ));
                     }
-                    Err(e) => {
-                        app.push_msg(ChatMessage::Error(format!("saveas failed: {}", e)));
-                    }
-                }
+                    _ => app.push_msg(ChatMessage::Error(format!(
+                        "saveas failed: {}",
+                        value["text"].as_str().unwrap_or("unknown error")
+                    ))),
+                },
+                Err(e) => app.push_msg(ChatMessage::Error(format!("saveas failed: {}", e))),
             }
         }
+
         "help" => {
             let trimmed = arg.trim();
             if trimmed == "find" || trimmed.starts_with("find ") {
@@ -929,7 +950,7 @@ pub(super) async fn handle_command(
             return CommandAction::Status;
         }
         "stats" => {
-            let receipt = build_stats_receipt(app, runtime);
+            let receipt = build_stats_receipt(app, &**link.view());
             app.push_msg(ChatMessage::System(receipt));
             return CommandAction::None;
         }
@@ -1124,7 +1145,10 @@ pub(super) async fn handle_command(
 ///
 /// Returns a multi-line string ready to be pushed as `ChatMessage::System`.
 /// Exported for unit testing.
-pub(crate) fn build_stats_receipt(app: &App, runtime: &Runtime) -> String {
+pub(crate) fn build_stats_receipt(
+    app: &App,
+    runtime: &impl agent_engine::session::RuntimeRead,
+) -> String {
     use synaps_cli::pricing::calculate_cost_split;
 
     let model = runtime.model().to_string();
@@ -1260,6 +1284,7 @@ pub(super) fn handle_streaming_command(
 }
 
 /// Notice shown when a model change forced a reasoning-level substitution.
+#[allow(dead_code)]
 pub(crate) fn reasoning_clamp_notice(
     clamp: &synaps_cli::runtime::ReasoningClamp,
     model: &str,
@@ -1272,13 +1297,24 @@ pub(crate) fn reasoning_clamp_notice(
     )
 }
 
+/// Same line from the wire form (`SettingApplied.clamp`).
+pub(crate) fn reasoning_clamp_notice_wire(
+    clamp: &agent_engine::session::ReasoningClampWire,
+    model: &str,
+) -> String {
+    format!(
+        "thinking → {} (clamped from {}: not supported by {})",
+        clamp.to, clamp.from, model
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::command_output_event_to_chat_message;
     use super::{
         build_stats_receipt, edit_distance, execute_command_action,
         execute_interactive_plugin_command_events, fuzzy_match, handle_command, resolve_prefix,
-        restore_session_reasoning, CommandAction, ExtensionsMemoryAction, ExtensionsTrustAction,
+        CommandAction, ExtensionsMemoryAction, ExtensionsTrustAction,
     };
     use crate::tui::app::ChatMessage;
     use async_trait::async_trait;
@@ -1352,7 +1388,7 @@ mod tests {
             }],
         );
         let mut app = crate::tui::app::App::new(synaps_cli::Session::new("test", "medium", None));
-        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
+        let mut link = scripted_link(synaps_cli::Runtime::new().await.unwrap());
         let system_prompt_path = PathBuf::from("/tmp/synaps-test-system-prompt");
         let registry = Arc::new(registry);
         let keybinds = synaps_cli::skills::keybinds::KeybindRegistry::new();
@@ -1361,7 +1397,7 @@ mod tests {
             "policy:mode",
             "strict",
             &mut app,
-            &mut runtime,
+            &mut link,
             &system_prompt_path,
             &registry,
             &keybinds,
@@ -1375,6 +1411,13 @@ mod tests {
             }
             _ => panic!("expected plugin command action"),
         }
+    }
+
+    /// A `SessionLink` over the scripted in-memory actor (A5).
+    fn scripted_link(runtime: synaps_cli::Runtime) -> crate::tui::session_link::SessionLink {
+        crate::tui::session_link::SessionLink::new(Box::new(
+            crate::tui::testing::scripted::ScriptedTransport::new(runtime),
+        ))
     }
 
     struct EchoTool;
@@ -1404,6 +1447,7 @@ mod tests {
         tools.register(Arc::new(EchoTool));
         let mut runtime = synaps_cli::Runtime::new().await.unwrap();
         runtime.set_tools(tools);
+        let mut link = scripted_link(runtime);
         let mut app = crate::tui::app::App::new(synaps_cli::Session::new("test", "medium", None));
         let command = Arc::new(RegisteredPluginCommand {
             plugin: "policy".to_string(),
@@ -1415,6 +1459,9 @@ mod tests {
             },
             plugin_root: PathBuf::from("/tmp/policy"),
         });
+        // The actor resolves the command by plugin:name on the host's
+        // registry; the scripted actor resolves it here.
+        crate::tui::testing::scripted::register_plugin_command(Arc::clone(&command));
 
         execute_command_action(
             CommandAction::PluginCommand {
@@ -1422,7 +1469,7 @@ mod tests {
                 arg: "hello".to_string(),
             },
             &mut app,
-            &runtime,
+            &mut link,
         )
         .await;
 
@@ -1642,7 +1689,7 @@ mod tests {
 
     async fn invoke_extensions(arg: &str) -> CommandAction {
         let mut app = crate::tui::app::App::new(synaps_cli::Session::new("test", "medium", None));
-        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
+        let mut link = scripted_link(synaps_cli::Runtime::new().await.unwrap());
         let system_prompt_path = PathBuf::from("/tmp/synaps-test-system-prompt");
         let registry = Arc::new(CommandRegistry::new_with_plugins(&[], vec![], vec![]));
         let keybinds = synaps_cli::skills::keybinds::KeybindRegistry::new();
@@ -1650,7 +1697,7 @@ mod tests {
             "extensions",
             arg,
             &mut app,
-            &mut runtime,
+            &mut link,
             &system_prompt_path,
             &registry,
             &keybinds,
@@ -1847,13 +1894,13 @@ mod tests {
             vec![lifecycle_plugin("sample-sidecar", "capture")],
         ));
         let mut app = crate::tui::app::App::new(synaps_cli::Session::new("test", "medium", None));
-        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
+        let mut link = scripted_link(synaps_cli::Runtime::new().await.unwrap());
         let keybinds = synaps_cli::skills::keybinds::KeybindRegistry::new();
         let action = handle_command(
             "capture",
             "toggle",
             &mut app,
-            &mut runtime,
+            &mut link,
             &PathBuf::from("/tmp/sp"),
             &registry,
             &keybinds,
@@ -1879,13 +1926,13 @@ mod tests {
             vec![lifecycle_plugin("sample-sidecar", "capture")],
         ));
         let mut app = crate::tui::app::App::new(synaps_cli::Session::new("test", "medium", None));
-        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
+        let mut link = scripted_link(synaps_cli::Runtime::new().await.unwrap());
         let keybinds = synaps_cli::skills::keybinds::KeybindRegistry::new();
         let action = handle_command(
             "capture",
             "",
             &mut app,
-            &mut runtime,
+            &mut link,
             &PathBuf::from("/tmp/sp"),
             &registry,
             &keybinds,
@@ -1902,13 +1949,13 @@ mod tests {
             vec![lifecycle_plugin("sample-sidecar", "capture")],
         ));
         let mut app = crate::tui::app::App::new(synaps_cli::Session::new("test", "medium", None));
-        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
+        let mut link = scripted_link(synaps_cli::Runtime::new().await.unwrap());
         let keybinds = synaps_cli::skills::keybinds::KeybindRegistry::new();
         let action = handle_command(
             "capture",
             "status",
             &mut app,
-            &mut runtime,
+            &mut link,
             &PathBuf::from("/tmp/sp"),
             &registry,
             &keybinds,
@@ -1937,13 +1984,13 @@ mod tests {
             vec![lifecycle_plugin("sample-sidecar", "capture")],
         ));
         let mut app = crate::tui::app::App::new(synaps_cli::Session::new("test", "medium", None));
-        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
+        let mut link = scripted_link(synaps_cli::Runtime::new().await.unwrap());
         let keybinds = synaps_cli::skills::keybinds::KeybindRegistry::new();
         let action = handle_command(
             "capture",
             "toggle",
             &mut app,
-            &mut runtime,
+            &mut link,
             &PathBuf::from("/tmp/sp"),
             &registry,
             &keybinds,
@@ -1963,13 +2010,13 @@ mod tests {
             vec![lifecycle_plugin("sample-sidecar", "capture")],
         ));
         let mut app = crate::tui::app::App::new(synaps_cli::Session::new("test", "medium", None));
-        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
+        let mut link = scripted_link(synaps_cli::Runtime::new().await.unwrap());
         let keybinds = synaps_cli::skills::keybinds::KeybindRegistry::new();
         let action = handle_command(
             "capture",
             "bogus",
             &mut app,
-            &mut runtime,
+            &mut link,
             &PathBuf::from("/tmp/sp"),
             &registry,
             &keybinds,
@@ -1987,14 +2034,14 @@ mod tests {
         plugins: Vec<synaps_cli::skills::Plugin>,
     ) -> (CommandAction, crate::tui::app::App) {
         let mut app = crate::tui::app::App::new(synaps_cli::Session::new("test", "medium", None));
-        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
+        let mut link = scripted_link(synaps_cli::Runtime::new().await.unwrap());
         let registry = Arc::new(CommandRegistry::new_with_plugins(&[], vec![], plugins));
         let keybinds = synaps_cli::skills::keybinds::KeybindRegistry::new();
         let action = handle_command(
             "sidecar",
             arg,
             &mut app,
-            &mut runtime,
+            &mut link,
             &PathBuf::from("/tmp/sp"),
             &registry,
             &keybinds,
@@ -2159,7 +2206,7 @@ mod tests {
         app.total_cache_write_1h = 200;
         app.session_cost = 0.0042;
 
-        let runtime = synaps_cli::Runtime::new().await.unwrap();
+        let runtime = synaps_cli::Runtime::new_headless();
         let receipt = build_stats_receipt(&app, &runtime);
 
         assert!(receipt.contains("Session Stats"), "missing header");
@@ -2169,40 +2216,5 @@ mod tests {
         assert!(receipt.contains("saved:"), "missing savings line");
         assert!(receipt.contains("5m:"), "missing 5m split");
         assert!(receipt.contains("1h:"), "missing 1h split");
-    }
-
-    #[tokio::test]
-    async fn resume_restores_ultra_with_explicit_provenance() {
-        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
-        runtime.set_model("openai-codex/gpt-5.6-sol".to_string());
-
-        restore_session_reasoning(&mut runtime, "ultra");
-
-        assert_eq!(
-            runtime.reasoning_level(),
-            agent_core::reasoning::ReasoningLevel::Ultra
-        );
-        assert!(runtime.is_reasoning_explicit());
-        runtime.set_model("openai-codex/gpt-5.6-terra".to_string());
-        assert_eq!(
-            runtime.reasoning_level(),
-            agent_core::reasoning::ReasoningLevel::Ultra,
-            "restored explicit Ultra must survive model switches"
-        );
-    }
-
-    #[tokio::test]
-    async fn resume_clamps_unsupported_saved_level() {
-        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
-        runtime.set_model("xai-auth/grok-4.6".to_string());
-
-        let notice = restore_session_reasoning(&mut runtime, "xhigh");
-
-        assert!(notice.is_some(), "clamp must be surfaced");
-        assert_eq!(
-            runtime.reasoning_level(),
-            agent_core::reasoning::ReasoningLevel::High
-        );
-        assert!(runtime.is_reasoning_explicit());
     }
 }

--- a/crates/agent-tui/src/tui/dispatch.rs
+++ b/crates/agent-tui/src/tui/dispatch.rs
@@ -27,9 +27,9 @@ use super::*;
 
 use std::ops::ControlFlow;
 
-fn spawn_auto_catalog_refreshes(app: &App, runtime: &synaps_cli::Runtime) {
+fn spawn_auto_catalog_refreshes(app: &App, http: &reqwest::Client) {
     for &provider_key in models::auto_refresh_catalog_providers() {
-        let client = runtime.http_client().clone();
+        let client = http.clone();
         let tx = app.model_list_tx.clone();
         let key = provider_key.to_string();
         tokio::spawn(async move {
@@ -76,7 +76,10 @@ fn spawn_auto_catalog_refreshes(app: &App, runtime: &synaps_cli::Runtime) {
 /// site and consumed by value, so no borrow outlives the arm.
 pub(crate) struct LoopState<'a> {
     pub app: &'a mut App,
-    pub runtime: &'a mut synaps_cli::Runtime,
+    /// The session behind its transport (+ the published `RuntimeView`).
+    pub link: &'a mut session_link::SessionLink,
+    /// Client-local HTTP client for catalog/model-list fetches.
+    pub http: &'a reqwest::Client,
     pub config: &'a mut synaps_cli::SynapsConfig,
     pub registry: &'a std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
     pub keybind_registry:
@@ -87,15 +90,54 @@ pub(crate) struct LoopState<'a> {
     /// reader early through a `&mut` without moving it; always `Some` on
     /// entry and on return.
     pub event_reader: &'a mut Option<EventStream>,
-    pub stream: &'a mut Option<
-        std::pin::Pin<Box<dyn futures::Stream<Item = synaps_cli::StreamEvent> + Send>>,
-    >,
-    pub secret_prompt_handle: &'a synaps_cli::tools::SecretPromptHandle,
-    pub cancel_token: &'a mut Option<CancellationToken>,
-    pub steer_tx: &'a mut Option<tokio::sync::mpsc::UnboundedSender<String>>,
-    pub ext_mgr_shared:
+    /// `Some` in-process; `None` over the socket (an empty manager stands
+    /// in so `/extensions` & friends answer "nothing loaded").
+    pub ext_mgr_shared: Option<
         &'a std::sync::Arc<tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>>,
+    >,
     pub exit_fx_sent: &'a mut bool,
+}
+
+/// Stand-in extension manager for the socket client (no extension host in
+/// this process).
+fn empty_ext_manager(
+) -> &'static std::sync::Arc<tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>>
+{
+    static EMPTY: std::sync::OnceLock<
+        std::sync::Arc<tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>>,
+    > = std::sync::OnceLock::new();
+    EMPTY.get_or_init(|| {
+        std::sync::Arc::new(tokio::sync::RwLock::new(
+            synaps_cli::extensions::manager::ExtensionManager::new(std::sync::Arc::new(
+                synaps_cli::extensions::hooks::HookBus::new(),
+            )),
+        ))
+    })
+}
+
+/// Pre-send presentation shared by Submit / LoadSkill (dispatch.rs Submit
+/// :1257-1272): "connecting…", streaming, spinner, one published frame.
+fn begin_turn_presentation(
+    app: &mut App,
+    view: &agent_engine::session::RuntimeView,
+    registry: &std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
+    render_handle: &render_thread::RenderHandle,
+) {
+    app.status_text = Some("connecting…".to_string());
+    app.streaming = true;
+    app.turn_baseline = app.api_messages.len();
+    app.spinner_frame = 0;
+    let term_size = crossterm::terminal::size()
+        .map(|(w, h)| ratatui::layout::Size {
+            width: w,
+            height: h,
+        })
+        .unwrap_or_default();
+    let built = build_render_model(&mut ViewInputs::from_app(app), view, registry, term_size);
+    if let Some((model, patch)) = built {
+        patch.apply(app);
+        render_handle.publish(model);
+    }
 }
 
 /// Dispatch one decoded [`InputAction`]. `ControlFlow::Continue(())` means
@@ -108,20 +150,23 @@ pub(crate) async fn handle_input_action(
 ) -> ControlFlow<()> {
     let LoopState {
         app,
-        runtime,
+        link,
+        http,
         config,
         registry,
         keybind_registry,
         system_prompt_path,
         render_handle,
         event_reader,
-        stream,
-        secret_prompt_handle,
-        cancel_token,
-        steer_tx,
         ext_mgr_shared,
         exit_fx_sent,
     } = state;
+    let ext_mgr_shared: &std::sync::Arc<
+        tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>,
+    > = match ext_mgr_shared {
+        Some(m) => m,
+        None => empty_ext_manager(),
+    };
     // Body verbatim from mod.rs:486-1796 (original indentation preserved for
     // diff-ability of the motion; see module header for the mechanical edits).
     match action {
@@ -132,58 +177,11 @@ pub(crate) async fn handle_input_action(
             *exit_fx_sent = true;
         }
         InputAction::Abort => {
-            if let Some(ref ct) = *cancel_token {
-                ct.cancel();
-            }
-            app.capture_abort_context();
-            if let Some(ref q) = app.queued_message.take() {
-                app.push_msg(ChatMessage::System(format!("dequeued: {}", q)));
-            }
-            // Flush any events that arrived during streaming
-            for formatted in app.pending_events.drain(..) {
-                app.api_messages
-                    .push(std::sync::Arc::new(serde_json::json!({
-                        "role": "user",
-                        "content": formatted
-                    })));
-            }
-            *stream = None;
-            *cancel_token = None;
-            *steer_tx = None;
-            app.streaming = false;
-            app.subagents.clear();
-            // Cancel all running reactive subagents. A poisoned
-            // registry mutex must not turn a user abort into a
-            // panic (the old `.unwrap()`), but nor should it
-            // silently skip cancellation and leave orphaned
-            // subagents burning tokens — recover the guard and
-            // cancel anyway, logging the poison. Scoped in its
-            // own block so the guard drops before any `.await`
-            // below (clippy::await_holding_lock).
-            {
-                let mut registry = match runtime.subagent_registry().lock() {
-                    Ok(g) => g,
-                    Err(poisoned) => {
-                        tracing::warn!(
-                                                "subagent registry mutex poisoned during abort; recovering to cancel running handles"
-                                            );
-                        poisoned.into_inner()
-                    }
-                };
-                for handle in registry.iter_mut_handles() {
-                    if handle.status() == synaps_cli::runtime::subagent::SubagentStatus::Running {
-                        handle.cancel();
-                    }
-                }
-            }
-            let abort_msg = if app.abort_context.is_some() {
-                "aborted — context saved for next message"
-            } else {
-                "aborted"
-            };
-            app.drop_empty_thinking();
-            app.push_msg(ChatMessage::Error(abort_msg.to_string()));
-            app.save_session().await;
+            // The actor cancels the turn, captures abort context, dequeues,
+            // flushes pending events, cancels subagents and saves; the
+            // presentation ("dequeued: …", the aborted line, HUD clear)
+            // follows on `Dequeued` / `Aborted` (stream_handler).
+            let _ = link.send(agent_engine::session::SessionCommand::Cancel).await;
         }
         InputAction::SlashCommand(cmd, arg) => {
             let kb_snapshot = {
@@ -194,7 +192,7 @@ pub(crate) async fn handle_input_action(
                 &cmd,
                 &arg,
                 app,
-                runtime,
+                link,
                 system_prompt_path,
                 registry,
                 &kb_snapshot,
@@ -237,21 +235,21 @@ pub(crate) async fn handle_input_action(
                     app.modal_stack.push(focus::PaneId::Models);
                     #[cfg(debug_assertions)]
                     focus::debug_assert_stack_sync(app);
-                    spawn_auto_catalog_refreshes(app, runtime);
+                    spawn_auto_catalog_refreshes(app, http);
                 }
                 CommandAction::OpenEffort => {
                     // Defense in depth: the streaming-input path already
                     // refuses /effort while streaming; this guard covers any
                     // future action source. Never open mid-stream.
-                    if app.streaming || stream.is_some() {
+                    if app.streaming {
                         app.push_msg(ChatMessage::System(
                             "/effort can't run while streaming — press Esc to cancel first"
                                 .to_string(),
                         ));
                     } else {
                         app.effort = Some(effort::EffortModalState::new(
-                            runtime.model(),
-                            runtime.thinking_level(),
+                            &link.view().model,
+                            &link.view().thinking_level,
                         ));
                         app.modal_stack.push(focus::PaneId::Effort);
                         #[cfg(debug_assertions)]
@@ -269,7 +267,7 @@ pub(crate) async fn handle_input_action(
                     focus::debug_assert_stack_sync(app);
                     // Same live-catalog refresh the /models modal runs: the
                     // settings model picker feeds off app.catalog_overrides.
-                    spawn_auto_catalog_refreshes(app, runtime);
+                    spawn_auto_catalog_refreshes(app, http);
                 }
                 CommandAction::OpenPlugins => {
                     let path = synaps_cli::skills::state::PluginsState::default_path();
@@ -327,7 +325,8 @@ pub(crate) async fn handle_input_action(
                             app.push_msg(ChatMessage::System(reason));
                         }
                         Ok(body) => {
-                            app.api_messages.push(std::sync::Arc::new(json!({
+                            let mut messages: Vec<synaps_cli::SharedMessage> = Vec::new();
+                            messages.push(std::sync::Arc::new(json!({
                                 "role": "assistant",
                                 "content": [{
                                     "type": "tool_use",
@@ -336,7 +335,7 @@ pub(crate) async fn handle_input_action(
                                     "input": {"skill": skill.name.clone()}
                                 }]
                             })));
-                            app.api_messages.push(std::sync::Arc::new(json!({
+                            messages.push(std::sync::Arc::new(json!({
                                 "role": "user",
                                 "content": [{
                                     "type": "tool_result",
@@ -353,50 +352,21 @@ pub(crate) async fn handle_input_action(
                                 display_name
                             )));
 
-                            if !arg.is_empty() {
-                                app.api_messages.push(std::sync::Arc::new(
-                                    json!({"role": "user", "content": arg.clone()}),
-                                ));
-                                app.push_msg(ChatMessage::User(arg));
-                            }
+                            let user_text = if !arg.is_empty() {
+                                app.push_msg(ChatMessage::User(arg.clone()));
+                                Some(arg)
+                            } else {
+                                None
+                            };
                             // Start stream — mirror InputAction::Submit stream-start pattern.
-                            let ct = CancellationToken::new();
-                            let (s_tx, s_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-                            app.status_text = Some("connecting…".to_string());
-                            app.streaming = true;
-                            app.turn_baseline = app.api_messages.len();
-                            app.spinner_frame = 0;
-                            let term_size = crossterm::terminal::size()
-                                .map(|(w, h)| ratatui::layout::Size {
-                                    width: w,
-                                    height: h,
+                            let view = std::sync::Arc::clone(link.view());
+                            begin_turn_presentation(app, &view, registry, render_handle);
+                            let _ = link
+                                .send(agent_engine::session::SessionCommand::SubmitPrepared {
+                                    messages,
+                                    user_text,
                                 })
-                                .unwrap_or_default();
-                            let built = build_render_model(
-                                &mut ViewInputs::from_app(app),
-                                runtime,
-                                registry,
-                                term_size,
-                            );
-                            if let Some((model, patch)) = built {
-                                patch.apply(app);
-                                render_handle.publish(model);
-                            }
-                            *stream = Some(
-                                runtime
-                                    .run_stream_with_messages(
-                                        app.api_messages.clone(),
-                                        ct.clone(),
-                                        Some(s_rx),
-                                        Some(secret_prompt_handle.clone()),
-                                        false,
-                                    )
-                                    .await,
-                            );
-                            app.status_text = None;
-                            app.push_msg(ChatMessage::Thinking(THINKING_PLACEHOLDER.to_string()));
-                            *cancel_token = Some(ct);
-                            *steer_tx = Some(s_tx);
+                                .await;
                         }
                     }
                 }
@@ -414,7 +384,7 @@ pub(crate) async fn handle_input_action(
                         commands::execute_command_action(
                             CommandAction::PluginCommand { command, arg },
                             app,
-                            runtime,
+                            link,
                         )
                         .await;
                     }
@@ -427,32 +397,18 @@ pub(crate) async fn handle_input_action(
                         app.push_msg(ChatMessage::System(
                             "nothing to compact (need at least 2 turns)".to_string(),
                         ));
-                    } else if app.compact_task.is_some() {
+                    } else if app.compacting {
                         app.push_msg(ChatMessage::System(
                             "compaction already in progress".to_string(),
                         ));
                     } else {
-                        // Spec §9.4: surface provider/model and approximate
-                        // disclosure BEFORE the summarization dispatch.
-                        let disclosure =
-                            synaps_cli::runtime::compaction::preview_compaction_disclosure(
-                                runtime,
-                                &app.api_messages,
-                            );
-                        app.push_msg(ChatMessage::System(disclosure.render_line()));
-                        app.push_msg(ChatMessage::System(
-                            "compacting conversation...".to_string(),
-                        ));
-                        app.status_text = Some("compacting…".to_string());
-                        app.spinner_frame = 0;
-
-                        let msgs = app.api_messages.clone();
-                        let rt = runtime.clone();
-                        let instr = custom_instructions.clone();
-                        let handle = tokio::spawn(async move {
-                            compact_conversation(&msgs, &rt, instr.as_deref()).await
-                        });
-                        app.compact_task = Some(handle);
+                        // Disclosure + "compacting conversation..." +
+                        // status arrive on `CompactionStarted` (§2.4).
+                        let _ = link
+                            .send(agent_engine::session::SessionCommand::Compact {
+                                instructions: custom_instructions.clone(),
+                            })
+                            .await;
                     }
                 }
                 CommandAction::Chain => {
@@ -575,7 +531,7 @@ pub(crate) async fn handle_input_action(
                     }
                 }
                 CommandAction::Status => {
-                    if runtime.model().contains('/') {
+                    if link.view().model.contains('/') {
                         app.push_msg(ChatMessage::System(
                             "Usage stats are only available for Anthropic models.".to_string(),
                         ));
@@ -1229,62 +1185,34 @@ pub(crate) async fn handle_input_action(
             }
         }
         InputAction::Submit(input) => {
-            // Queue input during compaction — will be sent after session swap
-            if app.compact_task.is_some() {
-                app.push_msg(ChatMessage::System(format!("queued: {}", input)));
-                app.queued_message = Some(input);
+            // Queue input during compaction — the actor queues it (B2) and
+            // answers `Steered{delivered:false}` → "queued: …".
+            if app.compacting {
+                let _ = link
+                    .send(agent_engine::session::SessionCommand::Submit {
+                        text: input,
+                        attachments: Vec::new(),
+                    })
+                    .await;
                 return ControlFlow::Continue(());
             }
             let display_text = app.user_display_text_for_submission(&input);
             app.push_msg(ChatMessage::User(display_text));
             app.input_before_paste = None;
             app.pasted_char_count = 0;
-            // Real user send — reset auto-turn counter.
+            // Real user send — reset auto-turn counter (mirrored back by
+            // `Conversation`; abort-context fold + history push are the
+            // actor's).
             app.consecutive_auto_turns = 0;
-            // Inject abort context if previous response was interrupted
-            let api_content = if let Some(ref ctx) = app.abort_context {
-                let combined = format!("{}\n\n{}", ctx, input);
-                app.abort_context = None;
-                combined
-            } else {
-                input
-            };
-            app.api_messages.push(std::sync::Arc::new(
-                json!({"role": "user", "content": api_content}),
-            ));
-            let ct = CancellationToken::new();
-            let (s_tx, s_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-            app.status_text = Some("connecting…".to_string());
-            app.streaming = true;
-            app.turn_baseline = app.api_messages.len();
-            app.spinner_frame = 0;
-            let term_size = crossterm::terminal::size()
-                .map(|(w, h)| ratatui::layout::Size {
-                    width: w,
-                    height: h,
+            let view = std::sync::Arc::clone(link.view());
+            begin_turn_presentation(app, &view, registry, render_handle);
+            app.last_submitted = Some(input.clone());
+            let _ = link
+                .send(agent_engine::session::SessionCommand::Submit {
+                    text: input,
+                    attachments: Vec::new(),
                 })
-                .unwrap_or_default();
-            let built =
-                build_render_model(&mut ViewInputs::from_app(app), runtime, registry, term_size);
-            if let Some((model, patch)) = built {
-                patch.apply(app);
-                render_handle.publish(model);
-            }
-            *stream = Some(
-                runtime
-                    .run_stream_with_messages(
-                        app.api_messages.clone(),
-                        ct.clone(),
-                        Some(s_rx),
-                        Some(secret_prompt_handle.clone()),
-                        false,
-                    )
-                    .await,
-            );
-            app.status_text = None;
-            app.push_msg(ChatMessage::Thinking(THINKING_PLACEHOLDER.to_string()));
-            *cancel_token = Some(ct);
-            *steer_tx = Some(s_tx);
+                .await;
         }
         InputAction::StreamingInput(input) => {
             // Check for streaming slash commands
@@ -1307,16 +1235,10 @@ pub(crate) async fn handle_input_action(
                             )));
                         } else {
                             // Unknown slash text — treat as steering
-                            let steered = steer_tx
-                                .as_ref()
-                                .map(|tx| tx.send(input.clone()).is_ok())
-                                .unwrap_or(false);
-                            if steered {
-                                app.push_msg(ChatMessage::System(format!("→ steering: {}", input)));
-                            } else {
-                                app.push_msg(ChatMessage::System(format!("queued: {}", input)));
-                            }
-                            app.queued_message = Some(input);
+                            // ("→ steering:" / "queued:" on `Steered`).
+                            let _ = link
+                                .send(agent_engine::session::SessionCommand::Steer { text: input })
+                                .await;
                         }
                     }
                     CommandAction::Quit => {
@@ -1366,41 +1288,44 @@ pub(crate) async fn handle_input_action(
                 }
             } else {
                 // Normal text during streaming — steer/queue
-                let steered = steer_tx
-                    .as_ref()
-                    .map(|tx| tx.send(input.clone()).is_ok())
-                    .unwrap_or(false);
-                if steered {
-                    app.push_msg(ChatMessage::System(format!("→ steering: {}", input)));
-                } else {
-                    app.push_msg(ChatMessage::System(format!("queued: {}", input)));
-                }
-                app.queued_message = Some(input);
+                // ("→ steering:" / "queued:" on `Steered`).
+                let _ = link
+                    .send(agent_engine::session::SessionCommand::Steer { text: input })
+                    .await;
             }
         }
-        InputAction::ModelsApply(model) => match runtime.try_set_model(model.clone()) {
-            Ok(clamp) => {
-                let applied = runtime.model().to_string();
-                let status = synaps_cli::engine::commands::persist_to_config("model", &applied);
-                app.session.model = applied.clone();
-                app.push_msg(ChatMessage::System(format!(
-                    "model set to: {} {}",
-                    applied, status
-                )));
-                // Session-only: the user's configured thinking value stays theirs.
-                if let Some(clamp) = clamp {
-                    app.session.thinking_level = runtime.thinking_level().to_string();
-                    app.push_msg(ChatMessage::System(
-                        crate::tui::commands::reasoning_clamp_notice(&clamp, &applied),
-                    ));
+        InputAction::ModelsApply(model) => {
+            match link
+                .set_checked(agent_engine::session::SessionSetting::Model { model })
+                .await
+            {
+                Ok(applied) => {
+                    let model_applied = applied.view.model.clone();
+                    let status =
+                        synaps_cli::engine::commands::persist_to_config("model", &model_applied);
+                    app.session.model = model_applied.clone();
+                    app.push_msg(ChatMessage::System(format!(
+                        "model set to: {} {}",
+                        model_applied, status
+                    )));
+                    // Session-only: the user's configured thinking value stays theirs.
+                    if let Some(clamp) = applied.clamp {
+                        app.session.thinking_level = applied.view.thinking_level.clone();
+                        app.push_msg(ChatMessage::System(
+                            crate::tui::commands::reasoning_clamp_notice_wire(
+                                &clamp,
+                                &model_applied,
+                            ),
+                        ));
+                    }
                 }
+                Err(error) => app.push_msg(ChatMessage::Error(error)),
             }
-            Err(error) => app.push_msg(ChatMessage::Error(error)),
-        },
+        }
         InputAction::EffortApply(apply) => {
             // Reject a selection derived from a different exact model or from
             // an older capability snapshot before mutation or persistence.
-            if runtime.model() != apply.model
+            if link.view().model != apply.model
                 || agent_engine::runtime::openai::catalog::capability_cache::generation()
                     != apply.generation
             {
@@ -1413,9 +1338,12 @@ pub(crate) async fn handle_input_action(
             // Reject without ANY state/config mutation; otherwise reuse the
             // existing checked mutation + persistence path (identical to
             // /thinking: set_reasoning_level_checked → persist → session).
-            match effort::apply_guard(app.streaming || stream.is_some(), &value, runtime.model()) {
-                Ok(level) => match runtime.set_reasoning_level_checked(level) {
-                    Ok(()) => {
+            match effort::apply_guard(app.streaming, &value, &link.view().model) {
+                Ok(level) => match link
+                    .set_checked(agent_engine::session::SessionSetting::ReasoningLevel { level })
+                    .await
+                {
+                    Ok(_) => {
                         let canonical = level.as_str();
                         app.session.thinking_level = canonical.to_string();
                         let status =
@@ -1486,7 +1414,7 @@ pub(crate) async fn handle_input_action(
                 });
                 return ControlFlow::Continue(());
             }
-            let client = runtime.http_client().clone();
+            let client = http.clone();
             let tx = app.model_list_tx.clone();
             tokio::spawn(async move {
                 if let Ok(provider) = provider_key.parse::<synaps_cli::auth::CloudProviderId>() {
@@ -1567,7 +1495,13 @@ pub(crate) async fn handle_input_action(
             });
         }
         InputAction::SettingsApply(key, value) => {
-            apply_setting(key, &value, app, runtime);
+            apply_setting(key, &value, app, link).await;
+        }
+        InputAction::GrantWorkerModel(model) => {
+            // input.rs route_models: result ignored as before.
+            let _ = link
+                .set(agent_engine::session::SessionSetting::GrantWorkerModel { model })
+                .await;
         }
         InputAction::PluginEditorOpen {
             plugin_id,

--- a/crates/agent-tui/src/tui/helpers.rs
+++ b/crates/agent-tui/src/tui/helpers.rs
@@ -5,7 +5,7 @@
 use std::time::Duration;
 
 use super::app::{App, ChatMessage};
-use super::settings;
+use super::{session_link, settings};
 
 /// Decide whether to repaint on this event-loop iteration.
 ///
@@ -31,19 +31,38 @@ pub(super) fn should_draw(
 ///
 /// The runtime mutation is delegated to the macro-generated dispatch in
 /// `settings/defs.rs` — single source of truth for schema + apply.
-pub(super) fn apply_setting(
+pub(super) async fn apply_setting(
     key: &'static str,
     value: &str,
     app: &mut App,
-    runtime: &mut synaps_cli::Runtime,
+    link: &mut session_link::SessionLink,
 ) {
-    // Runtime mutation (generated from settings/defs.rs).
-    // On Err: set row_error and do NOT write to config — the value was rejected.
-    if let Err(msg) = settings::defs::apply_setting_dispatch(key, value, runtime, app) {
-        if let Some(st) = app.settings.as_mut() {
-            st.row_error = Some((key.to_string(), msg));
+    // Resolve (generated from settings/defs.rs). Runtime keys round-trip
+    // through `Set{id}`; on Err/rejection: set row_error and do NOT write to
+    // config — the value was rejected.
+    match settings::defs::apply_setting_dispatch(key, value, app) {
+        settings::defs::SettingApply::Local(Ok(())) => {}
+        settings::defs::SettingApply::Local(Err(msg)) => {
+            if let Some(st) = app.settings.as_mut() {
+                st.row_error = Some((key.to_string(), msg));
+            }
+            return;
         }
-        return;
+        settings::defs::SettingApply::Session(setting) => match link.set_checked(setting).await {
+            Ok(applied) => {
+                if key == "context_window" {
+                    // Also update the bar denominator immediately so the UI
+                    // reflects the change.
+                    app.last_turn_context_window = applied.view.context_window;
+                }
+            }
+            Err(msg) => {
+                if let Some(st) = app.settings.as_mut() {
+                    st.row_error = Some((key.to_string(), msg));
+                }
+                return;
+            }
+        },
     }
 
     // Keep the embedded session in sync with settings changes so resume sees
@@ -51,7 +70,7 @@ pub(super) fn apply_setting(
     if key == "thinking" {
         app.session.thinking_level = value.to_string();
     } else if key == "model" {
-        app.session.model = runtime.model().to_string();
+        app.session.model = link.view().model.clone();
     }
 
     // `skills` is internal — not persisted via write_config_value.

--- a/crates/agent-tui/src/tui/input.rs
+++ b/crates/agent-tui/src/tui/input.rs
@@ -24,6 +24,9 @@ pub(super) enum InputAction {
     SettingsApply(&'static str, String),
     /// Models modal requested switching to a runtime model id.
     ModelsApply(String),
+    /// Models modal "trust" action → `Set{GrantWorkerModel}` (result ignored,
+    /// as the direct `grant_worker_model` call was).
+    GrantWorkerModel(String),
     /// Effort lightbox requested applying a reasoning level (string form).
     /// The dispatch arm re-checks streaming + exact-model validity
     /// (`effort::apply_guard`) before any mutation/persist.
@@ -65,7 +68,7 @@ pub(super) enum InputAction {
 pub(super) fn handle_event(
     event: Event,
     app: &mut App,
-    runtime: &synaps_cli::Runtime,
+    runtime: &impl agent_engine::session::RuntimeRead,
     streaming: bool,
     registry: &Arc<CommandRegistry>,
     keybinds: &synaps_cli::skills::keybinds::KeybindRegistry,
@@ -552,7 +555,11 @@ fn route_effort(event: Event, app: &mut App) -> InputAction {
 /// another modal (§6), so the `InputAction` is returned directly — the
 /// `PaneOutcome` mapping above is realized inline, matching the P7.4
 /// `route_help_find` shape.
-fn route_models(event: Event, app: &mut App, runtime: &synaps_cli::Runtime) -> InputAction {
+fn route_models(
+    event: Event,
+    app: &mut App,
+    runtime: &impl agent_engine::session::RuntimeRead,
+) -> InputAction {
     // Invariant (checked by the tripwire): top() == Models ⇒ models is Some.
     let Some(state) = &mut app.models else {
         return InputAction::None;
@@ -575,8 +582,7 @@ fn route_models(event: Event, app: &mut App, runtime: &synaps_cli::Runtime) -> I
                 // so subagent dispatch honors the grant this session. The
                 // config favorite is already persisted; a policy refusal (e.g.
                 // malformed ID) must not break the picker interaction.
-                let _ = runtime.grant_worker_model(&model);
-                InputAction::None
+                InputAction::GrantWorkerModel(model)
             }
             super::models::InputOutcome::ExpandProvider(provider) => {
                 InputAction::ModelsExpandProvider(provider)
@@ -646,7 +652,7 @@ fn route_plugins(event: Event, app: &mut App) -> InputAction {
 fn route_settings(
     event: Event,
     app: &mut App,
-    runtime: &synaps_cli::Runtime,
+    runtime: &impl agent_engine::session::RuntimeRead,
     registry: &Arc<CommandRegistry>,
 ) -> InputAction {
     // Invariant (checked by the tripwire): top() == Settings | PluginEditor ⇒

--- a/crates/agent-tui/src/tui/lifecycle.rs
+++ b/crates/agent-tui/src/tui/lifecycle.rs
@@ -95,46 +95,13 @@ pub(super) fn emergency_teardown_terminal() {
     execute!(stdout, cursor::Show).ok();
 }
 
-/// Bounded observability flush for TUI teardown (Task 11): stop intake on
-/// the session's telemetry/trace writer and drain it under the default
-/// shutdown budget.
-///
-/// Semantics: telemetry `off` → no writer → `None`, a true no-op.
-/// "Flushed" means every queued record was appended into OS file buffers
-/// (no fsync — best-effort diagnostic logs). A timeout logs a
-/// metadata-only warning (counter stats, never record content) and
-/// teardown continues — trace loss must never abort or fail an exit.
-pub(super) async fn flush_observability(runtime: &synaps_cli::Runtime) {
-    flush_observability_within(
-        runtime,
-        synaps_cli::runtime::telemetry::DEFAULT_SHUTDOWN_FLUSH_TIMEOUT,
-    )
-    .await;
-}
-
-/// Emergency-exit epilogue (session save timed out): short (1 s) bounded
-/// observability flush, then terminal restore and `process::exit(1)`. The
-/// exit reason is the save timeout — never trace loss; the flush is
-/// best-effort and cannot extend the exit beyond its own bound.
-pub(super) async fn emergency_flush_and_exit(runtime: &synaps_cli::Runtime) -> ! {
-    flush_observability_within(runtime, std::time::Duration::from_secs(1)).await;
+/// Emergency exit (the session did not report `Ended` within the teardown
+/// budget): terminal restore and `process::exit(1)`. The actor owns the
+/// save/hooks/observability flush; the host flushes logs at process exit.
+pub(super) fn emergency_exit() -> ! {
+    agent_engine::host::EngineHost::flush_installed_logs();
     emergency_teardown_terminal();
     std::process::exit(1);
-}
-
-async fn flush_observability_within(runtime: &synaps_cli::Runtime, budget: std::time::Duration) {
-    match runtime.shutdown_observability_async(budget).await {
-        None => {} // telemetry off — nothing to flush
-        Some(outcome) if outcome.is_flushed() => {
-            tracing::debug!("observability flush completed");
-        }
-        Some(outcome) => {
-            tracing::warn!(
-                stats = ?outcome.stats(),
-                "observability flush timed out — detached worker keeps draining"
-            );
-        }
-    }
 }
 
 // `teardown_terminal` was removed in the #116 render-thread work — the render

--- a/crates/agent-tui/src/tui/loop_arms.rs
+++ b/crates/agent-tui/src/tui/loop_arms.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-fn handle_widget_event(
+pub(crate) fn handle_widget_event(
     app: &mut App,
     event: synaps_cli::extensions::widgets::ExtensionWidgetEvent,
 ) -> bool {
@@ -112,12 +112,14 @@ fn handle_extension_loader_toast(app: &mut App, title: &str, lines: Vec<String>,
     app.invalidate();
 }
 
-async fn handle_extension_loader_event(
+/// `ext_mgr` is `Some` in-process (widget watchers + live handler count);
+/// `None` over the socket (`view.hook_handler_count`, frames via envelopes).
+pub(crate) async fn handle_extension_loader_event(
     app: &mut App,
-    runtime: &Runtime,
+    view: &agent_engine::session::RuntimeView,
     event: synaps_cli::extensions::loader::ExtensionLoaderEvent,
-    ext_mgr: &std::sync::Arc<
-        tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>,
+    ext_mgr: Option<
+        &std::sync::Arc<tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>>,
     >,
 ) {
     use synaps_cli::extensions::loader::ExtensionLoaderEvent;
@@ -171,7 +173,10 @@ async fn handle_extension_loader_event(
         }
         ExtensionLoaderEvent::Finished { loaded, failed } => {
             app.extension_loader_running = false;
-            let handler_count = runtime.hook_bus().handler_count().await;
+            let handler_count = match ext_mgr {
+                Some(m) => m.read().await.hook_bus().handler_count().await,
+                None => view.hook_handler_count,
+            };
             tracing::info!(
                 extensions = loaded.len(),
                 failures = failed.len(),
@@ -201,7 +206,10 @@ async fn handle_extension_loader_event(
             // `ext.<id>.<token>` overrides still win — they live inside the
             // Theme value and are checked first by `Theme::ext_token`.
             // Extensions with no `theme_tokens` contribute nothing here.
-            let ext_theme_tokens = ext_mgr.read().await.theme_tokens();
+            let ext_theme_tokens = match ext_mgr {
+                Some(m) => m.read().await.theme_tokens(),
+                None => Default::default(),
+            };
             if !ext_theme_tokens.is_empty() {
                 for (ext_id, tokens) in &ext_theme_tokens {
                     theme::register_ext_theme_tokens(
@@ -223,7 +231,10 @@ async fn handle_extension_loader_event(
             // warn instead: widget upserts are idempotent last-writer-wins
             // UI state, so the first event after the TUI loop resumes
             // consuming restores the display.
-            let handlers = ext_mgr.read().await.handlers();
+            let handlers = match ext_mgr {
+                Some(m) => m.read().await.handlers(),
+                None => Vec::new(),
+            };
             for (ext_id, handler) in handlers {
                 let widget_tx = app.widget_tx.clone();
                 tokio::spawn(async move {
@@ -586,14 +597,14 @@ pub(crate) fn handle_model_list_arm(
 /// Async extension-loader progress arm.
 pub(crate) async fn handle_extension_loader_arm(
     app: &mut App,
-    runtime: &Runtime,
+    view: &agent_engine::session::RuntimeView,
     event: Option<synaps_cli::extensions::loader::ExtensionLoaderEvent>,
-    ext_mgr: &std::sync::Arc<
-        tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>,
+    ext_mgr: Option<
+        &std::sync::Arc<tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>>,
     >,
 ) {
     if let Some(event) = event {
-        handle_extension_loader_event(app, runtime, event, ext_mgr).await;
+        handle_extension_loader_event(app, view, event, ext_mgr).await;
     } else {
         app.extension_loader_running = false;
         app.toasts.dismiss("extension-loader");
@@ -623,7 +634,6 @@ pub(crate) fn handle_widget_arm(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_animation_tick(
     app: &mut App,
-    runtime: &Runtime,
     config: &synaps_cli::SynapsConfig,
     registry: &std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
     render_handle: &render_thread::RenderHandle,
@@ -684,12 +694,8 @@ pub(crate) async fn handle_animation_tick(
         let should_reconcile =
             last_subagent_reconcile.map_or(true, |t| now.duration_since(t).as_secs_f64() >= 1.0);
         if should_reconcile {
-            let rows = runtime
-                .subagent_registry()
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
-                .display_rows();
-            super::stream_handler::reconcile_subagents(&mut app.subagents, &rows, now);
+            // From the `SubagentRows` cache the actor refreshes at 1 Hz.
+            super::stream_handler::reconcile_subagents(&mut app.subagents, &app.subagent_rows, now);
             *last_subagent_reconcile = Some(now);
             app.request_redraw();
         }
@@ -756,80 +762,8 @@ pub(crate) async fn handle_animation_tick(
         app.push_msg(ChatMessage::System(msg));
         app.invalidate(); // invalidate already sets needs_redraw
     }
-    // Poll background compaction task
-    if app.compact_task.as_ref().is_some_and(|t| t.is_finished()) {
-        let handle = app.compact_task.take().unwrap();
-        let msg_count = app.api_messages.len();
-        match handle.await {
-            Ok(Ok(outcome)) => {
-                // T30 (spec §9.2): apply through the ONE engine
-                // transition — successor policy, chain advancement,
-                // provenance, pending events/queued message, hooks,
-                // and save ordering all live in the engine now.
-                let pending: Vec<String> = app.pending_events.clone();
-                let queued = app.queued_message.clone();
-                match synaps_cli::runtime::compaction::apply_compaction(
-                    runtime,
-                    &app.session,
-                    &app.api_messages,
-                    &outcome,
-                    synaps_cli::runtime::compaction::CompactionTransition {
-                        policy: synaps_cli::runtime::compaction::CompactionPolicy::LinkedSuccessor,
-                        pending_events: pending,
-                        queued_message: queued.clone(),
-                        hook_source: "manual".to_string(),
-                    },
-                )
-                .await
-                {
-                    Ok(applied) => {
-                        let old_id = applied.previous_session_id.clone();
-                        app.pending_events.clear();
-                        app.queued_message = None;
-                        app.session = applied.session;
-                        app.api_messages = applied.api_messages;
-                        app.total_input_tokens = 0;
-                        app.total_output_tokens = 0;
-                        app.session_cost = 0.0;
-                        let msgs = app.api_messages.clone();
-                        rebuild_display_messages(&msgs, app);
-                        for name in &applied.chains_advanced {
-                            app.push_msg(ChatMessage::System(format!(
-                                "chain '{}' advanced: {} → {}",
-                                name, old_id, app.session.id
-                            )));
-                        }
-                        if let Some(q) = queued {
-                            app.push_msg(ChatMessage::System(format!(
-                                "queued message restored: {}",
-                                q
-                            )));
-                        }
-                        app.push_msg(ChatMessage::System(format!(
-                            "✓ compacted {} messages → new session {} (from {})",
-                            msg_count, app.session.id, old_id
-                        )));
-                    }
-                    Err(e) => {
-                        // Prior session state (including pending
-                        // events and the queued message) is intact.
-                        app.push_msg(ChatMessage::Error(format!("compaction failed: {}", e)));
-                    }
-                }
-            }
-            Ok(Err(e)) => {
-                app.push_msg(ChatMessage::Error(format!("compaction failed: {}", e)));
-            }
-            Err(e) => {
-                app.push_msg(ChatMessage::Error(format!(
-                    "compaction task panicked: {}",
-                    e
-                )));
-            }
-        }
-        app.status_text = None;
-        app.invalidate();
-    }
+    // Compaction outcome: `CompactionApplied`/`Failed`/`Cancelled` envelopes
+    // (stream_handler::handle_session_event_arm).
     if exit_done.load(Ordering::Acquire) {
         return true;
     }

--- a/crates/agent-tui/src/tui/mod.rs
+++ b/crates/agent-tui/src/tui/mod.rs
@@ -355,9 +355,12 @@ pub(crate) async fn run_loop(ctx: run_setup::RunContext) -> Result<()> {
 
     // ── PART 2: Bounded teardown — the actor saves, fires on_session_end
     // and flushes observability under its own budgets (`SessionActor::
-    // finish`); we ask for it and wait for `Ended` within the combined
-    // SAVE + HOOKS budget. Over the socket the session lives on: Detach.
-    let teardown = std::time::Duration::from_secs(signals::TEARDOWN_TIMEOUT_SECS);
+    // finish`); we ask for it and wait for `Ended` within the sum of those
+    // budgets plus margin (`SESSION_END_TIMEOUT_SECS`). The channel closing
+    // cleanly before `Ended` is observed is a clean exit too (exit 0); only
+    // an actor still running past its whole budget is an emergency exit.
+    // Over the socket the session lives on: Detach.
+    let teardown = std::time::Duration::from_secs(signals::SESSION_END_TIMEOUT_SECS);
     if !link.is_closed() {
         let cmd = match mode {
             run_setup::TransportMode::Local { .. } => SessionCommand::End {
@@ -371,10 +374,12 @@ pub(crate) async fn run_loop(ctx: run_setup::RunContext) -> Result<()> {
         if let run_setup::TransportMode::Local { .. } = mode {
             match tokio::time::timeout(teardown, link.wait_ended()).await {
                 Ok(true) => tracing::debug!("clean teardown completed"),
-                Ok(false) => tracing::debug!("session task gone before Ended"),
+                Ok(false) => {
+                    tracing::debug!("session channel closed before Ended — clean exit")
+                }
                 Err(_elapsed) => {
                     tracing::warn!(
-                        budget_secs = signals::TEARDOWN_TIMEOUT_SECS,
+                        budget_secs = signals::SESSION_END_TIMEOUT_SECS,
                         "session end timed out — data may be incomplete"
                     );
                     lifecycle::emergency_exit();

--- a/crates/agent-tui/src/tui/mod.rs
+++ b/crates/agent-tui/src/tui/mod.rs
@@ -2,6 +2,8 @@
 mod transcript;
 
 mod app;
+/// A4: the TUI over `SocketTransport` (`synaps --attach`).
+pub mod attach;
 mod clock;
 mod commands;
 mod dispatch;
@@ -23,6 +25,7 @@ mod render;
 mod render_model;
 mod render_thread;
 mod run_setup;
+mod session_link;
 mod settings;
 mod sidecar;
 mod signals;
@@ -47,7 +50,7 @@ mod viewport;
 #[cfg(test)]
 pub(crate) static CONFIG_ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-use app::{App, ChatMessage, THINKING_PLACEHOLDER};
+use app::{App, ChatMessage};
 use commands::CommandAction;
 use draw::{boot_effect, build_render_model, quit_effect};
 use helpers::{apply_setting, fetch_usage, rebuild_display_messages, should_draw};
@@ -60,9 +63,9 @@ use futures::StreamExt;
 use serde_json::json;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
-use synaps_cli::core::session_index::SessionIndexRecord;
-use synaps_cli::runtime::compaction::compact_conversation;
-use synaps_cli::{CancellationToken, Result, Runtime};
+use synaps_cli::Result;
+
+use agent_engine::session::{EndReason, SessionCommand};
 
 pub async fn run(
     continue_session: Option<Option<String>>,
@@ -76,9 +79,26 @@ pub async fn run(
     // resumed-session branch), channel/handle setup, render-thread spawn,
     // and tick-throttle init. Behavior byte-identical; the loop below owns
     // every field by value exactly as it did when they were locals.
+    let ctx = run_setup::run_setup(
+        continue_session,
+        system,
+        prompt_manifest,
+        profile,
+        no_extensions,
+    )
+    .await?;
+    run_loop(ctx).await
+}
+
+/// The event loop + teardown, shared by the in-process boot and the socket
+/// attach (`run_attached`).
+pub(crate) async fn run_loop(ctx: run_setup::RunContext) -> Result<()> {
     let run_setup::RunContext {
         mut app,
-        mut runtime,
+        mut link,
+        http,
+        mut prompt_bridge,
+        mode,
         mut config,
         registry,
         keybind_registry,
@@ -90,24 +110,12 @@ pub async fn run(
         event_reader,
         mut shutdown_signal_rx,
         shutdown_signal_task,
-        mut stream,
-        secret_prompt_handle,
         secret_prompt_rx,
-        mut cancel_token,
-        mut steer_tx,
-        background,
         ext_mgr_shared,
         mut boot_fx_sent,
         mut exit_fx_sent,
         mut last_draw,
-    } = run_setup::run_setup(
-        continue_session,
-        system,
-        prompt_manifest,
-        profile,
-        no_extensions,
-    )
-    .await?;
+    } = ctx;
     // P16.1+P16.2: terminal capabilities — env detection merged with the
     // DA1-fenced query burst run inside run_setup() (after raw-mode enable,
     // BEFORE the EventStream above was created; see run_setup.rs). Still
@@ -167,7 +175,7 @@ pub async fn run(
             last_draw = Instant::now();
             let built = build_render_model(
                 &mut view_model::ViewInputs::from_app(&mut app),
-                &runtime,
+                &**link.view(),
                 &registry,
                 term_size,
             );
@@ -189,12 +197,7 @@ pub async fn run(
                     // from signals does not affect interactive quit.
                     let signals::ShutdownAction::ImmediateExit = signals::shutdown_action(signal);
                     tracing::info!("immediate exit on {:?}", signal);
-                    // Cancel any in-flight stream so the tool/subagent is not
-                    // orphaned for the full watchdog window.
-                    if let Some(ref ct) = cancel_token { ct.cancel(); }
-                    // Abort any in-flight compaction so it doesn't hold state
-                    // open past the teardown budget.
-                    if let Some(ref h) = app.compact_task { h.abort(); }
+                    // The actor cancels the in-flight turn/compaction on End.
                     // Fall through to unified bounded-teardown below the loop.
                     break;
                 }
@@ -212,7 +215,7 @@ pub async fn run(
 
             // ── Async extension loader progress ──
             event = app.extension_loader_rx.recv(), if app.extension_loader_running => {
-                loop_arms::handle_extension_loader_arm(&mut app, &runtime, event, &ext_mgr_shared).await;
+                loop_arms::handle_extension_loader_arm(&mut app, link.view(), event, ext_mgr_shared.as_ref()).await;
             }
 
             // ── Widget events from background extension notification watchers ──
@@ -251,19 +254,16 @@ pub async fn run(
                 }
             }
 
-            // ── Event bus wake — fires instantly when an event is pushed to the queue.
-            // P12.4: arm body moved verbatim to stream_handler::handle_event_queue_arm.
-            _ = runtime.event_queue().notified() => {
-                stream_handler::handle_event_queue_arm(
-                    &mut app, &runtime, &secret_prompt_handle,
-                    &mut stream, &mut cancel_token, &mut steer_tx,
-                ).await;
+            // ── Secret-prompt answers from the pane (PromptBridge) → Answer ──
+            Some((prompt_id, value)) = prompt_bridge.answers_rx.recv() => {
+                prompt_bridge.on_local_answer(prompt_id);
+                let _ = link.send(SessionCommand::Answer { prompt_id, value }).await;
             }
 
             // ── Tick: animations + spinner (~60fps when active) ──
-            _ = tokio::time::sleep(std::time::Duration::from_millis(16)), if boot_fx_sent || exit_fx_sent || app.streaming || app.compact_task.is_some() || app.transcript.is_empty() || app.logo_dismiss_t.is_some() || app.logo_build_t.is_some() || app.gamba_child.is_some() || app.secret_prompts.is_active() || !app.toasts.is_empty() || app.plugins.as_ref().is_some_and(|p| p.is_install_active()) || !app.subagents.is_empty() || app.theme_transition.is_some() => {
+            _ = tokio::time::sleep(std::time::Duration::from_millis(16)), if boot_fx_sent || exit_fx_sent || app.streaming || app.compacting || app.transcript.is_empty() || app.logo_dismiss_t.is_some() || app.logo_build_t.is_some() || app.gamba_child.is_some() || app.secret_prompts.is_active() || !app.toasts.is_empty() || app.plugins.as_ref().is_some_and(|p| p.is_install_active()) || !app.subagents.is_empty() || app.theme_transition.is_some() => {
                 if loop_arms::handle_animation_tick(
-                    &mut app, &runtime, &config, &registry, &render_handle,
+                    &mut app, &config, &registry, &render_handle,
                     &secret_prompt_rx, &boot_done, &exit_done,
                     &mut boot_fx_sent, exit_fx_sent,
                     &mut last_subagent_reconcile,
@@ -288,7 +288,7 @@ pub async fn run(
                         // yield point.
                         let action = {
                             let kb_guard = keybind_registry.read().expect("keybind registry poisoned");
-                            input::handle_event(event, &mut app, &runtime, is_streaming, &registry, &kb_guard, config.scroll_lines.unwrap_or(3))
+                            input::handle_event(event, &mut app, &**link.view(), is_streaming, &registry, &kb_guard, config.scroll_lines.unwrap_or(3))
                         };
                         // Input events (keys, mouse, paste, resize) almost always
                         // change visible state (cursor, input buffer, scroll) and
@@ -301,18 +301,15 @@ pub async fn run(
                         // honored anyway), Continue to the old fall-through.
                         let state = dispatch::LoopState {
                             app: &mut app,
-                            runtime: &mut runtime,
+                            link: &mut link,
+                            http: &http,
                             config: &mut config,
                             registry: &registry,
                             keybind_registry: &keybind_registry,
                             system_prompt_path: &system_prompt_path,
                             render_handle: &render_handle,
                             event_reader: &mut event_reader,
-                            stream: &mut stream,
-                            secret_prompt_handle: &secret_prompt_handle,
-                            cancel_token: &mut cancel_token,
-                            steer_tx: &mut steer_tx,
-                            ext_mgr_shared: &ext_mgr_shared,
+                            ext_mgr_shared: ext_mgr_shared.as_ref(),
                             exit_fx_sent: &mut exit_fx_sent,
                         };
                         if dispatch::handle_input_action(action, state).await.is_break() {
@@ -330,21 +327,25 @@ pub async fn run(
                 }
             }
 
-            // ── Stream events from runtime. P12.4: the polling future stays
-            // inline (it borrows `stream`); the arm body moved verbatim to
-            // stream_handler::handle_stream_arm — delta/tool_use/done/abort
-            // lifecycle is preserved exactly (hot path).
-            maybe_event = async {
-                if let Some(ref mut s) = stream {
-                    s.next().await
-                } else {
-                    std::future::pending().await
+            // ── Session envelopes: stream events + every actor notification
+            // (PLAN-phase3 §2.4). `None` = the actor is gone (in-process) or
+            // the socket closed (reconnect flow, A4).
+            maybe_env = link.next_event() => {
+                match maybe_env {
+                    Some(env) => {
+                        if let stream_handler::ArmFlow::Ended = stream_handler::handle_session_event_arm(
+                            env, &mut app, &mut link, &registry, &render_handle,
+                            &mut prompt_bridge, ext_mgr_shared.as_ref(),
+                        ).await {
+                            break;
+                        }
+                    }
+                    None => {
+                        if !run_setup::try_reconnect(&mut app, &mut link, &mode).await {
+                            break;
+                        }
+                    }
                 }
-            } => {
-                stream_handler::handle_stream_arm(
-                    maybe_event, &mut app, &runtime, &registry, &render_handle,
-                    &secret_prompt_handle, &mut stream, &mut cancel_token, &mut steer_tx,
-                ).await;
             }
         }
     }
@@ -352,100 +353,45 @@ pub async fn run(
     // Stop the live-MXC subscriber FIRST — no background task writes past here.
     loop_arms::abort_myx_live(&mut app);
 
-    // ── PART 2: Bounded teardown — two sequential budgets.
-    //
-    // All timing constants are defined in signals.rs (single source of truth):
-    //   SAVE_TIMEOUT_SECS  — session save + index record (data safety first)
-    //   HOOKS_TIMEOUT_SECS — on_session_end hook emit (concurrent, fail-open)
-    //   TEARDOWN_TIMEOUT_SECS = SAVE_TIMEOUT_SECS + HOOKS_TIMEOUT_SECS
-    //
-    // Session save ALWAYS runs first in its own timeout so slow extension
-    // handlers cannot starve it.  Even if the hook budget is exhausted, the
-    // session data on disk is already safe before hooks are attempted.
-    {
-        let session_id = app.session.id.clone();
-        let api_messages = app.api_messages.clone();
-
-        // ── STEP 1: Save session data — own bounded timeout, highest priority ──
-        let save_fut = async {
-            app.save_session().await;
-
-            let mut index_record = SessionIndexRecord::end(&session_id);
-            index_record.turns = Some(api_messages.len());
-            if let Err(err) = synaps_cli::core::session_index::append_record(&index_record) {
-                tracing::warn!("failed to append session end index record: {}", err);
-            }
+    // ── PART 2: Bounded teardown — the actor saves, fires on_session_end
+    // and flushes observability under its own budgets (`SessionActor::
+    // finish`); we ask for it and wait for `Ended` within the combined
+    // SAVE + HOOKS budget. Over the socket the session lives on: Detach.
+    let teardown = std::time::Duration::from_secs(signals::TEARDOWN_TIMEOUT_SECS);
+    if !link.is_closed() {
+        let cmd = match mode {
+            run_setup::TransportMode::Local { .. } => SessionCommand::End {
+                reason: EndReason::ClientQuit,
+            },
+            run_setup::TransportMode::Socket => SessionCommand::Detach {
+                client: link.client_id(),
+            },
         };
-
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(signals::SAVE_TIMEOUT_SECS),
-            save_fut,
-        )
-        .await
-        {
-            Ok(()) => tracing::debug!("session save completed"),
-            Err(_elapsed) => {
-                tracing::warn!(
-                    budget_secs = signals::SAVE_TIMEOUT_SECS,
-                    "session save timed out — data may be incomplete"
-                );
-                // Task 11: bounded observability flush precedes the emergency exit.
-                lifecycle::emergency_flush_and_exit(&runtime).await;
+        let _ = link.send(cmd).await;
+        if let run_setup::TransportMode::Local { .. } = mode {
+            match tokio::time::timeout(teardown, link.wait_ended()).await {
+                Ok(true) => tracing::debug!("clean teardown completed"),
+                Ok(false) => tracing::debug!("session task gone before Ended"),
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        budget_secs = signals::TEARDOWN_TIMEOUT_SECS,
+                        "session end timed out — data may be incomplete"
+                    );
+                    lifecycle::emergency_exit();
+                }
             }
         }
-
-        // ── STEP 2: Fire on_session_end hook — own bounded timeout, after save ──
-        //
-        // emit_concurrent() dispatches all on_session_end handlers simultaneously
-        // under one shared timeout window instead of N×5 s serial.  This is safe
-        // because on_session_end only allows `Continue` results — handlers are
-        // independent fire-and-forget notification calls (deck, d20, jawz-widget,
-        // synaps-tasks each write to their own stores; no ordering dependency).
-        //
-        // Ordering-safety evidence: HookKind::OnSessionEnd::allowed_action_names()
-        // returns &["continue"] exclusively; allows_result() permits only Continue;
-        // emit_concurrent() merges injections (N/A here) and treats timeouts as
-        // continue (fail-open).  Serial ordering cannot matter when the return
-        // value is always Continue and handlers touch disjoint state.
-        let transcript = Some(api_messages);
-        let hook_event = synaps_cli::extensions::hooks::events::HookEvent::on_session_end(
-            &session_id,
-            transcript,
-        );
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(signals::HOOKS_TIMEOUT_SECS),
-            runtime.hook_bus().emit_concurrent(&hook_event),
-        )
-        .await
-        {
-            Ok(_) => tracing::debug!("on_session_end hooks completed"),
-            Err(_elapsed) => {
-                tracing::warn!(
-                    budget_secs = signals::HOOKS_TIMEOUT_SECS,
-                    "on_session_end hooks timed out — extensions may not have flushed"
-                );
-                // Session is already saved above — no data loss here.
-                // Fall through to normal teardown.
-            }
-        }
-
-        // STEP 3 (Task 11): bounded observability flush after save + hooks —
-        // Off/no-fsync/timeout semantics on lifecycle::flush_observability.
-        lifecycle::flush_observability(&runtime).await;
-        tracing::debug!("clean teardown completed");
     }
 
     // Let extension shutdown continue in the background; exit should not hang on
     // extension post/session-end cleanup or slow child-process teardown.
-    let _extension_shutdown =
+    let _extension_shutdown = ext_mgr_shared.as_ref().map(|m| {
         synaps_cli::extensions::manager::ExtensionManager::shutdown_all_detached(
-            std::sync::Arc::clone(&ext_mgr_shared),
-        );
+            std::sync::Arc::clone(m),
+        )
+    });
     // Stop the signal-listener thread (signal-hook handle, not a JoinHandle).
     shutdown_signal_task.close();
-
-    // Shut down background tasks (inbox watcher, socket, session registry)
-    background.shutdown();
 
     // ── Render-thread teardown ───────────────────────────────────────────────
     //

--- a/crates/agent-tui/src/tui/render_thread.rs
+++ b/crates/agent-tui/src/tui/render_thread.rs
@@ -138,6 +138,24 @@ pub(crate) struct RenderHandle {
 }
 
 impl RenderHandle {
+    /// A handle with no render thread behind it (harness): frames land in a
+    /// slot nobody reads; commands go to a receiver nobody polls. Unparking
+    /// the current thread is a no-op.
+    #[cfg(any(test, feature = "testing"))]
+    pub(crate) fn headless() -> Self {
+        let inner: Arc<parking_lot::Mutex<Option<Arc<RenderModel>>>> =
+            Arc::new(parking_lot::Mutex::new(None));
+        let (cmd_tx, cmd_rx) = mpsc::channel::<RenderCmd>();
+        // Keep the receiver alive for the handle's lifetime so sends never
+        // error (they are ignored either way).
+        std::mem::forget(cmd_rx);
+        RenderHandle {
+            slot: FrameSlot::new(inner, std::thread::current()),
+            cmd_tx,
+            join_handle: None,
+        }
+    }
+
     /// Publish a new frame snapshot to the render thread (latest-wins).
     /// Replaces any unread frame and wakes the render thread via `unpark()`.
     pub(crate) fn publish(&self, model: std::sync::Arc<super::render_model::RenderModel>) {

--- a/crates/agent-tui/src/tui/run_setup.rs
+++ b/crates/agent-tui/src/tui/run_setup.rs
@@ -9,15 +9,42 @@
 
 use super::*;
 
+use std::sync::Arc;
 use std::time::Instant;
-use synaps_cli::{CancellationToken, Result, StreamEvent};
+use synaps_cli::Result;
+
+use agent_engine::host::{EngineHost, HostOpts};
+use agent_engine::session::{
+    AttachMode, AttachSnapshot, ClientKind, ClientMeta, ClientTransport, CompactionPolicyWire,
+    LocalTransport, SessionConfig,
+};
+use session_link::{PromptBridge, SessionLink};
+
+/// How this TUI reaches its session (PLAN-phase3 §3.2).
+pub(crate) enum TransportMode {
+    /// In-process: the `EngineHost` + `SessionActor` live in this process
+    /// (the host is kept alive for the loop's lifetime).
+    Local {
+        #[allow(dead_code)]
+        host: Arc<EngineHost>,
+    },
+    /// Over the daemon socket (A4): no host, no runtime, no extension host.
+    Socket,
+}
 
 /// Everything `run()`'s event loop and teardown consume from the boot
 /// prologue. Fields are handed back by value so `run()` owns them exactly as
 /// it did when they were locals — the loop's `&mut` borrows are unchanged.
 pub(crate) struct RunContext {
     pub app: App,
-    pub runtime: synaps_cli::Runtime,
+    /// The session, behind a transport (in-process `LocalTransport` today;
+    /// `SocketTransport` for `--attach`).
+    pub link: SessionLink,
+    /// Client-local HTTP client for catalog/model-list fetches (the same
+    /// builder the host uses).
+    pub http: reqwest::Client,
+    pub prompt_bridge: PromptBridge,
+    pub mode: TransportMode,
     pub config: synaps_cli::SynapsConfig,
     pub registry: std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
     pub keybind_registry:
@@ -32,18 +59,16 @@ pub(crate) struct RunContext {
     pub event_reader: EventStream,
     pub shutdown_signal_rx: tokio::sync::mpsc::UnboundedReceiver<signals::ShutdownSignal>,
     pub shutdown_signal_task: signals::SignalHandle,
-    pub stream: Option<std::pin::Pin<Box<dyn futures::Stream<Item = StreamEvent> + Send>>>,
-    pub secret_prompt_handle: synaps_cli::tools::SecretPromptHandle,
     pub secret_prompt_rx: std::sync::Arc<
         std::sync::Mutex<
             tokio::sync::mpsc::UnboundedReceiver<synaps_cli::tools::SecretPromptRequest>,
         >,
     >,
-    pub cancel_token: Option<CancellationToken>,
-    pub steer_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
-    pub background: synaps_cli::engine::setup::BackgroundTasks,
-    pub ext_mgr_shared:
+    /// In-process only (`Some` under `TransportMode::Local`): the host's
+    /// extension manager, for `/extensions` and interactive plugin commands.
+    pub ext_mgr_shared: Option<
         std::sync::Arc<tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>>,
+    >,
     pub boot_fx_sent: bool,
     pub exit_fx_sent: bool,
     pub last_draw: Instant,
@@ -57,60 +82,42 @@ pub(crate) async fn run_setup(
     profile: Option<String>,
     no_extensions: bool,
 ) -> Result<RunContext> {
-    // ── Engine boot ──
-    let boot = synaps_cli::engine::setup::boot(synaps_cli::engine::setup::EngineOpts {
-        continue_session: continue_session.clone(),
-        system,
-        prompt_manifest,
+    // ── Engine boot: host + one session on the actor, attached in-process ──
+    let host = EngineHost::boot_and_install(HostOpts {
         profile,
         no_extensions,
     })
     .await?;
+    let handle = host
+        .create_session(SessionConfig {
+            continue_session,
+            system,
+            prompt_manifest,
+            cwd: None,
+            auto_approve_confirms: false,
+            model_override: None,
+            persist: true,
+            auto_compact: false,
+            compaction_policy: CompactionPolicyWire::LinkedSuccessor,
+            await_extensions: false,
+            keep_warm: false,
+        })
+        .await?;
+    let (transport, snapshot) =
+        LocalTransport::attach_with(handle, ClientMeta::new(ClientKind::Tui), AttachMode::Mirror)
+            .await
+            .map_err(|e| synaps_cli::RuntimeError::Config(format!("attach: {e}")))?;
 
-    let runtime = boot.runtime;
-    let config = boot.config;
-    let registry = boot.registry;
-    let keybind_registry = boot.keybind_registry;
-    let mcp_server_count = boot.mcp_server_count;
-    let system_prompt_path = boot.system_prompt_path;
+    let config: synaps_cli::SynapsConfig = (**host.config()).clone();
+    let registry = Arc::clone(host.command_registry());
+    let keybind_registry = Arc::clone(host.keybind_registry());
+    let mcp_server_count = host.mcp_server_count();
+    let system_prompt_path = synaps_cli::config::resolve_read_path("system.md");
+    let http = host.parts().client.clone();
+    let ext_mgr_shared = Arc::clone(host.ext_manager());
 
-    // Build App from engine boot results
-    let mut app = if boot.continued {
-        let mut app = App::new_with_clock(boot.session.clone(), clock::TuiClock::real());
-        app.api_messages = boot.api_messages;
-        app.total_input_tokens = boot.total_input_tokens;
-        app.total_output_tokens = boot.total_output_tokens;
-        app.session_cost = boot.session_cost;
-        app.abort_context = boot.abort_context;
-        // mem::take avoids deep-cloning the full history just to satisfy
-        // the borrow checker (P5 in REVIEW.md).
-        let msgs = std::mem::take(&mut app.api_messages);
-        rebuild_display_messages(&msgs, &mut app);
-        app.api_messages = msgs;
-        app.push_msg(ChatMessage::System(format!(
-            "resumed session {}",
-            boot.session.id
-        )));
-        if let Some(ref info) = boot.continue_info {
-            if let Some(ref via) = info.resolved_via {
-                app.push_msg(ChatMessage::System(format!(
-                    "  ↳ resolved via {} '{}'",
-                    via, info.query
-                )));
-            }
-        }
-        if app.abort_context.is_some() {
-            app.push_msg(ChatMessage::System(
-                "⚠ abort context from previous session will be injected into next message"
-                    .to_string(),
-            ));
-        }
-        app
-    } else {
-        App::new_with_clock(boot.session, clock::TuiClock::real())
-    };
+    let mut app = app_from_snapshot(&snapshot);
     app.keybinds = Some(keybind_registry.clone());
-    app.last_turn_context_window = runtime.context_window();
 
     // Surface config parse warnings once at startup (unknown keys, bad values).
     for w in &config.warnings {
@@ -139,6 +146,103 @@ pub(crate) async fn run_setup(
         );
     }
 
+    let mut ctx = finish_setup(
+        app,
+        Box::new(transport),
+        http,
+        TransportMode::Local { host },
+        config,
+        registry,
+        keybind_registry,
+        system_prompt_path,
+        Some(ext_mgr_shared),
+    )
+    .await?;
+
+    // Legacy sidecar key migration
+    loop_arms::migrate_sidecar_toggle_key_to_claimed_plugins(&ctx.registry.lifecycle_claims());
+
+    if !no_extensions {
+        let session_id_for_hook = ctx.app.session.id.clone();
+        ctx.app.extension_loader_running = true;
+        ctx.app.toasts.upsert(
+            toast::Toast::new("extension-loader", "Discovering extensions…")
+                .titled("Extensions")
+                .at(toast::ToastPosition::TOP_CENTER)
+                .ttl(None),
+        );
+        // on_session_start is emitted by the extension loader once
+        // subscribers exist — same moment, same bus as before the port.
+        // (When the actor's `await_extensions=false` waiter lands (B1) this
+        // becomes `None` — the actor emits it.)
+        synaps_cli::extensions::loader::spawn_discover_and_load(
+            std::sync::Arc::clone(ctx.ext_mgr_shared.as_ref().expect("local mode")),
+            ctx.app.extension_loader_tx.clone(),
+            Some(session_id_for_hook),
+        );
+    }
+    Ok(ctx)
+}
+
+/// Build `App` from the attach snapshot — the same lines and texts the
+/// `EngineBoot`-based construction produced (`continued` branch included).
+pub(crate) fn app_from_snapshot(snapshot: &AttachSnapshot) -> App {
+    let conv = &snapshot.conversation;
+    let session = app::session_from_header(&conv.header);
+    let mut app = if snapshot.meta.continued {
+        let mut app = App::new_with_clock(session, clock::TuiClock::real());
+        app.apply_conversation(conv);
+        // mem::take avoids deep-cloning the full history just to satisfy
+        // the borrow checker (P5 in REVIEW.md).
+        let msgs = std::mem::take(&mut app.api_messages);
+        rebuild_display_messages(&msgs, &mut app);
+        app.api_messages = msgs;
+        app.push_msg(ChatMessage::System(format!(
+            "resumed session {}",
+            conv.header.id
+        )));
+        if let Some(ref info) = snapshot.meta.continue_info {
+            if let Some(ref via) = info.resolved_via {
+                app.push_msg(ChatMessage::System(format!(
+                    "  ↳ resolved via {} '{}'",
+                    via, info.query
+                )));
+            }
+        }
+        if app.abort_context.is_some() {
+            app.push_msg(ChatMessage::System(
+                "⚠ abort context from previous session will be injected into next message"
+                    .to_string(),
+            ));
+        }
+        app
+    } else {
+        App::new_with_clock(session, clock::TuiClock::real())
+    };
+    app.last_turn_context_window = snapshot.view.context_window;
+    app
+}
+
+/// Terminal + render thread + channels — shared by the in-process boot and
+/// the socket attach (`run_attached`).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn finish_setup(
+    mut app: App,
+    transport: Box<dyn ClientTransport>,
+    http: reqwest::Client,
+    mode: TransportMode,
+    config: synaps_cli::SynapsConfig,
+    registry: std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
+    keybind_registry: std::sync::Arc<
+        std::sync::RwLock<synaps_cli::skills::keybinds::KeybindRegistry>,
+    >,
+    system_prompt_path: std::path::PathBuf,
+    ext_mgr_shared: Option<
+        std::sync::Arc<tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>>,
+    >,
+) -> Result<RunContext> {
+    let link = SessionLink::new(transport);
+    app.keybinds = Some(keybind_registry.clone());
     // ── Terminal setup + render thread ──
     //
     // The Terminal is moved into the render thread immediately after creation.
@@ -188,42 +292,12 @@ pub(crate) async fn run_setup(
     let event_reader = EventStream::new();
     let (shutdown_signal_tx, shutdown_signal_rx) = tokio::sync::mpsc::unbounded_channel();
     let shutdown_signal_task = signals::spawn_shutdown_signal_task(shutdown_signal_tx);
-    let stream: Option<std::pin::Pin<Box<dyn futures::Stream<Item = StreamEvent> + Send>>> = None;
     let (secret_prompt_tx, secret_prompt_rx) = tokio::sync::mpsc::unbounded_channel();
-    let secret_prompt_handle = synaps_cli::tools::SecretPromptHandle::new(secret_prompt_tx);
+    let prompt_bridge = PromptBridge::new(secret_prompt_tx);
     let secret_prompt_rx = std::sync::Arc::new(std::sync::Mutex::new(secret_prompt_rx));
     // P7.8: the secret-prompt queue now lives on `app.secret_prompts` (§5).
     // The mpsc channel wiring above is unchanged; only the queue moved onto
     // App so the pane handler / harness share production state.
-    let cancel_token: Option<CancellationToken> = None;
-    let steer_tx: Option<tokio::sync::mpsc::UnboundedSender<String>> = None;
-
-    // ── Engine-managed background tasks (inbox watcher, socket, extensions) ──
-    let background = boot.background;
-    let ext_mgr_shared = boot.ext_manager;
-    let session_id_for_hook = app.session.id.clone();
-
-    // Legacy sidecar key migration
-    loop_arms::migrate_sidecar_toggle_key_to_claimed_plugins(&registry.lifecycle_claims());
-
-    if !boot.no_extensions {
-        app.extension_loader_running = true;
-        app.toasts.upsert(
-            toast::Toast::new("extension-loader", "Discovering extensions…")
-                .titled("Extensions")
-                .at(toast::ToastPosition::TOP_CENTER)
-                .ttl(None),
-        );
-        synaps_cli::extensions::loader::spawn_discover_and_load(
-            std::sync::Arc::clone(&ext_mgr_shared),
-            app.extension_loader_tx.clone(),
-            Some(session_id_for_hook.clone()),
-        );
-    }
-
-    // on_session_start is emitted by the extension loader once subscribers
-    // exist — not at engine boot, where it reached nobody. See loader.rs.
-
     // ── Event loop ──
     // Track whether the render thread currently has an active boot or exit
     // effect.  The render thread owns the actual Effect values; we track
@@ -234,7 +308,10 @@ pub(crate) async fn run_setup(
 
     Ok(RunContext {
         app,
-        runtime,
+        link,
+        http,
+        prompt_bridge,
+        mode,
         config,
         registry,
         keybind_registry,
@@ -246,15 +323,54 @@ pub(crate) async fn run_setup(
         event_reader,
         shutdown_signal_rx,
         shutdown_signal_task,
-        stream,
-        secret_prompt_handle,
         secret_prompt_rx,
-        cancel_token,
-        steer_tx,
-        background,
         ext_mgr_shared,
         boot_fx_sent,
         exit_fx_sent,
         last_draw,
     })
+}
+
+/// The session envelope stream ended. In-process: the actor is gone — leave.
+/// Socket (A4): reconnect with backoff and re-mirror; `false` = give up.
+pub(crate) async fn try_reconnect(
+    app: &mut App,
+    link: &mut SessionLink,
+    mode: &TransportMode,
+) -> bool {
+    match mode {
+        TransportMode::Local { .. } => false,
+        TransportMode::Socket => {
+            let attach_mode = link.mode();
+            match link.transport_mut().reconnect(attach_mode).await {
+                Ok(snapshot) => {
+                    link.refresh_view();
+                    remirror(app, &snapshot);
+                    app.toasts.upsert(
+                        toast::Toast::new("reload", "reconnected").titled("Daemon"),
+                    );
+                    app.request_redraw();
+                    true
+                }
+                Err(e) => {
+                    app.push_msg(ChatMessage::Error(format!("connection lost: {e}")));
+                    app.request_redraw();
+                    false
+                }
+            }
+        }
+    }
+}
+
+/// Rebuild the transcript from an `AttachSnapshot` (reconnect / re-attach):
+/// the cancelled turn's partial text is gone by design (§2.8 step 7).
+pub(crate) fn remirror(app: &mut App, snapshot: &AttachSnapshot) {
+    app.transcript.clear();
+    app.invalidate();
+    app.apply_conversation(&snapshot.conversation);
+    let msgs = std::mem::take(&mut app.api_messages);
+    rebuild_display_messages(&msgs, &mut *app);
+    app.api_messages = msgs;
+    app.streaming = snapshot.streaming;
+    app.last_turn_context_window = snapshot.view.context_window;
 }

--- a/crates/agent-tui/src/tui/session_link.rs
+++ b/crates/agent-tui/src/tui/session_link.rs
@@ -427,7 +427,10 @@ mod tests {
         let r = tokio::time::timeout(std::time::Duration::from_secs(2), link.resume("x"))
             .await
             .unwrap();
-        assert!(r.unwrap_err().ends_with("input owned by client #2"));
+        match r {
+            Err(e) => assert!(e.ends_with("input owned by client #2"), "{e}"),
+            Ok(_) => panic!("resume must be refused"),
+        }
         // Nothing leaked into the loop's buffer.
         assert!(link.buffered.is_empty());
     }

--- a/crates/agent-tui/src/tui/session_link.rs
+++ b/crates/agent-tui/src/tui/session_link.rs
@@ -432,6 +432,28 @@ mod tests {
         assert!(link.buffered.is_empty());
     }
 
+    /// After `End`, a channel that closes without `Ended` is a clean close
+    /// (`false`, not a hang): `run()` exits 0 on it.
+    #[tokio::test]
+    async fn wait_ended_distinguishes_ended_from_clean_close() {
+        let mut t = ScriptedTransport::new(Runtime::new_headless());
+        t.push_event(SessionEventWire::Idle);
+        t.push_event(SessionEventWire::Ended {
+            reason: agent_engine::session::EndReason::ClientQuit,
+        });
+        let mut link = SessionLink::new(Box::new(t));
+        assert!(link.wait_ended().await);
+
+        let t = ScriptedTransport::new(Runtime::new_headless());
+        let mut link = SessionLink::new(Box::new(t));
+        assert!(!tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            link.wait_ended()
+        )
+        .await
+        .expect("closed channel returns at once"));
+    }
+
     /// A `Refused` addressed to ANOTHER client is not our reply: buffered
     /// for the loop, the real reply still picked.
     #[tokio::test]

--- a/crates/agent-tui/src/tui/session_link.rs
+++ b/crates/agent-tui/src/tui/session_link.rs
@@ -1,0 +1,372 @@
+//! The TUI's side of the session protocol (PLAN-phase3 §2.4, §3.2).
+//!
+//! [`SessionLink`] wraps a `Box<dyn ClientTransport>` + the published
+//! [`RuntimeView`] and adds the two things every slash-command/setter site
+//! needs: correlated round-trips (`Set{id}` → `SettingChanged{id}`,
+//! `EngineCommand{id}` → `QueryResult{id}`, …) and an envelope buffer so
+//! anything that arrives while a reply is awaited is replayed to the loop
+//! in order — presentation order is exactly today's (the reply line is
+//! pushed by the same handler that sent the command).
+//!
+//! [`PromptBridge`] turns `Prompt(req)` envelopes into the
+//! `SecretPromptRequest`s the (untouched) secret-prompt pane consumes, and
+//! routes the pane's answer back as `Answer{prompt_id}`.
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::Arc;
+
+use agent_engine::session::{
+    AttachMode, ClientId, ClientTransport, Envelope, PromptRequest, RuntimeView,
+    SessionCommand, SessionEventWire, SessionQuery, SessionSetting, SettingApplied,
+    TransportError,
+};
+
+/// Bound on any single command round-trip. The in-process actor answers in
+/// microseconds unless it is inside `run_stream_with_messages` setup or an
+/// inline compaction (B2 spawns it); the socket adds one hop.
+pub(crate) const ROUNDTRIP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Reply to `Resume{id}`.
+pub(crate) struct ResumedReply {
+    pub old_id: String,
+    pub new_id: String,
+    pub via: Option<String>,
+    pub clamp_notice: Option<String>,
+}
+
+pub(crate) struct SessionLink {
+    transport: Box<dyn ClientTransport>,
+    view: Arc<RuntimeView>,
+    buffered: VecDeque<Envelope>,
+    next_id: u64,
+    /// `true` once `next_event` returned `None` (actor gone / socket EOF).
+    closed: bool,
+}
+
+impl SessionLink {
+    pub(crate) fn new(transport: Box<dyn ClientTransport>) -> Self {
+        let view = transport.view();
+        Self {
+            transport,
+            view,
+            buffered: VecDeque::new(),
+            next_id: 1,
+            closed: false,
+        }
+    }
+
+    /// The view every synchronous getter reads (`impl RuntimeRead`).
+    pub(crate) fn view(&self) -> &Arc<RuntimeView> {
+        &self.view
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn transport(&self) -> &dyn ClientTransport {
+        &*self.transport
+    }
+
+    pub(crate) fn transport_mut(&mut self) -> &mut Box<dyn ClientTransport> {
+        &mut self.transport
+    }
+
+    pub(crate) fn client_id(&self) -> ClientId {
+        self.transport.client_id()
+    }
+
+    pub(crate) fn mode(&self) -> AttachMode {
+        self.transport.mode()
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.closed
+    }
+
+    /// Re-read the transport's published view (after `Attached`/reconnect).
+    pub(crate) fn refresh_view(&mut self) {
+        self.view = self.transport.view();
+    }
+
+    fn alloc_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
+    /// Fire-and-forget, stamped with this client's id.
+    pub(crate) async fn send(&self, cmd: SessionCommand) -> Result<(), TransportError> {
+        self.transport.send_from_self(cmd).await
+    }
+
+    /// Next envelope for the loop: buffered replays first. Keeps `view`
+    /// fresh from `SettingChanged` (carries the view) and `Resumed`/`Attached`.
+    pub(crate) async fn next_event(&mut self) -> Option<Envelope> {
+        if let Some(env) = self.buffered.pop_front() {
+            return Some(env);
+        }
+        let env = self.transport.next_event().await;
+        match env {
+            Some(env) => {
+                self.note(&env);
+                Some(env)
+            }
+            None => {
+                self.closed = true;
+                None
+            }
+        }
+    }
+
+    fn note(&mut self, env: &Envelope) {
+        match &env.event {
+            SessionEventWire::SettingChanged(applied) => {
+                self.view = Arc::new(applied.view.clone());
+            }
+            SessionEventWire::Resumed { .. } | SessionEventWire::Attached { .. } => {
+                self.view = self.transport.view();
+            }
+            _ => {}
+        }
+    }
+
+    /// Send `cmd` and pull envelopes until `pick` accepts one; everything
+    /// else is buffered for the loop in arrival order.
+    async fn roundtrip<T>(
+        &mut self,
+        cmd: SessionCommand,
+        mut pick: impl FnMut(&SessionEventWire) -> Option<T>,
+    ) -> Result<T, String> {
+        self.send(cmd).await.map_err(|e| e.to_string())?;
+        let deadline = tokio::time::Instant::now() + ROUNDTRIP_TIMEOUT;
+        loop {
+            let env = match tokio::time::timeout_at(deadline, self.transport.next_event()).await {
+                Ok(Some(env)) => env,
+                Ok(None) => {
+                    self.closed = true;
+                    return Err("session closed".to_string());
+                }
+                Err(_) => return Err("session did not reply in time".to_string()),
+            };
+            self.note(&env);
+            if let Some(t) = pick(&env.event) {
+                return Ok(t);
+            }
+            self.buffered.push_back(env);
+        }
+    }
+
+    /// `Set{id, setting}` → the matching `SettingChanged`.
+    pub(crate) async fn set(&mut self, setting: SessionSetting) -> Result<SettingApplied, String> {
+        let id = self.alloc_id();
+        self.roundtrip(SessionCommand::Set { id, setting }, |ev| match ev {
+            SessionEventWire::SettingChanged(a) if a.id == id => Some(a.clone()),
+            _ => None,
+        })
+        .await
+    }
+
+    /// `Set` that folds `ok=false` into `Err(message)`.
+    pub(crate) async fn set_checked(
+        &mut self,
+        setting: SessionSetting,
+    ) -> Result<SettingApplied, String> {
+        let applied = self.set(setting).await?;
+        if applied.ok {
+            Ok(applied)
+        } else {
+            Err(applied
+                .message
+                .clone()
+                .unwrap_or_else(|| "setting rejected".to_string()))
+        }
+    }
+
+    pub(crate) async fn query(&mut self, query: SessionQuery) -> Result<serde_json::Value, String> {
+        let id = self.alloc_id();
+        self.roundtrip(SessionCommand::Query { id, query }, |ev| match ev {
+            SessionEventWire::QueryResult { id: rid, value } if *rid == id => Some(value.clone()),
+            _ => None,
+        })
+        .await
+    }
+
+    pub(crate) async fn engine_command(
+        &mut self,
+        name: &str,
+        arg: &str,
+    ) -> Result<serde_json::Value, String> {
+        let id = self.alloc_id();
+        let value = self
+            .roundtrip(
+                SessionCommand::EngineCommand {
+                    id,
+                    name: name.to_string(),
+                    arg: arg.to_string(),
+                },
+                |ev| match ev {
+                    SessionEventWire::QueryResult { id: rid, value } if *rid == id => {
+                        Some(value.clone())
+                    }
+                    _ => None,
+                },
+            )
+            .await?;
+        // model/thinking changes republish the actor's view without a
+        // `SettingChanged`; re-read it so the footer/getters are current
+        // under either transport.
+        if value.get("event").is_some() {
+            if let Ok(v) = self.query(SessionQuery::View).await {
+                if let Ok(view) = serde_json::from_value::<RuntimeView>(v) {
+                    self.view = Arc::new(view);
+                }
+            }
+        }
+        Ok(value)
+    }
+
+    pub(crate) async fn plugin_command(
+        &mut self,
+        plugin: &str,
+        name: &str,
+        arg: &str,
+    ) -> Result<serde_json::Value, String> {
+        let id = self.alloc_id();
+        self.roundtrip(
+            SessionCommand::PluginCommand {
+                id,
+                plugin: plugin.to_string(),
+                name: name.to_string(),
+                arg: arg.to_string(),
+            },
+            |ev| match ev {
+                SessionEventWire::QueryResult { id: rid, value } if *rid == id => {
+                    Some(value.clone())
+                }
+                _ => None,
+            },
+        )
+        .await
+    }
+
+    /// `Resume{id, query}` → `Resumed{id, ..}` (or the actor's error reply as
+    /// a `QueryResult{id, {kind:"error", text}}`).
+    pub(crate) async fn resume(&mut self, query: &str) -> Result<ResumedReply, String> {
+        let id = self.alloc_id();
+        self.roundtrip(
+            SessionCommand::Resume {
+                id,
+                query: query.to_string(),
+            },
+            |ev| match ev {
+                SessionEventWire::Resumed {
+                    id: rid,
+                    old_id,
+                    new_id,
+                    via,
+                    clamp_notice,
+                } if *rid == id => Some(Ok(ResumedReply {
+                    old_id: old_id.clone(),
+                    new_id: new_id.clone(),
+                    via: via.clone(),
+                    clamp_notice: clamp_notice.clone(),
+                })),
+                SessionEventWire::QueryResult { id: rid, value } if *rid == id => Some(Err(value
+                    ["text"]
+                    .as_str()
+                    .unwrap_or("resume failed")
+                    .to_string())),
+                _ => None,
+            },
+        )
+        .await?
+    }
+
+    /// Wait for `Ended` (teardown). Buffered/late envelopes are dropped —
+    /// nothing renders past this point.
+    pub(crate) async fn wait_ended(&mut self) -> bool {
+        loop {
+            match self.transport.next_event().await {
+                Some(env) => {
+                    if matches!(env.event, SessionEventWire::Ended { .. }) {
+                        return true;
+                    }
+                }
+                None => return false,
+            }
+        }
+    }
+}
+
+// ── PromptBridge ─────────────────────────────────────────────────────────
+
+/// `Prompt(req)` → local `SecretPromptRequest` on the SAME channel the
+/// secret-prompt pane polls; the pane's oneshot answer comes back through
+/// `answers_rx` and the loop sends `Answer{prompt_id, value}`.
+pub(crate) struct PromptBridge {
+    secret_prompt_tx: tokio::sync::mpsc::UnboundedSender<synaps_cli::tools::SecretPromptRequest>,
+    answers_tx: tokio::sync::mpsc::UnboundedSender<(u64, Option<String>)>,
+    pub(crate) answers_rx: tokio::sync::mpsc::UnboundedReceiver<(u64, Option<String>)>,
+    /// Prompt ids fed to the pane, FIFO — the queue activates in this order.
+    order: VecDeque<u64>,
+    /// Prompt ids this client answered (its own `PromptResolved` is not a
+    /// dismissal).
+    answered: HashSet<u64>,
+}
+
+impl PromptBridge {
+    pub(crate) fn new(
+        secret_prompt_tx: tokio::sync::mpsc::UnboundedSender<
+            synaps_cli::tools::SecretPromptRequest,
+        >,
+    ) -> Self {
+        let (answers_tx, answers_rx) = tokio::sync::mpsc::unbounded_channel();
+        Self {
+            secret_prompt_tx,
+            answers_tx,
+            answers_rx,
+            order: VecDeque::new(),
+            answered: HashSet::new(),
+        }
+    }
+
+    pub(crate) fn on_prompt(&mut self, req: PromptRequest) {
+        let (response_tx, response_rx) = tokio::sync::oneshot::channel::<Option<String>>();
+        let _ = self
+            .secret_prompt_tx
+            .send(synaps_cli::tools::SecretPromptRequest {
+                title: req.title,
+                prompt: req.prompt,
+                response_tx,
+            });
+        self.order.push_back(req.id);
+        let answers = self.answers_tx.clone();
+        let id = req.id;
+        tokio::spawn(async move {
+            // Err = dismissed (oneshot dropped without an answer): another
+            // client answered; nothing to send.
+            if let Ok(value) = response_rx.await {
+                let _ = answers.send((id, value));
+            }
+        });
+    }
+
+    /// The pane answered `id` locally: remember it so the echoed
+    /// `PromptResolved` is not treated as a foreign resolution.
+    pub(crate) fn on_local_answer(&mut self, id: u64) {
+        self.answered.insert(id);
+        self.order.retain(|x| *x != id);
+    }
+
+    /// `PromptResolved{id}`: returns `true` when the ACTIVE pane prompt must
+    /// be dismissed (resolved by someone else).
+    pub(crate) fn on_resolved(&mut self, id: u64) -> bool {
+        if self.answered.remove(&id) {
+            return false;
+        }
+        if self.order.front() == Some(&id) {
+            self.order.pop_front();
+            return true;
+        }
+        self.order.retain(|x| *x != id);
+        false
+    }
+}

--- a/crates/agent-tui/src/tui/session_link.rs
+++ b/crates/agent-tui/src/tui/session_link.rs
@@ -129,12 +129,15 @@ impl SessionLink {
     }
 
     /// Send `cmd` and pull envelopes until `pick` accepts one; everything
-    /// else is buffered for the loop in arrival order.
+    /// else is buffered for the loop in arrival order. A `Refused` addressed
+    /// to this client (B1 ownership: a non-owner's setter) IS the reply —
+    /// `Err(reason)` immediately, never the 30 s timeout.
     async fn roundtrip<T>(
         &mut self,
         cmd: SessionCommand,
         mut pick: impl FnMut(&SessionEventWire) -> Option<T>,
     ) -> Result<T, String> {
+        let me = self.client_id();
         self.send(cmd).await.map_err(|e| e.to_string())?;
         let deadline = tokio::time::Instant::now() + ROUNDTRIP_TIMEOUT;
         loop {
@@ -149,6 +152,16 @@ impl SessionLink {
             self.note(&env);
             if let Some(t) = pick(&env.event) {
                 return Ok(t);
+            }
+            if let SessionEventWire::Refused {
+                client,
+                command,
+                reason,
+            } = &env.event
+            {
+                if *client == me {
+                    return Err(format!("{command} refused: {reason}"));
+                }
             }
             self.buffered.push_back(env);
         }
@@ -368,5 +381,75 @@ impl PromptBridge {
         }
         self.order.retain(|x| *x != id);
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::testing::scripted::ScriptedTransport;
+    use synaps_cli::Runtime;
+
+    fn refusing_link() -> SessionLink {
+        let mut t = ScriptedTransport::new(Runtime::new_headless());
+        t.set_refuse_input(Some("input owned by client #2".to_string()));
+        SessionLink::new(Box::new(t))
+    }
+
+    /// M2: a non-owner's setter is answered `Refused{client: me}`; the
+    /// round-trip must return that reason at once, not block until
+    /// `ROUNDTRIP_TIMEOUT`.
+    #[tokio::test]
+    async fn roundtrip_returns_refused_reason_immediately() {
+        let mut link = refusing_link();
+        let started = std::time::Instant::now();
+        let res = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            link.set(SessionSetting::Model {
+                model: "claude-opus-4-1".into(),
+            }),
+        )
+        .await
+        .expect("must not hit the round-trip timeout");
+        assert_eq!(
+            res.unwrap_err(),
+            "set refused: input owned by client #2"
+        );
+        assert!(started.elapsed() < std::time::Duration::from_secs(1));
+        // Same for every correlated verb.
+        let r = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            link.engine_command("model", "claude-opus-4-1"),
+        )
+        .await
+        .unwrap();
+        assert!(r.unwrap_err().ends_with("input owned by client #2"));
+        let r = tokio::time::timeout(std::time::Duration::from_secs(2), link.resume("x"))
+            .await
+            .unwrap();
+        assert!(r.unwrap_err().ends_with("input owned by client #2"));
+        // Nothing leaked into the loop's buffer.
+        assert!(link.buffered.is_empty());
+    }
+
+    /// A `Refused` addressed to ANOTHER client is not our reply: buffered
+    /// for the loop, the real reply still picked.
+    #[tokio::test]
+    async fn roundtrip_ignores_refused_for_other_clients() {
+        let mut t = ScriptedTransport::new(Runtime::new_headless());
+        t.push_event(SessionEventWire::Refused {
+            client: ClientId(7),
+            command: "set".into(),
+            reason: "not you".into(),
+        });
+        let mut link = SessionLink::new(Box::new(t));
+        let applied = link
+            .set(SessionSetting::ContextWindow {
+                tokens: Some(1_000_000),
+            })
+            .await
+            .expect("real reply picked");
+        assert!(applied.ok, "{applied:?}");
+        assert_eq!(link.buffered.len(), 1);
     }
 }

--- a/crates/agent-tui/src/tui/settings/defs.rs
+++ b/crates/agent-tui/src/tui/settings/defs.rs
@@ -1,10 +1,24 @@
 //! Single source of truth for every tweakable setting.
 //!
 //! One macro invocation generates both the UI schema (`ALL_SETTINGS`) and the
-//! runtime apply dispatch (`apply_setting_dispatch`). Add a setting here and
-//! both sides stay in sync — drift is impossible.
+//! apply dispatch (`apply_setting_dispatch`). Add a setting here and both
+//! sides stay in sync — drift is impossible.
+//!
+//! Runtime-backed keys produce a [`SettingApply::Session`] (the
+//! `SessionSetting` the caller sends as `Set{id, ..}`); local keys apply
+//! synchronously and yield [`SettingApply::Local`].
 
 use super::schema::{Category, EditorKind, SettingDef};
+use agent_engine::session::SessionSetting;
+
+/// What a settings apply resolves to (PLAN-phase3 §3.2 settings/defs).
+pub(crate) enum SettingApply {
+    /// Send this to the session; the reply decides the config write.
+    Session(SessionSetting),
+    /// Applied locally (theme, keybinds, …) or a no-op; `Err` = rejected
+    /// (the caller must NOT write the value to the config file).
+    Local(Result<(), String>),
+}
 
 macro_rules! define_settings {
     ($(
@@ -23,24 +37,23 @@ macro_rules! define_settings {
             )*
         ];
 
-        /// Apply a setting by key/value and return `Ok(())` on success or
-        /// `Err(user-facing message)` on validation failure.  Handlers that
-        /// do not perform validation always return `Ok(())`.  On `Err` the
-        /// caller must NOT write the value to the config file.
+        /// Resolve a setting by key/value: a `SessionSetting` to send, or the
+        /// local outcome. Handlers that do not perform validation always
+        /// yield `Local(Ok(()))`. On `Local(Err)` the caller must NOT write
+        /// the value to the config file.
         pub(crate) fn apply_setting_dispatch(
             key: &str,
             value: &str,
-            runtime: &mut synaps_cli::Runtime,
             app: &mut crate::tui::app::App,
-        ) -> Result<(), String> {
+        ) -> SettingApply {
             match key {
                 $(
                     stringify!($key) => {
-                        let handler: fn(&mut synaps_cli::Runtime, &mut crate::tui::app::App, &str) -> Result<(), String> = $apply;
-                        handler(runtime, app, value)
+                        let handler: fn(&mut crate::tui::app::App, &str) -> SettingApply = $apply;
+                        handler(app, value)
                     }
                 )*
-                _ => Ok(())
+                _ => SettingApply::Local(Ok(()))
             }
         }
     };
@@ -49,123 +62,127 @@ macro_rules! define_settings {
 define_settings! {
     model, "Model", Model, EditorKind::ModelPicker,
         "Which Claude model to use.",
-        |runtime, _app, value| { runtime.set_model(value.to_string()); Ok(()) };
+        |_app, value| SettingApply::Session(SessionSetting::Model { model: value.to_string() });
 
     thinking, "Thinking", Model,
         EditorKind::DynamicCycler,
         "Thinking depth — controls effort on adaptive models, budget on legacy.",
-        |runtime, _app, value| {
+        |app, value| {
             use agent_core::reasoning::ReasoningLevel;
             if let Some(level) = ReasoningLevel::parse(value) {
-                // Validate against capability cache/static before mutating.
-                // On Err: return the error so apply_setting can skip config write.
-                runtime.set_reasoning_level_checked(level)
+                // Validate against capability cache/static before sending
+                // (client-local pre-check; the actor re-validates). On Err:
+                // return the error so apply_setting can skip config write.
+                if let Err(e) = synaps_cli::runtime::openai::catalog::validation::validate_reasoning_mutation(
+                    &app.session.model, level,
+                ) {
+                    return SettingApply::Local(Err(e));
+                }
+                SettingApply::Session(SessionSetting::ReasoningLevel { level })
             } else {
                 // Unknown string — ignore silently (cycler only emits valid strings).
-                Ok(())
+                SettingApply::Local(Ok(()))
             }
         };
 
     reasoning_type, "Reasoning", Model,
         EditorKind::Display,
         "How the active model expresses reasoning depth (derived from exact model capabilities; read-only).",
-        |_runtime, _app, _value| { /* display-only: no editor emits Apply for this key */ Ok(()) };
+        |_app, _value| { /* display-only: no editor emits Apply for this key */ SettingApply::Local(Ok(())) };
 
     context_window, "Context window", Model,
         EditorKind::Cycler(&["200k", "1m", "auto"]),
         "Override context window limit (auto = model default).",
-        |runtime, app, value| {
+        |_app, value| {
             let window = match value {
                 "200k" | "200K" => Some(200_000u64),
                 "1m" | "1M" => Some(1_000_000u64),
                 "auto" => None,
-                _ => return Ok(()),
+                _ => return SettingApply::Local(Ok(())),
             };
-            runtime.set_context_window(window);
-            // Also update the bar denominator immediately so the UI reflects the change.
-            app.last_turn_context_window = runtime.context_window();
-            Ok(())
+            // The bar denominator (`last_turn_context_window`) follows the
+            // reply's view in apply_setting().
+            SettingApply::Session(SessionSetting::ContextWindow { tokens: window })
         };
 
     compaction_model, "Compaction model", Model,
         EditorKind::ModelPicker,
         "Model used for /compact (default: claude-sonnet-4-6).",
-        |runtime, _app, value| {
+        |_app, value| {
             let model = if value.is_empty() || value == "auto" || value == "default" {
                 None
             } else {
                 Some(value.to_string())
             };
-            runtime.set_compaction_model(model);
-            Ok(())
+            SettingApply::Session(SessionSetting::CompactionModel { model })
         };
 
     api_retries, "API retries", Agent, EditorKind::Text { numeric: true },
         "Retries on transient API errors.",
-        |runtime, _app, value| {
-            if let Ok(n) = value.parse::<u32>() { runtime.set_api_retries(n); }
-            Ok(())
+        |_app, value| match value.parse::<u32>() {
+            Ok(n) => SettingApply::Session(SessionSetting::ApiRetries { n }),
+            Err(_) => SettingApply::Local(Ok(())),
         };
 
     subagent_timeout, "Subagent timeout", Agent, EditorKind::Text { numeric: true },
         "Seconds before a dispatched subagent is canceled.",
-        |runtime, _app, value| {
-            if let Ok(n) = value.parse::<u64>() { runtime.set_subagent_timeout(n); }
-            Ok(())
+        |_app, value| match value.parse::<u64>() {
+            Ok(secs) => SettingApply::Session(SessionSetting::SubagentTimeout { secs }),
+            Err(_) => SettingApply::Local(Ok(())),
         };
 
     max_tool_output, "Max tool output", ToolLimits, EditorKind::Text { numeric: true },
         "Bytes to capture from a tool before truncating.",
-        |runtime, _app, value| {
-            if let Ok(n) = value.parse::<usize>() { runtime.set_max_tool_output(n); }
-            Ok(())
+        |_app, value| match value.parse::<usize>() {
+            Ok(bytes) => SettingApply::Session(SessionSetting::MaxToolOutput { bytes }),
+            Err(_) => SettingApply::Local(Ok(())),
         };
 
     bash_timeout, "Bash timeout", ToolLimits, EditorKind::Text { numeric: true },
         "Default seconds allowed for a bash command.",
-        |runtime, _app, value| {
-            if let Ok(n) = value.parse::<u64>() { runtime.set_bash_timeout(n); }
-            Ok(())
+        |_app, value| match value.parse::<u64>() {
+            Ok(secs) => SettingApply::Session(SessionSetting::BashTimeout { secs }),
+            Err(_) => SettingApply::Local(Ok(())),
         };
 
     bash_max_timeout, "Bash max timeout", ToolLimits, EditorKind::Text { numeric: true },
         "Legacy setting retained for config compatibility; requested bash timeouts are no longer clamped.",
-        |runtime, _app, value| {
-            if let Ok(n) = value.parse::<u64>() { runtime.set_bash_max_timeout(n); }
-            Ok(())
+        |_app, value| match value.parse::<u64>() {
+            Ok(secs) => SettingApply::Session(SessionSetting::BashMaxTimeout { secs }),
+            Err(_) => SettingApply::Local(Ok(())),
         };
 
     theme, "Theme", Appearance, EditorKind::ThemePicker,
         "Color theme (restart required).",
-        |_runtime, _app, _value| { /* handled after write_config_value in apply_setting() */ Ok(()) };
+        |_app, _value| { /* handled after write_config_value in apply_setting() */ SettingApply::Local(Ok(())) };
 
     tui_background_opaque, "Background", Appearance, EditorKind::Cycler(&["opaque", "invisible"]),
         "Opaque paints Synaps' theme background; invisible uses your terminal background.",
-        |_runtime, _app, value| {
+        |_app, value| {
             match value {
                 "opaque" => super::super::theme::set_background_opaque(true),
                 "invisible" => super::super::theme::set_background_opaque(false),
-                _ => return Err("expected opaque or invisible".to_string()),
+                _ => return SettingApply::Local(Err("expected opaque or invisible".to_string())),
             }
-            Ok(())
+            SettingApply::Local(Ok(()))
         };
 
     theme_transition, "Theme transition", Appearance, EditorKind::Cycler(&["on", "off"]),
         "Animated cross-fade on theme changes (on = 350ms). Off = instant snap. Integer ms (0-2000) accepted in the config file.",
-        |_runtime, _app, value| {
+        |_app, value| {
             match synaps_cli::config::ThemeTransitionMode::parse(value) {
                 Some(mode) => {
                     super::super::theme::transition::set_transition_mode(mode);
-                    Ok(())
+                    SettingApply::Local(Ok(()))
                 }
-                None => Err("expected on, off, or milliseconds (0-2000)".to_string()),
+                None => SettingApply::Local(Err("expected on, off, or milliseconds (0-2000)".to_string())),
             }
         };
 
     sidecar_toggle_key, "Sidecar toggle key", Sidecar,
         EditorKind::Cycler(&["F8", "F2", "F12", "C-V", "C-G"]),
         "Keybind that toggles the active sidecar plugin. Takes effect immediately.",
-        |_runtime, app, value| {
+        |app, value| {
             if let Some(kb) = app.keybinds.as_ref() {
                 match kb.write() {
                     Ok(mut g) => {
@@ -176,7 +193,7 @@ define_settings! {
                     Err(_) => tracing::warn!("sidecar_toggle_key apply: registry poisoned"),
                 }
             }
-            Ok(())
+            SettingApply::Local(Ok(()))
         };
 }
 
@@ -227,80 +244,84 @@ mod tests {
         }
     }
 
-    // B2: apply_setting_dispatch returns Result; rejected thinking must not mutate.
-    #[test]
-    fn thinking_dispatch_rejects_unsupported_level_returns_err_no_mutation() {
-        let mut rt = synaps_cli::Runtime::new_headless();
-        rt.set_model("openai-codex/gpt-5.6-luna".to_string()); // luna: no ultra
-        let before = rt.reasoning_level();
-        let mut app = crate::tui::app::App::new(synaps_cli::Session::new("m", "medium", None));
+    fn app_with_model(model: &str) -> crate::tui::app::App {
+        crate::tui::app::App::new(synaps_cli::Session::new(model, "medium", None))
+    }
 
-        let result = apply_setting_dispatch("thinking", "ultra", &mut rt, &mut app);
-        assert!(result.is_err(), "ultra must be rejected for luna");
-        assert_eq!(
-            rt.reasoning_level(),
-            before,
-            "runtime must not be mutated when dispatch returns Err"
-        );
+    // Rejected thinking never becomes a `Set` (the config write is skipped).
+    #[test]
+    fn thinking_dispatch_rejects_unsupported_level_returns_err_no_set() {
+        let mut app = app_with_model("openai-codex/gpt-5.6-luna"); // luna: no ultra
+        match apply_setting_dispatch("thinking", "ultra", &mut app) {
+            SettingApply::Local(Err(_)) => {}
+            _ => panic!("ultra must be rejected for luna before any Set"),
+        }
     }
 
     #[test]
-    fn thinking_dispatch_accepts_valid_level_returns_ok_and_mutates() {
-        let mut rt = synaps_cli::Runtime::new_headless();
-        rt.set_model("openai-codex/gpt-5.6-sol".to_string()); // sol: supports ultra
-        let mut app = crate::tui::app::App::new(synaps_cli::Session::new("m", "medium", None));
-
-        let result = apply_setting_dispatch("thinking", "ultra", &mut rt, &mut app);
-        assert!(result.is_ok(), "ultra must be accepted for sol");
-        assert_eq!(
-            rt.reasoning_level(),
-            agent_core::reasoning::ReasoningLevel::Ultra,
-            "runtime must be updated when dispatch returns Ok"
-        );
+    fn thinking_dispatch_accepts_valid_level_yields_set() {
+        let mut app = app_with_model("openai-codex/gpt-5.6-sol"); // sol: supports ultra
+        match apply_setting_dispatch("thinking", "ultra", &mut app) {
+            SettingApply::Session(SessionSetting::ReasoningLevel { level }) => {
+                assert_eq!(level, agent_core::reasoning::ReasoningLevel::Ultra)
+            }
+            _ => panic!("ultra must be accepted for sol"),
+        }
     }
 
     #[test]
-    fn thinking_dispatch_rejects_off_on_xai_45_no_mutation_or_persist() {
-        let mut rt = synaps_cli::Runtime::new_headless();
-        rt.set_model("xai-auth/grok-4.5".to_string());
-        // Documented model default applied on switch.
-        assert_eq!(
-            rt.reasoning_level(),
-            agent_core::reasoning::ReasoningLevel::High
-        );
-        let mut app = crate::tui::app::App::new(synaps_cli::Session::new("m", "medium", None));
-
+    fn thinking_dispatch_rejects_off_on_xai_45_no_set() {
+        let mut app = app_with_model("xai-auth/grok-4.5");
         // Off must be rejected (reasoning cannot be disabled), never omitted.
-        let result = apply_setting_dispatch("thinking", "off", &mut rt, &mut app);
-        assert!(result.is_err(), "off must be rejected for grok-4.5");
-        assert_eq!(
-            rt.reasoning_level(),
-            agent_core::reasoning::ReasoningLevel::High
-        );
-
+        assert!(matches!(
+            apply_setting_dispatch("thinking", "off", &mut app),
+            SettingApply::Local(Err(_))
+        ));
         // xhigh is not documented for grok-4.5 either.
-        assert!(apply_setting_dispatch("thinking", "xhigh", &mut rt, &mut app).is_err());
-        assert_eq!(
-            rt.reasoning_level(),
-            agent_core::reasoning::ReasoningLevel::High
-        );
-
+        assert!(matches!(
+            apply_setting_dispatch("thinking", "xhigh", &mut app),
+            SettingApply::Local(Err(_))
+        ));
         // A documented effort is accepted.
-        assert!(apply_setting_dispatch("thinking", "low", &mut rt, &mut app).is_ok());
-        assert_eq!(
-            rt.reasoning_level(),
-            agent_core::reasoning::ReasoningLevel::Low
-        );
+        assert!(matches!(
+            apply_setting_dispatch("thinking", "low", &mut app),
+            SettingApply::Session(SessionSetting::ReasoningLevel {
+                level: agent_core::reasoning::ReasoningLevel::Low
+            })
+        ));
     }
 
     #[test]
-    fn non_thinking_dispatches_always_return_ok() {
-        let mut rt = synaps_cli::Runtime::new_headless();
-        let mut app = crate::tui::app::App::new(synaps_cli::Session::new("m", "medium", None));
-        // model, api_retries, etc. return Ok(()) unconditionally.
-        assert!(apply_setting_dispatch("model", "claude-opus-4-7", &mut rt, &mut app).is_ok());
-        assert!(apply_setting_dispatch("api_retries", "5", &mut rt, &mut app).is_ok());
-        assert!(apply_setting_dispatch("bash_timeout", "30", &mut rt, &mut app).is_ok());
-        assert!(apply_setting_dispatch("unknown_key_xyz", "val", &mut rt, &mut app).is_ok());
+    fn runtime_keys_yield_the_expected_session_setting() {
+        let mut app = app_with_model("m");
+        assert!(matches!(
+            apply_setting_dispatch("model", "claude-opus-4-7", &mut app),
+            SettingApply::Session(SessionSetting::Model { model }) if model == "claude-opus-4-7"
+        ));
+        assert!(matches!(
+            apply_setting_dispatch("api_retries", "5", &mut app),
+            SettingApply::Session(SessionSetting::ApiRetries { n: 5 })
+        ));
+        assert!(matches!(
+            apply_setting_dispatch("bash_timeout", "30", &mut app),
+            SettingApply::Session(SessionSetting::BashTimeout { secs: 30 })
+        ));
+        assert!(matches!(
+            apply_setting_dispatch("context_window", "1m", &mut app),
+            SettingApply::Session(SessionSetting::ContextWindow { tokens: Some(1_000_000) })
+        ));
+        assert!(matches!(
+            apply_setting_dispatch("compaction_model", "auto", &mut app),
+            SettingApply::Session(SessionSetting::CompactionModel { model: None })
+        ));
+        // Unparseable numerics and unknown keys are local no-ops.
+        assert!(matches!(
+            apply_setting_dispatch("api_retries", "x", &mut app),
+            SettingApply::Local(Ok(()))
+        ));
+        assert!(matches!(
+            apply_setting_dispatch("unknown_key_xyz", "val", &mut app),
+            SettingApply::Local(Ok(()))
+        ));
     }
 }

--- a/crates/agent-tui/src/tui/settings/mod.rs
+++ b/crates/agent-tui/src/tui/settings/mod.rs
@@ -520,21 +520,28 @@ mod thinking_options_tests {
         let mut rt = synaps_cli::Runtime::new_headless();
         let mut app = crate::tui::app::App::new(synaps_cli::Session::new("m", "medium", None));
 
-        super::defs::apply_setting_dispatch("model", "xai-auth/grok-4.5", &mut rt, &mut app)
-            .unwrap();
+        // The dispatch yields the `Set{Model}`; the actor applies it. Here
+        // the headless runtime plays the actor.
+        let mut apply = |rt: &mut synaps_cli::Runtime, model: &str| {
+            match super::defs::apply_setting_dispatch("model", model, &mut app) {
+                super::defs::SettingApply::Session(
+                    agent_engine::session::SessionSetting::Model { model },
+                ) => rt.set_model(model),
+                _ => panic!("model must resolve to Set{{Model}}"),
+            };
+        };
+        apply(&mut rt, "xai-auth/grok-4.5");
         assert_eq!(super::reasoning_type_for_model(rt.model()), "effort");
         assert_eq!(
             thinking_options_for_model(rt.model()),
             vec!["adaptive", "low", "medium", "high"]
         );
 
-        super::defs::apply_setting_dispatch("model", "xai-auth/grok-4.3", &mut rt, &mut app)
-            .unwrap();
+        apply(&mut rt, "xai-auth/grok-4.3");
         assert_eq!(super::reasoning_type_for_model(rt.model()), "intrinsic");
         assert_eq!(thinking_options_for_model(rt.model()), vec!["adaptive"]);
 
-        super::defs::apply_setting_dispatch("model", "openai-codex/gpt-5.6-sol", &mut rt, &mut app)
-            .unwrap();
+        apply(&mut rt, "openai-codex/gpt-5.6-sol");
         assert_eq!(
             super::reasoning_type_for_model(rt.model()),
             "effort (named)"

--- a/crates/agent-tui/src/tui/signals.rs
+++ b/crates/agent-tui/src/tui/signals.rs
@@ -28,16 +28,21 @@
 //! `render_thread.rs`).  The main task never blocks on stdout, so the
 //! `select!` is always free to receive a signal, and the bounded teardown in
 //! `mod.rs` always runs.  The watchdog was therefore **removed** — shutdown is
-//! self-bounding via `SAVE_TIMEOUT_SECS` + `HOOKS_TIMEOUT_SECS` (plus the
-//! render thread's own teardown-ack budget).
+//! self-bounding via the actor's budgets (plus the render thread's own
+//! teardown-ack budget).
 //!
 //! # Teardown timeout budgets
 //!
-//! The post-loop teardown in `mod.rs` is split into two sequential budgets:
+//! The session teardown runs inside `SessionActor::finish` under the
+//! engine's budgets (`agent_engine::session::budgets`, re-exported here):
 //!   - `SAVE_TIMEOUT_SECS`  : save_session + append_record (data safety first)
 //!   - `HOOKS_TIMEOUT_SECS` : on_session_end hook emit (concurrent, fail-open)
+//!   - plus the observability flush and, when quitting mid-turn, the
+//!     cancel-turn save.
 //!
-//! `TEARDOWN_TIMEOUT_SECS` = their sum (total teardown budget).
+//! `SESSION_END_TIMEOUT_SECS` is what the TUI waits for `Ended`: the sum of
+//! those plus a margin. `TEARDOWN_TIMEOUT_SECS` (= SAVE + HOOKS) is the
+//! render thread's budget.
 
 // ── Teardown timing constants ────────────────────────────────────────────────
 //
@@ -48,9 +53,29 @@
 //   SAVE_TIMEOUT_SECS  — budget for save_session() + append_record()
 //   HOOKS_TIMEOUT_SECS — budget for concurrent on_session_end hook emit
 //   TEARDOWN_TIMEOUT_SECS — sum of the above; total teardown budget for mod.rs
-pub(crate) const SAVE_TIMEOUT_SECS: u64 = 2;
-pub(crate) const HOOKS_TIMEOUT_SECS: u64 = 5;
-pub(crate) const TEARDOWN_TIMEOUT_SECS: u64 = SAVE_TIMEOUT_SECS + HOOKS_TIMEOUT_SECS;
+pub(crate) use agent_engine::session::budgets::{
+    HOOKS_TIMEOUT_SECS, SAVE_TIMEOUT_SECS, TEARDOWN_TIMEOUT_SECS,
+};
+
+/// Bounded observability flush inside `SessionActor::finish` (STEP 3).
+pub(crate) const FLUSH_TIMEOUT_SECS: u64 =
+    agent_engine::runtime::telemetry::DEFAULT_SHUTDOWN_FLUSH_TIMEOUT.as_secs();
+
+/// Slack for `background.shutdown()` + channel delivery of `Ended`.
+pub(crate) const SESSION_END_MARGIN_SECS: u64 = 2;
+
+/// How long the TUI waits for `Ended` after sending `End` (in-process).
+/// `SessionActor::finish` runs, sequentially and each under its own
+/// budget: the cancel-turn save (streaming quit) + the final save
+/// (`SAVE_TIMEOUT` each), `on_session_end` (`HOOKS_TIMEOUT`), the
+/// observability flush (`FLUSH_TIMEOUT`); then `background.shutdown()`.
+/// The wait covers the worst case plus margin so a slow-but-in-budget
+/// teardown never turns into `emergency_exit()` (exit 1).
+pub(crate) const SESSION_END_TIMEOUT_SECS: u64 = SAVE_TIMEOUT_SECS
+    + SAVE_TIMEOUT_SECS
+    + HOOKS_TIMEOUT_SECS
+    + FLUSH_TIMEOUT_SECS
+    + SESSION_END_MARGIN_SECS;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ShutdownSignal {
@@ -217,5 +242,23 @@ mod tests {
             TEARDOWN_TIMEOUT_SECS,
             SAVE_TIMEOUT_SECS + HOOKS_TIMEOUT_SECS
         );
+    }
+}
+
+#[cfg(test)]
+mod budget_tests {
+    use super::*;
+
+    /// M5: the TUI's wait for `Ended` must cover `SessionActor::finish`'s
+    /// worst case (cancel save + save + hooks + flush ≈ 11 s) with margin;
+    /// the old 7 s wait turned a slow-but-in-budget teardown into exit 1.
+    #[test]
+    fn session_end_wait_covers_actor_finish_worst_case() {
+        let actor_worst_case =
+            SAVE_TIMEOUT_SECS + SAVE_TIMEOUT_SECS + HOOKS_TIMEOUT_SECS + FLUSH_TIMEOUT_SECS;
+        assert_eq!(actor_worst_case, 11);
+        assert!(SESSION_END_TIMEOUT_SECS > actor_worst_case);
+        assert!(SESSION_END_TIMEOUT_SECS >= actor_worst_case + SESSION_END_MARGIN_SECS);
+        assert!(SESSION_END_TIMEOUT_SECS > TEARDOWN_TIMEOUT_SECS);
     }
 }

--- a/crates/agent-tui/src/tui/stream_handler.rs
+++ b/crates/agent-tui/src/tui/stream_handler.rs
@@ -1,25 +1,17 @@
-//! Stream event handling — processes StreamEvent variants from the runtime.
+//! Session-event handling — the presentation half of the turn machine
+//! (PLAN-phase3 §2.4). `Stream(ev)` keeps `handle_stream_event` as it was;
+//! every other envelope maps to the `ChatMessage`/state mutation the inline
+//! turn machine used to perform. The actor never renders.
 
-use serde_json::json;
-use synaps_cli::engine::reactor::{
-    claim_auto_turn, drain_event_queue, wake_action, EventDisposition, WakeAction, AUTO_TURN_CAP,
-};
-use synaps_cli::{AgentEvent, CancellationToken, LlmEvent, Runtime, SessionEvent, StreamEvent};
+use synaps_cli::{AgentEvent, LlmEvent, SessionEvent, StreamEvent};
+
+use agent_engine::session::{Envelope, RuntimeView, SessionEventWire, TurnTrigger};
 
 use super::app::{App, ChatMessage, SubagentState, THINKING_PLACEHOLDER};
 use super::draw::build_render_model;
 use super::render_thread::RenderHandle;
+use super::session_link::{PromptBridge, SessionLink};
 use super::view_model::ViewInputs;
-
-/// What the event loop should do after processing a stream event.
-pub(super) enum StreamAction {
-    /// Continue processing — no special action needed.
-    Continue,
-    /// Stream completed and a queued message should be auto-sent.
-    AutoSendQueued(String),
-    /// Stream completed and buffered events need a model turn.
-    AutoTriggerEvents,
-}
 
 /// Returns true if the event should trigger an immediate redraw.
 pub(super) fn needs_immediate_draw(event: &StreamEvent) -> bool {
@@ -36,12 +28,10 @@ pub(super) fn needs_immediate_draw(event: &StreamEvent) -> bool {
     )
 }
 
-/// Process a StreamEvent, update app state, return what the loop should do.
-pub(super) async fn handle_stream_event(
-    event: StreamEvent,
-    app: &mut App,
-    runtime: &Runtime,
-) -> StreamAction {
+/// Process a StreamEvent, update app state. Presentation only: history,
+/// saves, queued/pending flushes and auto-turns are the actor's (mirrored
+/// back by `Conversation` / `TurnStarted`).
+pub(super) fn handle_stream_event(event: StreamEvent, app: &mut App, view: &RuntimeView) {
     match event {
         StreamEvent::Llm(LlmEvent::Thinking(text)) => {
             app.append_or_update_thinking(&text);
@@ -62,19 +52,15 @@ pub(super) async fn handle_stream_event(
         }) => {
             let input_str = serde_json::to_string(&input).unwrap_or_default();
             app.on_tool_use_finalized(tool_id, tool_name, input_str);
-            return StreamAction::Continue;
         }
         StreamEvent::Llm(LlmEvent::ToolResultDelta { delta, tool_id }) => {
             app.on_tool_result_delta(tool_id, delta);
-            return StreamAction::Continue;
         }
         StreamEvent::Llm(LlmEvent::ToolResult { result, tool_id }) => {
             app.on_tool_result(tool_id, result);
-            return StreamAction::Continue;
         }
         StreamEvent::Session(SessionEvent::MessageHistory(history)) => {
             app.api_messages = history;
-            app.save_session().await;
         }
         StreamEvent::Agent(AgentEvent::SubagentStart {
             subagent_id,
@@ -148,7 +134,7 @@ pub(super) async fn handle_stream_event(
             cache_creation_1h,
             model: usage_model,
         }) => {
-            let model_for_pricing = usage_model.as_deref().unwrap_or(runtime.model());
+            let model_for_pricing = usage_model.as_deref().unwrap_or(&view.model);
             app.add_usage(
                 input_tokens,
                 output_tokens,
@@ -157,7 +143,7 @@ pub(super) async fn handle_stream_event(
                 cache_creation_5m,
                 cache_creation_1h,
                 model_for_pricing,
-                Some(runtime.context_window()),
+                Some(view.context_window),
             );
         }
         StreamEvent::Session(SessionEvent::Notice(text)) => {
@@ -169,40 +155,18 @@ pub(super) async fn handle_stream_event(
         StreamEvent::Session(SessionEvent::Done) => {
             app.streaming = false;
             app.drop_empty_thinking();
-            // Reconcile HUD against registry instead of clearing — retains running entries
-            // whose tx_events is now dead (stream dropped) but threads live on.
-            // Poison-recovering lock: a panicked subagent thread must not block teardown.
-            {
-                let rows = runtime
-                    .subagent_registry()
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .display_rows();
-                reconcile_subagents(&mut app.subagents, &rows, std::time::Instant::now());
-            }
+            // Reconcile HUD against the registry rows (last `SubagentRows`)
+            // instead of clearing — retains running entries whose tx_events
+            // is now dead (stream dropped) but threads live on.
+            reconcile_subagents(
+                &mut app.subagents,
+                &app.subagent_rows,
+                std::time::Instant::now(),
+            );
             // NOTE: cleanup_finished removed — engine now reaps at turn completion
             // inside the tokio::spawn wrapper (runtime/mod.rs) before Done is sent.
-
-            // Flush events that arrived during streaming into api_messages
-            let had_pending = !app.pending_events.is_empty();
-            for formatted in app.pending_events.drain(..) {
-                app.api_messages
-                    .push(std::sync::Arc::new(serde_json::json!({
-                        "role": "user",
-                        "content": formatted
-                    })));
-            }
-
-            // Check for queued message to auto-send
-            if let Some(queued) = app.queued_message.take() {
-                return StreamAction::AutoSendQueued(queued);
-            }
-
-            // If events arrived during streaming, trigger a new model turn
-            if had_pending {
-                app.save_session().await;
-                return StreamAction::AutoTriggerEvents;
-            }
+            // Pending-event flush / queued auto-send / auto-trigger: the
+            // actor's; it announces the next turn with `TurnStarted`.
         }
         StreamEvent::Session(SessionEvent::Error(err)) => {
             app.drop_empty_thinking();
@@ -214,330 +178,431 @@ pub(super) async fn handle_stream_event(
                 err.category_label()
             )));
             app.streaming = false;
-            // Reconcile HUD against registry on error path too (same as Done).
-            {
-                let rows = runtime
-                    .subagent_registry()
-                    .lock()
-                    .unwrap_or_else(|p| p.into_inner())
-                    .display_rows();
-                reconcile_subagents(&mut app.subagents, &rows, std::time::Instant::now());
-            }
-            // Restore a valid trailing state: remove only invalid messages
-            // appended by the ACTIVE turn. A pre-existing trailing user
-            // message (the prompt that started the turn) is never removed —
-            // it stays in history so the failed turn can be retried with
-            // full context (spec §5.2).
-            synaps_cli::engine::stream::repair_history_after_failure(
-                &mut app.api_messages,
-                app.turn_baseline,
+            // Reconcile HUD against registry rows on error path too (same as Done).
+            reconcile_subagents(
+                &mut app.subagents,
+                &app.subagent_rows,
+                std::time::Instant::now(),
             );
+            // History repair is the actor's (mirrored by `Conversation`).
         }
     }
-    StreamAction::Continue
 }
 
-// ── P12.4: stream-lifecycle select! arms — pure code-motion from run(). ──
-// The select! arm EXPRESSIONS (the event-queue `notified()` wake and the
-// `stream.next()` polling future) stay inline in mod.rs; only the arm
-// BODIES moved here, verbatim, apart from `*`-derefs for the loop-owned
-// locals now borrowed via `&mut` and dropping the `stream_handler::` path
-// prefix at the new scope. Behavior byte-identical — streaming lifecycle
-// (delta → tool_use → done/abort) is the product's hot path.
+// ── Session-event arm (PLAN-phase3 §2.4) ─────────────────────────────────
 
-/// The in-flight response stream, owned by the `run()` loop and lent to the
-/// arm handlers below so they can clear/replace it exactly as the inline
-/// arms did.
-pub(super) type ActiveStream = std::pin::Pin<Box<dyn futures::Stream<Item = StreamEvent> + Send>>;
+/// Outcome of one envelope for the `run()` loop.
+pub(super) enum ArmFlow {
+    Continue,
+    /// `Ended` arrived: the session is gone; leave the loop.
+    Ended,
+}
 
-/// Event-bus wake arm body: drain queued engine events into the transcript,
-/// steer them into an active stream (or buffer), and auto-trigger a model
-/// turn when idle.
-pub(super) async fn handle_event_queue_arm(
+fn publish_frame(
     app: &mut App,
-    runtime: &Runtime,
-    secret_prompt_handle: &synaps_cli::tools::SecretPromptHandle,
-    stream: &mut Option<ActiveStream>,
-    cancel_token: &mut Option<CancellationToken>,
-    steer_tx: &mut Option<tokio::sync::mpsc::UnboundedSender<String>>,
+    view: &RuntimeView,
+    registry: &std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
+    render_handle: &RenderHandle,
 ) {
-    let busy = app.streaming || app.compact_task.is_some();
-
-    // Drain via the central reactor function.
-    let drained = drain_event_queue(
-        runtime.event_queue(),
-        &mut app.api_messages,
-        &mut app.pending_events,
-        busy,
-        steer_tx.as_ref(),
-    );
-
-    if drained.is_empty() {
-        return;
+    let term_size = crossterm::terminal::size()
+        .map(|(w, h)| ratatui::layout::Size {
+            width: w,
+            height: h,
+        })
+        .unwrap_or_default();
+    let built = build_render_model(&mut ViewInputs::from_app(app), view, registry, term_size);
+    if let Some((model, patch)) = built {
+        patch.apply(app);
+        render_handle.publish(model);
     }
+}
 
-    // Presentation: push each event to the transcript and update the HUD.
-    for de in &drained {
-        let event = &de.event;
-        let severity_str = event
-            .content
-            .severity
-            .as_ref()
-            .map(|s| s.as_str().to_string())
-            .unwrap_or_else(|| "medium".to_string());
-        app.push_msg(ChatMessage::Event {
-            source: event.source.source_type.clone(),
-            severity: severity_str,
-            text: event.content.text.clone(),
-        });
+/// The two strings the actor still sends as `SystemNotice` where the TUI
+/// used to push a typed line (until the actor emits `Aborted`/`Cleared`
+/// itself). Returns the typed envelope, or the notice unchanged.
+fn shim_notice(text: String) -> SessionEventWire {
+    match text.as_str() {
+        "aborted" => SessionEventWire::Aborted {
+            context_saved: false,
+        },
+        "aborted — context saved for next message" => SessionEventWire::Aborted {
+            context_saved: true,
+        },
+        s if s.starts_with("session cleared → ") => SessionEventWire::Cleared {
+            session_id: s["session cleared → ".len()..].to_string(),
+        },
+        _ => SessionEventWire::SystemNotice(text),
+    }
+}
 
-        // Seam 3: subagent_completion → mark HUD entry done directly from
-        // event data (no lock needed — data was embedded at finalizer time).
-        if event.content.content_type == "subagent_completion" {
-            if let Some(data) = &event.content.data {
-                let maybe_id = data["subagent_id"].as_u64();
-                let maybe_status = data["status"].as_str();
-                let maybe_duration = data["duration_secs"].as_f64();
-                if let (Some(sid), Some(status_str)) = (maybe_id, maybe_status) {
-                    let now = std::time::Instant::now();
-                    if let Some(sa) = app.subagents.iter_mut().find(|s| s.id == sid && !s.done) {
-                        sa.done = true;
-                        sa.done_at = Some(now);
-                        if let Some(dur) = maybe_duration {
-                            sa.duration_secs = Some(dur);
-                        }
-                        sa.status = match status_str {
-                            "completed" => "\u{2714} done".to_string(),
-                            "cancelled" => "\u{26a0} cancelled".to_string(),
-                            "timed_out" => "\u{26a0} timed out".to_string(),
-                            s if s.starts_with("fail") => {
-                                let reason = data["error"].as_str().unwrap_or("error");
-                                let preview: String = reason.chars().take(30).collect();
-                                format!("\u{2718} {}", preview)
-                            }
-                            _ => format!("\u{2714} {status_str}"),
-                        };
+/// Event card + HUD mark for a drained engine event (was the presentation
+/// half of `handle_event_queue_arm`, verbatim).
+pub(super) fn on_external(app: &mut App, event: &synaps_cli::events::types::Event) {
+    let severity_str = event
+        .content
+        .severity
+        .as_ref()
+        .map(|s| s.as_str().to_string())
+        .unwrap_or_else(|| "medium".to_string());
+    app.push_msg(ChatMessage::Event {
+        source: event.source.source_type.clone(),
+        severity: severity_str,
+        text: event.content.text.clone(),
+    });
+
+    // Seam 3: subagent_completion → mark HUD entry done directly from
+    // event data (no lock needed — data was embedded at finalizer time).
+    if event.content.content_type == "subagent_completion" {
+        if let Some(data) = &event.content.data {
+            let maybe_id = data["subagent_id"].as_u64();
+            let maybe_status = data["status"].as_str();
+            let maybe_duration = data["duration_secs"].as_f64();
+            if let (Some(sid), Some(status_str)) = (maybe_id, maybe_status) {
+                let now = std::time::Instant::now();
+                if let Some(sa) = app.subagents.iter_mut().find(|s| s.id == sid && !s.done) {
+                    sa.done = true;
+                    sa.done_at = Some(now);
+                    if let Some(dur) = maybe_duration {
+                        sa.duration_secs = Some(dur);
                     }
+                    sa.status = match status_str {
+                        "completed" => "\u{2714} done".to_string(),
+                        "cancelled" => "\u{26a0} cancelled".to_string(),
+                        "timed_out" => "\u{26a0} timed out".to_string(),
+                        s if s.starts_with("fail") => {
+                            let reason = data["error"].as_str().unwrap_or("error");
+                            let preview: String = reason.chars().take(30).collect();
+                            format!("\u{2718} {}", preview)
+                        }
+                        _ => format!("\u{2714} {status_str}"),
+                    };
                 }
             }
         }
     }
     app.invalidate();
-
-    // Wake decision.
-    let auto_turn_enabled = true; // C2+ will wire config; always on for C1
-    let action = wake_action(
-        &drained,
-        &app.api_messages,
-        busy,
-        auto_turn_enabled,
-        app.consecutive_auto_turns,
-    );
-
-    match action {
-        WakeAction::RunTurn => {
-            // Cap check: if we ARE at cap this would have returned Forward.
-            // Increment before spawning so cap is visible for the next wake.
-            // Optional guard: skip if a stream is already active (shouldn't
-            // happen if wake_action saw busy=false, but defend against it).
-            if stream.is_some() {
-                tracing::warn!("handle_event_arm: RunTurn with active stream — skipping");
-            } else {
-                app.consecutive_auto_turns += 1;
-                let ct = CancellationToken::new();
-                let (s_tx, s_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-                app.streaming = true;
-                app.turn_baseline = app.api_messages.len();
-                app.spinner_frame = 0;
-                *stream = Some(
-                    runtime
-                        .run_stream_with_messages(
-                            app.api_messages.clone(),
-                            ct.clone(),
-                            Some(s_rx),
-                            Some(secret_prompt_handle.clone()),
-                            false,
-                        )
-                        .await,
-                );
-                app.push_msg(ChatMessage::Thinking(THINKING_PLACEHOLDER.to_string()));
-                *cancel_token = Some(ct);
-                *steer_tx = Some(s_tx);
-            }
-        }
-        WakeAction::Forward => {
-            // Check if we hit the cap (some Injected events but cap blocked RunTurn).
-            let hit_cap = drained
-                .iter()
-                .any(|d| d.disposition == EventDisposition::Injected)
-                && !busy
-                && auto_turn_enabled
-                && app.consecutive_auto_turns >= synaps_cli::engine::reactor::AUTO_TURN_CAP;
-            if hit_cap {
-                app.push_msg(ChatMessage::System(format!(
-                    "auto-turn cap reached ({} consecutive) — waiting for your input",
-                    synaps_cli::engine::reactor::AUTO_TURN_CAP
-                )));
-                app.invalidate();
-            }
-        }
-        WakeAction::Nothing => {}
-    }
 }
 
-/// Stream-event arm body: route one `StreamEvent` through
-/// [`handle_stream_event`] and act on the returned [`StreamAction`] —
-/// continue (incl. Done/Error stream-state teardown + gamba reclaim),
-/// auto-send a queued message, or auto-trigger buffered events.
+/// The auto-turn cap line (was stream_handler.rs:368-378 / :516-520).
+pub(super) fn on_auto_turn_cap(app: &mut App, cap: u32) {
+    app.push_msg(ChatMessage::System(format!(
+        "auto-turn cap reached ({} consecutive) — waiting for your input",
+        cap
+    )));
+    app.invalidate();
+}
+
+/// One envelope from the session → the exact `ChatMessage`s / state
+/// mutations the inline turn machine performed (§2.4 table).
 #[allow(clippy::too_many_arguments)]
-pub(super) async fn handle_stream_arm(
-    maybe_event: Option<StreamEvent>,
+pub(super) async fn handle_session_event_arm(
+    env: Envelope,
     app: &mut App,
-    runtime: &Runtime,
+    link: &mut SessionLink,
     registry: &std::sync::Arc<synaps_cli::skills::registry::CommandRegistry>,
     render_handle: &RenderHandle,
-    secret_prompt_handle: &synaps_cli::tools::SecretPromptHandle,
-    stream: &mut Option<ActiveStream>,
-    cancel_token: &mut Option<CancellationToken>,
-    steer_tx: &mut Option<tokio::sync::mpsc::UnboundedSender<String>>,
-) {
-    if let Some(event) = maybe_event {
-        let do_draw = needs_immediate_draw(&event);
-        let action = handle_stream_event(event, app, runtime).await;
-
-        match action {
-            StreamAction::Continue => {
-                // For Done/Error, clear stream state
-                if !app.streaming {
-                    *stream = None;
-                    *cancel_token = None;
-                    *steer_tx = None;
-                    // Reclaim gamba if running — resume render thread
-                    // after reclaim restores the terminal.
-                    if let Some(msg) = app.reclaim_gamba() {
-                        render_handle.resume();
-                        app.push_msg(ChatMessage::System(msg));
-                        app.invalidate();
-                    }
-                }
-            }
-            StreamAction::AutoSendQueued(queued) => {
-                // Drop old stream state (important for cleanup)
-                drop(stream.take());
-                drop(cancel_token.take());
-                drop(steer_tx.take());
-                // Reclaim gamba if running — resume render thread
-                // after reclaim restores the terminal.
+    prompt_bridge: &mut PromptBridge,
+    ext_mgr: Option<
+        &std::sync::Arc<tokio::sync::RwLock<synaps_cli::extensions::manager::ExtensionManager>>,
+    >,
+) -> ArmFlow {
+    let me = link.client_id();
+    let event = match env.event {
+        SessionEventWire::SystemNotice(text) => shim_notice(text),
+        other => other,
+    };
+    match event {
+        SessionEventWire::Stream(ev) => {
+            let do_draw = needs_immediate_draw(&ev);
+            let view = std::sync::Arc::clone(link.view());
+            handle_stream_event(ev, app, &view);
+            // For Done/Error: reclaim gamba if running — resume render
+            // thread after reclaim restores the terminal.
+            if !app.streaming {
                 if let Some(msg) = app.reclaim_gamba() {
                     render_handle.resume();
                     app.push_msg(ChatMessage::System(msg));
                     app.invalidate();
                 }
-                // Auto-send the queued message (user-authored — reset auto-turn counter)
-                app.consecutive_auto_turns = 0;
-                app.push_msg(ChatMessage::User(queued.clone()));
-                app.transcript.scroll_to_bottom();
-                let api_content = if let Some(ref ctx) = app.abort_context {
-                    let combined = format!("{}\n\n{}", ctx, queued);
-                    app.abort_context = None;
-                    combined
-                } else {
-                    queued
-                };
-                app.api_messages.push(std::sync::Arc::new(
-                    json!({"role": "user", "content": api_content}),
-                ));
-                let ct = CancellationToken::new();
-                let (s_tx, s_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-                app.status_text = Some("connecting…".to_string());
+            }
+            if do_draw {
+                publish_frame(app, &view, registry, render_handle);
+            }
+        }
+        SessionEventWire::TurnStarted {
+            turn_baseline,
+            trigger,
+            user_text,
+        } => match trigger {
+            TurnTrigger::User | TurnTrigger::PluginCommand => {
+                // Pre-send presentation (User card, "connecting…",
+                // streaming=true, spinner, frame) already happened in the
+                // dispatch arm; this is the tail after the stream opened.
                 app.streaming = true;
-                app.turn_baseline = app.api_messages.len();
-                app.spinner_frame = 0;
-                let term_size = crossterm::terminal::size()
-                    .map(|(w, h)| ratatui::layout::Size {
-                        width: w,
-                        height: h,
-                    })
-                    .unwrap_or_default();
-                let built = build_render_model(
-                    &mut ViewInputs::from_app(app),
-                    runtime,
-                    registry,
-                    term_size,
-                );
-                if let Some((model, patch)) = built {
-                    patch.apply(app);
-                    render_handle.publish(model);
-                }
-                *stream = Some(
-                    runtime
-                        .run_stream_with_messages(
-                            app.api_messages.clone(),
-                            ct.clone(),
-                            Some(s_rx),
-                            Some(secret_prompt_handle.clone()),
-                            false,
-                        )
-                        .await,
-                );
+                app.turn_baseline = turn_baseline;
                 app.status_text = None;
                 app.push_msg(ChatMessage::Thinking(THINKING_PLACEHOLDER.to_string()));
-                *cancel_token = Some(ct);
-                *steer_tx = Some(s_tx);
             }
-            StreamAction::AutoTriggerEvents => {
-                drop(stream.take());
-                drop(cancel_token.take());
-                drop(steer_tx.take());
-
-                // Use the central claim_auto_turn gate: allows turns 1-5
-                // (counter < CAP), denies the 6th (counter == CAP).
-                // Increment happens inside claim on success — no inline +=.
-                if claim_auto_turn(&mut app.consecutive_auto_turns) {
-                    let ct = CancellationToken::new();
-                    let (s_tx, s_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-                    app.streaming = true;
-                    app.turn_baseline = app.api_messages.len();
-                    app.spinner_frame = 0;
-                    *stream = Some(
-                        runtime
-                            .run_stream_with_messages(
-                                app.api_messages.clone(),
-                                ct.clone(),
-                                Some(s_rx),
-                                Some(secret_prompt_handle.clone()),
-                                false,
-                            )
-                            .await,
-                    );
-                    app.push_msg(ChatMessage::Thinking(THINKING_PLACEHOLDER.to_string()));
-                    *cancel_token = Some(ct);
-                    *steer_tx = Some(s_tx);
-                } else {
-                    app.push_msg(ChatMessage::System(format!(
-                        "auto-turn cap reached ({} consecutive) — waiting for your input",
-                        AUTO_TURN_CAP
-                    )));
+            TurnTrigger::QueuedAuto => {
+                if let Some(msg) = app.reclaim_gamba() {
+                    render_handle.resume();
+                    app.push_msg(ChatMessage::System(msg));
                     app.invalidate();
+                }
+                // Auto-send of the queued message (user-authored).
+                app.consecutive_auto_turns = 0;
+                if let Some(q) = user_text {
+                    app.push_msg(ChatMessage::User(q));
+                }
+                app.transcript.scroll_to_bottom();
+                app.status_text = Some("connecting…".to_string());
+                app.streaming = true;
+                app.turn_baseline = turn_baseline;
+                app.spinner_frame = 0;
+                let view = std::sync::Arc::clone(link.view());
+                publish_frame(app, &view, registry, render_handle);
+                app.status_text = None;
+                app.push_msg(ChatMessage::Thinking(THINKING_PLACEHOLDER.to_string()));
+            }
+            TurnTrigger::EventAuto | TurnTrigger::Compaction => {
+                app.streaming = true;
+                app.turn_baseline = turn_baseline;
+                app.spinner_frame = 0;
+                app.push_msg(ChatMessage::Thinking(THINKING_PLACEHOLDER.to_string()));
+            }
+        },
+        SessionEventWire::Conversation(snap) => {
+            app.apply_conversation(&snap);
+            if let Some(applied) = app.compaction_applied.take() {
+                finish_compaction(app, applied);
+            }
+            if let Some(pending) = app.resume_pending.take() {
+                let msgs = app.api_messages.clone();
+                super::helpers::rebuild_display_messages(&msgs, app);
+                if let Some(notice) = pending.clamp_notice {
+                    app.push_msg(ChatMessage::System(notice));
+                }
+                let via = pending
+                    .via
+                    .map(|v| format!(" (via {v})"))
+                    .unwrap_or_default();
+                app.push_msg(ChatMessage::System(format!(
+                    "switched from {} to {}{}",
+                    pending.old_id, pending.new_id, via
+                )));
+            }
+        }
+        SessionEventWire::Prompt(req) => prompt_bridge.on_prompt(req),
+        SessionEventWire::PromptResolved { prompt_id } => {
+            if prompt_bridge.on_resolved(prompt_id) {
+                app.secret_prompts.dismiss();
+                app.invalidate();
+            }
+        }
+        SessionEventWire::External(ev) => on_external(app, &ev),
+        SessionEventWire::AutoTurnCapReached { cap } => on_auto_turn_cap(app, cap),
+        SessionEventWire::Idle => {}
+        SessionEventWire::Steered { text, delivered } => {
+            if delivered {
+                app.push_msg(ChatMessage::System(format!("→ steering: {}", text)));
+            } else {
+                app.push_msg(ChatMessage::System(format!("queued: {}", text)));
+            }
+            app.queued_message = Some(text);
+        }
+        SessionEventWire::Dequeued { text } => {
+            app.push_msg(ChatMessage::System(format!("dequeued: {}", text)));
+        }
+        SessionEventWire::SystemNotice(text) => {
+            app.push_msg(ChatMessage::System(sanitize_notice(&text)));
+        }
+        SessionEventWire::LoaderProgress(ev) => {
+            super::loop_arms::handle_extension_loader_event(app, link.view(), ev, ext_mgr).await;
+            app.request_redraw();
+        }
+        SessionEventWire::ExtensionNotification {
+            extension_id,
+            method,
+            params,
+        } => {
+            // Socket path: the in-process watchers are not running, so the
+            // widget frames arrive here (same parse the watchers use). In
+            // process the watchers own `widget_rx`; the actor sees no frames.
+            if ext_mgr.is_none() && synaps_cli::extensions::widgets::is_widget_method(&method) {
+                if let Ok(event) =
+                    synaps_cli::extensions::widgets::parse_widget_event(&method, &params)
+                {
+                    let ev = synaps_cli::extensions::widgets::ExtensionWidgetEvent {
+                        extension_id,
+                        event,
+                    };
+                    if super::loop_arms::handle_widget_event(app, ev) {
+                        app.request_redraw();
+                    }
                 }
             }
         }
-
-        if do_draw {
-            let term_size = crossterm::terminal::size()
-                .map(|(w, h)| ratatui::layout::Size {
-                    width: w,
-                    height: h,
-                })
-                .unwrap_or_default();
-            let built =
-                build_render_model(&mut ViewInputs::from_app(app), runtime, registry, term_size);
-            if let Some((model, patch)) = built {
-                patch.apply(app);
-                render_handle.publish(model);
+        SessionEventWire::SettingChanged(_) | SessionEventWire::QueryResult { .. } => {
+            // Unsolicited (another client's Set / a host query): the view
+            // was refreshed by `SessionLink::note`; nothing to render.
+        }
+        SessionEventWire::Attached { .. }
+        | SessionEventWire::ClientJoined { .. }
+        | SessionEventWire::ClientLeft { .. } => {}
+        SessionEventWire::Ended { .. } => return ArmFlow::Ended,
+        SessionEventWire::Aborted { context_saved } => {
+            app.streaming = false;
+            app.subagents.clear();
+            // The actor decided (`TurnLog::abort_context`); the mirror's
+            // `abort_context` only lands with the `Conversation` that follows.
+            let abort_msg = if context_saved {
+                "aborted — context saved for next message"
+            } else {
+                "aborted"
+            };
+            app.drop_empty_thinking();
+            app.push_msg(ChatMessage::Error(abort_msg.to_string()));
+        }
+        SessionEventWire::Cleared { .. } => {
+            app.transcript.clear();
+            app.invalidate();
+            app.api_messages.clear();
+            app.total_input_tokens = 0;
+            app.total_output_tokens = 0;
+            app.total_cache_read_tokens = 0;
+            app.total_cache_creation_tokens = 0;
+            app.session_cost = 0.0;
+            app.input_tokens = 0;
+            app.output_tokens = 0;
+            app.push_msg(ChatMessage::System("new session started".to_string()));
+        }
+        SessionEventWire::CompactionStarted { disclosure, .. } => {
+            app.push_msg(ChatMessage::System(disclosure));
+            app.push_msg(ChatMessage::System(
+                "compacting conversation...".to_string(),
+            ));
+            app.status_text = Some("compacting…".to_string());
+            app.spinner_frame = 0;
+            app.compacting = true;
+        }
+        SessionEventWire::CompactionApplied {
+            previous_session_id,
+            session_id,
+            chains_advanced,
+            queued_restored,
+            msg_count,
+        } => {
+            // The successor's messages/header arrive in the `Conversation`
+            // that follows; the lines are pushed once it has been applied.
+            app.compaction_applied = Some(super::app::CompactionApplied {
+                previous_session_id,
+                session_id,
+                chains_advanced,
+                queued_restored,
+                msg_count,
+            });
+        }
+        SessionEventWire::CompactionFailed { message, panicked } => {
+            if panicked {
+                app.push_msg(ChatMessage::Error(format!(
+                    "compaction task panicked: {}",
+                    message
+                )));
+            } else {
+                app.push_msg(ChatMessage::Error(format!("compaction failed: {}", message)));
+            }
+            app.status_text = None;
+            app.compacting = false;
+            app.invalidate();
+        }
+        SessionEventWire::CompactionCancelled => {
+            app.push_msg(ChatMessage::System("compaction cancelled".to_string()));
+            app.status_text = None;
+            app.compacting = false;
+            app.invalidate();
+        }
+        SessionEventWire::SubagentRows(rows) => app.subagent_rows = rows,
+        SessionEventWire::Resumed { .. } => {}
+        SessionEventWire::InputOwnerChanged { from, to, .. } => {
+            if from == Some(me) && to != Some(me) {
+                let who = to
+                    .map(|c| format!("client #{}", c.0))
+                    .unwrap_or_else(|| "nobody".to_string());
+                app.toasts.upsert(
+                    super::toast::Toast::new("input-owner", format!("input taken over by {who}"))
+                        .titled("Session"),
+                );
+            } else if to == Some(me) && from != Some(me) {
+                app.toasts.upsert(
+                    super::toast::Toast::new("input-owner", "you own input").titled("Session"),
+                );
+            }
+            app.request_redraw();
+        }
+        SessionEventWire::Refused {
+            client,
+            command,
+            reason,
+        } => {
+            if client == me {
+                app.push_msg(ChatMessage::Error(format!("{command} refused: {reason}")));
+                // §6 #9: a Submit refused after the editor was cleared —
+                // give the text back.
+                if let Some(text) = app.last_submitted.take() {
+                    app.set_input_text(&text);
+                }
             }
         }
+        SessionEventWire::AttachRefused { message } => {
+            app.push_msg(ChatMessage::Error(format!("attach refused: {message}")));
+        }
+        SessionEventWire::Lifecycle(state) => {
+            app.toasts.upsert(
+                super::toast::Toast::new("lifecycle", format!("session {state:?}"))
+                    .titled("Session"),
+            );
+            app.request_redraw();
+        }
+        SessionEventWire::Reloading { generation, .. } => {
+            app.toasts.upsert(
+                super::toast::Toast::new(
+                    "reload",
+                    format!("daemon reloading (generation {generation})…"),
+                )
+                .titled("Daemon")
+                .ttl(None),
+            );
+            app.request_redraw();
+        }
     }
+    ArmFlow::Continue
+}
+
+/// `CompactionApplied` + the `Conversation` that followed: the lines the
+/// compaction poll used to push (loop_arms.rs:783-812).
+fn finish_compaction(app: &mut App, applied: super::app::CompactionApplied) {
+    let old_id = applied.previous_session_id;
+    let msgs = app.api_messages.clone();
+    super::helpers::rebuild_display_messages(&msgs, app);
+    for name in &applied.chains_advanced {
+        app.push_msg(ChatMessage::System(format!(
+            "chain '{}' advanced: {} → {}",
+            name, old_id, app.session.id
+        )));
+    }
+    if let Some(q) = applied.queued_restored {
+        app.push_msg(ChatMessage::System(format!(
+            "queued message restored: {}",
+            q
+        )));
+    }
+    app.push_msg(ChatMessage::System(format!(
+        "✓ compacted {} messages → new session {} (from {})",
+        applied.msg_count, app.session.id, old_id
+    )));
+    app.status_text = None;
+    app.compacting = false;
+    app.invalidate();
 }
 
 /// Strip ASCII control characters (except `\n` and `\t`) from notice text

--- a/crates/agent-tui/src/tui/stream_handler.rs
+++ b/crates/agent-tui/src/tui/stream_handler.rs
@@ -217,47 +217,6 @@ fn publish_frame(
     }
 }
 
-/// The two strings the actor still sends as `SystemNotice` where the TUI
-/// used to push a typed line (until the actor emits `Aborted`/`Cleared`
-/// itself). Returns the typed envelope, or the notice unchanged.
-/// Idempotent with the typed event via [`shim_dedup`]: if both the notice
-/// and `Aborted`/`Cleared` arrive, the second is dropped.
-fn shim_notice(text: String) -> SessionEventWire {
-    match text.as_str() {
-        "aborted" => SessionEventWire::Aborted {
-            context_saved: false,
-        },
-        "aborted — context saved for next message" => SessionEventWire::Aborted {
-            context_saved: true,
-        },
-        s if s.starts_with("session cleared → ") => SessionEventWire::Cleared {
-            session_id: s["session cleared → ".len()..].to_string(),
-        },
-        _ => SessionEventWire::SystemNotice(text),
-    }
-}
-
-/// `true` when `event` is an `Aborted`/`Cleared` already rendered since the
-/// last `TurnStarted` (the shimmed notice and the typed event both arrived).
-/// Keyed on the full value: two `/clear`s carry different session ids and
-/// both render; two aborts without a turn between them are impossible.
-fn shim_dedup(app: &mut App, event: &SessionEventWire) -> bool {
-    let key = match event {
-        SessionEventWire::Aborted { context_saved } => format!("aborted:{context_saved}"),
-        SessionEventWire::Cleared { session_id } => format!("cleared:{session_id}"),
-        SessionEventWire::TurnStarted { .. } => {
-            app.shim_seen = None;
-            return false;
-        }
-        _ => return false,
-    };
-    if app.shim_seen.as_deref() == Some(key.as_str()) {
-        return true;
-    }
-    app.shim_seen = Some(key);
-    false
-}
-
 /// Event card + HUD mark for a drained engine event (was the presentation
 /// half of `handle_event_queue_arm`, verbatim).
 pub(super) fn on_external(app: &mut App, event: &synaps_cli::events::types::Event) {
@@ -330,14 +289,7 @@ pub(super) async fn handle_session_event_arm(
     >,
 ) -> ArmFlow {
     let me = link.client_id();
-    let event = match env.event {
-        SessionEventWire::SystemNotice(text) => shim_notice(text),
-        other => other,
-    };
-    if shim_dedup(app, &event) {
-        return ArmFlow::Continue;
-    }
-    match event {
+    match env.event {
         SessionEventWire::Stream(ev) => {
             let do_draw = needs_immediate_draw(&ev);
             let view = std::sync::Arc::clone(link.view());

--- a/crates/agent-tui/src/tui/stream_handler.rs
+++ b/crates/agent-tui/src/tui/stream_handler.rs
@@ -338,6 +338,7 @@ pub(super) async fn handle_session_event_arm(
                 // Pre-send presentation (User card, "connecting…",
                 // streaming=true, spinner, frame) already happened in the
                 // dispatch arm; this is the tail after the stream opened.
+                app.last_submitted = None;
                 app.streaming = true;
                 app.turn_baseline = turn_baseline;
                 app.status_text = None;
@@ -546,6 +547,12 @@ pub(super) async fn handle_session_event_arm(
         } => {
             if client == me {
                 app.push_msg(ChatMessage::Error(format!("{command} refused: {reason}")));
+                // The pre-send presentation assumed a turn: undo it.
+                if app.streaming && app.turn_baseline == app.api_messages.len() {
+                    app.streaming = false;
+                    app.status_text = None;
+                    app.drop_empty_thinking();
+                }
                 // §6 #9: a Submit refused after the editor was cleared —
                 // give the text back.
                 if let Some(text) = app.last_submitted.take() {

--- a/crates/agent-tui/src/tui/stream_handler.rs
+++ b/crates/agent-tui/src/tui/stream_handler.rs
@@ -220,6 +220,8 @@ fn publish_frame(
 /// The two strings the actor still sends as `SystemNotice` where the TUI
 /// used to push a typed line (until the actor emits `Aborted`/`Cleared`
 /// itself). Returns the typed envelope, or the notice unchanged.
+/// Idempotent with the typed event via [`shim_dedup`]: if both the notice
+/// and `Aborted`/`Cleared` arrive, the second is dropped.
 fn shim_notice(text: String) -> SessionEventWire {
     match text.as_str() {
         "aborted" => SessionEventWire::Aborted {
@@ -233,6 +235,27 @@ fn shim_notice(text: String) -> SessionEventWire {
         },
         _ => SessionEventWire::SystemNotice(text),
     }
+}
+
+/// `true` when `event` is an `Aborted`/`Cleared` already rendered since the
+/// last `TurnStarted` (the shimmed notice and the typed event both arrived).
+/// Keyed on the full value: two `/clear`s carry different session ids and
+/// both render; two aborts without a turn between them are impossible.
+fn shim_dedup(app: &mut App, event: &SessionEventWire) -> bool {
+    let key = match event {
+        SessionEventWire::Aborted { context_saved } => format!("aborted:{context_saved}"),
+        SessionEventWire::Cleared { session_id } => format!("cleared:{session_id}"),
+        SessionEventWire::TurnStarted { .. } => {
+            app.shim_seen = None;
+            return false;
+        }
+        _ => return false,
+    };
+    if app.shim_seen.as_deref() == Some(key.as_str()) {
+        return true;
+    }
+    app.shim_seen = Some(key);
+    false
 }
 
 /// Event card + HUD mark for a drained engine event (was the presentation
@@ -311,6 +334,9 @@ pub(super) async fn handle_session_event_arm(
         SessionEventWire::SystemNotice(text) => shim_notice(text),
         other => other,
     };
+    if shim_dedup(app, &event) {
+        return ArmFlow::Continue;
+    }
     match event {
         SessionEventWire::Stream(ev) => {
             let do_draw = needs_immediate_draw(&ev);

--- a/crates/agent-tui/src/tui/testing.rs
+++ b/crates/agent-tui/src/tui/testing.rs
@@ -59,6 +59,11 @@ use std::sync::Arc;
 /// harness's driver surface directly.
 #[path = "testing/tape.rs"]
 pub mod tape;
+/// A3/A5 — the in-memory `ClientTransport` the harness drives commands
+/// through (`Set`/`EngineCommand`/`Query` answered from a headless
+/// `Runtime`; envelopes fed by tests).
+#[path = "testing/scripted.rs"]
+pub mod scripted;
 
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent};
 use ratatui::backend::{CrosstermBackend, TestBackend};
@@ -72,6 +77,8 @@ use synaps_cli::skills::BUILTIN_COMMANDS;
 use synaps_cli::{Runtime, Session};
 
 use super::app::{App, ChatMessage};
+use super::session_link::{PromptBridge, SessionLink};
+use agent_engine::session::SessionEventWire;
 use super::draw::{build_render_model, render_frame_into};
 use super::input::{self, InputAction};
 
@@ -81,7 +88,17 @@ use super::input::{self, InputAction};
 /// See the [module docs](self) for the loop it replicates and its limits.
 pub struct TestHarness {
     app: App,
-    runtime: Runtime,
+    /// The session behind a [`scripted::ScriptedTransport`] (+ the published
+    /// `RuntimeView` every getter reads).
+    link: SessionLink,
+    /// Feeds the secret-prompt pane exactly like production (`Prompt` envelopes).
+    prompt_bridge: PromptBridge,
+    scripted_log: std::sync::Arc<std::sync::Mutex<scripted::ScriptedLog>>,
+    secret_prompt_rx: std::sync::Arc<
+        std::sync::Mutex<
+            tokio::sync::mpsc::UnboundedReceiver<synaps_cli::tools::SecretPromptRequest>,
+        >,
+    >,
     registry: Arc<CommandRegistry>,
     keybinds: KeybindRegistry,
     terminal: Terminal<TestBackend>,
@@ -151,9 +168,15 @@ impl TestHarness {
         )
         .expect("TestBackend terminal construction is infallible");
 
+        let transport = scripted::ScriptedTransport::new(Runtime::new_headless());
+        let scripted_log = std::sync::Arc::clone(&transport.log);
+        let (secret_prompt_tx, secret_prompt_rx) = tokio::sync::mpsc::unbounded_channel();
         TestHarness {
             app,
-            runtime: Runtime::new_headless(),
+            link: SessionLink::new(Box::new(transport)),
+            prompt_bridge: PromptBridge::new(secret_prompt_tx),
+            scripted_log,
+            secret_prompt_rx: std::sync::Arc::new(std::sync::Mutex::new(secret_prompt_rx)),
             registry: Arc::new(CommandRegistry::new(BUILTIN_COMMANDS, Vec::new())),
             keybinds: KeybindRegistry::new(),
             terminal,
@@ -203,7 +226,7 @@ impl TestHarness {
         let action = input::handle_event(
             event,
             &mut self.app,
-            &self.runtime,
+            &**self.link.view(),
             streaming,
             &self.registry,
             &self.keybinds,
@@ -227,7 +250,7 @@ impl TestHarness {
     pub fn render(&mut self) -> &Buffer {
         let (model, patch) = build_render_model(
             &mut super::view_model::ViewInputs::from_app(&mut self.app),
-            &self.runtime,
+            &**self.link.view(),
             &self.registry,
             self.size,
         )
@@ -269,7 +292,7 @@ impl TestHarness {
     pub fn render_ansi(&mut self) -> Vec<u8> {
         let (model, patch) = build_render_model(
             &mut super::view_model::ViewInputs::from_app(&mut self.app),
-            &self.runtime,
+            &**self.link.view(),
             &self.registry,
             self.size,
         )
@@ -627,6 +650,58 @@ impl TestHarness {
         self
     }
 
+    // ── Session envelopes (PLAN-phase3 §5.1 layer 2) ─────────────────────────
+
+    /// Feed session events through the PRODUCTION presentation arm
+    /// (`stream_handler::handle_session_event_arm`) — the same code path the
+    /// `run()` loop executes for every envelope under either transport.
+    /// Rendering is skipped (no render thread): `render()`/`snapshot()`
+    /// show the resulting steady state, as the tmux differential does.
+    pub fn feed_events(&mut self, events: &[SessionEventWire]) -> &mut Self {
+        for ev in events {
+            self.feed_event(ev.clone());
+        }
+        self
+    }
+
+    /// One envelope through the production arm (bounded like the slash
+    /// drive). After it, the tick arm's secret-prompt poll + stack reconcile
+    /// run so a `Prompt` activates the pane exactly as in production.
+    pub fn feed_event(&mut self, event: SessionEventWire) -> &mut Self {
+        let env = agent_engine::session::Envelope {
+            session_id: self.link.transport().session_id().clone(),
+            seq: 0,
+            ts: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap_or_default(),
+            event,
+        };
+        let render_handle = super::render_thread::RenderHandle::headless();
+        let what = "handle_session_event_arm";
+        let flow = block_on_bounded(
+            what,
+            super::stream_handler::handle_session_event_arm(
+                env,
+                &mut self.app,
+                &mut self.link,
+                &self.registry,
+                &render_handle,
+                &mut self.prompt_bridge,
+                None,
+            ),
+        );
+        if let super::stream_handler::ArmFlow::Ended = flow {
+            self.actions.push("session-ended".to_string());
+        }
+        self.app.secret_prompts.poll_requests(&self.secret_prompt_rx);
+        input::reconcile_secret_prompt(&mut self.app);
+        self
+    }
+
+    /// Commands the harness sent to its scripted session so far
+    /// (`Debug` renderings; bodies redacted).
+    pub fn sent_commands(&self) -> Vec<String> {
+        self.scripted_log.lock().unwrap().sent.clone()
+    }
+
     // ── Bounded async slash drive (P6.3) ─────────────────────────────────────
 
     /// Execute every slash command recorded since the last drive through the
@@ -662,7 +737,7 @@ impl TestHarness {
                 cmd,
                 arg,
                 &mut self.app,
-                &mut self.runtime,
+                &mut self.link,
                 &system_prompt_path,
                 &self.registry,
                 &self.keybinds,
@@ -702,8 +777,8 @@ impl TestHarness {
                 // via the streaming-input route).
                 if !self.app.streaming {
                     self.app.effort = Some(super::effort::EffortModalState::new(
-                        self.runtime.model(),
-                        self.runtime.thinking_level(),
+                        &self.link.view().model,
+                        &self.link.view().thinking_level,
                     ));
                     self.app.modal_stack.push(super::focus::PaneId::Effort);
                 }
@@ -733,7 +808,7 @@ impl TestHarness {
                     super::commands::execute_command_action(
                         CommandAction::PluginCommand { command, arg },
                         &mut self.app,
-                        &self.runtime,
+                        &mut self.link,
                     ),
                 );
             }
@@ -773,6 +848,7 @@ impl TestHarness {
             InputAction::Abort => "abort".to_string(),
             InputAction::SettingsApply(key, value) => format!("settings-apply:{key}={value}"),
             InputAction::ModelsApply(model) => format!("models-apply:{model}"),
+            InputAction::GrantWorkerModel(model) => format!("grant-worker-model:{model}"),
             InputAction::EffortApply(apply) => format!(
                 "effort-apply:{}:{}:{}",
                 apply.model, apply.generation, apply.value

--- a/crates/agent-tui/src/tui/testing/scripted.rs
+++ b/crates/agent-tui/src/tui/testing/scripted.rs
@@ -35,6 +35,9 @@ pub struct ScriptedTransport {
     pub log: Arc<Mutex<ScriptedLog>>,
     /// Commands sent through `&self`, handled at the next `next_event`.
     pending: Mutex<VecDeque<SessionCommand>>,
+    /// When set, every input command is answered `Refused{client: me,
+    /// reason}` with no side effect (B1 ownership, non-owner client).
+    refuse_input: Option<String>,
 }
 
 impl ScriptedTransport {
@@ -72,7 +75,14 @@ impl ScriptedTransport {
             seq: 0,
             log: Arc::new(Mutex::new(ScriptedLog::default())),
             pending: Mutex::new(VecDeque::new()),
+            refuse_input: None,
         }
+    }
+
+    /// Behave as the actor does for a non-owner: input commands are
+    /// `Refused` with `reason` (None = owner, normal handling).
+    pub fn set_refuse_input(&mut self, reason: Option<String>) {
+        self.refuse_input = reason;
     }
 
     pub fn runtime(&self) -> &Runtime {
@@ -204,6 +214,27 @@ impl ScriptedTransport {
     }
 
     async fn handle(&mut self, cmd: SessionCommand) {
+        if let Some(reason) = self.refuse_input.clone() {
+            let command = match &cmd {
+                SessionCommand::Submit { .. } => Some("submit"),
+                SessionCommand::Steer { .. } => Some("steer"),
+                SessionCommand::Set { .. } => Some("set"),
+                SessionCommand::EngineCommand { .. } => Some("engine_command"),
+                SessionCommand::PluginCommand { .. } => Some("plugin_command"),
+                SessionCommand::Resume { .. } => Some("resume"),
+                SessionCommand::Compact { .. } => Some("compact"),
+                SessionCommand::NewSession => Some("new_session"),
+                _ => None,
+            };
+            if let Some(command) = command {
+                self.push_event(SessionEventWire::Refused {
+                    client: ClientId(1),
+                    command: command.to_string(),
+                    reason,
+                });
+                return;
+            }
+        }
         match cmd {
             SessionCommand::Set { id, setting } => self.apply_setting(id, setting),
             SessionCommand::EngineCommand { id, name, arg } => {

--- a/crates/agent-tui/src/tui/testing/scripted.rs
+++ b/crates/agent-tui/src/tui/testing/scripted.rs
@@ -1,0 +1,360 @@
+//! `ScriptedTransport` — an in-memory `ClientTransport` for the harness and
+//! unit tests (PLAN-phase3 §5.1 layer 2). Records every command it is sent,
+//! answers the correlated ones (`Set{id}` → `SettingChanged{id}`,
+//! `EngineCommand{id}` / `PluginCommand{id}` / `Query{id}` → `QueryResult`)
+//! from a headless `Runtime` exactly as the actor would, and lets a test
+//! feed arbitrary envelopes (`push_event`) that `next_event` then yields.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+use agent_engine::session::{
+    AttachMode, AttachSnapshot, ClientId, ClientTransport, Envelope, ReasoningClampWire,
+    RuntimeView, SessionCommand, SessionEventWire, SessionId, SessionMeta, SessionQuery,
+    SessionSetting, SettingApplied, TransportError,
+};
+use synaps_cli::{Runtime, Session};
+
+/// Shared state so a test can inspect what was sent while the harness owns
+/// the `Box<dyn ClientTransport>`.
+#[derive(Default)]
+pub struct ScriptedLog {
+    /// `Debug` renderings (bodies redacted by the manual impl).
+    pub sent: Vec<String>,
+}
+
+pub struct ScriptedTransport {
+    id: SessionId,
+    meta: SessionMeta,
+    runtime: Runtime,
+    session: Session,
+    api_messages: Vec<synaps_cli::SharedMessage>,
+    view: Arc<RuntimeView>,
+    queue: VecDeque<Envelope>,
+    seq: u64,
+    pub log: Arc<Mutex<ScriptedLog>>,
+    /// Commands sent through `&self`, handled at the next `next_event`.
+    pending: Mutex<VecDeque<SessionCommand>>,
+}
+
+impl ScriptedTransport {
+    pub fn new(runtime: Runtime) -> Self {
+        let session = Session::new(runtime.model(), runtime.thinking_level(), None);
+        Self::with_session(runtime, session)
+    }
+
+    pub fn with_session(runtime: Runtime, session: Session) -> Self {
+        let id = SessionId::from(session.id.clone());
+        let meta = SessionMeta {
+            id: id.clone(),
+            name: session.name.clone(),
+            model: runtime.model().to_string(),
+            cwd: None,
+            created_at: session.created_at,
+            continued: false,
+            continue_info: None,
+            host_pid: std::process::id(),
+            lifecycle: Default::default(),
+            clients: 1,
+            input_owner: Some(ClientId(1)),
+            awaiting_input: 0,
+            journal_id: session.id.clone(),
+        };
+        let view = Arc::new(RuntimeView::snapshot(&runtime, 0));
+        Self {
+            id,
+            meta,
+            runtime,
+            session,
+            api_messages: Vec::new(),
+            view,
+            queue: VecDeque::new(),
+            seq: 0,
+            log: Arc::new(Mutex::new(ScriptedLog::default())),
+            pending: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    pub fn runtime(&self) -> &Runtime {
+        &self.runtime
+    }
+
+    pub fn runtime_mut(&mut self) -> &mut Runtime {
+        &mut self.runtime
+    }
+
+    pub fn set_api_messages(&mut self, msgs: Vec<synaps_cli::SharedMessage>) {
+        self.api_messages = msgs;
+    }
+
+    /// Queue an envelope for `next_event` (tape `SessionEvent` steps).
+    pub fn push_event(&mut self, event: SessionEventWire) {
+        let env = Envelope {
+            session_id: self.id.clone(),
+            seq: self.seq,
+            ts: chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap_or_default(),
+            event,
+        };
+        self.seq += 1;
+        self.queue.push_back(env);
+    }
+
+    pub fn sent(&self) -> Vec<String> {
+        self.log.lock().unwrap().sent.clone()
+    }
+
+    fn refresh_view(&mut self) {
+        self.view = Arc::new(RuntimeView::snapshot(&self.runtime, 0));
+    }
+
+    /// = `SessionActor::apply_setting` (actor.rs) on the headless runtime.
+    fn apply_setting(&mut self, id: u64, setting: SessionSetting) {
+        let name = match &setting {
+            SessionSetting::Model { .. } => "model",
+            SessionSetting::ReasoningLevel { .. } => "reasoning_level",
+            SessionSetting::ContextWindow { .. } => "context_window",
+            SessionSetting::CompactionModel { .. } => "compaction_model",
+            SessionSetting::ApiRetries { .. } => "api_retries",
+            SessionSetting::SubagentTimeout { .. } => "subagent_timeout",
+            SessionSetting::MaxToolOutput { .. } => "max_tool_output",
+            SessionSetting::BashTimeout { .. } => "bash_timeout",
+            SessionSetting::BashMaxTimeout { .. } => "bash_max_timeout",
+            SessionSetting::SystemPrompt { .. } => "system_prompt",
+            SessionSetting::ReloadPrompt => "reload_prompt",
+            SessionSetting::GrantWorkerModel { .. } => "grant_worker_model",
+        };
+        let rt = &mut self.runtime;
+        let mut clamp_wire = None;
+        let result: Result<Option<String>, String> = match setting {
+            SessionSetting::Model { model } => rt.try_set_model(model).map(|clamp| {
+                self.session.model = rt.model().to_string();
+                clamp.map(|c| {
+                    self.session.thinking_level = rt.thinking_level().to_string();
+                    clamp_wire = Some(ReasoningClampWire {
+                        from: c.from.as_str().to_string(),
+                        to: c.to.as_str().to_string(),
+                    });
+                    format!(
+                        "thinking → {} (clamped from {}: not supported by {})",
+                        c.to.as_str(),
+                        c.from.as_str(),
+                        rt.model()
+                    )
+                })
+            }),
+            SessionSetting::ReasoningLevel { level } => {
+                rt.set_reasoning_level_checked(level).map(|_| {
+                    self.session.thinking_level = rt.thinking_level().to_string();
+                    None
+                })
+            }
+            SessionSetting::ContextWindow { tokens } => {
+                rt.set_context_window(tokens);
+                Ok(None)
+            }
+            SessionSetting::CompactionModel { model } => {
+                rt.set_compaction_model(model);
+                Ok(None)
+            }
+            SessionSetting::ApiRetries { n } => {
+                rt.set_api_retries(n);
+                Ok(None)
+            }
+            SessionSetting::SubagentTimeout { secs } => {
+                rt.set_subagent_timeout(secs);
+                Ok(None)
+            }
+            SessionSetting::MaxToolOutput { bytes } => {
+                rt.set_max_tool_output(bytes);
+                Ok(None)
+            }
+            SessionSetting::BashTimeout { secs } => {
+                rt.set_bash_timeout(secs);
+                Ok(None)
+            }
+            SessionSetting::BashMaxTimeout { secs } => {
+                rt.set_bash_max_timeout(secs);
+                Ok(None)
+            }
+            SessionSetting::SystemPrompt { text } => {
+                rt.set_system_prompt(text);
+                Ok(None)
+            }
+            SessionSetting::ReloadPrompt => rt
+                .reload_prompt()
+                .map(|generation| Some(format!("prompt reloaded (generation {generation})")))
+                .map_err(|e| e.to_string()),
+            SessionSetting::GrantWorkerModel { model } => {
+                rt.grant_worker_model(&model).map(|_| None)
+            }
+        };
+        self.refresh_view();
+        let (ok, message) = match result {
+            Ok(m) => (true, m),
+            Err(e) => (false, Some(e)),
+        };
+        self.push_event(SessionEventWire::SettingChanged(SettingApplied {
+            id,
+            setting: name.to_string(),
+            ok,
+            message,
+            view: (*self.view).clone(),
+            clamp: clamp_wire,
+        }));
+    }
+
+    async fn handle(&mut self, cmd: SessionCommand) {
+        match cmd {
+            SessionCommand::Set { id, setting } => self.apply_setting(id, setting),
+            SessionCommand::EngineCommand { id, name, arg } => {
+                let (value, view_changed) = agent_engine::session::actor_cmds::engine_command_reply(
+                    &name,
+                    &arg,
+                    &mut self.runtime,
+                    &mut self.session,
+                );
+                if view_changed {
+                    self.refresh_view();
+                }
+                self.push_event(SessionEventWire::QueryResult { id, value });
+            }
+            SessionCommand::PluginCommand {
+                id,
+                plugin,
+                name,
+                arg,
+            } => {
+                // Test seam: the command is looked up in the scripted
+                // registry the test installed via `plugin_commands`.
+                let value = match self.plugin_command(&plugin, &name) {
+                    Some(command) => {
+                        match synaps_cli::skills::commands::execute_plugin_command_with_tools(
+                            &command,
+                            &arg,
+                            self.runtime.tools_shared(),
+                        )
+                        .await
+                        {
+                            Ok(output) => serde_json::json!({
+                                "kind": "plugin_output",
+                                "status": output.status,
+                                "stdout": output.stdout,
+                                "stderr": output.stderr,
+                            }),
+                            Err(e) => serde_json::json!({ "kind": "error", "text": e.to_string() }),
+                        }
+                    }
+                    None => serde_json::json!({
+                        "kind": "error",
+                        "text": format!("unknown plugin command /{plugin}:{name}"),
+                    }),
+                };
+                self.push_event(SessionEventWire::QueryResult { id, value });
+            }
+            SessionCommand::Query { id, query } => {
+                let value = match query {
+                    SessionQuery::View => serde_json::to_value(&*self.view).unwrap_or_default(),
+                    SessionQuery::ContextReport => {
+                        use synaps_cli::engine::commands::{context_command, CommandResult};
+                        match context_command(&self.runtime, Some(&self.api_messages)) {
+                            CommandResult::Output(text) => serde_json::json!({ "text": text }),
+                            CommandResult::Error(e) => serde_json::json!({ "error": e }),
+                            other => serde_json::json!({ "unsupported": format!("{other:?}") }),
+                        }
+                    }
+                    SessionQuery::Messages => {
+                        serde_json::to_value(&self.api_messages).unwrap_or_default()
+                    }
+                    other => serde_json::json!({ "unsupported": format!("{other:?}") }),
+                };
+                self.push_event(SessionEventWire::QueryResult { id, value });
+            }
+            SessionCommand::Resume { id, .. } => self.push_event(SessionEventWire::QueryResult {
+                id,
+                value: serde_json::json!({ "kind": "error", "text": "scripted: no sessions on disk" }),
+            }),
+            SessionCommand::NewSession => {
+                self.session = Session::new(
+                    self.runtime.model(),
+                    self.runtime.thinking_level(),
+                    self.runtime.system_prompt(),
+                );
+                self.api_messages.clear();
+                self.push_event(SessionEventWire::Cleared {
+                    session_id: self.session.id.clone(),
+                });
+                self.push_event(SessionEventWire::Conversation(
+                    agent_engine::session::ConversationSnapshot {
+                        header: agent_engine::session::SessionHeader::from(&self.session),
+                        ..Default::default()
+                    },
+                ));
+            }
+            // Turn-machine commands: recorded only (the tape feeds the
+            // envelopes a real actor would answer with).
+            _ => {}
+        }
+    }
+
+    fn plugin_command(
+        &self,
+        plugin: &str,
+        name: &str,
+    ) -> Option<Arc<synaps_cli::skills::registry::RegisteredPluginCommand>> {
+        let reg = PLUGIN_COMMANDS.lock().unwrap();
+        reg.iter()
+            .find(|c| c.plugin == plugin && c.name == name)
+            .cloned()
+    }
+}
+
+/// Plugin commands the scripted actor can run (tests register theirs).
+static PLUGIN_COMMANDS: Mutex<Vec<Arc<synaps_cli::skills::registry::RegisteredPluginCommand>>> =
+    Mutex::new(Vec::new());
+
+/// Register a plugin command for `ScriptedTransport::plugin_command`.
+pub fn register_plugin_command(cmd: Arc<synaps_cli::skills::registry::RegisteredPluginCommand>) {
+    PLUGIN_COMMANDS.lock().unwrap().push(cmd);
+}
+
+#[async_trait::async_trait]
+impl ClientTransport for ScriptedTransport {
+    fn session_id(&self) -> &SessionId {
+        &self.id
+    }
+    fn meta(&self) -> &SessionMeta {
+        &self.meta
+    }
+    async fn send(&self, cmd: SessionCommand) -> Result<(), TransportError> {
+        // `&self`: handling happens in `next_event`'s drain.
+        self.log.lock().unwrap().sent.push(format!("{cmd:?}"));
+        self.pending.lock().unwrap().push_back(cmd);
+        Ok(())
+    }
+    async fn send_from_self(&self, cmd: SessionCommand) -> Result<(), TransportError> {
+        self.send(cmd).await
+    }
+    async fn next_event(&mut self) -> Option<Envelope> {
+        // Handle everything sent since the last poll (in order), then yield.
+        let pending: Vec<SessionCommand> = self.pending.lock().unwrap().drain(..).collect();
+        for cmd in pending {
+            self.handle(cmd).await;
+        }
+        self.queue.pop_front()
+    }
+    fn view(&self) -> Arc<RuntimeView> {
+        Arc::clone(&self.view)
+    }
+    fn client_id(&self) -> ClientId {
+        ClientId(1)
+    }
+    fn mode(&self) -> AttachMode {
+        AttachMode::Mirror
+    }
+    fn input_owner(&self) -> Option<ClientId> {
+        Some(ClientId(1))
+    }
+    async fn reconnect(&mut self, _mode: AttachMode) -> Result<AttachSnapshot, TransportError> {
+        Err(TransportError::Unsupported("reconnect: scripted transport"))
+    }
+}

--- a/crates/agent-tui/src/tui/testing/tape.rs
+++ b/crates/agent-tui/src/tui/testing/tape.rs
@@ -113,6 +113,13 @@ pub enum TapeStep {
     /// Checkpoint: materialize a frame here (a no-op for state, but records
     /// author intent and forces line-cache maintenance mid-tape).
     Snapshot,
+    /// PLAN-phase3 §5.1 layer 2: one session envelope (the serde mirror of
+    /// `SessionEventWire`) through the production presentation arm
+    /// (`stream_handler::handle_session_event_arm`) — the same code path
+    /// under `LocalTransport` and `SocketTransport`. `Conversation` carries
+    /// its digest only (no messages), as on the wire. Stored as the wire
+    /// JSON (`WireSessionEvent` has no `PartialEq`).
+    SessionEvent(serde_json::Value),
 }
 
 /// Which modal an [`TapeStep::OpenModal`] opens.
@@ -474,6 +481,14 @@ impl<'h> TapeRecorder<'h> {
         self
     }
 
+    /// Record + feed one session envelope (layer-2 differential tapes).
+    pub fn session_event(&mut self, ev: agent_engine::session::wire::WireSessionEvent) -> &mut Self {
+        let json = serde_json::to_value(&ev).expect("WireSessionEvent serialises");
+        self.harness.feed_event(ev.into());
+        self.steps.push(TapeStep::SessionEvent(json));
+        self
+    }
+
     /// Record a snapshot checkpoint and return the rendered frame.
     pub fn snapshot(&mut self) -> String {
         self.steps.push(TapeStep::Snapshot);
@@ -556,6 +571,11 @@ impl TestHarness {
                 }
                 TapeStep::Snapshot => {
                     let _ = self.snapshot();
+                }
+                TapeStep::SessionEvent(json) => {
+                    let ev: agent_engine::session::wire::WireSessionEvent =
+                        serde_json::from_value(json.clone()).expect("tape SessionEvent parses");
+                    self.feed_event(ev.into());
                 }
             }
         }

--- a/crates/agent-tui/tests/harness_session_events.rs
+++ b/crates/agent-tui/tests/harness_session_events.rs
@@ -192,6 +192,73 @@ fn session_owner_change_toasts_previous_owner() {
 }
 
 #[test]
+fn session_abort_notice_plus_typed_renders_once() {
+    // Shim idempotency: the actor may send BOTH the notice text and the
+    // typed `Aborted` (engine emitting typed events while the notice is
+    // still there) — exactly one "aborted" line, same frame as typed-only.
+    let (typed, _) = frame_for(vec![
+        turn(TurnTrigger::User, None),
+        text("partial"),
+        W::Aborted {
+            context_saved: true,
+        },
+        W::Idle,
+    ]);
+    let (both, _) = frame_for(vec![
+        turn(TurnTrigger::User, None),
+        text("partial"),
+        W::SystemNotice {
+            text: "aborted — context saved for next message".into(),
+        },
+        W::Aborted {
+            context_saved: true,
+        },
+        W::Idle,
+    ]);
+    assert_eq!(typed, both);
+    assert_eq!(both.matches("aborted — context saved").count(), 1, "{both}");
+    // A later turn's abort renders again (latch resets on TurnStarted).
+    let (two_turns, _) = frame_for(vec![
+        turn(TurnTrigger::User, None),
+        text("partial"),
+        W::Aborted {
+            context_saved: false,
+        },
+        W::Idle,
+        turn(TurnTrigger::User, None),
+        text("partial 2"),
+        W::SystemNotice {
+            text: "aborted".into(),
+        },
+        W::Aborted {
+            context_saved: false,
+        },
+        W::Idle,
+    ]);
+    assert_eq!(two_turns.matches("aborted").count(), 2, "{two_turns}");
+}
+
+#[test]
+fn session_cleared_notice_plus_typed_renders_once() {
+    let (both, _) = frame_for(vec![
+        turn(TurnTrigger::User, None),
+        text("old stuff"),
+        done(),
+        W::SystemNotice {
+            text: "session cleared → new-1".into(),
+        },
+        W::Cleared {
+            session_id: "new-1".into(),
+        },
+        // A second /clear (different id) must still render.
+        W::Cleared {
+            session_id: "new-2".into(),
+        },
+    ]);
+    assert_eq!(both.matches("new session started").count(), 2, "{both}");
+}
+
+#[test]
 fn session_cleared_resets_transcript() {
     let (frame, _) = frame_for(vec![
         turn(TurnTrigger::User, None),

--- a/crates/agent-tui/tests/harness_session_events.rs
+++ b/crates/agent-tui/tests/harness_session_events.rs
@@ -1,0 +1,222 @@
+//! PLAN-phase3 §5.1 layer 2 — the presentation half of the TUI's turn
+//! machine, driven by session envelopes through the PRODUCTION arm
+//! (`stream_handler::handle_session_event_arm`). The code path is one for
+//! both transports (`Box<dyn ClientTransport>`), so identical envelopes →
+//! identical frames under `LocalTransport` and `SocketTransport`.
+//!
+//! Each scenario asserts the §2.4 contract lines (transcript kinds + text
+//! via the rendered frame) and pins determinism (two replays, same bytes).
+
+use agent_engine::session::wire::{
+    WireLlmEvent, WireSessionEvent as W, WireSessionStreamEvent, WireStreamEvent,
+};
+use agent_engine::session::{ClientId, OwnerChangeReason, TurnTrigger};
+use agent_tui::tui::testing::tape::Tape;
+use agent_tui::tui::testing::TestHarness;
+
+fn text(t: &str) -> W {
+    W::Stream {
+        event: WireStreamEvent::Llm(WireLlmEvent::Text { text: t.into() }),
+    }
+}
+fn done() -> W {
+    W::Stream {
+        event: WireStreamEvent::Session(WireSessionStreamEvent::Done),
+    }
+}
+fn turn(trigger: TurnTrigger, user_text: Option<&str>) -> W {
+    W::TurnStarted {
+        turn_baseline: 1,
+        trigger,
+        user_text: user_text.map(str::to_string),
+    }
+}
+
+/// Record a tape of `events` on a fresh harness, replay it twice, return the
+/// frame (asserting determinism).
+fn frame_for(events: Vec<W>) -> (String, Tape) {
+    let mut h = TestHarness::boot_with_size(100, 30);
+    let tape = {
+        let mut rec = h.record_tape();
+        for ev in events {
+            rec.session_event(ev);
+        }
+        rec.finish()
+    };
+    let a = TestHarness::replay_with_size(&tape, 100, 30);
+    let b = TestHarness::replay_with_size(&tape, 100, 30);
+    assert_eq!(a, b, "session tape replay must be deterministic");
+    (a, tape)
+}
+
+#[test]
+fn session_plain_turn_renders_text_and_idles() {
+    let (frame, tape) = frame_for(vec![
+        turn(TurnTrigger::User, None),
+        text("hello from the actor"),
+        done(),
+        W::Idle,
+    ]);
+    assert!(frame.contains("hello from the actor"), "{frame}");
+    // The tape serialises (fixture-authorable) and round-trips.
+    let json = tape.to_json();
+    let back = Tape::from_json(&json).expect("tape parses");
+    assert_eq!(TestHarness::replay_with_size(&back, 100, 30), frame);
+}
+
+#[test]
+fn session_queued_autosend_pushes_user_card() {
+    let (frame, _) = frame_for(vec![
+        turn(TurnTrigger::User, None),
+        text("first"),
+        W::Steered {
+            text: "second please".into(),
+            delivered: false,
+        },
+        done(),
+        turn(TurnTrigger::QueuedAuto, Some("second please")),
+        text("second answer"),
+        done(),
+        W::Idle,
+    ]);
+    assert!(frame.contains("queued: second please"), "{frame}");
+    assert!(frame.contains("second answer"), "{frame}");
+}
+
+#[test]
+fn session_steer_line() {
+    let (frame, _) = frame_for(vec![
+        turn(TurnTrigger::User, None),
+        W::Steered {
+            text: "turn left".into(),
+            delivered: true,
+        },
+    ]);
+    assert!(frame.contains("→ steering: turn left"), "{frame}");
+}
+
+#[test]
+fn session_abort_renders_error_line_and_stops_streaming() {
+    let (frame, _) = frame_for(vec![
+        turn(TurnTrigger::User, None),
+        text("partial"),
+        W::Dequeued {
+            text: "later".into(),
+        },
+        W::Aborted {
+            context_saved: false,
+        },
+        W::Idle,
+    ]);
+    assert!(frame.contains("dequeued: later"), "{frame}");
+    assert!(frame.contains("aborted"), "{frame}");
+}
+
+#[test]
+fn session_abort_via_actor_notice_shim_matches_typed() {
+    // Until the actor emits `Aborted`, it sends the same text as a notice;
+    // both must render the identical frame.
+    let (typed, _) = frame_for(vec![
+        turn(TurnTrigger::User, None),
+        text("partial"),
+        W::Aborted {
+            context_saved: true,
+        },
+    ]);
+    let (shim, _) = frame_for(vec![
+        turn(TurnTrigger::User, None),
+        text("partial"),
+        W::SystemNotice {
+            text: "aborted — context saved for next message".into(),
+        },
+    ]);
+    assert_eq!(typed, shim);
+    assert!(typed.contains("aborted — context saved for next message"));
+}
+
+#[test]
+fn session_event_card_and_cap_notice() {
+    let ev = agent_engine::events::types::Event::simple("watcher", "disk is full", None);
+    let (frame, _) = frame_for(vec![
+        W::External { event: ev },
+        W::AutoTurnCapReached { cap: 5 },
+    ]);
+    assert!(frame.contains("disk is full"), "{frame}");
+    assert!(
+        frame.contains("auto-turn cap reached (5 consecutive)"),
+        "{frame}"
+    );
+}
+
+#[test]
+fn session_prompt_activates_pane_and_resolution_by_other_dismisses() {
+    let mut h = TestHarness::boot_with_size(100, 30);
+    h.feed_events(&[agent_engine::session::SessionEventWire::Prompt(
+        agent_engine::session::PromptRequest {
+            id: 7,
+            kind: agent_engine::session::PromptKind::Secret,
+            title: "API key".into(),
+            prompt: "paste it".into(),
+            raised_at: chrono::Utc::now(),
+        },
+    )]);
+    assert!(h.secret_prompt_active(), "Prompt must activate the pane");
+    h.feed_events(&[agent_engine::session::SessionEventWire::PromptResolved { prompt_id: 7 }]);
+    assert!(!h.secret_prompt_active(), "foreign resolution dismisses");
+}
+
+#[test]
+fn session_refused_is_rendered_only_for_me() {
+    let (mine, _) = frame_for(vec![W::Refused {
+        client: ClientId(1),
+        command: "submit".into(),
+        reason: "input owned by client #2".into(),
+    }]);
+    assert!(mine.contains("submit refused: input owned by client #2"), "{mine}");
+    let (theirs, _) = frame_for(vec![W::Refused {
+        client: ClientId(9),
+        command: "submit".into(),
+        reason: "input owned by client #2".into(),
+    }]);
+    assert!(!theirs.contains("refused"), "{theirs}");
+}
+
+#[test]
+fn session_owner_change_toasts_previous_owner() {
+    let (frame, _) = frame_for(vec![W::InputOwnerChanged {
+        from: Some(ClientId(1)),
+        to: Some(ClientId(3)),
+        reason: OwnerChangeReason::Takeover,
+    }]);
+    assert!(frame.contains("input taken over by client #3"), "{frame}");
+}
+
+#[test]
+fn session_cleared_resets_transcript() {
+    let (frame, _) = frame_for(vec![
+        turn(TurnTrigger::User, None),
+        text("old stuff"),
+        done(),
+        W::Cleared {
+            session_id: "new".into(),
+        },
+    ]);
+    assert!(!frame.contains("old stuff"), "{frame}");
+    assert!(frame.contains("new session started"), "{frame}");
+}
+
+#[test]
+fn session_compaction_lines() {
+    let (frame, _) = frame_for(vec![
+        W::CompactionStarted {
+            source: "manual".into(),
+            disclosure: "[compaction: model x, ~10 tokens]".into(),
+        },
+        W::CompactionFailed {
+            message: "boom".into(),
+            panicked: false,
+        },
+    ]);
+    assert!(frame.contains("compacting conversation..."), "{frame}");
+    assert!(frame.contains("compaction failed: boom"), "{frame}");
+}

--- a/crates/agent-tui/tests/harness_session_events.rs
+++ b/crates/agent-tui/tests/harness_session_events.rs
@@ -113,28 +113,6 @@ fn session_abort_renders_error_line_and_stops_streaming() {
 }
 
 #[test]
-fn session_abort_via_actor_notice_shim_matches_typed() {
-    // Until the actor emits `Aborted`, it sends the same text as a notice;
-    // both must render the identical frame.
-    let (typed, _) = frame_for(vec![
-        turn(TurnTrigger::User, None),
-        text("partial"),
-        W::Aborted {
-            context_saved: true,
-        },
-    ]);
-    let (shim, _) = frame_for(vec![
-        turn(TurnTrigger::User, None),
-        text("partial"),
-        W::SystemNotice {
-            text: "aborted — context saved for next message".into(),
-        },
-    ]);
-    assert_eq!(typed, shim);
-    assert!(typed.contains("aborted — context saved for next message"));
-}
-
-#[test]
 fn session_event_card_and_cap_notice() {
     let ev = agent_engine::events::types::Event::simple("watcher", "disk is full", None);
     let (frame, _) = frame_for(vec![
@@ -191,71 +169,21 @@ fn session_owner_change_toasts_previous_owner() {
     assert!(frame.contains("input taken over by client #3"), "{frame}");
 }
 
+/// The actor's `SystemNotice` text is rendered as a plain system line —
+/// there is no text→typed shim any more: `Aborted`/`Cleared` are typed
+/// events on the wire (engine db603206), so a notice that happens to read
+/// "aborted" is just a notice.
 #[test]
-fn session_abort_notice_plus_typed_renders_once() {
-    // Shim idempotency: the actor may send BOTH the notice text and the
-    // typed `Aborted` (engine emitting typed events while the notice is
-    // still there) — exactly one "aborted" line, same frame as typed-only.
-    let (typed, _) = frame_for(vec![
+fn session_notice_text_is_not_a_typed_event() {
+    let (frame, _) = frame_for(vec![
         turn(TurnTrigger::User, None),
         text("partial"),
-        W::Aborted {
-            context_saved: true,
-        },
-        W::Idle,
-    ]);
-    let (both, _) = frame_for(vec![
-        turn(TurnTrigger::User, None),
-        text("partial"),
-        W::SystemNotice {
-            text: "aborted — context saved for next message".into(),
-        },
-        W::Aborted {
-            context_saved: true,
-        },
-        W::Idle,
-    ]);
-    assert_eq!(typed, both);
-    assert_eq!(both.matches("aborted — context saved").count(), 1, "{both}");
-    // A later turn's abort renders again (latch resets on TurnStarted).
-    let (two_turns, _) = frame_for(vec![
-        turn(TurnTrigger::User, None),
-        text("partial"),
-        W::Aborted {
-            context_saved: false,
-        },
-        W::Idle,
-        turn(TurnTrigger::User, None),
-        text("partial 2"),
-        W::SystemNotice {
-            text: "aborted".into(),
-        },
-        W::Aborted {
-            context_saved: false,
-        },
-        W::Idle,
-    ]);
-    assert_eq!(two_turns.matches("aborted").count(), 2, "{two_turns}");
-}
-
-#[test]
-fn session_cleared_notice_plus_typed_renders_once() {
-    let (both, _) = frame_for(vec![
-        turn(TurnTrigger::User, None),
-        text("old stuff"),
-        done(),
         W::SystemNotice {
             text: "session cleared → new-1".into(),
         },
-        W::Cleared {
-            session_id: "new-1".into(),
-        },
-        // A second /clear (different id) must still render.
-        W::Cleared {
-            session_id: "new-2".into(),
-        },
     ]);
-    assert_eq!(both.matches("new session started").count(), 2, "{both}");
+    assert!(frame.contains("partial"), "{frame}");
+    assert!(!frame.contains("new session started"), "{frame}");
 }
 
 #[test]

--- a/scripts/tui-e2e/differential.sh
+++ b/scripts/tui-e2e/differential.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# differential.sh — PLAN-phase3 §5.1 layer 3: tmux differential of the TUI
+# against the REFERENCE BINARY built at f0ee1e62.
+#
+# usage: scripts/tui-e2e/differential.sh [REF_BIN]
+#   REF_BIN defaults to ~/Projects/agent-runtime-ref/target/release/synaps
+#   (git worktree add ~/Projects/agent-runtime-ref f0ee1e62 && cargo build --release).
+#
+# Runs tests/tui_transport_differential.rs (ignored by default) with
+# SYNAPS_TUI_E2E=1. Captures land in target/tui-e2e/<scenario>.<step>.{ref,new}.txt.
+# Prints "REFERENCE DIFF: empty" on success. Uses a private tmux server (-L tuidiff).
+set -u
+HERE=$(cd "$(dirname "$0")/../.." && pwd)
+REF=${1:-$HOME/Projects/agent-runtime-ref/target/release/synaps}
+[ -x "$REF" ] || { echo "reference binary not found: $REF" >&2; exit 2; }
+command -v tmux >/dev/null || { echo "tmux required" >&2; exit 2; }
+cd "$HERE"
+SYNAPS_TUI_E2E=1 SYNAPS_REF_BIN="$REF" ${SYNAPS_TUI_E2E_ONLY:+SYNAPS_TUI_E2E_ONLY=$SYNAPS_TUI_E2E_ONLY} \
+  cargo test --test tui_transport_differential -- --ignored --nocapture 2>&1 | tail -60

--- a/scripts/tui-e2e/differential.sh
+++ b/scripts/tui-e2e/differential.sh
@@ -6,9 +6,19 @@
 #   REF_BIN defaults to ~/Projects/agent-runtime-ref/target/release/synaps
 #   (git worktree add ~/Projects/agent-runtime-ref f0ee1e62 && cargo build --release).
 #
+# Two panes per scenario: (R) the reference binary, (L) this binary
+# in-process. There is no socket pane — L≡S is #111's gate, not this script's.
+#
+# Scenarios (SYNAPS_TUI_E2E_ONLY=<name> to run one): plain_turn, tool_loop,
+# abort_mid_stream, steer_mid_stream, settings_model_change, clear,
+# compaction, queued_during_compaction, secret_prompt, extension_loaded
+# (the only one that runs WITHOUT --no-extensions; plants the in-tree
+# process-extension fixture). Needs python3 on PATH for that one.
+#
 # Runs tests/tui_transport_differential.rs (ignored by default) with
 # SYNAPS_TUI_E2E=1. Captures land in target/tui-e2e/<scenario>.<step>.{ref,new}.txt.
-# Prints "REFERENCE DIFF: empty" on success. Uses a private tmux server (-L tuidiff).
+# Prints a scenario → "diff empty?" table, then "REFERENCE DIFF: empty (N
+# scenarios)" on success. Uses a private tmux server (-L tuidiff).
 set -u
 HERE=$(cd "$(dirname "$0")/../.." && pwd)
 REF=${1:-$HOME/Projects/agent-runtime-ref/target/release/synaps}

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,10 @@ struct Cli {
     /// EXPERIMENTAL (SYNAPS_DAEMON=1): run the TUI attached to a daemon
     /// session instead of in-process. Optionally a session ID (prefix ok);
     /// with no live session a new one is created (`--continue` continues).
+    /// The daemon must already be running (`synaps daemon --detach`).
+    /// Modifiers: --observe (read-only), --takeover (steal input),
+    /// --keep-warm (never parked); default mode is SYNAPS_ATTACH_MODE or
+    /// mirror (input only if nobody owns it).
     #[arg(long = "attach", value_name = "ID", global = true, num_args = 0..=1)]
     attach: Option<Option<String>>,
 
@@ -97,7 +101,9 @@ struct Cli {
     #[arg(long, global = true, conflicts_with = "takeover")]
     observe: bool,
 
-    /// With --attach: steal input ownership from the current owner.
+    /// With --attach: steal input ownership from the current owner (the
+    /// previous owner is told; without it a second client is read-only
+    /// while the owner is attached).
     #[arg(long, global = true)]
     takeover: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,11 +87,23 @@ struct Cli {
     #[arg(long)]
     no_extensions: bool,
 
-    /// EXPERIMENTAL (SYNAPS_DAEMON=1): attach to a daemon session instead of
-    /// running in-process. Optionally a session ID. Today routes to
-    /// `synaps attach` (the daemon-attached TUI lands in phase 2 day 2).
+    /// EXPERIMENTAL (SYNAPS_DAEMON=1): run the TUI attached to a daemon
+    /// session instead of in-process. Optionally a session ID (prefix ok);
+    /// with no live session a new one is created (`--continue` continues).
     #[arg(long = "attach", value_name = "ID", global = true, num_args = 0..=1)]
     attach: Option<Option<String>>,
+
+    /// With --attach: mirror without input (read-only).
+    #[arg(long, global = true, conflicts_with = "takeover")]
+    observe: bool,
+
+    /// With --attach: steal input ownership from the current owner.
+    #[arg(long, global = true)]
+    takeover: bool,
+
+    /// With --attach: pin the session live (never parked).
+    #[arg(long = "keep-warm", global = true)]
+    keep_warm: bool,
 
     #[command(subcommand)]
     command: Option<Command>,
@@ -359,17 +371,16 @@ async fn async_main() -> anyhow::Result<()> {
                 )
                 .await?;
             } else {
-                eprintln!("daemon-attached TUI lands in phase 2 day 2; using `synaps attach`");
                 let id = cli.attach.flatten();
-                cmd::attach::run(
-                    cli.profile,
-                    cmd::attach::AttachArgs {
-                        id,
-                        create: false,
-                        continue_session: cli.continue_session.flatten(),
-                        system: cli.system,
-                    },
-                )
+                tui::attach::run_attached(tui::attach::AttachOpts {
+                    profile: cli.profile,
+                    id,
+                    continue_session: cli.continue_session.flatten(),
+                    system: cli.system,
+                    prompt_manifest: cli.prompt_manifest,
+                    mode: tui::attach::attach_mode(cli.observe, cli.takeover),
+                    keep_warm: cli.keep_warm,
+                })
                 .await?;
             }
         }

--- a/tests/phase5_compaction.rs
+++ b/tests/phase5_compaction.rs
@@ -28,7 +28,9 @@ fn every_compacting_frontend_uses_the_engine_transition() {
         "src/cmd/chat.rs",
         "src/cmd/rpc.rs",
         "src/cmd/server.rs",
-        "crates/agent-tui/src/tui/loop_arms.rs",
+        // The TUI compacts on the SessionActor since phase 3 (A2); the
+        // actor is the frontend's transition site.
+        "crates/agent-engine/src/session/actor.rs",
     ] {
         let src = read(rel);
         assert!(

--- a/tests/phase5_context_memory.rs
+++ b/tests/phase5_context_memory.rs
@@ -191,7 +191,8 @@ fn s9_1_no_frontend_splices_summaries_locally() {
         "src/cmd/chat.rs",
         "src/cmd/rpc.rs",
         "src/cmd/server.rs",
-        "crates/agent-tui/src/tui/loop_arms.rs",
+        // The TUI compacts on the SessionActor since phase 3 (A2).
+        "crates/agent-engine/src/session/actor.rs",
     ] {
         let src = std::fs::read_to_string(format!("{root}/{rel}")).unwrap();
         assert!(

--- a/tests/phase5_disclosure.rs
+++ b/tests/phase5_disclosure.rs
@@ -26,7 +26,9 @@ fn every_frontend_surfaces_disclosure_before_dispatch() {
         "src/cmd/chat.rs",
         "src/cmd/rpc.rs",
         "src/cmd/server.rs",
-        "crates/agent-tui/src/tui/dispatch.rs",
+        // The TUI compacts on the SessionActor since phase 3 (A2): the
+        // disclosure is computed there and shipped as `CompactionStarted`.
+        "crates/agent-engine/src/session/actor.rs",
     ] {
         let src = read(rel);
         assert!(

--- a/tests/support/phase2/mod.rs
+++ b/tests/support/phase2/mod.rs
@@ -91,6 +91,15 @@ pub const ANTHROPIC_SSE_TOOL_USE: &str = concat!(
     "data: {\"type\":\"message_stop\"}\n\n",
 );
 
+/// Minimal non-streaming Anthropic Messages response (what
+/// `call_api_simple` — the compaction summary path — parses).
+pub const ANTHROPIC_MESSAGES_JSON: &str = concat!(
+    "{\"id\":\"msg_05\",\"type\":\"message\",\"role\":\"assistant\",",
+    "\"model\":\"claude-sonnet-4-5\",\"content\":[{\"type\":\"text\",\"text\":\"summary\"}],",
+    "\"stop_reason\":\"end_turn\",\"stop_sequence\":null,",
+    "\"usage\":{\"input_tokens\":10,\"output_tokens\":2}}"
+);
+
 /// Minimal OpenAI Chat Completions SSE success body.
 pub const OAI_CHAT_SSE: &str = concat!(
     "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"hi\"}}]}\n\n",
@@ -178,6 +187,15 @@ pub enum Script {
         body: &'static str,
         frame_delay: Duration,
     },
+    /// Streaming requests (`"stream":true` in the body) get `sse`;
+    /// non-streaming ones (the compaction summary via `call_api_simple`)
+    /// get `json` — a Messages response body — after `json_delay`. Lets a
+    /// `/compact` scenario run end-to-end against the same stub.
+    SseOrJson {
+        sse: &'static str,
+        json: &'static str,
+        json_delay: Duration,
+    },
     /// Delay headers, then a comment first byte, then the model events, with
     /// each SSE frame fragmented into small chunks.
     Timed {
@@ -188,8 +206,27 @@ pub enum Script {
     },
 }
 
+fn is_streaming_request(req_body: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(req_body)
+        .ok()
+        .and_then(|v| v.get("stream").and_then(|s| s.as_bool()))
+        .unwrap_or(false)
+}
+
 fn scripted_response(script: &Script, hit: usize, req_body: &[u8]) -> Response {
     match script {
+        Script::SseOrJson { sse, json, .. } => {
+            if is_streaming_request(req_body) {
+                sse((*sse).to_string())
+            } else {
+                (
+                    StatusCode::OK,
+                    [("content-type", "application/json")],
+                    (*json).to_string(),
+                )
+                    .into_response()
+            }
+        }
         Script::Sse(body) => sse((*body).to_string()),
         Script::SeqSse(bodies) => {
             let body = bodies
@@ -353,8 +390,12 @@ pub async fn spawn_stub(script: Script) -> (String, Arc<AtomicUsize>, Bodies) {
         async move {
             let hit = hits.fetch_add(1, Ordering::SeqCst);
             bodies.lock().unwrap().push(body.to_vec());
-            if let Script::Timed { header_delay, .. } = &script {
-                tokio::time::sleep(*header_delay).await;
+            match &script {
+                Script::Timed { header_delay, .. } => tokio::time::sleep(*header_delay).await,
+                Script::SseOrJson { json_delay, .. } if !is_streaming_request(&body) => {
+                    tokio::time::sleep(*json_delay).await
+                }
+                _ => {}
             }
             scripted_response(&script, hit, &body)
         }

--- a/tests/support/phase2/mod.rs
+++ b/tests/support/phase2/mod.rs
@@ -215,9 +215,11 @@ fn is_streaming_request(req_body: &[u8]) -> bool {
 
 fn scripted_response(script: &Script, hit: usize, req_body: &[u8]) -> Response {
     match script {
-        Script::SseOrJson { sse, json, .. } => {
+        Script::SseOrJson {
+            sse: sse_body, json, ..
+        } => {
             if is_streaming_request(req_body) {
-                sse((*sse).to_string())
+                sse((*sse_body).to_string())
             } else {
                 (
                     StatusCode::OK,

--- a/tests/tui_no_journal_writes.rs
+++ b/tests/tui_no_journal_writes.rs
@@ -1,0 +1,76 @@
+//! PLAN-phase3 §3.2 / Appendix A guards for the TUI port: after A2 the TUI
+//! never writes the journal and never owns a `Runtime` — the `SessionActor`
+//! does (in-process via `LocalTransport`, over the socket via
+//! `SocketTransport`). Presentation-only code is all that remains.
+
+use std::path::Path;
+
+fn tui_src() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/agent-tui/src")
+}
+
+fn walk(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("read_dir") {
+        let p = entry.expect("entry").path();
+        if p.is_dir() {
+            walk(&p, out);
+        } else if p.extension().is_some_and(|e| e == "rs") {
+            out.push(p);
+        }
+    }
+}
+
+/// Lines that are code (not `//` comments) and match any needle.
+fn offenders(needles: &[&str], skip_tests: bool) -> Vec<String> {
+    let mut files = Vec::new();
+    walk(&tui_src(), &mut files);
+    let mut hits = Vec::new();
+    for f in files {
+        let rel = f.strip_prefix(tui_src()).unwrap().display().to_string();
+        if skip_tests && rel.starts_with("tui/testing") {
+            continue;
+        }
+        let src = std::fs::read_to_string(&f).unwrap();
+        let mut in_tests = false;
+        for (i, line) in src.lines().enumerate() {
+            if line.trim_start().starts_with("#[cfg(test)]") {
+                in_tests = true;
+            }
+            if skip_tests && in_tests {
+                continue;
+            }
+            let code = line.split("//").next().unwrap_or("");
+            if needles.iter().any(|n| code.contains(n)) {
+                hits.push(format!("{rel}:{}: {}", i + 1, line.trim()));
+            }
+        }
+    }
+    hits
+}
+
+#[test]
+fn tui_never_writes_the_journal() {
+    let hits = offenders(
+        &[
+            "save_session",
+            "Session::save",
+            ".session.save(",
+            "save_session_in_dir",
+            "run_stream_with_messages",
+            "event_queue()",
+            "apply_compaction(",
+            "compact_conversation(",
+        ],
+        false,
+    );
+    assert!(hits.is_empty(), "journal/turn-machine code in the TUI:\n{}", hits.join("\n"));
+}
+
+#[test]
+fn tui_holds_no_runtime_outside_tests() {
+    let hits = offenders(
+        &["synaps_cli::Runtime ", "synaps_cli::Runtime,", "synaps_cli::Runtime)", "synaps_cli::Runtime>", "&Runtime ", "&Runtime)", "&Runtime,", "&mut Runtime", "Runtime::new("],
+        true,
+    );
+    assert!(hits.is_empty(), "Runtime in TUI production code:\n{}", hits.join("\n"));
+}

--- a/tests/tui_transport_differential.rs
+++ b/tests/tui_transport_differential.rs
@@ -1,0 +1,323 @@
+//! PLAN-phase3 §5.1 layer 3 — the terminal differential against the
+//! REFERENCE BINARY built at `f0ee1e62` (the in-process TUI before the port):
+//! the only oracle independent of the actor's author.
+//!
+//! For each scenario, three tmux panes run identical `send-keys` scripts
+//! against the same scripted provider stub: (R) the reference binary,
+//! (L) this binary in-process, (S) `synaps daemon --foreground` + this
+//! binary `--attach` (when `SYNAPS_TUI_E2E_SOCKET=1`). After each step the
+//! pane is captured, normalised and diffed. The journals are diffed too.
+//!
+//! Ignored unless `SYNAPS_TUI_E2E=1`; needs `SYNAPS_REF_BIN=<path>` and
+//! `tmux`. Run via `scripts/tui-e2e/differential.sh`.
+
+#[path = "support/phase2/mod.rs"]
+#[allow(dead_code)]
+mod phase2;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use phase2::{spawn_stub, Script, ANTHROPIC_SSE, ANTHROPIC_SSE_PREFIX, ANTHROPIC_SSE_TOOL_USE};
+
+const COLS: u16 = 100;
+const ROWS: u16 = 30;
+const TMUX: &str = "tuidiff";
+
+enum Step {
+    /// `tmux send-keys` literal text (no Enter).
+    Type(&'static str),
+    /// A tmux key name (`Enter`, `Escape`, …).
+    Key(&'static str),
+    /// Settle then capture (label for the diff).
+    Capture(&'static str),
+    Wait(u64),
+}
+
+struct Scenario {
+    name: &'static str,
+    script: Script,
+    steps: Vec<Step>,
+}
+
+fn scenarios() -> Vec<Scenario> {
+    use Step::*;
+    vec![
+        Scenario {
+            name: "plain_turn",
+            script: Script::Sse(ANTHROPIC_SSE),
+            steps: vec![
+                Type("hello"),
+                Key("Enter"),
+                Wait(1500),
+                Capture("after_turn"),
+            ],
+        },
+        Scenario {
+            name: "tool_loop",
+            script: Script::SeqSse(&[ANTHROPIC_SSE_TOOL_USE, ANTHROPIC_SSE]),
+            steps: vec![
+                Type("list it"),
+                Key("Enter"),
+                Wait(2500),
+                Capture("after_tool_turn"),
+            ],
+        },
+        Scenario {
+            name: "abort_mid_stream",
+            script: Script::Endless(ANTHROPIC_SSE_PREFIX),
+            steps: vec![
+                Type("go"),
+                Key("Enter"),
+                Wait(1200),
+                Capture("streaming"),
+                Key("Escape"),
+                Wait(800),
+                Capture("after_abort"),
+            ],
+        },
+        Scenario {
+            name: "steer_mid_stream",
+            script: Script::Endless(ANTHROPIC_SSE_PREFIX),
+            steps: vec![
+                Type("go"),
+                Key("Enter"),
+                Wait(1200),
+                Type("turn left"),
+                Key("Enter"),
+                Wait(600),
+                Capture("after_steer"),
+                Key("Escape"),
+                Wait(800),
+                Capture("after_abort"),
+            ],
+        },
+        Scenario {
+            name: "settings_model_change",
+            script: Script::Sse(ANTHROPIC_SSE),
+            steps: vec![
+                Type("/model claude-opus-4-1"),
+                Key("Enter"),
+                Wait(600),
+                Capture("after_model"),
+                Type("/thinking high"),
+                Key("Enter"),
+                Wait(600),
+                Capture("after_thinking"),
+                Type("/context 1m"),
+                Key("Enter"),
+                Wait(600),
+                Capture("after_context"),
+            ],
+        },
+        Scenario {
+            name: "clear",
+            script: Script::Sse(ANTHROPIC_SSE),
+            steps: vec![
+                Type("hello"),
+                Key("Enter"),
+                Wait(1500),
+                Type("/clear"),
+                Key("Enter"),
+                Wait(600),
+                Capture("after_clear"),
+            ],
+        },
+    ]
+}
+
+fn tmux(args: &[&str]) -> String {
+    let out = Command::new("tmux")
+        .arg("-L")
+        .arg(TMUX)
+        .args(args)
+        .output()
+        .expect("tmux");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn wait_ready(pane: &str) {
+    for _ in 0..500 {
+        std::thread::sleep(Duration::from_millis(20));
+        let cap = tmux(&["capture-pane", "-pt", pane]);
+        if cap.contains('❯') || cap.lines().any(|l| l.trim_end().ends_with('>')) {
+            return;
+        }
+    }
+    panic!("pane {pane} never became ready:\n{}", tmux(&["capture-pane", "-pt", pane]));
+}
+
+/// Strip what is allowed to differ (§5.1): session ids, timings, spinner.
+fn normalise(frame: &str) -> String {
+    let id_re = regex::Regex::new(r"\d{8}-\d{6}-[0-9a-f]{4}").unwrap();
+    let ms_re = regex::Regex::new(r"\b\d+(\.\d+)?\s?(ms|s)\b").unwrap();
+    let sha_re = regex::Regex::new(r"\b[0-9a-f]{8}(-dirty)?\b").unwrap();
+    let spinner = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏', '◐', '◓', '◑', '◒'];
+    frame
+        .lines()
+        .map(|l| {
+            let l = id_re.replace_all(l, "<id>");
+            let l = ms_re.replace_all(&l, "<t>");
+            let l = sha_re.replace_all(&l, "<sha>");
+            let l: String = l.chars().map(|c| if spinner.contains(&c) { '·' } else { c }).collect();
+            l.trim_end().to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn normalise_journal(dir: &Path) -> String {
+    let mut out = Vec::new();
+    if let Ok(rd) = std::fs::read_dir(dir) {
+        let mut files: Vec<_> = rd.flatten().map(|e| e.path()).collect();
+        files.sort();
+        for f in files {
+            let raw = std::fs::read_to_string(&f).unwrap_or_default();
+            let mut v: serde_json::Value = serde_json::from_str(&raw).unwrap_or_default();
+            if let Some(o) = v.as_object_mut() {
+                for k in ["id", "created_at", "updated_at", "parent_session", "compacted_into"] {
+                    o.remove(k);
+                }
+            }
+            out.push(serde_json::to_string_pretty(&v).unwrap_or_default());
+        }
+    }
+    out.join("\n---\n")
+}
+
+struct Pane {
+    name: String,
+    home: tempfile::TempDir,
+}
+
+fn spawn_pane(name: &str, bin: &Path, base_url: &str, extra: &[&str]) -> Pane {
+    let home = tempfile::TempDir::new().unwrap();
+    let base = home.path().join(".synaps-cli");
+    std::fs::create_dir_all(&base).unwrap();
+    std::fs::write(base.join("config"), "theme = \"default\"\n").unwrap();
+    std::fs::write(base.join("auth.json"), phase2::synthetic_auth_json()).unwrap();
+    let env = format!(
+        "HOME={h} SYNAPS_BASE_DIR={b} SYNAPS_ANTHROPIC_BASE_URL={u} SYNAPS_NO_BOOT_FX=1 TERM=xterm-256color COLUMNS={c} LINES={r}",
+        h = home.path().display(),
+        b = base.display(),
+        u = base_url,
+        c = COLS,
+        r = ROWS,
+    );
+    let cmd = format!(
+        "exec env {env} {} --no-extensions {}",
+        bin.display(),
+        extra.join(" ")
+    );
+    tmux(&[
+        "new",
+        "-d",
+        "-s",
+        name,
+        "-x",
+        &COLS.to_string(),
+        "-y",
+        &ROWS.to_string(),
+        &cmd,
+    ]);
+    wait_ready(name);
+    Pane {
+        name: name.to_string(),
+        home,
+    }
+}
+
+fn drive(panes: &[&Pane], steps: &[Step], captures: &mut Vec<(String, Vec<String>)>) {
+    for step in steps {
+        match step {
+            Step::Type(t) => {
+                for p in panes {
+                    tmux(&["send-keys", "-t", &p.name, "-l", t]);
+                }
+            }
+            Step::Key(k) => {
+                for p in panes {
+                    tmux(&["send-keys", "-t", &p.name, k]);
+                }
+            }
+            Step::Wait(ms) => std::thread::sleep(Duration::from_millis(*ms)),
+            Step::Capture(label) => {
+                std::thread::sleep(Duration::from_millis(300));
+                let frames = panes
+                    .iter()
+                    .map(|p| normalise(&tmux(&["capture-pane", "-pt", &p.name])))
+                    .collect();
+                captures.push((label.to_string(), frames));
+            }
+        }
+    }
+}
+
+fn diff_report(label: &str, a: &str, b: &str) -> Option<String> {
+    if a == b {
+        return None;
+    }
+    let mut out = format!("--- {label}: reference vs new ---\n");
+    for (i, (la, lb)) in a.lines().zip(b.lines()).enumerate() {
+        if la != lb {
+            out.push_str(&format!("{i:3}| R: {la}\n   | L: {lb}\n"));
+        }
+    }
+    Some(out)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "tmux differential; SYNAPS_TUI_E2E=1 SYNAPS_REF_BIN=<f0ee1e62 build>"]
+async fn tui_reference_binary_differential() {
+    if std::env::var("SYNAPS_TUI_E2E").ok().as_deref() != Some("1") {
+        eprintln!("SYNAPS_TUI_E2E != 1; skipping");
+        return;
+    }
+    let ref_bin = PathBuf::from(std::env::var("SYNAPS_REF_BIN").expect("SYNAPS_REF_BIN"));
+    let new_bin = PathBuf::from(env!("CARGO_BIN_EXE_synaps"));
+    let only = std::env::var("SYNAPS_TUI_E2E_ONLY").ok();
+    let mut failures = Vec::new();
+    let out_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/tui-e2e");
+    let _ = std::fs::create_dir_all(&out_dir);
+
+    for sc in scenarios() {
+        if only.as_deref().is_some_and(|o| o != sc.name) {
+            continue;
+        }
+        tmux(&["kill-server"]);
+        // One stub per pane: `SeqSse` scripts count hits per stub, so the
+        // two binaries must not share the arrival order.
+        let (url_r, _h1, _b1) = spawn_stub(sc.script.clone()).await;
+        let (url_l, _h2, _b2) = spawn_stub(sc.script.clone()).await;
+        let r = spawn_pane("r", &ref_bin, &url_r, &[]);
+        let l = spawn_pane("l", &new_bin, &url_l, &[]);
+        let mut captures = Vec::new();
+        drive(&[&r, &l], &sc.steps, &mut captures);
+        // Quit both so the journals are flushed.
+        for p in [&r, &l] {
+            tmux(&["send-keys", "-t", &p.name, "-l", "/quit"]);
+            tmux(&["send-keys", "-t", &p.name, "Enter"]);
+        }
+        std::thread::sleep(Duration::from_millis(1500));
+        for (label, frames) in &captures {
+            let file = out_dir.join(format!("{}.{label}", sc.name));
+            let _ = std::fs::write(file.with_extension("ref.txt"), &frames[0]);
+            let _ = std::fs::write(file.with_extension("new.txt"), &frames[1]);
+            if let Some(d) = diff_report(&format!("{}/{label}", sc.name), &frames[0], &frames[1]) {
+                failures.push(d);
+            }
+        }
+        let jr = normalise_journal(&r.home.path().join(".synaps-cli/sessions"));
+        let jl = normalise_journal(&l.home.path().join(".synaps-cli/sessions"));
+        if let Some(d) = diff_report(&format!("{}/journal", sc.name), &jr, &jl) {
+            failures.push(d);
+        }
+        tmux(&["kill-server"]);
+    }
+    if failures.is_empty() {
+        println!("REFERENCE DIFF: empty");
+    } else {
+        panic!("REFERENCE DIFF:\n{}", failures.join("\n"));
+    }
+}

--- a/tests/tui_transport_differential.rs
+++ b/tests/tui_transport_differential.rs
@@ -181,7 +181,7 @@ fn scenarios() -> Vec<Scenario> {
             script: Script::SseOrJson {
                 sse: ANTHROPIC_SSE,
                 json: ANTHROPIC_MESSAGES_JSON,
-                json_delay: Duration::from_millis(0),
+                json_delay: Duration::from_millis(1500),
             },
             steps: vec![
                 Type("hello"),
@@ -192,6 +192,10 @@ fn scenarios() -> Vec<Scenario> {
                 Wait(1500),
                 Type("/compact"),
                 Key("Enter"),
+                Wait(300),
+                // The transcript is rebuilt after the swap, so the lines
+                // pushed at dispatch are only visible DURING the summary.
+                Capture("during_compact"),
                 Wait(2500),
                 Capture("after_compact"),
             ],
@@ -308,7 +312,24 @@ fn normalise(frame: &str) -> String {
         .join("\n")
 }
 
+/// Journal normalisation: session ids and RFC 3339 timestamps are allowed
+/// to differ (§5.1) — wherever they appear (top level and inside the
+/// compaction metadata block). Everything else must be byte-equal.
 fn normalise_journal(dir: &Path) -> String {
+    let id_re = regex::Regex::new(r"\d{8}-\d{6}-[0-9a-f]{4}").unwrap();
+    let ts_re = regex::Regex::new(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z").unwrap();
+    fn walk(v: &mut serde_json::Value, id_re: &regex::Regex, ts_re: &regex::Regex) {
+        match v {
+            serde_json::Value::String(s) => {
+                let t = id_re.replace_all(s, "<id>");
+                let t = ts_re.replace_all(&t, "<ts>");
+                *s = t.into_owned();
+            }
+            serde_json::Value::Array(a) => a.iter_mut().for_each(|x| walk(x, id_re, ts_re)),
+            serde_json::Value::Object(o) => o.values_mut().for_each(|x| walk(x, id_re, ts_re)),
+            _ => {}
+        }
+    }
     let mut out = Vec::new();
     if let Ok(rd) = std::fs::read_dir(dir) {
         let mut files: Vec<_> = rd.flatten().map(|e| e.path()).collect();
@@ -316,11 +337,7 @@ fn normalise_journal(dir: &Path) -> String {
         for f in files {
             let raw = std::fs::read_to_string(&f).unwrap_or_default();
             let mut v: serde_json::Value = serde_json::from_str(&raw).unwrap_or_default();
-            if let Some(o) = v.as_object_mut() {
-                for k in ["id", "created_at", "updated_at", "parent_session", "compacted_into"] {
-                    o.remove(k);
-                }
-            }
+            walk(&mut v, &id_re, &ts_re);
             out.push(serde_json::to_string_pretty(&v).unwrap_or_default());
         }
     }

--- a/tests/tui_transport_differential.rs
+++ b/tests/tui_transport_differential.rs
@@ -29,7 +29,10 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
-use phase2::{spawn_stub, Script, ANTHROPIC_SSE, ANTHROPIC_SSE_PREFIX, ANTHROPIC_SSE_TOOL_USE};
+use phase2::{
+    spawn_stub, Script, ANTHROPIC_MESSAGES_JSON, ANTHROPIC_SSE, ANTHROPIC_SSE_PREFIX,
+    ANTHROPIC_SSE_TOOL_USE,
+};
 
 /// Anthropic SSE turn calling `bash` with a command that prints a password
 /// prompt on stderr and reads the answer from stdin — the bash tool's
@@ -171,11 +174,15 @@ fn scenarios() -> Vec<Scenario> {
         },
         // HIGH #1: `/compact` must push exactly the reference's lines
         // (disclosure + "compacting conversation..." then the ✓ line). The
-        // summary request is answered by the same stub (`compact_call` goes
-        // through the session's provider client).
+        // summary request (non-streaming `call_api_simple`) is answered by
+        // the same stub with a Messages JSON body.
         Scenario {
             name: "compaction",
-            script: Script::Sse(ANTHROPIC_SSE),
+            script: Script::SseOrJson {
+                sse: ANTHROPIC_SSE,
+                json: ANTHROPIC_MESSAGES_JSON,
+                json_delay: Duration::from_millis(0),
+            },
             steps: vec![
                 Type("hello"),
                 Key("Enter"),
@@ -193,28 +200,29 @@ fn scenarios() -> Vec<Scenario> {
         // Submit while the compaction summary is in flight → "queued: …"
         // then "queued message restored: …" after the swap (the reference's
         // `compact_task.is_some()` branch / the actor's `compact.is_some()`).
-        // Every request is paced so the summary call is a ~2 s window.
+        // The summary reply is delayed 2 s to open the window.
         Scenario {
             name: "queued_during_compaction",
-            script: Script::Paced {
-                body: ANTHROPIC_SSE,
-                frame_delay: Duration::from_millis(300),
+            script: Script::SseOrJson {
+                sse: ANTHROPIC_SSE,
+                json: ANTHROPIC_MESSAGES_JSON,
+                json_delay: Duration::from_millis(2000),
             },
             steps: vec![
                 Type("hello"),
                 Key("Enter"),
-                Wait(3000),
+                Wait(1500),
                 Type("again"),
                 Key("Enter"),
-                Wait(3000),
+                Wait(1500),
                 Type("/compact"),
                 Key("Enter"),
-                Wait(700),
+                Wait(600),
                 Type("later"),
                 Key("Enter"),
                 Wait(400),
                 Capture("queued"),
-                Wait(3500),
+                Wait(3000),
                 Capture("after_compact"),
             ],
             extensions: false,
@@ -462,9 +470,14 @@ async fn tui_reference_binary_differential() {
         std::thread::sleep(Duration::from_millis(1500));
         let before = failures.len();
         for (label, frames) in &captures {
-            let file = out_dir.join(format!("{}.{label}", sc.name));
-            let _ = std::fs::write(file.with_extension("ref.txt"), &frames[0]);
-            let _ = std::fs::write(file.with_extension("new.txt"), &frames[1]);
+            let _ = std::fs::write(
+                out_dir.join(format!("{}.{label}.ref.txt", sc.name)),
+                &frames[0],
+            );
+            let _ = std::fs::write(
+                out_dir.join(format!("{}.{label}.new.txt", sc.name)),
+                &frames[1],
+            );
             if let Some(d) = diff_report(&format!("{}/{label}", sc.name), &frames[0], &frames[1]) {
                 failures.push(d);
             }

--- a/tests/tui_transport_differential.rs
+++ b/tests/tui_transport_differential.rs
@@ -2,11 +2,21 @@
 //! REFERENCE BINARY built at `f0ee1e62` (the in-process TUI before the port):
 //! the only oracle independent of the actor's author.
 //!
-//! For each scenario, three tmux panes run identical `send-keys` scripts
-//! against the same scripted provider stub: (R) the reference binary,
-//! (L) this binary in-process, (S) `synaps daemon --foreground` + this
-//! binary `--attach` (when `SYNAPS_TUI_E2E_SOCKET=1`). After each step the
-//! pane is captured, normalised and diffed. The journals are diffed too.
+//! For each scenario, two tmux panes run identical `send-keys` scripts
+//! against the same scripted provider stub: (R) the reference binary and
+//! (L) this binary in-process. After each step the pane is captured,
+//! normalised and diffed. The journals are diffed too.
+//!
+//! There is NO socket pane here: L≡S (`--attach` against a daemon) is
+//! #111's gate and is not claimed by this file.
+//!
+//! Scenarios: plain_turn, tool_loop, abort_mid_stream, steer_mid_stream,
+//! settings_model_change, clear, compaction, queued_during_compaction,
+//! secret_prompt, extension_loaded. `queue_while_busy_then_autosend`
+//! (the `Steered{delivered:false}` → auto-send-on-Done branch) is NOT
+//! here: it needs the stream's steering receiver closed before `Done` is
+//! processed, which neither binary reaches deterministically (same reason
+//! as `session_actor_differential.rs` ext header #2).
 //!
 //! Ignored unless `SYNAPS_TUI_E2E=1`; needs `SYNAPS_REF_BIN=<path>` and
 //! `tmux`. Run via `scripts/tui-e2e/differential.sh`.
@@ -20,6 +30,33 @@ use std::process::Command;
 use std::time::Duration;
 
 use phase2::{spawn_stub, Script, ANTHROPIC_SSE, ANTHROPIC_SSE_PREFIX, ANTHROPIC_SSE_TOOL_USE};
+
+/// Anthropic SSE turn calling `bash` with a command that prints a password
+/// prompt on stderr and reads the answer from stdin — the bash tool's
+/// `detect_password_prompt` raises a secret prompt (`Prompt` envelope →
+/// secret-prompt pane on both binaries). Deterministic: the tool result is
+/// `len=<answer length>`.
+const ANTHROPIC_SSE_BASH_PASSWORD: &str = concat!(
+    "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_04\",\"type\":\"message\",",
+    "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-sonnet-4-5\",\"stop_reason\":null,",
+    "\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n",
+    "data: {\"type\":\"content_block_start\",\"index\":0,",
+    "\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_pw\",\"name\":\"bash\",\"input\":{}}}\n\n",
+    "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",",
+    "\"partial_json\":\"{\\\"command\\\":\\\"printf 'Password: ' >&2; read -r p; echo len=${#p}\\\"}\"}}\n\n",
+    "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",",
+    "\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":5,",
+    "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}\n\n",
+    "data: {\"type\":\"message_stop\"}\n\n",
+);
+
+/// The in-tree process-extension fixture (`crates/agent-tui/tests/fixtures/
+/// interactive_command_extension.py`), planted as an installed plugin under
+/// the pane's `SYNAPS_BASE_DIR/plugins/` so the loader arm, `ext_ready`
+/// waiter and `on_session_start` timing are inside the oracle.
+const EXTENSION_FIXTURE: &str = "crates/agent-tui/tests/fixtures/interactive_command_extension.py";
 
 const COLS: u16 = 100;
 const ROWS: u16 = 30;
@@ -39,6 +76,8 @@ struct Scenario {
     name: &'static str,
     script: Script,
     steps: Vec<Step>,
+    /// Plant the extension fixture and run WITHOUT `--no-extensions`.
+    extensions: bool,
 }
 
 fn scenarios() -> Vec<Scenario> {
@@ -53,6 +92,7 @@ fn scenarios() -> Vec<Scenario> {
                 Wait(1500),
                 Capture("after_turn"),
             ],
+            extensions: false,
         },
         Scenario {
             name: "tool_loop",
@@ -63,6 +103,7 @@ fn scenarios() -> Vec<Scenario> {
                 Wait(2500),
                 Capture("after_tool_turn"),
             ],
+            extensions: false,
         },
         Scenario {
             name: "abort_mid_stream",
@@ -76,6 +117,7 @@ fn scenarios() -> Vec<Scenario> {
                 Wait(800),
                 Capture("after_abort"),
             ],
+            extensions: false,
         },
         Scenario {
             name: "steer_mid_stream",
@@ -92,6 +134,7 @@ fn scenarios() -> Vec<Scenario> {
                 Wait(800),
                 Capture("after_abort"),
             ],
+            extensions: false,
         },
         Scenario {
             name: "settings_model_change",
@@ -110,6 +153,7 @@ fn scenarios() -> Vec<Scenario> {
                 Wait(600),
                 Capture("after_context"),
             ],
+            extensions: false,
         },
         Scenario {
             name: "clear",
@@ -123,6 +167,90 @@ fn scenarios() -> Vec<Scenario> {
                 Wait(600),
                 Capture("after_clear"),
             ],
+            extensions: false,
+        },
+        // HIGH #1: `/compact` must push exactly the reference's lines
+        // (disclosure + "compacting conversation..." then the ✓ line). The
+        // summary request is answered by the same stub (`compact_call` goes
+        // through the session's provider client).
+        Scenario {
+            name: "compaction",
+            script: Script::Sse(ANTHROPIC_SSE),
+            steps: vec![
+                Type("hello"),
+                Key("Enter"),
+                Wait(1500),
+                Type("again"),
+                Key("Enter"),
+                Wait(1500),
+                Type("/compact"),
+                Key("Enter"),
+                Wait(2500),
+                Capture("after_compact"),
+            ],
+            extensions: false,
+        },
+        // Submit while the compaction summary is in flight → "queued: …"
+        // then "queued message restored: …" after the swap (the reference's
+        // `compact_task.is_some()` branch / the actor's `compact.is_some()`).
+        // Every request is paced so the summary call is a ~2 s window.
+        Scenario {
+            name: "queued_during_compaction",
+            script: Script::Paced {
+                body: ANTHROPIC_SSE,
+                frame_delay: Duration::from_millis(300),
+            },
+            steps: vec![
+                Type("hello"),
+                Key("Enter"),
+                Wait(3000),
+                Type("again"),
+                Key("Enter"),
+                Wait(3000),
+                Type("/compact"),
+                Key("Enter"),
+                Wait(700),
+                Type("later"),
+                Key("Enter"),
+                Wait(400),
+                Capture("queued"),
+                Wait(3500),
+                Capture("after_compact"),
+            ],
+            extensions: false,
+        },
+        // `bash` prints `Password:` on stderr → secret prompt pane on both
+        // binaries; the answer goes back to the tool's stdin (`PromptBridge`
+        // on the new side, the inline pane on the reference).
+        Scenario {
+            name: "secret_prompt",
+            script: Script::SeqSse(&[ANTHROPIC_SSE_BASH_PASSWORD, ANTHROPIC_SSE]),
+            steps: vec![
+                Type("do it"),
+                Key("Enter"),
+                Wait(2000),
+                Capture("prompting"),
+                Type("abc"),
+                Key("Enter"),
+                Wait(2500),
+                Capture("after_answer"),
+            ],
+            extensions: false,
+        },
+        // Extension loader arm + `ext_ready` wait + on_session_start with a
+        // real process extension loaded (no `--no-extensions`).
+        Scenario {
+            name: "extension_loaded",
+            script: Script::Sse(ANTHROPIC_SSE),
+            steps: vec![
+                Wait(1500),
+                Capture("booted"),
+                Type("hello"),
+                Key("Enter"),
+                Wait(1500),
+                Capture("after_turn"),
+            ],
+            extensions: true,
         },
     ]
 }
@@ -148,18 +276,23 @@ fn wait_ready(pane: &str) {
     panic!("pane {pane} never became ready:\n{}", tmux(&["capture-pane", "-pt", pane]));
 }
 
-/// Strip what is allowed to differ (§5.1): session ids, timings, spinner.
+/// Strip what is allowed to differ (§5.1): session ids, timings, the build
+/// sha in the welcome banner, spinner. Deliberately narrow — a bare 8-digit
+/// number (token counts, cost cents) must survive so a real footer diff is
+/// visible.
 fn normalise(frame: &str) -> String {
     let id_re = regex::Regex::new(r"\d{8}-\d{6}-[0-9a-f]{4}").unwrap();
     let ms_re = regex::Regex::new(r"\b\d+(\.\d+)?\s?(ms|s)\b").unwrap();
-    let sha_re = regex::Regex::new(r"\b[0-9a-f]{8}(-dirty)?\b").unwrap();
+    // The build sha (`GIT_HASH`, `git rev-parse --short`) is rendered
+    // exactly once: `v<ver> · <sha>[-dirty] ` in the banner (draw.rs).
+    let sha_re = regex::Regex::new(r"(?P<pre>· )[0-9a-f]{7,12}(-dirty)?\b").unwrap();
     let spinner = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏', '◐', '◓', '◑', '◒'];
     frame
         .lines()
         .map(|l| {
             let l = id_re.replace_all(l, "<id>");
             let l = ms_re.replace_all(&l, "<t>");
-            let l = sha_re.replace_all(&l, "<sha>");
+            let l = sha_re.replace_all(&l, "${pre}<sha>");
             let l: String = l.chars().map(|c| if spinner.contains(&c) { '·' } else { c }).collect();
             l.trim_end().to_string()
         })
@@ -191,12 +324,38 @@ struct Pane {
     home: tempfile::TempDir,
 }
 
-fn spawn_pane(name: &str, bin: &Path, base_url: &str, extra: &[&str]) -> Pane {
+fn plant_extension(base: &Path) {
+    let root = base.join("plugins").join("demo-plugin");
+    std::fs::create_dir_all(root.join(".synaps-plugin")).unwrap();
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(EXTENSION_FIXTURE);
+    std::fs::copy(&src, root.join("ext.py")).expect("extension fixture present");
+    std::fs::write(
+        root.join(".synaps-plugin").join("plugin.json"),
+        serde_json::json!({
+            "name": "demo-plugin",
+            "version": "0.0.1",
+            "extension": {
+                "protocol_version": 1,
+                "runtime": "process",
+                "command": "python3",
+                "args": ["ext.py"],
+                "permissions": ["tools.register"],
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
+fn spawn_pane(name: &str, bin: &Path, base_url: &str, extensions: bool) -> Pane {
     let home = tempfile::TempDir::new().unwrap();
     let base = home.path().join(".synaps-cli");
     std::fs::create_dir_all(&base).unwrap();
     std::fs::write(base.join("config"), "theme = \"default\"\n").unwrap();
     std::fs::write(base.join("auth.json"), phase2::synthetic_auth_json()).unwrap();
+    if extensions {
+        plant_extension(&base);
+    }
     let env = format!(
         "HOME={h} SYNAPS_BASE_DIR={b} SYNAPS_ANTHROPIC_BASE_URL={u} SYNAPS_NO_BOOT_FX=1 TERM=xterm-256color COLUMNS={c} LINES={r}",
         h = home.path().display(),
@@ -206,9 +365,9 @@ fn spawn_pane(name: &str, bin: &Path, base_url: &str, extra: &[&str]) -> Pane {
         r = ROWS,
     );
     let cmd = format!(
-        "exec env {env} {} --no-extensions {}",
+        "exec env {env} {} {}",
         bin.display(),
-        extra.join(" ")
+        if extensions { "" } else { "--no-extensions" }
     );
     tmux(&[
         "new",
@@ -278,6 +437,7 @@ async fn tui_reference_binary_differential() {
     let new_bin = PathBuf::from(env!("CARGO_BIN_EXE_synaps"));
     let only = std::env::var("SYNAPS_TUI_E2E_ONLY").ok();
     let mut failures = Vec::new();
+    let mut table: Vec<(&'static str, bool)> = Vec::new();
     let out_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/tui-e2e");
     let _ = std::fs::create_dir_all(&out_dir);
 
@@ -290,8 +450,8 @@ async fn tui_reference_binary_differential() {
         // two binaries must not share the arrival order.
         let (url_r, _h1, _b1) = spawn_stub(sc.script.clone()).await;
         let (url_l, _h2, _b2) = spawn_stub(sc.script.clone()).await;
-        let r = spawn_pane("r", &ref_bin, &url_r, &[]);
-        let l = spawn_pane("l", &new_bin, &url_l, &[]);
+        let r = spawn_pane("r", &ref_bin, &url_r, sc.extensions);
+        let l = spawn_pane("l", &new_bin, &url_l, sc.extensions);
         let mut captures = Vec::new();
         drive(&[&r, &l], &sc.steps, &mut captures);
         // Quit both so the journals are flushed.
@@ -300,6 +460,7 @@ async fn tui_reference_binary_differential() {
             tmux(&["send-keys", "-t", &p.name, "Enter"]);
         }
         std::thread::sleep(Duration::from_millis(1500));
+        let before = failures.len();
         for (label, frames) in &captures {
             let file = out_dir.join(format!("{}.{label}", sc.name));
             let _ = std::fs::write(file.with_extension("ref.txt"), &frames[0]);
@@ -313,10 +474,15 @@ async fn tui_reference_binary_differential() {
         if let Some(d) = diff_report(&format!("{}/journal", sc.name), &jr, &jl) {
             failures.push(d);
         }
+        table.push((sc.name, failures.len() == before));
         tmux(&["kill-server"]);
     }
+    println!("scenario                   diff empty?");
+    for (name, ok) in &table {
+        println!("{name:<26} {}", if *ok { "yes" } else { "NO" });
+    }
     if failures.is_empty() {
-        println!("REFERENCE DIFF: empty");
+        println!("REFERENCE DIFF: empty ({} scenarios)", table.len());
     } else {
         panic!("REFERENCE DIFF:\n{}", failures.join("\n"));
     }


### PR DESCRIPTION
**Stacked on #108 ← #107 ← #105.** Base is `feat/daemon-mode-p3-engine`. **This is the one default-path change of the whole daemon project**: every `synaps` user's TUI now runs on the `SessionActor` via `LocalTransport`, whether or not `SYNAPS_DAEMON` is set. It is carried by evidence, not by a flag.

## What
- **`RunContext` on `ClientTransport` + `RuntimeView`**: the TUI's copy of the turn machine (stream / event-queue / compaction arms, `save_session`) is deleted; the actor owns it. `App` mirrors `ConversationSnapshot`. Setters become `Set{id}` / `EngineCommand` / `Resume` / `PluginCommand` / `SubmitPrepared` round-trips; `settings/defs` produce `SettingApply`. `PromptBridge` carries permission/secret prompts. `tui/mod.rs` 476 → 420 lines. A guard test asserts no journal writes and no `Runtime` in TUI production code.
- **`synaps --attach [ID] [--observe|--takeover|--keep-warm]`** runs the real TUI over `SocketTransport` — no host boot, no extensions/MCP/skills on the client path; reconnect re-mirrors; `Refused` renders immediately (no 30 s hang for a non-owner); teardown budget (13 s) exceeds the actor's worst case (11 s) and exits 0 when the channel closed cleanly; "no daemon is running — start one with …" when there isn't one.
- Typed `Aborted`/`Cleared`/`Compaction*` rendered once (the notice-text shims are gone).

## Proof — three layers
1. Frozen engine differential (#108's 10 scenarios).
2. Tape harness: `TapeStep::SessionEvent` + `ScriptedTransport`, 11 layer-2 scenarios; **all existing `harness_*` suites unchanged and green** (41/11/19/7/4), no snapshot changes.
3. **Reference-binary differential** — `scripts/tui-e2e/differential.sh` runs the same scripted session in tmux against a binary built at `f0ee1e62` (#107's tip — nobody who wrote the actor touched it) and diffs frames after every step **and** normalized journals:
   ```
   plain_turn  tool_loop  abort_mid_stream  steer_mid_stream  settings_model_change
   clear  compaction  queued_during_compaction  secret_prompt  extension_loaded
   REFERENCE DIFF: empty (10 scenarios)
   ```
   The oracle earned its keep: `compaction` and `queued_during_compaction` showed an extra rendered line against the reference until #108 removed the actor's notice; two other real bugs (engine-command reply key, stale footer after `/model`) were found by it and fixed. `queue_while_busy_then_autosend` remains out (needs a scheduling race).
- `cargo test --workspace --no-fail-fast` on bella: **3968 passed / 1 failed** — the 1 is `e_opens_expanded_provider_browser` (#344), order-dependent, **fails identically on the reference tree at `f0ee1e62`** (556/1) and passes alone 3/3 and in its module group.

## Client memory (bella, release, `--no-extensions`, informational)
| | RssAnon | threads |
|---|---:|---:|
| in-process TUI | 21.4 MB | 16 |
| `--attach` TUI client | 19.1 MB | 8 |
Half the threads; the heap is render/highlight/theme + jemalloc retention — client diet continues later.

## Review
Part of the phase-3 review (NO-SHIP as one PR → split): all TUI-side must-fix items closed. Recommend merging #108 first, soaking a day, then this.

Refs #343.