### PR TITLE
Release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.1] — 2026-09-07
+
+### Added
+
+- **Vision — the model can see images.** The `read` tool now returns PNG, JPEG,
+  GIF, and WebP as image content blocks instead of a path or error, so the model
+  receives the actual pixels. Zero-dimension images are rejected before they
+  reach the provider.
+- **Session UI overhaul** plus support for `~/.synaps-cli/subagent-preamble.md`:
+  a user-authored preamble loaded into every subagent spawn.
+- **`system_msg` theme field** — system messages get their own configurable
+  color, independent of assistant/user text.
+
+### Changed
+
+- **Execution gate: per-tool digest + provenance validation.** Tool-call
+  authorization is now validated per tool against its catalog digest and
+  provenance, replacing the coarser set-wide generation-denial check — tighter,
+  and it stops a stale catalog entry from denying an otherwise-valid call.
+
+### Fixed
+
+- **Providers:** surface Kimi Code quota `403`s as an actionable message, clamp
+  Grok reasoning effort on model switch, and retry xAI capacity errors.
+- **Concurrency:** uniform `runtime`-before-`conv` lock order across the server
+  (`/model`, `/compact`, command-result mirroring) — removes a lock inversion.
+- **Sessions:** persist `message_count` in the session header and refresh it at
+  write time without cloning the session; clamp a resumed session's thinking
+  level against the model's supported range.
+- Replace silent `unwrap_or_default` fallbacks in the watcher and agent paths
+  with logged fallbacks, so failures are visible instead of swallowed.
+- Normalize the `ToolOutput::Blocks` text-first invariant in release builds and
+  report dropped output completely.
+- Use an absolute shell path in the PTY integration tests (fixes flakiness
+  under restricted `PATH`).
+
+### Internal
+
+- Centralize the crate version and the three internal dependencies via
+  `[workspace.package]` / `[workspace.dependencies]` inheritance — a version
+  bump is now a single edit in the root manifest.
+
 ## [0.9.0] — 2026-08-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "synaps"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3308,7 +3308,7 @@ dependencies = [
 
 [[package]]
 name = "synaps-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "synaps-engine"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3389,7 +3389,7 @@ dependencies = [
 
 [[package]]
 name = "synaps-tui"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ tempfile = "3"
 clap_complete = "4.5.67"
 
 [dev-dependencies]
+# Unlocks `Runtime::new_headless()` for bin tests (feature-unified in test builds).
+agent-engine = { path = "crates/agent-engine", version = "0.9.0", package = "synaps-engine", features = ["testing"] }
 serial_test = "3.4.0"
 tempfile = "3"
 rcgen = { version = "0.14", default-features = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synaps"
-version = "0.9.0"
+version.workspace = true
 edition = "2021"
 authors = ["Haseeb Khalid <haseebkhalid1507@gmail.com>"]
 license = "Apache-2.0"
@@ -18,9 +18,9 @@ testing = ["agent-tui/testing", "agent-engine/testing"]
 [dependencies]
 # Non-musl only: jemalloc + background purge to stop glibc RSS ratchet on
 # long sessions (see src/main.rs). musl keeps its own allocator.
-agent-core = { path = "crates/agent-core", version = "0.9.0", package = "synaps-core" }
-agent-engine = { path = "crates/agent-engine", version = "0.9.0", package = "synaps-engine" }
-agent-tui = { path = "crates/agent-tui", version = "0.9.0", package = "synaps-tui" }
+agent-core = { workspace = true }
+agent-engine = { workspace = true }
+agent-tui = { workspace = true }
 arc-swap = "1"
 tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls-webpki-roots", "rustls-tls-native-roots"] }
@@ -72,7 +72,7 @@ clap_complete = "4.5.67"
 
 [dev-dependencies]
 # Unlocks `Runtime::new_headless()` for bin tests (feature-unified in test builds).
-agent-engine = { path = "crates/agent-engine", version = "0.9.0", package = "synaps-engine", features = ["testing"] }
+agent-engine = { workspace = true, features = ["testing"] }
 serial_test = "3.4.0"
 tempfile = "3"
 rcgen = { version = "0.14", default-features = true }
@@ -127,3 +127,11 @@ tikv-jemallocator = { version = "0.6", features = ["background_threads"] }
 [workspace]
 members = ["crates/agent-core", "crates/agent-engine", "crates/agent-tui"]
 resolver = "2"
+
+[workspace.package]
+version = "0.9.0"
+
+[workspace.dependencies]
+agent-core   = { path = "crates/agent-core",   version = "0.9.0", package = "synaps-core" }
+agent-engine = { path = "crates/agent-engine", version = "0.9.0", package = "synaps-engine" }
+agent-tui    = { path = "crates/agent-tui",    version = "0.9.0", package = "synaps-tui" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,9 +129,9 @@ members = ["crates/agent-core", "crates/agent-engine", "crates/agent-tui"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 
 [workspace.dependencies]
-agent-core   = { path = "crates/agent-core",   version = "0.9.0", package = "synaps-core" }
-agent-engine = { path = "crates/agent-engine", version = "0.9.0", package = "synaps-engine" }
-agent-tui    = { path = "crates/agent-tui",    version = "0.9.0", package = "synaps-tui" }
+agent-core   = { path = "crates/agent-core",   version = "0.9.1", package = "synaps-core" }
+agent-engine = { path = "crates/agent-engine", version = "0.9.1", package = "synaps-engine" }
+agent-tui    = { path = "crates/agent-tui",    version = "0.9.1", package = "synaps-tui" }

--- a/crates/agent-core/Cargo.toml
+++ b/crates/agent-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synaps-core"
-version = "0.9.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.80"
 description = "Foundation types, config, session, auth, protocol — leaf crate for agent-runtime"

--- a/crates/agent-core/src/core/auth/broker.rs
+++ b/crates/agent-core/src/core/auth/broker.rs
@@ -1724,6 +1724,33 @@ async fn read_body_capped(resp: reqwest::Response, cap: usize) -> Result<String,
         .map_err(|_| BrokerError::Transport("response body was not valid UTF-8".into()))
 }
 
+/// Cap on how much of a non-2xx upstream body is read for *classification*
+/// only (spec §5.1). Error envelopes are tiny; anything larger is cut off
+/// and simply fails to classify.
+const MAX_PROXY_ERROR_CLASSIFY_BYTES: usize = 8 * 1024;
+
+/// Read at most `cap` bytes of an untrusted error body for classification.
+/// Never fails: overflow truncates (so JSON no longer parses → no label),
+/// transport errors and non-UTF-8 yield `None`. The returned text must only
+/// ever be fed to a vetted classifier — never to an error string or log.
+async fn read_error_body_for_classification(resp: reqwest::Response, cap: usize) -> Option<String> {
+    use futures::StreamExt;
+    let mut buf: Vec<u8> = Vec::with_capacity(cap.min(1024));
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.ok()?;
+        let room = cap.saturating_sub(buf.len());
+        if chunk.len() >= room {
+            buf.extend_from_slice(&chunk[..room]);
+            // Drop the rest unread: truncated JSON cannot classify, which is
+            // the intended fail-closed outcome for oversized bodies.
+            return String::from_utf8(buf).ok();
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    String::from_utf8(buf).ok()
+}
+
 /// Legacy discovery for a static key: login config first, then env vars.
 /// Only callable from inside the broker boundary.
 fn discover_legacy_static_key(spec: &StaticProviderSpec) -> Option<String> {
@@ -1886,14 +1913,27 @@ impl CredentialBroker for LocalBroker {
         let status = resp.status();
         if !status.is_success() {
             // Spec §5.1: the upstream may echo the full request (prompts,
-            // tool schemas, credentials) in its error body. Drop the body
-            // unread — only the typed status reaches the error. The stable
-            // `provider request failed: {status}` prefix (with canonical
-            // reason phrase, e.g. `429 Too Many Requests`) is the transport
-            // contract engine-side classifiers parse.
-            drop(resp);
+            // tool schemas, credentials) in its error body. The body is read
+            // (bounded) for *classification only*: it selects one of OUR
+            // static labels or nothing — no provider bytes reach the error
+            // or the log. The stable `provider request failed: {status}`
+            // prefix (with canonical reason phrase, e.g. `429 Too Many
+            // Requests`) is the transport contract engine-side classifiers
+            // parse; the optional ` [label]` suffix follows it and contains
+            // no ':' so `redact_provider_proxy_error` keeps it intact.
+            let label = read_error_body_for_classification(resp, MAX_PROXY_ERROR_CLASSIFY_BYTES)
+                .await
+                .as_deref()
+                .and_then(crate::error::vetted_proxy_error_label);
+            tracing::warn!(
+                provider = %request.provider,
+                status = status.as_u16(),
+                label = label.unwrap_or("-"),
+                "provider request failed"
+            );
+            let label_suffix = label.map(|l| format!(" [{l}]")).unwrap_or_default();
             return Err(BrokerError::Transport(format!(
-                "provider request failed: {status}"
+                "provider request failed: {status}{label_suffix}"
             )));
         }
         use futures::StreamExt;
@@ -3328,6 +3368,148 @@ mod tests {
             "escapes must not reach errors: {msg}"
         );
         assert_no_hostile_bytes(&msg);
+    }
+
+    /// Drive `proxy_stream` against an upstream that answers `/chat/completions`
+    /// with `status` + `body`, returning the Transport error message.
+    async fn stream_error_message(status: axum::http::StatusCode, body: String) -> String {
+        use axum::routing::post;
+        let app = axum::Router::new().route(
+            "/chat/completions",
+            post(move || async move { (status, body) }),
+        );
+        let url = spawn_upstream(app).await;
+        let broker = LocalBroker::with_local_base_url(reqwest::Client::new(), url);
+        let err = broker
+            .proxy_stream(ProxyRequest {
+                provider: LOCAL_PROVIDER_KEY.into(),
+                method: ProxyMethod::Post,
+                path: "/chat/completions".into(),
+                body: None,
+                stream: true,
+                body_bytes: None,
+            })
+            .await
+            .err()
+            .expect("non-2xx upstream must not yield a stream");
+        assert!(matches!(err, BrokerError::Transport(_)));
+        format!("{err}")
+    }
+
+    /// Everything after the `provider request failed: ` marker.
+    fn after_marker(msg: &str) -> &str {
+        let marker = "provider request failed: ";
+        let idx = msg.find(marker).expect("marker present");
+        &msg[idx + marker.len()..]
+    }
+
+    /// Kimi Code weekly-quota 403: the vetted `access_terminated_error`
+    /// class is surfaced as OUR static label so callers can tell quota
+    /// exhaustion from an auth failure — while none of the body's text
+    /// reaches the error, and the suffix stays ':'-free so engine-side
+    /// `redact_provider_proxy_error` / `broker_error_status` keep parsing.
+    #[tokio::test]
+    async fn local_broker_stream_403_kimi_quota_surfaces_vetted_label_only() {
+        let kimi_body = "{\"error\":{\"type\":\"access_terminated_error\",\"message\":\
+                         \"You've reached your weekly (7-day) usage limit. Your quota will \
+                         reset when the current 7-day window ends. \"}}";
+        let msg = stream_error_message(axum::http::StatusCode::FORBIDDEN, kimi_body.into()).await;
+        assert!(
+            msg.ends_with("provider request failed: 403 Forbidden [access_terminated_error]"),
+            "expected exact labelled prefix: {msg}"
+        );
+        assert!(!msg.contains("weekly"), "body text leaked: {msg}");
+        assert!(!msg.contains("quota"), "body text leaked: {msg}");
+        assert!(!msg.contains('{'), "raw JSON leaked: {msg}");
+        assert!(
+            !after_marker(&msg).contains(':'),
+            "suffix must not contain ':' (engine truncates there): {msg}"
+        );
+    }
+
+    /// Hostile/unvetted `error.type` never becomes a label and its bytes
+    /// never reach the error.
+    #[tokio::test]
+    async fn local_broker_stream_429_unvetted_type_yields_no_label() {
+        let body = format!(
+            "{{\"error\":{{\"type\":\"<script>ECHO:secret\",\"message\":\"ECHOED {HOSTILE_SENTINEL}\"}}}}"
+        );
+        let msg = stream_error_message(axum::http::StatusCode::TOO_MANY_REQUESTS, body).await;
+        assert!(
+            msg.ends_with("provider request failed: 429 Too Many Requests"),
+            "no label expected: {msg}"
+        );
+        assert!(!msg.contains('['), "unexpected label: {msg}");
+        assert!(!msg.contains("script"), "hostile type leaked: {msg}");
+        assert!(!msg.contains("secret"), "hostile type leaked: {msg}");
+        assert!(!after_marker(&msg).contains(':'), "got: {msg}");
+        assert_no_hostile_bytes(&msg);
+    }
+
+    /// Non-JSON (HTML) error page → no label, no leak.
+    #[tokio::test]
+    async fn local_broker_stream_html_body_yields_no_label() {
+        let body =
+            format!("<html><body>ECHOED {HOSTILE_SENTINEL} access_terminated_error</body></html>");
+        let msg = stream_error_message(axum::http::StatusCode::BAD_GATEWAY, body).await;
+        assert!(
+            msg.ends_with("provider request failed: 502 Bad Gateway"),
+            "no label expected: {msg}"
+        );
+        assert!(!msg.contains("html"), "body leaked: {msg}");
+        assert!(!msg.contains('['), "unexpected label: {msg}");
+        assert_no_hostile_bytes(&msg);
+    }
+
+    /// Body larger than the classification cap: truncated read, no label,
+    /// no panic, no error from the reader itself.
+    #[tokio::test]
+    async fn local_broker_stream_oversized_body_yields_no_label_without_panic() {
+        // Valid vetted envelope, but padded far past the cap so the read is
+        // cut off before the closing braces → cannot parse → no label.
+        let pad = "x".repeat(MAX_PROXY_ERROR_CLASSIFY_BYTES * 4);
+        let body = format!(
+            "{{\"error\":{{\"message\":\"ECHOED {HOSTILE_SENTINEL} {pad}\",\"type\":\"access_terminated_error\"}}}}"
+        );
+        let msg = stream_error_message(axum::http::StatusCode::FORBIDDEN, body).await;
+        assert!(
+            msg.ends_with("provider request failed: 403 Forbidden"),
+            "no label expected for oversized body: {msg}"
+        );
+        assert!(!msg.contains('['), "unexpected label: {msg}");
+        assert!(
+            msg.len() < 200,
+            "oversized body leaked: {} bytes",
+            msg.len()
+        );
+        assert_no_hostile_bytes(&msg);
+    }
+
+    /// The truncating reader itself: overflow returns the first `cap` bytes
+    /// (never an error), and a multibyte char split at the cap yields `None`
+    /// rather than panicking.
+    #[tokio::test]
+    async fn read_error_body_for_classification_truncates_and_never_fails() {
+        use axum::routing::get;
+        let app = axum::Router::new()
+            .route("/big", get(|| async { "a".repeat(100) }))
+            .route("/utf8", get(|| async { format!("{}é", "a".repeat(9)) }));
+        let url = spawn_upstream(app).await;
+        let client = reqwest::Client::new();
+
+        let resp = client.get(format!("{url}/big")).send().await.unwrap();
+        let got = read_error_body_for_classification(resp, 10).await;
+        assert_eq!(got.as_deref(), Some("aaaaaaaaaa"));
+
+        // 'é' is 2 bytes at offset 9..11; cap 10 splits it.
+        let resp = client.get(format!("{url}/utf8")).send().await.unwrap();
+        let got = read_error_body_for_classification(resp, 10).await;
+        assert_eq!(got, None);
+
+        // Under the cap: whole body.
+        let resp = client.get(format!("{url}/utf8")).send().await.unwrap();
+        let got = read_error_body_for_classification(resp, 1024).await;
+        assert_eq!(got.as_deref(), Some("aaaaaaaaaé"));
     }
 
     /// LocalBroker::anthropic_usage: a non-2xx usage-endpoint body must never

--- a/crates/agent-core/src/core/error.rs
+++ b/crates/agent-core/src/core/error.rs
@@ -132,8 +132,7 @@ pub fn humanize_proxy_status_error(
             );
             if provider == "kimi-code" {
                 msg.push_str(
-                    " Kimi Code quotas are weekly; `synaps status` or the Kimi membership page \
-                     shows the reset time.",
+                    " Kimi Code quotas are weekly; the Kimi membership page shows the reset time.",
                 );
             }
             Some(msg)
@@ -364,7 +363,7 @@ mod tests {
         );
         assert!(msg.contains("/model"), "got: {msg}");
         assert!(msg.contains("weekly"), "kimi-specific hint missing: {msg}");
-        assert!(msg.contains("synaps status"), "got: {msg}");
+        assert!(msg.contains("membership page"), "got: {msg}");
         assert!(
             !msg.contains("login"),
             "quota must not be misreported as auth: {msg}"

--- a/crates/agent-core/src/core/error.rs
+++ b/crates/agent-core/src/core/error.rs
@@ -57,6 +57,103 @@ fn vetted_error_type(body: &str) -> Option<&'static str> {
     VETTED_ERROR_TYPES.iter().find(|t| **t == ty).copied()
 }
 
+/// Wire error classes we recognise on broker-proxied (OpenAI-compatible)
+/// non-2xx responses. Superset of [`VETTED_ERROR_TYPES`]: it adds the
+/// OpenAI/Kimi/xAI-style `error.type` / `error.code` values so a proxied
+/// failure can be named via OUR static label — never the provider's bytes.
+///
+/// INVARIANT: no label may contain `':'`. Engine-side
+/// `redact_provider_proxy_error` truncates the transport message at the
+/// first `':'` after the `provider request failed: {status}` marker, so a
+/// colon in a label would silently strip it.
+pub const VETTED_PROXY_ERROR_TYPES: &[&str] = &[
+    // Anthropic classes (kept in sync with `VETTED_ERROR_TYPES`).
+    "invalid_request_error",
+    "authentication_error",
+    "permission_error",
+    "not_found_error",
+    "request_too_large",
+    "rate_limit_error",
+    "api_error",
+    "overloaded_error",
+    "billing_error",
+    "timeout_error",
+    // OpenAI-compatible / Kimi / xAI classes.
+    "access_terminated_error",
+    "invalid_authentication_error",
+    "insufficient_quota",
+    "quota_exceeded",
+    "server_error",
+    "model_not_found",
+    "invalid_api_key",
+];
+
+/// Classify an untrusted proxied error body onto a vetted static label.
+///
+/// Parses `body` as JSON and reads, in order, `error.type`, `error.code`,
+/// then top-level `type` / `code` (each must be a JSON string). Returns OUR
+/// constant only on an exact match; the untrusted value itself is never
+/// surfaced. Non-JSON, oversized-truncated, or unrecognised bodies yield
+/// `None` — classification never fails loudly.
+pub fn vetted_proxy_error_label(body: &str) -> Option<&'static str> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    let candidates = [
+        v.get("error").and_then(|e| e.get("type")),
+        v.get("error").and_then(|e| e.get("code")),
+        v.get("type"),
+        v.get("code"),
+    ];
+    let label = candidates
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .find_map(|ty| VETTED_PROXY_ERROR_TYPES.iter().find(|t| **t == ty).copied());
+    label
+}
+
+/// User-actionable message for a broker-proxied non-2xx response when the
+/// (status, vetted label) pair is one we understand; `None` otherwise so the
+/// caller keeps the raw `provider request failed: …` prefix.
+///
+/// `provider` is a runtime-owned key (e.g. `kimi-code`, `xai-auth`) — never
+/// provider bytes. `label` must be one of OUR constants (typically from
+/// [`vetted_proxy_error_label`]); an unknown label is treated as absent.
+pub fn humanize_proxy_status_error(
+    provider: &str,
+    status: u16,
+    label: Option<&str>,
+) -> Option<String> {
+    let label = label.and_then(|l| VETTED_PROXY_ERROR_TYPES.iter().find(|t| **t == l).copied());
+    match (status, label?) {
+        (403, "access_terminated_error") => {
+            let mut msg = format!(
+                "{provider}: usage quota exhausted (HTTP 403). Your plan's usage window is used up — \
+                 wait for the reset or upgrade, or switch models with /model."
+            );
+            if provider == "kimi-code" {
+                msg.push_str(
+                    " Kimi Code quotas are weekly; `synaps status` or the Kimi membership page \
+                     shows the reset time.",
+                );
+            }
+            Some(msg)
+        }
+        (401, "invalid_authentication_error" | "authentication_error" | "invalid_api_key") => {
+            Some(format!(
+                "{provider}: authentication rejected (HTTP 401). Run `synaps login --provider {provider}`."
+            ))
+        }
+        (429, "rate_limit_error") => Some(format!(
+            "{provider}: rate limited (HTTP 429). Wait for the limit to reset, or switch models with /model."
+        )),
+        (429, "insufficient_quota" | "quota_exceeded") => Some(format!(
+            "{provider}: usage quota exhausted (HTTP 429). Add credit or wait for the quota to reset, \
+             or switch models with /model."
+        )),
+        _ => None,
+    }
+}
+
 /// Classification-only peek at the untrusted error body: true when it
 /// contains the given fixed pattern. The body text itself is never emitted.
 fn body_mentions(body: &str, pattern: &str) -> bool {
@@ -179,6 +276,160 @@ pub type Result<T> = std::result::Result<T, RuntimeError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const KIMI_403_BODY: &str = r#"{"error":{"type":"access_terminated_error","message":"You've reached your weekly (7-day) usage limit. Your quota will reset when the current 7-day window ends."}}"#;
+
+    #[test]
+    fn proxy_labels_never_contain_colon_and_are_superset_of_anthropic() {
+        for label in VETTED_PROXY_ERROR_TYPES {
+            assert!(
+                !label.contains(':'),
+                "label {label:?} would be truncated by the engine"
+            );
+            assert!(
+                !label.contains('['),
+                "label {label:?} breaks the [label] suffix"
+            );
+        }
+        for label in VETTED_ERROR_TYPES {
+            assert!(
+                VETTED_PROXY_ERROR_TYPES.contains(label),
+                "proxy list must be a superset: missing {label}"
+            );
+        }
+    }
+
+    #[test]
+    fn proxy_label_reads_error_type() {
+        assert_eq!(
+            vetted_proxy_error_label(KIMI_403_BODY),
+            Some("access_terminated_error")
+        );
+    }
+
+    #[test]
+    fn proxy_label_falls_back_to_error_code_then_top_level() {
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"code":"invalid_api_key","message":"x"}}"#),
+            Some("invalid_api_key")
+        );
+        // error.type present but unvetted → fall through to error.code.
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"type":"weird","code":"insufficient_quota"}}"#),
+            Some("insufficient_quota")
+        );
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"type":"server_error"}"#),
+            Some("server_error")
+        );
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"code":"model_not_found"}"#),
+            Some("model_not_found")
+        );
+    }
+
+    #[test]
+    fn proxy_label_rejects_non_string_non_json_and_hostile_values() {
+        assert_eq!(vetted_proxy_error_label(r#"{"error":{"type":42}}"#), None);
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"code":["a"]}}"#),
+            None
+        );
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"type":"<script>ECHO:secret"}}"#),
+            None
+        );
+        // Prefix/suffix variants must not match — exact only.
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"type":"access_terminated_error2"}}"#),
+            None
+        );
+        assert_eq!(
+            vetted_proxy_error_label(r#"{"error":{"type":"Access_Terminated_Error"}}"#),
+            None
+        );
+        assert_eq!(vetted_proxy_error_label("<html>403 Forbidden</html>"), None);
+        assert_eq!(vetted_proxy_error_label(""), None);
+        // Truncated JSON (oversized body cut at the cap) must not parse.
+        assert_eq!(vetted_proxy_error_label(&KIMI_403_BODY[..40]), None);
+    }
+
+    #[test]
+    fn humanize_proxy_403_access_terminated_is_quota_not_auth() {
+        let msg = humanize_proxy_status_error("kimi-code", 403, Some("access_terminated_error"))
+            .expect("known combo");
+        assert!(
+            msg.starts_with("kimi-code: usage quota exhausted (HTTP 403)"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("/model"), "got: {msg}");
+        assert!(msg.contains("weekly"), "kimi-specific hint missing: {msg}");
+        assert!(msg.contains("synaps status"), "got: {msg}");
+        assert!(
+            !msg.contains("login"),
+            "quota must not be misreported as auth: {msg}"
+        );
+
+        let generic = humanize_proxy_status_error("xai-auth", 403, Some("access_terminated_error"))
+            .expect("known combo");
+        assert!(
+            generic.starts_with("xai-auth: usage quota exhausted (HTTP 403)"),
+            "got: {generic}"
+        );
+        assert!(
+            !generic.contains("weekly"),
+            "kimi hint leaked to other provider: {generic}"
+        );
+    }
+
+    #[test]
+    fn humanize_proxy_401_points_to_provider_login() {
+        for label in [
+            "invalid_authentication_error",
+            "authentication_error",
+            "invalid_api_key",
+        ] {
+            let msg = humanize_proxy_status_error("xai-auth", 401, Some(label)).expect(label);
+            assert!(msg.contains("HTTP 401"), "got: {msg}");
+            assert!(
+                msg.contains("synaps login --provider xai-auth"),
+                "got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn humanize_proxy_429_distinguishes_rate_limit_from_quota() {
+        let rl = humanize_proxy_status_error("groq", 429, Some("rate_limit_error")).unwrap();
+        let q1 = humanize_proxy_status_error("groq", 429, Some("insufficient_quota")).unwrap();
+        let q2 = humanize_proxy_status_error("groq", 429, Some("quota_exceeded")).unwrap();
+        assert!(rl.contains("rate limited"), "got: {rl}");
+        assert!(q1.contains("quota exhausted"), "got: {q1}");
+        assert_eq!(q1, q2);
+        assert_ne!(rl, q1);
+    }
+
+    #[test]
+    fn humanize_proxy_unknown_combos_return_none() {
+        assert_eq!(humanize_proxy_status_error("kimi-code", 403, None), None);
+        assert_eq!(
+            humanize_proxy_status_error("kimi-code", 403, Some("rate_limit_error")),
+            None
+        );
+        assert_eq!(
+            humanize_proxy_status_error("kimi-code", 500, Some("server_error")),
+            None
+        );
+        assert_eq!(
+            humanize_proxy_status_error("kimi-code", 401, Some("access_terminated_error")),
+            None
+        );
+        // Unvetted label strings are treated as absent, never echoed.
+        assert_eq!(
+            humanize_proxy_status_error("kimi-code", 403, Some("<script>ECHO")),
+            None
+        );
+    }
 
     #[test]
     fn test_humanize_529_overloaded() {

--- a/crates/agent-core/src/core/session.rs
+++ b/crates/agent-core/src/core/session.rs
@@ -408,6 +408,9 @@ fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<Sessio
     }
     let header = read_session_header(dir, file_name)?;
     let meta: SessionMetadata = serde_json::from_str(&header).ok()?;
+    // Cheap message count: each api_message has exactly one "role" field.
+    // Count occurrences without deserializing the full array.
+    let message_count = header.matches("\"role\":").count();
     let mut info = SessionInfo {
         id: meta.id,
         title: meta.title,
@@ -416,7 +419,7 @@ fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<Sessio
         created_at: meta.created_at,
         updated_at: meta.updated_at,
         session_cost: meta.session_cost,
-        message_count: 0,
+        message_count,
     };
     // Journal freshness overlay (Task 35): when an opt-in journal exists,
     // its bounded meta tail is newer than the (possibly lagging) snapshot

--- a/crates/agent-core/src/core/session.rs
+++ b/crates/agent-core/src/core/session.rs
@@ -17,6 +17,13 @@ pub struct Session {
     pub total_input_tokens: u64,
     pub total_output_tokens: u64,
     pub session_cost: f64,
+    /// Persisted listing hint: `api_messages.len()` at save time. Declared
+    /// BEFORE `api_messages` so it lands in the header that
+    /// `read_session_header` reads without touching the message array.
+    /// Not authoritative in memory — use `api_messages.len()`; refreshed by
+    /// `session_journal::save_session_in_dir`. Legacy files → 0.
+    #[serde(default)]
+    pub message_count: usize,
     pub api_messages: Vec<SharedMessage>,
     /// Saved abort context — injected into the next user message on /continue
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -69,6 +76,7 @@ impl Session {
             total_input_tokens: 0,
             total_output_tokens: 0,
             session_cost: 0.0,
+            message_count: 0,
             api_messages: Vec::new(),
             abort_context: None,
             parent_session: None,
@@ -117,6 +125,7 @@ impl Session {
             total_input_tokens: 0,
             total_output_tokens: 0,
             session_cost: 0.0,
+            message_count: 0,
             api_messages: crate::compaction::compaction_context_messages(summary_text),
             abort_context: None,
             parent_session: Some(parent.id.clone()),
@@ -390,8 +399,9 @@ pub fn list_recent_sessions(limit: usize) -> std::io::Result<Vec<SessionInfo>> {
 }
 
 /// Read + parse just the metadata header of one session file into a
-/// [`SessionInfo`] (no message history). `message_count` is left 0 — it isn't
-/// parsed in the header read; use [`Session::info`] when an exact count matters.
+/// [`SessionInfo`] (no message history). `message_count` comes from the
+/// persisted header field (written at save time); legacy files without it
+/// report 0.
 fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<SessionInfo> {
     #[derive(Deserialize)]
     struct SessionMetadata {
@@ -405,12 +415,11 @@ fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<Sessio
         updated_at: DateTime<Utc>,
         #[serde(default)]
         session_cost: f64,
+        #[serde(default)]
+        message_count: usize,
     }
     let header = read_session_header(dir, file_name)?;
     let meta: SessionMetadata = serde_json::from_str(&header).ok()?;
-    // Cheap message count: each api_message has exactly one "role" field.
-    // Count occurrences without deserializing the full array.
-    let message_count = header.matches("\"role\":").count();
     let mut info = SessionInfo {
         id: meta.id,
         title: meta.title,
@@ -419,7 +428,7 @@ fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<Sessio
         created_at: meta.created_at,
         updated_at: meta.updated_at,
         session_cost: meta.session_cost,
-        message_count,
+        message_count: meta.message_count,
     };
     // Journal freshness overlay (Task 35): when an opt-in journal exists,
     // its bounded meta tail is newer than the (possibly lagging) snapshot
@@ -428,6 +437,9 @@ fn parse_session_header(dir: &std::path::Path, file_name: &str) -> Option<Sessio
         if tail.updated_at > info.updated_at {
             info.updated_at = tail.updated_at;
             info.session_cost = tail.session_cost;
+            if let Some(count) = tail.message_count {
+                info.message_count = count;
+            }
         }
     }
     Some(info)
@@ -1029,6 +1041,70 @@ mod tests {
                 "original",
                 "no bytes may be written through the planted symlink"
             );
+        }
+    }
+
+    mod header_message_count {
+        use super::*;
+        use crate::core::session_journal::{save_session_in_dir, SessionPersistence};
+        use std::sync::Arc;
+
+        fn session_with(n: usize) -> Session {
+            let mut s = Session::new("claude-sonnet-4-6", "medium", None);
+            for i in 0..n {
+                let role = if i % 2 == 0 { "user" } else { "assistant" };
+                s.api_messages
+                    .push(Arc::new(serde_json::json!({"role": role, "content": format!("m{i}")})));
+            }
+            s
+        }
+
+        /// save → header reader round-trip: the count is persisted in the
+        /// header (before `api_messages`), so the truncating reader sees it.
+        #[test]
+        fn json_save_persists_count_in_header() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let dir = tmp.path().join("sessions");
+            let s = session_with(7);
+            save_session_in_dir(&dir, &s, SessionPersistence::Json).unwrap();
+            let header = read_session_header(&dir, &format!("{}.json", s.id)).unwrap();
+            assert!(
+                !header.contains("\"api_messages\""),
+                "header must stop before the message array"
+            );
+            let info = parse_session_header(&dir, &format!("{}.json", s.id)).unwrap();
+            assert_eq!(info.message_count, 7);
+        }
+
+        /// Journal mode: appended messages update the count via the meta tail.
+        #[test]
+        fn journal_append_updates_count() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let dir = tmp.path().join("sessions");
+            let mut s = session_with(2);
+            save_session_in_dir(&dir, &s, SessionPersistence::Journal).unwrap();
+            s.api_messages
+                .push(Arc::new(serde_json::json!({"role": "user", "content": "more"})));
+            s.updated_at = Utc::now();
+            save_session_in_dir(&dir, &s, SessionPersistence::Journal).unwrap();
+            let info = parse_session_header(&dir, &format!("{}.json", s.id)).unwrap();
+            assert_eq!(info.message_count, 3);
+        }
+
+        /// Legacy files without the field report 0, never fail to parse.
+        #[test]
+        fn legacy_header_defaults_to_zero() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let dir = tmp.path().join("sessions");
+            let s = session_with(3);
+            // Strip the field textually to keep declaration order (a
+            // `to_value` round-trip would re-sort keys alphabetically).
+            let json = serde_json::to_string(&s).unwrap();
+            assert!(json.contains("\"message_count\":0,"));
+            let legacy = json.replace("\"message_count\":0,", "");
+            save_json_in_dir(&dir, &s.id, legacy.as_bytes()).unwrap();
+            let info = parse_session_header(&dir, &format!("{}.json", s.id)).unwrap();
+            assert_eq!(info.message_count, 0);
         }
     }
 }

--- a/crates/agent-core/src/core/session_journal.rs
+++ b/crates/agent-core/src/core/session_journal.rs
@@ -825,10 +825,11 @@ mod tests {
         s.abort_context = Some("ctx".into());
         s.parent_session = Some("parent".into());
         s.compacted_into = Some("child".into());
-        s.api_messages
-            .push(std::sync::Arc::new(serde_json::json!({"role": "user", "content": "hi"})));
+        s.api_messages.push(std::sync::Arc::new(
+            serde_json::json!({"role": "user", "content": "hi"}),
+        ));
         s.message_count = 0; // stale in memory — snapshot must not trust it
-        // Expected = the old clone-and-refresh path, byte for byte.
+                             // Expected = the old clone-and-refresh path, byte for byte.
         let mut expected = s.clone();
         expected.message_count = expected.api_messages.len();
         let expected = serde_json::to_string(&expected).unwrap();
@@ -839,7 +840,10 @@ mod tests {
         let s = Session::new("model-x", "medium", None);
         let mut expected = s.clone();
         expected.message_count = 0;
-        assert_eq!(snapshot_json(&s).unwrap(), serde_json::to_string(&expected).unwrap());
+        assert_eq!(
+            snapshot_json(&s).unwrap(),
+            serde_json::to_string(&expected).unwrap()
+        );
     }
 
     #[test]

--- a/crates/agent-core/src/core/session_journal.rs
+++ b/crates/agent-core/src/core/session_journal.rs
@@ -292,6 +292,8 @@ pub struct SaveReceipt {
 pub struct JournalMetaTail {
     pub updated_at: DateTime<Utc>,
     pub session_cost: f64,
+    /// `None` for meta records written before the count was journaled.
+    pub message_count: Option<usize>,
 }
 
 /// `sessions/<id>.journal` — single-extension name so the session id stays
@@ -344,6 +346,8 @@ struct SessionMeta {
     total_output_tokens: u64,
     session_cost: f64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    message_count: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     abort_context: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     parent_session: Option<String>,
@@ -369,6 +373,7 @@ impl SessionMeta {
             total_input_tokens: s.total_input_tokens,
             total_output_tokens: s.total_output_tokens,
             session_cost: s.session_cost,
+            message_count: Some(s.api_messages.len()),
             abort_context: s.abort_context.clone(),
             parent_session: s.parent_session.clone(),
             compacted_into: s.compacted_into.clone(),
@@ -503,6 +508,12 @@ pub fn save_session_in_dir(
     // ONE strict resolution per save (fix2); every artifact operation below
     // is relative to this handle.
     let handle = create_sessions_dir(dir)?;
+    // Refresh the persisted listing hint at the single save choke point so
+    // the header always carries the current count (messages are Arc-shared;
+    // the clone is cheap).
+    let mut session = session.clone();
+    session.message_count = session.api_messages.len();
+    let session = &session;
     match mode {
         SessionPersistence::Json => {
             let json = serde_json::to_string(session).map_err(std::io::Error::other)?;
@@ -699,6 +710,7 @@ pub fn journal_meta_tail(dir: &Path, id: &str) -> Option<JournalMetaTail> {
                 freshest = Some(JournalMetaTail {
                     updated_at: meta.updated_at,
                     session_cost: meta.session_cost,
+                    message_count: meta.message_count,
                 });
             }
         }

--- a/crates/agent-core/src/core/session_journal.rs
+++ b/crates/agent-core/src/core/session_journal.rs
@@ -19,6 +19,7 @@
 //! 0600 files, symlink-refusing, atomic snapshot replacement, synced appends.
 
 use crate::core::session::Session;
+use crate::core::stream_types::SharedMessage;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::io::Write;
@@ -508,15 +509,12 @@ pub fn save_session_in_dir(
     // ONE strict resolution per save (fix2); every artifact operation below
     // is relative to this handle.
     let handle = create_sessions_dir(dir)?;
-    // Refresh the persisted listing hint at the single save choke point so
-    // the header always carries the current count (messages are Arc-shared;
-    // the clone is cheap).
-    let mut session = session.clone();
-    session.message_count = session.api_messages.len();
-    let session = &session;
+    // The persisted listing hint (`message_count`) is refreshed at write
+    // time by `snapshot_json` / `SessionMeta::of` — no `Session` clone, so
+    // the journal delta path stays O(delta) rather than O(history).
     match mode {
         SessionPersistence::Json => {
-            let json = serde_json::to_string(session).map_err(std::io::Error::other)?;
+            let json = snapshot_json(session)?;
             handle.write_atomic(&format!("{}.json", session.id), json.as_bytes())?;
             // Rollback fold: the snapshot now holds everything; a stale
             // journal must not shadow future legacy-only readers.
@@ -607,11 +605,75 @@ fn save_journal_mode(
 /// Atomic full snapshot (unchanged legacy schema) followed by an atomic
 /// journal reset to a lone `open` record. Snapshot strictly first: a crash
 /// between the two leaves a stale-but-idempotent journal, never data loss.
+/// Borrowing mirror of [`Session`] used ONLY for snapshot serialization:
+/// identical field order and serde attributes, with `message_count`
+/// computed from `api_messages.len()` at write time instead of read from
+/// the (non-authoritative) in-memory field. Field order matters —
+/// `message_count` must precede `api_messages` for `read_session_header`.
+/// The `snapshot_json_matches_session_schema` test guards drift.
+#[derive(Serialize)]
+struct SessionSnapshotRef<'a> {
+    id: &'a str,
+    title: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: &'a Option<String>,
+    model: &'a str,
+    thinking_level: &'a str,
+    system_prompt: &'a Option<String>,
+    created_at: &'a DateTime<Utc>,
+    updated_at: &'a DateTime<Utc>,
+    total_input_tokens: u64,
+    total_output_tokens: u64,
+    session_cost: f64,
+    message_count: usize,
+    api_messages: &'a [SharedMessage],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    abort_context: &'a Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_session: &'a Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compacted_into: &'a Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_provenance: &'a Option<crate::prompt::PromptProvenance>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compaction: &'a Option<crate::core::compaction::CompactionRecord>,
+}
+
+impl<'a> SessionSnapshotRef<'a> {
+    fn of(s: &'a Session) -> Self {
+        Self {
+            id: &s.id,
+            title: &s.title,
+            name: &s.name,
+            model: &s.model,
+            thinking_level: &s.thinking_level,
+            system_prompt: &s.system_prompt,
+            created_at: &s.created_at,
+            updated_at: &s.updated_at,
+            total_input_tokens: s.total_input_tokens,
+            total_output_tokens: s.total_output_tokens,
+            session_cost: s.session_cost,
+            message_count: s.api_messages.len(),
+            api_messages: &s.api_messages,
+            abort_context: &s.abort_context,
+            parent_session: &s.parent_session,
+            compacted_into: &s.compacted_into,
+            prompt_provenance: &s.prompt_provenance,
+            compaction: &s.compaction,
+        }
+    }
+}
+
+/// Full-snapshot JSON with a fresh `message_count`, without cloning.
+fn snapshot_json(session: &Session) -> std::io::Result<String> {
+    serde_json::to_string(&SessionSnapshotRef::of(session)).map_err(std::io::Error::other)
+}
+
 fn full_snapshot_reset(
     handle: &SessionsDirHandle,
     session: &Session,
 ) -> std::io::Result<SaveReceipt> {
-    let json = serde_json::to_string(session).map_err(std::io::Error::other)?;
+    let json = snapshot_json(session)?;
     handle.write_atomic(&format!("{}.json", session.id), json.as_bytes())?;
 
     let open = JournalRecord::Open {
@@ -756,6 +818,30 @@ mod tests {
     /// field. Serializing a full `Session`, dropping `api_messages`, and
     /// parsing the rest as `SessionMeta` (deny_unknown_fields) fails the
     /// moment `Session` grows a field this module does not journal.
+    #[test]
+    fn snapshot_json_matches_session_schema() {
+        let mut s = Session::new("model-x", "medium", Some("prompt"));
+        s.name = Some("named".into());
+        s.abort_context = Some("ctx".into());
+        s.parent_session = Some("parent".into());
+        s.compacted_into = Some("child".into());
+        s.api_messages
+            .push(std::sync::Arc::new(serde_json::json!({"role": "user", "content": "hi"})));
+        s.message_count = 0; // stale in memory — snapshot must not trust it
+        // Expected = the old clone-and-refresh path, byte for byte.
+        let mut expected = s.clone();
+        expected.message_count = expected.api_messages.len();
+        let expected = serde_json::to_string(&expected).unwrap();
+        assert_eq!(snapshot_json(&s).unwrap(), expected);
+        let back: Session = serde_json::from_str(&snapshot_json(&s).unwrap()).unwrap();
+        assert_eq!(back.message_count, 1);
+        // Same check with every optional absent.
+        let s = Session::new("model-x", "medium", None);
+        let mut expected = s.clone();
+        expected.message_count = 0;
+        assert_eq!(snapshot_json(&s).unwrap(), serde_json::to_string(&expected).unwrap());
+    }
+
     #[test]
     fn session_meta_stays_in_sync_with_session_schema() {
         let mut s = Session::new("model-x", "medium", Some("prompt"));

--- a/crates/agent-engine/Cargo.toml
+++ b/crates/agent-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synaps-engine"
-version = "0.9.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.80"
 description = "Runtime engine — streaming, tools, MCP, skills, extensions, sidecar"
@@ -11,7 +11,7 @@ name = "agent_engine"
 path = "src/lib.rs"
 
 [dependencies]
-agent-core = { path = "../agent-core", version = "0.9.0", package = "synaps-core" }
+agent-core = { workspace = true }
 
 # Async runtime + utilities
 tokio              = { version = "1.0", features = ["full"] }

--- a/crates/agent-engine/src/engine/commands.rs
+++ b/crates/agent-engine/src/engine/commands.rs
@@ -53,9 +53,12 @@ pub enum CommandResult {
     /// Error message.
     Error(String),
 
-    /// Model was changed.
+    /// Model was changed. `reasoning_clamped` is populated when the runtime
+    /// had to substitute the active reasoning level because the new model does
+    /// not support it (see `Runtime::try_set_model`).
     ModelChanged {
         model: String,
+        reasoning_clamped: Option<crate::runtime::ReasoningClamp>,
     },
 
     /// Thinking level was changed.
@@ -190,9 +193,12 @@ pub fn handle_engine_command(
         "memory" => return Some(memory_command(arg, runtime)),
         _ => {}
     }
-    let result = evaluate_engine_command(cmd, arg)?;
-    match &result {
-        CommandResult::ModelChanged { model } => runtime.set_model(model.clone()),
+    let mut result = evaluate_engine_command(cmd, arg)?;
+    match &mut result {
+        CommandResult::ModelChanged {
+            model,
+            reasoning_clamped,
+        } => *reasoning_clamped = runtime.set_model(model.clone()),
         CommandResult::ThinkingChanged { spec } => {
             // Validate and apply the spec against model capabilities BEFORE
             // mutating runtime. State is unchanged on Err.
@@ -222,6 +228,7 @@ pub fn evaluate_engine_command(cmd: &str, arg: &str) -> Option<CommandResult> {
     match cmd {
         "model" | "models" if !arg.is_empty() => Some(CommandResult::ModelChanged {
             model: arg.to_string(),
+            reasoning_clamped: None,
         }),
         "thinking" if !arg.is_empty() => match parse_thinking_arg(arg) {
             Ok(spec) => Some(CommandResult::ThinkingChanged { spec }),
@@ -385,7 +392,9 @@ mod tests {
     #[test]
     fn model_command_carries_model_name() {
         match evaluate_engine_command("model", "claude-sonnet-4-6") {
-            Some(CommandResult::ModelChanged { model }) => assert_eq!(model, "claude-sonnet-4-6"),
+            Some(CommandResult::ModelChanged { model, .. }) => {
+                assert_eq!(model, "claude-sonnet-4-6")
+            }
             other => panic!("expected ModelChanged, got {:?}", other),
         }
         assert!(matches!(
@@ -745,6 +754,40 @@ mod tests {
         }
         assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
         assert!(rt.is_reasoning_explicit());
+    }
+
+    /// `/model` onto a model that rejects the explicit level reports the clamp
+    /// so surfaces can tell the user, and leaves the runtime in a usable state.
+    #[test]
+    fn model_command_reports_reasoning_clamp_for_unsupported_explicit_level() {
+        let mut rt = crate::Runtime::new_headless();
+        handle_engine_command("thinking", "xhigh", &mut rt).expect("thinking applies");
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::XHigh);
+        match handle_engine_command("model", "xai-auth/grok-4.6", &mut rt) {
+            Some(CommandResult::ModelChanged {
+                model,
+                reasoning_clamped,
+            }) => {
+                assert_eq!(model, "xai-auth/grok-4.6");
+                assert_eq!(
+                    reasoning_clamped,
+                    Some(crate::runtime::ReasoningClamp {
+                        from: ReasoningLevel::XHigh,
+                        to: ReasoningLevel::High,
+                    })
+                );
+            }
+            other => panic!("expected ModelChanged, got {:?}", other),
+        }
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(rt.is_reasoning_explicit());
+        // Supported explicit level: no clamp reported.
+        match handle_engine_command("model", "xai-auth/grok-4.5", &mut rt) {
+            Some(CommandResult::ModelChanged {
+                reasoning_clamped, ..
+            }) => assert_eq!(reasoning_clamped, None),
+            other => panic!("expected ModelChanged, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/agent-engine/src/engine/setup.rs
+++ b/crates/agent-engine/src/engine/setup.rs
@@ -353,7 +353,7 @@ fn resolve_or_create_session(
 ) -> Result<SessionBootResult> {
     match continue_session {
         Some(ref maybe_id) => {
-            let session = match maybe_id {
+            let mut session = match maybe_id {
                 Some(ref id) => resolve_session(id).map_err(|e| {
                     crate::error::RuntimeError::Tool(format!(
                         "Failed to load session '{}': {}",
@@ -366,15 +366,17 @@ fn resolve_or_create_session(
             };
             runtime.set_model(session.model.clone());
             // Restore the session's named reasoning level so max/ultra/off
-            // and custom budgets survive --continue.
-            if let Some(level) =
-                agent_core::reasoning::ReasoningLevel::parse(&session.thinking_level)
-            {
-                runtime.set_reasoning_level_explicit(level);
-            } else if let Some(budget) =
-                crate::models::budget_for_thinking_level(&session.thinking_level)
-            {
-                runtime.set_thinking_budget_explicit(budget);
+            // and custom budgets survive --continue — then clamp against the
+            // model so old grok+xhigh session files don't resume into a
+            // permanently failing state.
+            if let Some(clamp) = runtime.restore_session_reasoning(&session.thinking_level) {
+                tracing::warn!(
+                    from = %clamp.from,
+                    to = %clamp.to,
+                    model = %session.model,
+                    "saved session thinking level not supported by model; clamped"
+                );
+                session.thinking_level = runtime.thinking_level().to_string();
             }
             if let Some(ref sp) = session.system_prompt {
                 runtime.set_system_prompt(sp.clone());

--- a/crates/agent-engine/src/lib.rs
+++ b/crates/agent-engine/src/lib.rs
@@ -36,7 +36,7 @@ pub use session::{
     resolve_session, validate_name, Session, SessionInfo,
 };
 pub use tokio_util::sync::CancellationToken;
-pub use tools::{Tool, ToolContext, ToolRegistry};
+pub use tools::{Tool, ToolContext, ToolOutput, ToolRegistry};
 pub use watcher_types::{
     AgentConfig, AgentStatusInfo, ExitReason, HandoffState, SessionLimits, SessionStats,
     WatcherCommand, WatcherResponse,

--- a/crates/agent-engine/src/runtime/api.rs
+++ b/crates/agent-engine/src/runtime/api.rs
@@ -1026,7 +1026,8 @@ impl ApiMethods {
         {
             // Classify honestly: transport blips are API failures, not
             // config problems (incident: session 20260714-025948-3dab).
-            return result.map_err(crate::runtime::openai::net::provider_error_to_runtime);
+            return result
+                .map_err(|e| crate::runtime::openai::net::provider_error_to_runtime_for(model, e));
         }
         // Provider qualification is application identity; Anthropic's wire API
         // still receives its native bare model id.

--- a/crates/agent-engine/src/runtime/api_sync.rs
+++ b/crates/agent-engine/src/runtime/api_sync.rs
@@ -127,7 +127,8 @@ impl ApiMethods {
         {
             drop(tx);
             let _ = drain.await;
-            return result.map_err(crate::runtime::openai::net::provider_error_to_runtime);
+            return result
+                .map_err(|e| crate::runtime::openai::net::provider_error_to_runtime_for(model, e));
         }
         let qualified_model = model;
         let execution_plan = options
@@ -563,8 +564,9 @@ impl ApiMethods {
         {
             drop(tx);
             let _ = drain.await;
-            let response =
-                result.map_err(crate::runtime::openai::net::provider_error_to_runtime)?;
+            let response = result.map_err(|e| {
+                crate::runtime::openai::net::provider_error_to_runtime_for(model, e)
+            })?;
             return Ok(Self::concat_response_text(&response));
         }
         let model = model.strip_prefix("anthropic/").unwrap_or(model);

--- a/crates/agent-engine/src/runtime/context.rs
+++ b/crates/agent-engine/src/runtime/context.rs
@@ -49,6 +49,14 @@ pub const SAFETY_MARGIN_PERCENT: u64 = 15;
 /// is what prevents recompaction loops without frontend-local bookkeeping.
 pub const MIN_COMPACTION_MESSAGES: usize = 4;
 
+/// Flat charge per base64 image block. Anthropic bills ≈ w·h/750 tokens
+/// AFTER its 1568-px / ~1.15 MP downscale, so 1,600 is the per-image
+/// ceiling (Goose uses the same figure; gemini-cli uses 3,000; Codex
+/// subtracts the payload and adds a ~7 KB estimate). Serialized base64 at
+/// 2.5 chars/token would charge ~1.9 M tokens for a 3.5 MiB image and trip
+/// compaction every turn.
+pub const IMAGE_TOKEN_ESTIMATE: u64 = 1_600;
+
 /// Provider-side per-message framing charge (role tags, message boundaries)
 /// on top of the serialized content itself.
 const PER_MESSAGE_FRAMING_TOKENS: u64 = 4;
@@ -266,7 +274,7 @@ pub fn assess(inputs: &ContextBudgetInputs<'_>) -> ContextAssessment {
     let history_tokens: u64 = inputs
         .messages
         .iter()
-        .map(|msg| estimate_serialized(&estimator, msg))
+        .map(|msg| estimate_message(&estimator, msg))
         .sum();
     let framing_tokens = PER_MESSAGE_FRAMING_TOKENS * inputs.messages.len() as u64;
 
@@ -327,11 +335,123 @@ fn estimate_serialized(estimator: &TokenEstimator, value: &Value) -> u64 {
     }
 }
 
+/// Like `estimate_serialized` but charges base64 image blocks at a flat
+/// `IMAGE_TOKEN_ESTIMATE` instead of by payload length. Walks
+/// `content[]` and nested `tool_result.content[]`; every other block is
+/// still charged on its serialized form.
+fn estimate_message(estimator: &TokenEstimator, msg: &Value) -> u64 {
+    let Some(blocks) = msg["content"].as_array() else {
+        return estimate_serialized(estimator, msg);
+    };
+    let mut total = 0u64;
+    for block in blocks {
+        if is_base64_image(block) {
+            total += IMAGE_TOKEN_ESTIMATE;
+            continue;
+        }
+        if block["type"] == "tool_result" {
+            if let Some(inner) = block["content"].as_array() {
+                total += 8; // wrapper keys: type, tool_use_id
+                for b in inner {
+                    total += if is_base64_image(b) {
+                        IMAGE_TOKEN_ESTIMATE
+                    } else {
+                        estimate_serialized(estimator, b)
+                    };
+                }
+                continue;
+            }
+        }
+        total += estimate_serialized(estimator, block);
+    }
+    total
+}
+
+fn is_base64_image(b: &Value) -> bool {
+    b["type"] == "image" && b["source"]["type"] == "base64"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
     use std::sync::Arc;
+
+    fn history_tokens_of(messages: &[SharedMessage]) -> u64 {
+        let inputs = ContextBudgetInputs {
+            model: "claude-sonnet-4-6",
+            provider_window: 200_000,
+            system_prompt: None,
+            tools_schema: &[],
+            messages,
+            skill_contents: &[],
+            memory_contents: &[],
+            thinking_budget_tokens: 0,
+            next_tool_result_bytes: 0,
+            output_reserve_tokens: 0,
+        };
+        assess(&inputs).breakdown.history_tokens
+    }
+
+    fn image_block(len: usize) -> Value {
+        json!({
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "A".repeat(len)}
+        })
+    }
+
+    #[test]
+    fn image_block_in_tool_result_charged_flat() {
+        let messages: Vec<SharedMessage> = vec![Arc::new(json!({
+            "role": "user",
+            "content": [{
+                "type": "tool_result",
+                "tool_use_id": "toolu_1",
+                "content": [
+                    {"type": "text", "text": "Image: /tmp/x.png (1024x1536, image/png, 2292 KB)"},
+                    image_block(3_000_000),
+                ]
+            }]
+        }))];
+        let tokens = history_tokens_of(&messages);
+        assert!(tokens >= IMAGE_TOKEN_ESTIMATE, "{tokens}");
+        assert!(tokens <= IMAGE_TOKEN_ESTIMATE + 200, "{tokens}");
+        assert!(tokens < 10_000, "{tokens}");
+    }
+
+    #[test]
+    fn user_message_image_charged_flat() {
+        let messages: Vec<SharedMessage> = vec![Arc::new(json!({
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this?"},
+                image_block(3_000_000),
+            ]
+        }))];
+        let tokens = history_tokens_of(&messages);
+        assert!(tokens >= IMAGE_TOKEN_ESTIMATE, "{tokens}");
+        assert!(tokens <= IMAGE_TOKEN_ESTIMATE + 200, "{tokens}");
+    }
+
+    #[test]
+    fn string_content_unchanged() {
+        let msg = json!({"role": "user", "content": "plain string content, no blocks here"});
+        let estimator = estimator_for_model("claude-sonnet-4-6");
+        assert_eq!(
+            estimate_message(&estimator, &msg),
+            estimate_serialized(&estimator, &msg)
+        );
+    }
+
+    #[test]
+    fn non_image_blocks_still_charged_by_payload() {
+        // A big text block must NOT get the flat image discount.
+        let msg = json!({"role": "user", "content": [
+            {"type": "text", "text": "A".repeat(100_000)}
+        ]});
+        let estimator = estimator_for_model("claude-sonnet-4-6");
+        assert!(estimate_message(&estimator, &msg) > 10_000);
+    }
 
     #[test]
     fn ascii_is_charged_at_the_dense_bpe_rate() {

--- a/crates/agent-engine/src/runtime/context.rs
+++ b/crates/agent-engine/src/runtime/context.rs
@@ -343,6 +343,12 @@ fn estimate_message(estimator: &TokenEstimator, msg: &Value) -> u64 {
     let Some(blocks) = msg["content"].as_array() else {
         return estimate_serialized(estimator, msg);
     };
+    // Zero drift for messages without images: charge exactly as before.
+    if !blocks.iter().any(|b| {
+        is_base64_image(b) || b["content"].as_array().is_some_and(|a| a.iter().any(is_base64_image))
+    }) {
+        return estimate_serialized(estimator, msg);
+    }
     let mut total = 0u64;
     for block in blocks {
         if is_base64_image(block) {
@@ -441,6 +447,31 @@ mod tests {
             estimate_message(&estimator, &msg),
             estimate_serialized(&estimator, &msg)
         );
+    }
+
+    #[test]
+    fn array_content_without_images_unchanged() {
+        let estimator = estimator_for_model("claude-sonnet-4-6");
+        for msg in [
+            json!({"role": "assistant", "content": [
+                {"type": "text", "text": "let me look"},
+                {"type": "tool_use", "id": "toolu_1", "name": "read", "input": {"path": "x"}}
+            ]}),
+            json!({"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_1", "content": "1\tfoo\n2\tbar"}
+            ]}),
+            json!({"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_1", "content": [
+                    {"type": "text", "text": "nested text only"}
+                ]}
+            ]}),
+        ] {
+            assert_eq!(
+                estimate_message(&estimator, &msg),
+                estimate_serialized(&estimator, &msg),
+                "{msg}"
+            );
+        }
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/google_gemini/runtime.rs
+++ b/crates/agent-engine/src/runtime/google_gemini/runtime.rs
@@ -120,6 +120,14 @@ fn messages_to_gemini_turns(messages: &[crate::SharedMessage]) -> Vec<ChatTurn> 
                                         let text = arr
                                             .iter()
                                             .filter_map(|b| {
+                                                if b["type"] == "image" {
+                                                    let mt = b["source"]["media_type"]
+                                                        .as_str()
+                                                        .unwrap_or("image");
+                                                    return Some(format!(
+                                                        "\n[image omitted: {mt} — this provider does not accept images in tool results]"
+                                                    ));
+                                                }
                                                 b.get("text")
                                                     .and_then(|t| t.as_str())
                                                     .map(String::from)

--- a/crates/agent-engine/src/runtime/google_gemini/runtime_tests.rs
+++ b/crates/agent-engine/src/runtime/google_gemini/runtime_tests.rs
@@ -312,6 +312,32 @@ Begin now and continue autonomously until the exercise reaches a verified safe o
 }
 
 #[test]
+fn messages_to_gemini_turns_degrades_image_tool_result_with_omission_note() {
+    let b64 = "iVBORw0KGgo".repeat(200);
+    let msgs: Vec<crate::SharedMessage> = vec![
+        Arc::new(json!({"role":"assistant","content":[
+            {"type":"tool_use","id":"t1","name":"read","input":{"path":"x.png"}}
+        ]})),
+        Arc::new(json!({"role":"user","content":[
+            {"type":"tool_result","tool_use_id":"t1","content":[
+                {"type":"text","text":"Image: x"},
+                {"type":"image","source":{"type":"base64","media_type":"image/png","data":b64}}
+            ]}
+        ]})),
+    ];
+    let turns = messages_to_gemini_turns(&msgs);
+    let ChatTurn::ToolResult { name, result } = &turns[1] else {
+        panic!("expected ToolResult, got {:?}", turns.len());
+    };
+    assert_eq!(name, "read");
+    assert_eq!(
+        result,
+        &json!({"output": "Image: x\n[image omitted: image/png — this provider does not accept images in tool results]"})
+    );
+    assert!(!result.to_string().contains("iVBORw0KGgo"));
+}
+
+#[test]
 fn messages_to_gemini_turns_preserves_object_tool_results_and_error_metadata() {
     let msgs: Vec<crate::SharedMessage> = vec![
         Arc::new(json!({"role":"assistant","content":[

--- a/crates/agent-engine/src/runtime/helpers.rs
+++ b/crates/agent-engine/src/runtime/helpers.rs
@@ -320,6 +320,8 @@ impl HelperMethods {
     /// shared [`agent_core::BoundedText`] helper (T2; the legacy code applied
     /// a char budget, so multibyte output could exceed the byte cap). Marker
     /// format intentionally changed from "total chars" to "total bytes".
+    // Rich (array) tool_result content never passes through here — see
+    // stream.rs `select_tool_result_content`.
     pub(crate) fn truncate_tool_result(result: &str, max_bytes: usize) -> String {
         let bounded = agent_core::BoundedText::new(result, max_bytes);
         if !bounded.truncated {

--- a/crates/agent-engine/src/runtime/memory_history.rs
+++ b/crates/agent-engine/src/runtime/memory_history.rs
@@ -1274,6 +1274,7 @@ mod tests {
                 total_input_tokens: 0,
                 total_output_tokens: 0,
                 session_cost: 0.0,
+                message_count: 0,
                 api_messages: vec![
                     Arc::new(json!({"role": "user", "content": user})),
                     Arc::new(json!({"role": "assistant", "content": assistant})),

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -207,6 +207,14 @@ pub async fn emit_after_tool_call(
     crate::runtime::helpers::HelperMethods::truncate_tool_result(&post_hook, max_tool_output)
 }
 
+/// A reasoning-level substitution performed during a model change because the
+/// newly selected model does not support the previously active level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReasoningClamp {
+    pub from: agent_core::reasoning::ReasoningLevel,
+    pub to: agent_core::reasoning::ReasoningLevel,
+}
+
 /// The core runtime — manages API communication, tool execution, authentication,
 /// and streaming for all SynapsCLI binaries (chat, chatui, server, agent, watcher).
 #[derive(Clone)]
@@ -1104,15 +1112,23 @@ impl Runtime {
             .grant_worker_model(model)
     }
 
-    pub fn set_model(&mut self, model: String) {
-        let _ = self.try_set_model(model);
+    /// Infallible model change. Returns the reasoning clamp applied (if any)
+    /// when the current level is not supported by the new model; errors from
+    /// `try_set_model` are swallowed (model left unchanged).
+    pub fn set_model(&mut self, model: String) -> Option<ReasoningClamp> {
+        self.try_set_model(model).ok().flatten()
     }
 
     /// Apply a model change while preserving orchestration lifecycle invariants.
     /// Returns an error instead of mutating either model or policy when active
     /// workers still require collection/reconciliation or when the replacement
     /// foreground cannot produce a trusted manifestless policy snapshot.
-    pub fn try_set_model(&mut self, model: String) -> std::result::Result<(), String> {
+    /// On success, returns `Some(ReasoningClamp)` when an explicit reasoning
+    /// level had to be substituted because the new model does not support it.
+    pub fn try_set_model(
+        &mut self,
+        model: String,
+    ) -> std::result::Result<Option<ReasoningClamp>, String> {
         // Older model pickers passed the rendered health row back here, e.g.
         // `✅  339ms  groq/llama-3.3-70b`. Remove that exact decoration shape,
         // rather than searching inside the ID: provider-qualified IDs may
@@ -1185,7 +1201,39 @@ impl Runtime {
                 self.set_reasoning_level(level);
             }
         }
-        Ok(())
+        // An explicit level that the new model rejects would otherwise make
+        // every subsequent turn fail pre-network until the user runs
+        // `/thinking`. Substitute the nearest documented level instead, keeping
+        // the explicit provenance flag so later switches still honor the user.
+        Ok(self.clamp_reasoning_to_model())
+    }
+
+    /// If the current effective reasoning level fails validation against the
+    /// current model, replace it with the model's documented default (or the
+    /// first documented option that validates). The `explicit_reasoning` flag
+    /// is preserved. Returns the substitution performed, if any; leaves state
+    /// untouched (and returns `None`) when nothing validates.
+    fn clamp_reasoning_to_model(&mut self) -> Option<ReasoningClamp> {
+        use crate::runtime::openai::catalog::validation::{
+            default_level_for_model, thinking_options_for_model, validate_reasoning_mutation,
+        };
+        let model = self.model.as_str();
+        let from = self.reasoning_level();
+        if validate_reasoning_mutation(model, from).is_ok() {
+            return None;
+        }
+        let to = default_level_for_model(model)
+            .filter(|level| validate_reasoning_mutation(model, *level).is_ok())
+            .or_else(|| {
+                thinking_options_for_model(model)
+                    .iter()
+                    .filter_map(|opt| agent_core::reasoning::ReasoningLevel::parse(opt))
+                    .find(|level| validate_reasoning_mutation(model, *level).is_ok())
+            })?;
+        let explicit = self.explicit_reasoning;
+        self.set_reasoning_level(to);
+        self.explicit_reasoning = explicit;
+        Some(ReasoningClamp { from, to })
     }
 
     pub fn set_tools(&mut self, tools: ToolRegistry) {
@@ -1921,6 +1969,16 @@ impl Runtime {
             self.set_reasoning_level_explicit(level);
         } else if let Some(budget) = config.thinking_budget {
             self.set_thinking_budget_explicit(budget);
+        }
+        // A configured level the configured model rejects would boot into a
+        // permanently failing state; clamp exactly as `/model` does.
+        if let Some(clamp) = self.clamp_reasoning_to_model() {
+            tracing::warn!(
+                from = clamp.from.as_str(),
+                to = clamp.to.as_str(),
+                model = %self.model,
+                "configured reasoning level not supported by model; clamped"
+            );
         }
         self.context_window_override = config.context_window;
         self.compaction_model = config.compaction_model.clone();
@@ -4652,6 +4710,102 @@ mod set_reasoning_level_checked_tests {
             ReasoningLevel::Low,
             "explicit level must not be overwritten by the model default"
         );
+    }
+
+    /// Explicit level the new model rejects is clamped to the model default;
+    /// provenance stays explicit so later switches still honor the user.
+    #[test]
+    fn explicit_unsupported_level_is_clamped_to_model_default_on_switch() {
+        let mut rt = Runtime::new_headless();
+        rt.set_reasoning_level_explicit(ReasoningLevel::XHigh);
+        let clamp = rt
+            .try_set_model("xai-auth/grok-4.6".to_string())
+            .expect("model switch succeeds");
+        assert_eq!(
+            clamp,
+            Some(ReasoningClamp {
+                from: ReasoningLevel::XHigh,
+                to: ReasoningLevel::High,
+            })
+        );
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(
+            rt.is_reasoning_explicit(),
+            "clamp keeps explicit provenance"
+        );
+        assert_eq!(rt.model(), "xai-auth/grok-4.6");
+    }
+
+    /// Explicit level the new model supports is left alone: no clamp reported.
+    #[test]
+    fn explicit_supported_level_is_not_clamped_on_switch() {
+        let mut rt = Runtime::new_headless();
+        rt.set_reasoning_level_explicit(ReasoningLevel::High);
+        let clamp = rt.try_set_model("xai-auth/grok-4.6".to_string()).unwrap();
+        assert_eq!(clamp, None);
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(rt.is_reasoning_explicit());
+    }
+
+    /// Non-explicit levels keep taking the new model's default (unchanged
+    /// behavior) and report no clamp — the default is applied, not substituted.
+    #[test]
+    fn non_explicit_default_application_reports_no_clamp() {
+        let mut rt = Runtime::new_headless();
+        rt.set_reasoning_level(ReasoningLevel::XHigh);
+        let clamp = rt.try_set_model("xai-auth/grok-4.6".to_string()).unwrap();
+        assert_eq!(clamp, None);
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(!rt.is_reasoning_explicit());
+    }
+
+    /// Explicit Max on an xAI model without Max support clamps to a level that
+    /// validates for that exact model (documented default Adaptive).
+    #[test]
+    fn explicit_max_clamps_to_validating_option_on_multi_agent_model() {
+        let model = "xai-auth/grok-4.20-multi-agent-0309";
+        let mut rt = Runtime::new_headless();
+        rt.set_reasoning_level_explicit(ReasoningLevel::Max);
+        let clamp = rt
+            .try_set_model(model.to_string())
+            .unwrap()
+            .expect("Max is not supported: must clamp");
+        assert_eq!(clamp.from, ReasoningLevel::Max);
+        assert!(
+            crate::runtime::openai::catalog::validation::validate_reasoning_mutation(
+                model, clamp.to
+            )
+            .is_ok(),
+            "clamped level {} must validate",
+            clamp.to
+        );
+        assert_eq!(rt.reasoning_level(), clamp.to);
+        assert!(rt.is_reasoning_explicit());
+    }
+
+    /// `set_model` (infallible wrapper) still surfaces the clamp.
+    #[test]
+    fn set_model_returns_clamp() {
+        let mut rt = Runtime::new_headless();
+        rt.set_reasoning_level_explicit(ReasoningLevel::XHigh);
+        let clamp = rt.set_model("xai-auth/grok-4.6".to_string());
+        assert_eq!(clamp.map(|c| c.to), Some(ReasoningLevel::High));
+    }
+
+    /// Boot path: config `model` + unsupported explicit `thinking` no longer
+    /// boots into a permanently failing state.
+    #[test]
+    fn apply_config_clamps_unsupported_explicit_level_against_config_model() {
+        let mut rt = Runtime::new_headless();
+        rt.apply_config(&crate::config::SynapsConfig {
+            model: Some("xai-auth/grok-4.6".to_string()),
+            thinking_level: Some(ReasoningLevel::XHigh),
+            ..Default::default()
+        });
+        assert_eq!(rt.model(), "xai-auth/grok-4.6");
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(rt.is_reasoning_explicit());
+        assert!(rt.set_reasoning_level_checked(rt.reasoning_level()).is_ok());
     }
 }
 

--- a/crates/agent-engine/src/runtime/mod.rs
+++ b/crates/agent-engine/src/runtime/mod.rs
@@ -1305,6 +1305,22 @@ impl Runtime {
         self.explicit_reasoning = true;
     }
 
+    /// Restore a saved session's `thinking_level` string as an explicit user
+    /// choice, then clamp it against the current model. Call **after**
+    /// `set_model(session.model)`: re-applying the saved level would otherwise
+    /// undo the clamp `set_model` performed (old grok+xhigh session files).
+    /// Returns the clamp applied, if any, so callers can surface it.
+    pub fn restore_session_reasoning(&mut self, thinking_level: &str) -> Option<ReasoningClamp> {
+        if let Some(level) = agent_core::reasoning::ReasoningLevel::parse(thinking_level) {
+            self.set_reasoning_level_explicit(level);
+        } else if let Some(budget) = crate::models::budget_for_thinking_level(thinking_level) {
+            self.set_thinking_budget_explicit(budget);
+        } else {
+            return None;
+        }
+        self.clamp_reasoning_to_model()
+    }
+
     /// Set a custom numeric thinking budget as an **explicit user choice**
     /// (e.g. `/thinking 8192`). Retains the exact budget in `thinking_budget`
     /// while syncing `named_level` to the nearest named level for display.
@@ -4790,6 +4806,35 @@ mod set_reasoning_level_checked_tests {
         rt.set_reasoning_level_explicit(ReasoningLevel::XHigh);
         let clamp = rt.set_model("xai-auth/grok-4.6".to_string());
         assert_eq!(clamp.map(|c| c.to), Some(ReasoningLevel::High));
+    }
+
+    /// Resume path: a saved grok+xhigh session (written before clamping
+    /// existed) must not resume into a permanently failing state.
+    #[test]
+    fn restore_session_reasoning_clamps_after_reapply() {
+        let mut rt = Runtime::new_headless();
+        rt.set_model("xai-auth/grok-4.6".to_string());
+        let clamp = rt.restore_session_reasoning("xhigh");
+        assert_eq!(
+            clamp,
+            Some(ReasoningClamp {
+                from: ReasoningLevel::XHigh,
+                to: ReasoningLevel::High,
+            })
+        );
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::High);
+        assert!(rt.is_reasoning_explicit());
+        assert!(rt.set_reasoning_level_checked(rt.reasoning_level()).is_ok());
+    }
+
+    /// Supported saved level restores verbatim with no clamp.
+    #[test]
+    fn restore_session_reasoning_keeps_supported_level() {
+        let mut rt = Runtime::new_headless();
+        rt.set_model("xai-auth/grok-4.6".to_string());
+        assert_eq!(rt.restore_session_reasoning("low"), None);
+        assert_eq!(rt.reasoning_level(), ReasoningLevel::Low);
+        assert!(rt.is_reasoning_explicit());
     }
 
     /// Boot path: config `model` + unsupported explicit `thinking` no longer

--- a/crates/agent-engine/src/runtime/openai/extension_route.rs
+++ b/crates/agent-engine/src/runtime/openai/extension_route.rs
@@ -312,22 +312,20 @@ pub(crate) async fn route_extension_provider(
             // call the extension provider requests. When the runtime
             // threads its RETAINED per-stream set (Task 17), THAT set's
             // current state — including exact activations — is consumed at
-            // its pinned generation; a stale retained set is DENIED typed,
-            // never silently replaced by a fresh default-core mint. Only
-            // callers with no retained handle at all fall back to a fresh
-            // default-core set with zero activations.
-            let session_tools = match crate::tools::activation::route_session_set(
+            // its pinned generation; a drifted retained set is SERVED (a
+            // wholesale denial would kill the round for an unrelated
+            // catalog mutation) and never silently replaced by a fresh
+            // default-core mint. Only callers with no retained handle at
+            // all fall back to a fresh default-core set with zero
+            // activations. The audit trail is per tool now: each drifted
+            // member's call is denied typed inside the loop by
+            // `ExecutionGate::authorize`, which emits a tracing::warn per
+            // drift denial/survival (see tools/activation.rs).
+            let session_tools = crate::tools::activation::route_session_set(
                 session_tool_set,
                 registry.catalog(),
                 || tool_session_id.cloned().unwrap_or_else(local_gate_session),
-            ) {
-                Ok(session_tools) => session_tools,
-                Err(denial) => {
-                    attempt.finish_failed(trace_ext::EXTENSION_PROVIDER_ERROR_CODE);
-                    emit_audit(false, "error", Some("stale_session_tool_set"), 0);
-                    return Err(format!("extension provider tool loop denied: {denial}").into());
-                }
-            };
+            );
             crate::extensions::runtime::process::complete_provider_with_tools(
                 handler.clone(),
                 params,

--- a/crates/agent-engine/src/runtime/openai/mod.rs
+++ b/crates/agent-engine/src/runtime/openai/mod.rs
@@ -290,6 +290,10 @@ pub async fn try_route(
                     max_tokens,
                     reasoning_level,
                     cancel,
+                    // In-stream capacity errors (HTTP 200 + lone `error`
+                    // event) are transient; re-send identical bytes with
+                    // the configured retry budget.
+                    max_retries,
                     trace,
                     exact_wire_bytes,
                 )

--- a/crates/agent-engine/src/runtime/openai/net.rs
+++ b/crates/agent-engine/src/runtime/openai/net.rs
@@ -24,7 +24,22 @@ pub type BoxedProviderError = Box<dyn std::error::Error + Send + Sync>;
 /// Classify an error escaping the OpenAI/Codex provider route into the
 /// right `RuntimeError` variant. Also logs the full cause chain at WARN —
 /// provider-route failures were previously invisible in the logs.
+///
+/// Provider-agnostic form: broker status labels are classified but not
+/// humanized. Prefer [`provider_error_to_runtime_for`] when the qualified
+/// model (and therefore the provider key) is known.
 pub fn provider_error_to_runtime(e: BoxedProviderError) -> RuntimeError {
+    provider_error_to_runtime_for("", e)
+}
+
+/// Like [`provider_error_to_runtime`], but `qualified_model` (e.g.
+/// `kimi-code/k3`) lets a vetted broker status label such as
+/// `provider request failed: 403 Forbidden [access_terminated_error]` be
+/// rendered as an actionable, provider-aware message. The label is one of
+/// OUR static constants (selected broker-side, never provider bytes) and the
+/// humanizer only ever returns our own text; the raw prefix message is kept
+/// for the log line.
+pub fn provider_error_to_runtime_for(qualified_model: &str, e: BoxedProviderError) -> RuntimeError {
     // Transport-level failure (connect / timeout / mid-stream drop)?
     if let Some(re) = find_reqwest_error(e.as_ref()) {
         let msg = humanize_provider_network_error(re);
@@ -45,11 +60,44 @@ pub fn provider_error_to_runtime(e: BoxedProviderError) -> RuntimeError {
         || is_responses_terminal_failure_message(&msg)
     {
         tracing::warn!(error = %msg, "provider API error");
+        if let Some(human) = humanize_broker_status_message(qualified_model, &msg) {
+            return RuntimeError::ApiStatus(human);
+        }
         return RuntimeError::ApiStatus(msg);
     }
 
     tracing::warn!(error = %msg, "provider config error");
     RuntimeError::Config(format!("openai provider: {msg}"))
+}
+
+/// Render a broker status failure carrying a vetted label as an actionable
+/// message. `None` when the message has no label, the label is unknown to
+/// the humanizer, or the provider key cannot be derived from the model.
+fn humanize_broker_status_message(qualified_model: &str, msg: &str) -> Option<String> {
+    let provider = qualified_model.split_once('/')?.0;
+    if provider.is_empty() {
+        return None;
+    }
+    let status = crate::runtime::trace::openai::broker_error_status(msg)?;
+    let label = broker_error_label(msg)?;
+    crate::core::error::humanize_proxy_status_error(provider, status, Some(label))
+}
+
+/// Extract the `[label]` the broker appends after the canonical reason
+/// phrase (`provider request failed: 403 Forbidden [access_terminated_error]`).
+/// Only identifier-shaped labels are accepted; anything else is `None`.
+pub(crate) fn broker_error_label(msg: &str) -> Option<&str> {
+    const MARKER: &str = "provider request failed: ";
+    let rest = &msg[msg.find(MARKER)? + MARKER.len()..];
+    let open = rest.find(" [")?;
+    let after = &rest[open + 2..];
+    let close = after.find(']')?;
+    let label = &after[..close];
+    (!label.is_empty()
+        && label
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_'))
+    .then_some(label)
 }
 
 /// Responses-API terminal stream failures are `"{label}{suffix}"` where the
@@ -270,6 +318,86 @@ mod tests {
                 .to_string()
                 .starts_with("Config error: openai provider: "),
             "must keep the historical prefix for genuine config errors: {runtime_err}"
+        );
+    }
+
+    /// A broker status failure carrying a vetted label is humanized into an
+    /// actionable, provider-aware message when the qualified model is known
+    /// — and never echoes anything but our own text.
+    #[test]
+    fn vetted_kimi_quota_label_is_humanized_for_known_provider() {
+        let raw = "openai request failed: broker transport error: provider request failed: 403 Forbidden [access_terminated_error]";
+        let err: BoxedProviderError = raw.into();
+        let runtime_err = provider_error_to_runtime_for("kimi-code/k3", err);
+        let RuntimeError::ApiStatus(msg) = runtime_err else {
+            panic!("expected ApiStatus, got {runtime_err:?}");
+        };
+        assert!(
+            msg.starts_with("kimi-code: usage quota exhausted (HTTP 403)"),
+            "{msg}"
+        );
+        assert!(msg.contains("weekly"), "{msg}");
+        assert!(
+            !msg.contains("login"),
+            "quota must not read as an auth failure: {msg}"
+        );
+        assert!(
+            !msg.contains("[access_terminated_error]"),
+            "label must be rendered, not leaked: {msg}"
+        );
+    }
+
+    /// Without a provider key (legacy entry point) or without a label the
+    /// raw, status-only prefix message is preserved verbatim.
+    #[test]
+    fn broker_status_without_label_or_provider_keeps_raw_message() {
+        let labelled = "openai request failed: broker transport error: provider request failed: 403 Forbidden [access_terminated_error]";
+        match provider_error_to_runtime(labelled.into()) {
+            RuntimeError::ApiStatus(msg) => assert_eq!(msg, labelled),
+            other => panic!("expected ApiStatus, got {other:?}"),
+        }
+        let plain =
+            "openai request failed: broker transport error: provider request failed: 403 Forbidden";
+        match provider_error_to_runtime_for("kimi-code/k3", plain.into()) {
+            RuntimeError::ApiStatus(msg) => assert_eq!(msg, plain),
+            other => panic!("expected ApiStatus, got {other:?}"),
+        }
+        // Unknown (status, label) combos also fall through unchanged.
+        let unknown =
+            "openai request failed: provider request failed: 418 I'm a teapot [server_error]";
+        match provider_error_to_runtime_for("groq/llama", unknown.into()) {
+            RuntimeError::ApiStatus(msg) => assert_eq!(msg, unknown),
+            other => panic!("expected ApiStatus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn broker_error_label_accepts_only_identifier_shaped_labels() {
+        assert_eq!(
+            broker_error_label(
+                "x: provider request failed: 403 Forbidden [access_terminated_error]"
+            ),
+            Some("access_terminated_error")
+        );
+        assert_eq!(
+            broker_error_label("provider request failed: 403 Forbidden"),
+            None
+        );
+        assert_eq!(
+            broker_error_label("provider request failed: 403 Forbidden []"),
+            None
+        );
+        assert_eq!(
+            broker_error_label("provider request failed: 403 Forbidden [<script>ECHO]"),
+            None
+        );
+        assert_eq!(
+            broker_error_label("provider request failed: 403 Forbidden [Mixed-Case]"),
+            None
+        );
+        assert_eq!(
+            broker_error_label("no marker here [access_terminated_error]"),
+            None
         );
     }
 }

--- a/crates/agent-engine/src/runtime/openai/net.rs
+++ b/crates/agent-engine/src/runtime/openai/net.rs
@@ -42,10 +42,7 @@ pub fn provider_error_to_runtime(e: BoxedProviderError) -> RuntimeError {
     // terminal stream failure — API failures, not configuration errors.
     if msg.starts_with("codex request failed:")
         || msg.starts_with("openai request failed:")
-        || msg.starts_with("Codex response failed in stream.")
-        || msg.starts_with("Codex response was incomplete.")
-        || msg.starts_with("Codex completed without text or tool output.")
-        || msg.starts_with("Codex response stream ended without a terminal event.")
+        || is_responses_terminal_failure_message(&msg)
     {
         tracing::warn!(error = %msg, "provider API error");
         return RuntimeError::ApiStatus(msg);
@@ -53,6 +50,29 @@ pub fn provider_error_to_runtime(e: BoxedProviderError) -> RuntimeError {
 
     tracing::warn!(error = %msg, "provider config error");
     RuntimeError::Config(format!("openai provider: {msg}"))
+}
+
+/// Responses-API terminal stream failures are `"{label}{suffix}"` where the
+/// label is a provider display name ("Codex", "xAI") and the suffix is one of
+/// the static templates in `stream.rs`. Match label-independently on the
+/// suffix so every provider label classifies as an API failure.
+fn is_responses_terminal_failure_message(msg: &str) -> bool {
+    use super::stream::{
+        RESPONSES_CAPACITY_SUFFIX, RESPONSES_CONTEXT_SUFFIX, RESPONSES_EMPTY_SUFFIX,
+        RESPONSES_FAILED_SUFFIX, RESPONSES_INCOMPLETE_SUFFIX, RESPONSES_MISSING_TERMINAL_SUFFIX,
+    };
+    const SUFFIXES: &[&str] = &[
+        RESPONSES_FAILED_SUFFIX,
+        RESPONSES_CAPACITY_SUFFIX,
+        RESPONSES_CONTEXT_SUFFIX,
+        RESPONSES_INCOMPLETE_SUFFIX,
+        RESPONSES_EMPTY_SUFFIX,
+        RESPONSES_MISSING_TERMINAL_SUFFIX,
+    ];
+    SUFFIXES.iter().any(|suffix| {
+        msg.strip_suffix(suffix)
+            .is_some_and(|label| !label.is_empty() && !label.contains(char::is_whitespace))
+    })
 }
 
 /// Walk the boxed error and its source chain looking for a `reqwest::Error`.
@@ -166,6 +186,13 @@ mod tests {
             "Codex response was incomplete. Retry the request or reduce the requested output/context size.",
             "Codex completed without text or tool output. Retry the request.",
             "Codex response stream ended without a terminal event. Retry the request.",
+            "Codex rejected the request: the conversation exceeds this model's context window. Run /compact or start a fresh session to continue.",
+            // xAI-labelled variants (xai-auth Responses route).
+            "xAI response failed in stream. Provider error details withheld because they can echo request content.",
+            "xAI reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model.",
+            "xAI completed without text or tool output. Retry the request.",
+            "xAI response stream ended without a terminal event. Retry the request.",
+            "xAI response was incomplete. Retry the request or reduce the requested output/context size.",
         ] {
             let err = provider_error_to_runtime(msg.into());
             assert!(
@@ -174,6 +201,21 @@ mod tests {
             );
             assert!(!err.to_string().starts_with("Config error"));
         }
+    }
+
+    /// A message that merely mentions a suffix mid-sentence (or carries a
+    /// non-label prefix) must not be mistaken for a Responses terminal.
+    #[test]
+    fn responses_terminal_matcher_requires_bare_label_prefix() {
+        assert!(!is_responses_terminal_failure_message(
+            "No API key for 'xai'. response failed in stream."
+        ));
+        assert!(!is_responses_terminal_failure_message(
+            " response failed in stream. Provider error details withheld because they can echo request content."
+        ));
+        assert!(is_responses_terminal_failure_message(
+            "xAI reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model."
+        ));
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/openai/stream.rs
+++ b/crates/agent-engine/src/runtime/openai/stream.rs
@@ -883,14 +883,65 @@ fn codex_input_messages(messages: Vec<ChatMessage>) -> Vec<Value> {
     out
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct ResponsesStreamFailure {
     code: &'static str,
-    message: &'static str,
+    /// User-facing text built from OUR static templates plus the provider
+    /// display label — never provider free-text.
+    message: String,
 }
 
-#[derive(Default)]
+impl ResponsesStreamFailure {
+    /// Terminal failures that are transient by nature and safe to re-send
+    /// with identical request bytes: provider capacity exhaustion, an empty
+    /// completion, or a stream that ended without any terminal event.
+    fn is_retryable(&self) -> bool {
+        matches!(
+            self.code,
+            "responses_capacity" | "responses_empty" | "responses_missing_terminal"
+        )
+    }
+}
+
+/// Sanitized provider error codes that mean "try again later" on the
+/// Responses wire. Classification-only: the code is matched against this
+/// fixed set, never echoed beyond the local sanitized log line.
+const CAPACITY_ERROR_CODES: &[&str] = &[
+    "rate_limit_exceeded",
+    "server_overloaded",
+    "overloaded",
+    "capacity",
+    "server_error",
+];
+
+/// Fixed substrings that mark a provider free-text error message as a
+/// transient capacity condition (xAI: "The model is currently at capacity
+/// due to high demand. Please try again in a few minutes…"). The message is
+/// consulted ONLY to produce a boolean — it is never logged, stored, or
+/// surfaced (privacy invariant: provider bodies can echo request content).
+const CAPACITY_MESSAGE_PATTERNS: &[&str] = &[
+    "at capacity",
+    "high demand",
+    "try again in a few minutes",
+    "overloaded",
+];
+
+/// Classification-only capacity check. `error_code` is already sanitized;
+/// `message` is raw provider text used solely as a boolean signal.
+fn is_capacity_failure(error_code: &str, message: Option<&str>) -> bool {
+    if CAPACITY_ERROR_CODES.contains(&error_code) {
+        return true;
+    }
+    message.is_some_and(|m| {
+        let lower = m.to_ascii_lowercase();
+        CAPACITY_MESSAGE_PATTERNS.iter().any(|p| lower.contains(p))
+    })
+}
+
 struct CodexSseDecoder {
+    /// Provider display label used in user-facing terminal messages
+    /// ("Codex", "xAI"). Static, ours — never provider-supplied.
+    provider_label: &'static str,
     buffer: String,
     active_tools: Vec<CodexToolAccumulator>,
     completed_tools: Vec<ToolCall>,
@@ -906,6 +957,12 @@ struct CodexSseDecoder {
     /// Trace (Task 10A): provider-reported usage from `response.completed`
     /// (input including cached, output, cached slice). `None` until observed.
     observed_usage: Option<(u64, u64, u64)>,
+}
+
+impl Default for CodexSseDecoder {
+    fn default() -> Self {
+        Self::for_provider("Codex")
+    }
 }
 
 #[derive(Default)]
@@ -966,21 +1023,67 @@ fn sanitize_error_identifier(raw: Option<&str>) -> &str {
     }
 }
 
-/// Map a Codex terminal failure to a user-facing message. Only reacts to the
-/// already-sanitized enum identifiers (`error.type` / `error.code`) — never to
-/// provider free-text — so no request content can leak. Known, user-actionable
-/// conditions get a specific remedy; everything else keeps the neutral,
-/// details-withheld default.
-fn user_message_for_terminal_failure(error_kind: &str, error_code: &str) -> &'static str {
+/// Static message suffixes for Responses terminal failures. The provider
+/// display label is prefixed at construction; `net.rs` classifies on these
+/// label-independent suffixes so every label maps to `ApiStatus`.
+pub(crate) const RESPONSES_FAILED_SUFFIX: &str =
+    " response failed in stream. Provider error details withheld because they can echo request content.";
+pub(crate) const RESPONSES_CONTEXT_SUFFIX: &str = " rejected the request: the conversation exceeds this model's context window. Run /compact or start a fresh session to continue.";
+pub(crate) const RESPONSES_CAPACITY_SUFFIX: &str = " reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model.";
+pub(crate) const RESPONSES_INCOMPLETE_SUFFIX: &str =
+    " response was incomplete. Retry the request or reduce the requested output/context size.";
+pub(crate) const RESPONSES_EMPTY_SUFFIX: &str =
+    " completed without text or tool output. Retry the request.";
+pub(crate) const RESPONSES_MISSING_TERMINAL_SUFFIX: &str =
+    " response stream ended without a terminal event. Retry the request.";
+
+/// Map a Responses terminal failure to a user-facing message. Only reacts to
+/// the already-sanitized enum identifiers (`error.type` / `error.code`) and
+/// the boolean capacity classification — never to provider free-text — so no
+/// request content can leak. Known, user-actionable conditions get a specific
+/// remedy; everything else keeps the neutral, details-withheld default.
+fn user_message_for_terminal_failure(
+    label: &str,
+    error_kind: &str,
+    error_code: &str,
+    capacity: bool,
+) -> String {
     // Context-window overflow is deterministic and user-fixable: the turn
     // cannot succeed until the conversation is smaller.
     if error_code == "context_length_exceeded" || error_kind == "context_length_exceeded" {
-        return "Codex rejected the request: the conversation exceeds this model's context window. Run /compact or start a fresh session to continue.";
+        return format!("{label}{RESPONSES_CONTEXT_SUFFIX}");
     }
-    "Codex response failed in stream. Provider error details withheld because they can echo request content."
+    if capacity {
+        return format!("{label}{RESPONSES_CAPACITY_SUFFIX}");
+    }
+    format!("{label}{RESPONSES_FAILED_SUFFIX}")
 }
 
 impl CodexSseDecoder {
+    /// Decoder whose user-facing messages name `label` as the provider.
+    fn for_provider(label: &'static str) -> Self {
+        Self {
+            provider_label: label,
+            buffer: String::new(),
+            active_tools: Vec::new(),
+            completed_tools: Vec::new(),
+            saw_model_event: false,
+            terminal_success: false,
+            terminal_failure: None,
+            emitted_output: false,
+            observed_usage: None,
+        }
+    }
+
+    /// True once anything was streamed to the UI for this attempt (text
+    /// deltas, tool starts, or completed tools). A retry after this point
+    /// would duplicate output, so callers must treat the failure as terminal.
+    fn emitted_any_output(&self) -> bool {
+        self.emitted_output
+            || !self.completed_tools.is_empty()
+            || self.active_tools.iter().any(|tool| tool.started)
+    }
+
     fn push_line(
         &mut self,
         line: &str,
@@ -1099,10 +1202,17 @@ impl CodexSseDecoder {
                 // identifiers (`type` / `code`) after sanitizing them down to a
                 // short identifier charset. The free-text `message` field is
                 // never logged or surfaced — it can echo request content.
+                //
+                // Two envelope shapes are accepted: the nested Responses form
+                // (`response.error.{type,code,message}` / `error.{…}`) and
+                // xAI's flat form (`{"type":"error","code":…,"message":…}`)
+                // where the event's own `type` is just "error", so only the
+                // top-level `code` is a meaningful identifier there.
                 let error_obj = event
                     .get("response")
                     .and_then(|r| r.get("error"))
-                    .or_else(|| event.get("error"));
+                    .or_else(|| event.get("error"))
+                    .filter(|e| e.is_object());
                 let error_kind = sanitize_error_identifier(
                     error_obj
                         .and_then(|e| e.get("type"))
@@ -1111,17 +1221,38 @@ impl CodexSseDecoder {
                 let error_code = sanitize_error_identifier(
                     error_obj
                         .and_then(|e| e.get("code"))
+                        .or_else(|| event.get("code"))
+                        .and_then(Value::as_str),
+                );
+                // Provider free-text: classification-only boolean, never
+                // retained past this expression.
+                let capacity = is_capacity_failure(
+                    error_code,
+                    error_obj
+                        .and_then(|e| e.get("message"))
+                        .or_else(|| event.get("message"))
                         .and_then(Value::as_str),
                 );
                 tracing::warn!(
+                    provider = self.provider_label,
                     event_type,
                     error_kind,
                     error_code,
-                    "codex stream terminal failure (provider message withheld)"
+                    capacity,
+                    "responses stream terminal failure (provider message withheld)"
                 );
                 self.terminal_failure = Some(ResponsesStreamFailure {
-                    code: "responses_failed",
-                    message: user_message_for_terminal_failure(error_kind, error_code),
+                    code: if capacity {
+                        "responses_capacity"
+                    } else {
+                        "responses_failed"
+                    },
+                    message: user_message_for_terminal_failure(
+                        self.provider_label,
+                        error_kind,
+                        error_code,
+                        capacity,
+                    ),
                 });
                 self.finish();
             }
@@ -1134,10 +1265,14 @@ impl CodexSseDecoder {
                         .and_then(|d| d.get("reason"))
                         .and_then(Value::as_str),
                 );
-                tracing::warn!(reason, "codex stream terminal incomplete");
+                tracing::warn!(
+                    provider = self.provider_label,
+                    reason,
+                    "responses stream terminal incomplete"
+                );
                 self.terminal_failure = Some(ResponsesStreamFailure {
                     code: "responses_incomplete",
-                    message: "Codex response was incomplete. Retry the request or reduce the requested output/context size.",
+                    message: format!("{}{RESPONSES_INCOMPLETE_SUFFIX}", self.provider_label),
                 });
                 self.finish();
             }
@@ -1150,8 +1285,8 @@ impl CodexSseDecoder {
     }
 
     fn terminal_result(&self) -> Result<(), ResponsesStreamFailure> {
-        if let Some(failure) = self.terminal_failure {
-            return Err(failure);
+        if let Some(failure) = &self.terminal_failure {
+            return Err(failure.clone());
         }
         if self.terminal_success {
             if self.emitted_output || !self.completed_tools.is_empty() {
@@ -1159,13 +1294,13 @@ impl CodexSseDecoder {
             } else {
                 Err(ResponsesStreamFailure {
                     code: "responses_empty",
-                    message: "Codex completed without text or tool output. Retry the request.",
+                    message: format!("{}{RESPONSES_EMPTY_SUFFIX}", self.provider_label),
                 })
             }
         } else {
             Err(ResponsesStreamFailure {
                 code: "responses_missing_terminal",
-                message: "Codex response stream ended without a terminal event. Retry the request.",
+                message: format!("{}{RESPONSES_MISSING_TERMINAL_SUFFIX}", self.provider_label),
             })
         }
     }
@@ -1886,19 +2021,133 @@ mod codex_decoder_tests {
     #[test]
     fn terminal_failure_user_message_is_specific_only_for_known_codes() {
         assert!(user_message_for_terminal_failure(
+            "Codex",
             "invalid_request_error",
-            "context_length_exceeded"
+            "context_length_exceeded",
+            false
         )
         .contains("/compact"));
         // Code carried on `type` rather than `code` still maps.
-        assert!(
-            user_message_for_terminal_failure("context_length_exceeded", "absent")
-                .contains("context window")
-        );
+        assert!(user_message_for_terminal_failure(
+            "Codex",
+            "context_length_exceeded",
+            "absent",
+            false
+        )
+        .contains("context window"));
         // Unknown/other codes keep the neutral default (no remedy claim).
-        let default = user_message_for_terminal_failure("server_error", "unlisted_identifier");
+        let default = user_message_for_terminal_failure(
+            "Codex",
+            "server_error",
+            "unlisted_identifier",
+            false,
+        );
         assert!(default.starts_with("Codex response failed in stream."));
         assert!(!default.contains("/compact"));
+        // Capacity gets the specific remedy, labelled for the provider.
+        let capacity = user_message_for_terminal_failure("xAI", "absent", "absent", true);
+        assert_eq!(
+            capacity,
+            "xAI reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model."
+        );
+    }
+
+    /// The exact flat envelope xAI emits (HTTP 200, one SSE event, close):
+    /// no nested `error` object, `code` null, free-text `message`. It must
+    /// classify as retryable capacity — labelled for the provider, and the
+    /// provider prose must never reach the surfaced message.
+    #[test]
+    fn xai_flat_capacity_error_is_retryable_capacity_failure() {
+        let lines = [
+            r#"data: {"sequence_number":0,"type":"error","code":null,"message":"The model is currently at capacity due to high demand. Please try again in a few minutes, or use a higher service tier for priority processing: https://docs.x.ai/developers/advanced-api-usage/priority-processing","param":null}"#,
+            "",
+        ];
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut decoder = CodexSseDecoder::for_provider("xAI");
+        let mut text = String::new();
+        for line in lines {
+            decoder.push_line(line, &tx, &mut text);
+        }
+        decoder.finish();
+        let failure = decoder.terminal_result().expect_err("must fail");
+        assert_eq!(failure.code, "responses_capacity");
+        assert!(failure.is_retryable());
+        assert_eq!(
+            failure.message,
+            "xAI reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model."
+        );
+        for banned in ["high demand", "docs.x.ai", "service tier", "Codex"] {
+            assert!(
+                !failure.message.contains(banned),
+                "provider text `{banned}` leaked: {}",
+                failure.message
+            );
+        }
+        assert!(text.is_empty());
+        assert!(!decoder.emitted_any_output());
+        assert!(rx.try_recv().is_err(), "no events for an error-only stream");
+    }
+
+    /// Flat `code` identifiers are honoured when no nested error object is
+    /// present; only vetted codes classify as capacity.
+    #[test]
+    fn flat_code_classifies_capacity_only_for_vetted_codes() {
+        let capacity = [
+            r#"data: {"type":"error","code":"rate_limit_exceeded","message":"private"}"#,
+            "",
+        ];
+        let (decoder, _, _) = drive(&capacity);
+        let failure = decoder.terminal_result().expect_err("must fail");
+        assert_eq!(failure.code, "responses_capacity");
+        assert!(failure.is_retryable());
+
+        let other = [
+            r#"data: {"type":"error","code":"invalid_api_key","message":"private"}"#,
+            "",
+        ];
+        let (decoder, _, _) = drive(&other);
+        let failure = decoder.terminal_result().expect_err("must fail");
+        assert_eq!(failure.code, "responses_failed");
+        assert!(!failure.is_retryable());
+        assert!(!failure.message.contains("private"));
+    }
+
+    #[test]
+    fn provider_label_is_carried_into_every_terminal_message() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut text = String::new();
+        let mut decoder = CodexSseDecoder::for_provider("xAI");
+        decoder.push_line(
+            r#"data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":0}}}"#,
+            &tx,
+            &mut text,
+        );
+        decoder.push_line("", &tx, &mut text);
+        let failure = decoder.terminal_result().expect_err("empty");
+        assert_eq!(failure.code, "responses_empty");
+        assert!(failure.is_retryable());
+        assert_eq!(
+            failure.message,
+            "xAI completed without text or tool output. Retry the request."
+        );
+
+        let decoder = CodexSseDecoder::for_provider("xAI");
+        let failure = decoder.terminal_result().expect_err("missing terminal");
+        assert_eq!(failure.code, "responses_missing_terminal");
+        assert!(failure.is_retryable());
+        assert!(failure.message.starts_with("xAI response stream ended"));
+
+        let mut decoder = CodexSseDecoder::for_provider("xAI");
+        decoder.push_line(
+            r#"data: {"type":"response.incomplete","response":{"incomplete_details":{"reason":"max_output_tokens"}}}"#,
+            &tx,
+            &mut text,
+        );
+        decoder.push_line("", &tx, &mut text);
+        let failure = decoder.terminal_result().expect_err("incomplete");
+        assert_eq!(failure.code, "responses_incomplete");
+        assert!(!failure.is_retryable());
+        assert!(failure.message.starts_with("xAI response was incomplete."));
     }
 
     #[test]
@@ -2209,6 +2458,9 @@ mod broker_stream_tests {
     }
 }
 
+/// Provider display label for the xai-auth Responses route.
+const XAI_PROVIDER_LABEL: &str = "xAI";
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn call_xai_responses_stream_inner(
     cfg: &ProviderConfig,
@@ -2220,6 +2472,7 @@ pub(crate) async fn call_xai_responses_stream_inner(
     max_tokens: Option<u32>,
     reasoning_level: agent_core::reasoning::ReasoningLevel,
     cancel: &tokio_util::sync::CancellationToken,
+    max_retries: u32,
     trace: &crate::runtime::trace::TraceContext,
     exact_wire_bytes: bool,
 ) -> Result<Value, Box<dyn std::error::Error + Send + Sync>> {
@@ -2250,7 +2503,9 @@ pub(crate) async fn call_xai_responses_stream_inner(
     // the very bytes the broker sends upstream (`body_bytes` handoff,
     // LocalBroker verbatim) — `body`/`body_bytes` cannot diverge. On a
     // remote broker the daemon re-serializes out of process → honest
-    // `CloudProxy` kind and no wire-byte claim.
+    // `CloudProxy` kind and no wire-byte claim. Every retry clones this
+    // same request (identical `body` and `body_bytes`), so one wire digest
+    // is honest for all attempt records.
     let (proxy_request, body_bytes) =
         crate::auth::ProxyRequest::post_json_exact("xai-auth", "/responses", body, true)?;
     let tracer = tr::begin_openai_tracer(
@@ -2279,80 +2534,115 @@ pub(crate) async fn call_xai_responses_stream_inner(
         trace.capture_request_content(tracer.request_id(), body_bytes.as_ref());
     }
     let mut attempt = tr::StreamAttempt::new(tracer);
-    let stream = broker
-        .proxy_stream(proxy_request)
-        .await
-        // Privacy (spec §5.1): a broker proxy error may carry an upstream
-        // response-body snippet; redact it to status-only before surfacing.
-        .map_err(|e| super::net::redact_provider_proxy_error(&e.to_string()));
-    let mut stream = match stream {
-        Ok(stream) => {
-            attempt.mark_headers();
-            stream
-        }
-        Err(msg) => {
-            let status = tr::broker_error_status(&msg);
-            let code = status.map_or_else(|| "broker_error".to_string(), |s| format!("http_{s}"));
-            attempt.finish_failed(&code, status, None);
-            return Err(msg.into());
-        }
-    };
-    let mut text = String::new();
-    let mut parser = CodexSseDecoder::default();
-    let mut buf = bytes::BytesMut::new();
-    while let Some(chunk) = tokio::select! {
-        c = stream.next() => c,
-        _ = cancel.cancelled() => {
-            attempt.finish_canceled(None, parser.trace_usage());
-            return Err("request canceled".into());
-        }
-    } {
-        let chunk = match chunk {
-            Ok(chunk) => {
-                attempt.mark_first_byte();
-                chunk
+    let mut stream_retry = 0u32;
+
+    loop {
+        let stream = broker
+            .proxy_stream(proxy_request.clone())
+            .await
+            // Privacy (spec §5.1): a broker proxy error may carry an upstream
+            // response-body snippet; redact it to status-only before surfacing.
+            .map_err(|e| super::net::redact_provider_proxy_error(&e.to_string()));
+        let mut stream = match stream {
+            Ok(stream) => {
+                attempt.mark_headers();
+                stream
             }
-            Err(e) => {
-                attempt.finish_failed("stream_error", None, None);
-                return Err(e.into());
+            Err(msg) => {
+                let status = tr::broker_error_status(&msg);
+                let code =
+                    status.map_or_else(|| "broker_error".to_string(), |s| format!("http_{s}"));
+                attempt.finish_failed(&code, status, None);
+                return Err(msg.into());
             }
         };
-        buf.extend_from_slice(&chunk);
-        while let Some(n) = memchr::memchr(b'\n', &buf) {
-            let line = buf.split_to(n + 1);
-            parser.push_line(std::str::from_utf8(&line[..n]).unwrap_or(""), tx, &mut text);
+        let mut text = String::new();
+        let mut parser = CodexSseDecoder::for_provider(XAI_PROVIDER_LABEL);
+        let mut buf = bytes::BytesMut::new();
+        while let Some(chunk) = tokio::select! {
+            c = stream.next() => c,
+            _ = cancel.cancelled() => {
+                attempt.finish_canceled(None, parser.trace_usage());
+                return Err("request canceled".into());
+            }
+        } {
+            let chunk = match chunk {
+                Ok(chunk) => {
+                    attempt.mark_first_byte();
+                    chunk
+                }
+                Err(e) => {
+                    attempt.finish_failed("stream_error", None, None);
+                    return Err(e.into());
+                }
+            };
+            buf.extend_from_slice(&chunk);
+            while let Some(n) = memchr::memchr(b'\n', &buf) {
+                let line = buf.split_to(n + 1);
+                parser.push_line(std::str::from_utf8(&line[..n]).unwrap_or(""), tx, &mut text);
+            }
+            if parser.saw_model_event {
+                attempt.mark_first_model_event();
+            }
         }
+        if !buf.is_empty() {
+            parser.push_line(std::str::from_utf8(&buf).unwrap_or(""), tx, &mut text);
+        }
+        parser.finish();
+        // Trailing-buffer flush and finish() can surface the first (or only)
+        // model event; mark it so first_model_event_ms is honest for tail-only
+        // streams (mirrors the Codex direct path above).
         if parser.saw_model_event {
             attempt.mark_first_model_event();
         }
+        // Broker paths never observe the upstream HTTP status; the Responses
+        // stream does not yet expose a normalized stop reason — both stay
+        // honest `None` rather than guessed values.
+        if let Err(failure) = parser.terminal_result() {
+            // xAI answers HTTP 200 + a lone `{"type":"error",…}` capacity
+            // event while the model is saturated; a re-send seconds later
+            // usually succeeds. Retry only when NOTHING reached the UI on
+            // this attempt — text or tool events already streamed would be
+            // emitted twice on a re-send, so those failures stay terminal.
+            let output_already_streamed = !text.is_empty() || parser.emitted_any_output();
+            if failure.is_retryable() && !output_already_streamed && stream_retry < max_retries {
+                stream_retry += 1;
+                let delay = retry_delay(stream_retry);
+                attempt.attempt_failed(
+                    crate::runtime::trace::RetryClass::Other,
+                    delay,
+                    None,
+                    None,
+                    failure.code,
+                );
+                tracing::warn!(
+                    code = failure.code,
+                    "xai stream retry {stream_retry}/{max_retries} after {delay:?}"
+                );
+                tokio::select! {
+                    _ = tokio::time::sleep(delay) => {}
+                    _ = cancel.cancelled() => {
+                        attempt.finish_canceled(None, None);
+                        return Err("request canceled".into());
+                    }
+                }
+                attempt.restart_clock();
+                continue;
+            }
+            attempt.finish_failed(failure.code, None, None);
+            return Err(failure.message.into());
+        }
+        attempt.finish_success(None, None, None, parser.trace_usage());
+        let mut content = Vec::new();
+        if !text.is_empty() {
+            content.push(json!({"type":"text","text":text}));
+        }
+        content.extend(translate::tool_calls_to_content_blocks(
+            &parser.completed_tools,
+            &names,
+        ));
+        return Ok(json!({"role":"assistant","content":content}));
     }
-    if !buf.is_empty() {
-        parser.push_line(std::str::from_utf8(&buf).unwrap_or(""), tx, &mut text);
-    }
-    parser.finish();
-    // Trailing-buffer flush and finish() can surface the first (or only)
-    // model event; mark it so first_model_event_ms is honest for tail-only
-    // streams (mirrors the Codex direct path above).
-    if parser.saw_model_event {
-        attempt.mark_first_model_event();
-    }
-    // Broker paths never observe the upstream HTTP status; the Responses
-    // stream does not yet expose a normalized stop reason — both stay
-    // honest `None` rather than guessed values.
-    if let Err(failure) = parser.terminal_result() {
-        attempt.finish_failed(failure.code, None, None);
-        return Err(failure.message.into());
-    }
-    attempt.finish_success(None, None, None, parser.trace_usage());
-    let mut content = Vec::new();
-    if !text.is_empty() {
-        content.push(json!({"type":"text","text":text}));
-    }
-    content.extend(translate::tool_calls_to_content_blocks(
-        &parser.completed_tools,
-        &names,
-    ));
-    Ok(json!({"role":"assistant","content":content}))
 }
 
 /// Pure, validated body construction for the xAI Responses API.
@@ -2519,6 +2809,243 @@ mod xai_tests {
         assert!(body.get("input").is_some());
         assert!(body.get("messages").is_none());
         assert!(body.get("max_output_tokens").is_none());
+    }
+}
+
+#[cfg(test)]
+mod xai_capacity_retry_tests {
+    //! Regression tests for the xai-auth Responses route: xAI answers HTTP
+    //! 200 + a lone flat `{"type":"error",…}` capacity event while the model
+    //! is saturated (reproduced live: grok-4.6 failed 3 of 4 turns, a re-send
+    //! seconds later succeeded). The route must retry with identical request
+    //! bytes, label its messages "xAI" (not "Codex"), and never surface the
+    //! provider prose. A scripted fake broker serves the SSE bodies directly
+    //! through `proxy_stream` — no HTTP server involved.
+
+    use super::*;
+    use agent_core::auth::{
+        AccessToken, BrokerError, ProxyByteStream, ProxyRequest, ProxyResponse,
+    };
+    use async_trait::async_trait;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    /// The exact envelope observed on the wire (flat: `type` is the event
+    /// type, `code` null, `message` top-level, no nested `error` object).
+    const XAI_CAPACITY_SSE: &str = "data: {\"sequence_number\":0,\"type\":\"error\",\"code\":null,\"message\":\"The model is currently at capacity due to high demand. Please try again in a few minutes, or use a higher service tier for priority processing: https://docs.x.ai/developers/advanced-api-usage/priority-processing\",\"param\":null}\n\n";
+
+    const XAI_SUCCESS_SSE: &str = concat!(
+        "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\n\n",
+        "data: {\"type\":\"response.output_text.delta\",\"delta\":\"GROK_OK\"}\n\n",
+        "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":7,\"output_tokens\":2}}}\n\n",
+    );
+
+    /// Serves `bodies[n]` for the n-th `proxy_stream` call (the last body
+    /// repeats once exhausted) and records every request body it saw.
+    struct ScriptedXaiBroker {
+        bodies: Vec<&'static str>,
+        calls: Arc<AtomicUsize>,
+        seen: Arc<std::sync::Mutex<Vec<ProxyRequest>>>,
+    }
+
+    #[async_trait]
+    impl crate::auth::CredentialBroker for ScriptedXaiBroker {
+        async fn access_token(
+            &self,
+            _p: agent_core::auth::OAuthProviderId,
+        ) -> Result<AccessToken, BrokerError> {
+            Err(BrokerError::Denied(
+                "xai route must use proxy_stream".into(),
+            ))
+        }
+        async fn proxy(&self, _request: ProxyRequest) -> Result<ProxyResponse, BrokerError> {
+            Err(BrokerError::Denied("not implemented in stub".into()))
+        }
+        async fn proxy_stream(
+            &self,
+            request: ProxyRequest,
+        ) -> Result<ProxyByteStream, BrokerError> {
+            request.validate()?;
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            self.seen.lock().unwrap().push(request);
+            let body = self.bodies[n.min(self.bodies.len() - 1)];
+            Ok(Box::pin(futures::stream::iter(vec![Ok(
+                bytes::Bytes::from(body),
+            )])))
+        }
+        async fn anthropic_usage(&self) -> Result<serde_json::Value, BrokerError> {
+            Err(BrokerError::Denied("not implemented in stub".into()))
+        }
+        async fn capabilities(&self) -> Result<Vec<agent_core::auth::ProviderStatus>, BrokerError> {
+            Ok(vec![])
+        }
+    }
+
+    struct Run {
+        result: Result<Value, Box<dyn std::error::Error + Send + Sync>>,
+        calls: usize,
+        seen: Vec<ProxyRequest>,
+        events: Vec<StreamEvent>,
+    }
+
+    async fn run_xai(bodies: Vec<&'static str>, max_retries: u32) -> Run {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let broker: Arc<dyn crate::auth::CredentialBroker> = Arc::new(ScriptedXaiBroker {
+            bodies,
+            calls: Arc::clone(&calls),
+            seen: Arc::clone(&seen),
+        });
+        let cfg = ProviderConfig {
+            base_url: "https://api.x.ai/v1".to_string(),
+            model: "grok-4.5".to_string(),
+            provider: "xai-auth".to_string(),
+        };
+        let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
+        let result = call_xai_responses_stream_inner(
+            &cfg,
+            &broker,
+            &[],
+            &Some("system".to_string()),
+            &[],
+            &tx,
+            None,
+            agent_core::reasoning::ReasoningLevel::Adaptive,
+            &tokio_util::sync::CancellationToken::new(),
+            max_retries,
+            &crate::runtime::trace::TraceContext::disabled(),
+            true,
+        )
+        .await;
+        drop(tx);
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+        let seen = std::mem::take(&mut *seen.lock().unwrap());
+        Run {
+            result,
+            calls: calls.load(Ordering::SeqCst),
+            seen,
+            events,
+        }
+    }
+
+    fn text_events(events: &[StreamEvent]) -> Vec<String> {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                StreamEvent::Llm(crate::runtime::types::LlmEvent::Text(t)) => Some(t.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn xai_capacity_error_is_retried_with_identical_bytes_then_succeeds() {
+        let run = run_xai(vec![XAI_CAPACITY_SSE, XAI_SUCCESS_SSE], 3).await;
+        let value = run.result.expect("second attempt must succeed");
+        assert_eq!(value["content"][0]["text"], "GROK_OK");
+        assert_eq!(run.calls, 2, "exactly one retry");
+        assert_eq!(run.seen.len(), 2);
+        assert_eq!(
+            run.seen[0].body_bytes, run.seen[1].body_bytes,
+            "retry must re-send the identical serialized body"
+        );
+        assert_eq!(run.seen[0].body, run.seen[1].body);
+        assert_eq!(run.seen[0].provider, "xai-auth");
+        assert_eq!(run.seen[0].path, "/responses");
+        // No output was streamed twice: the failed attempt emitted nothing.
+        assert_eq!(text_events(&run.events), vec!["GROK_OK".to_string()]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn xai_capacity_error_with_zero_retries_surfaces_xai_capacity_message() {
+        let run = run_xai(vec![XAI_CAPACITY_SSE], 0).await;
+        let err = run.result.expect_err("no retry budget → terminal");
+        let msg = err.to_string();
+        assert_eq!(
+            msg,
+            "xAI reports the model is at capacity (retries exhausted). Try again in a few minutes or switch models with /model."
+        );
+        assert_eq!(run.calls, 1);
+        for banned in ["Codex", "high demand", "docs.x.ai", "service tier"] {
+            assert!(!msg.contains(banned), "`{banned}` leaked: {msg}");
+        }
+        // And the runtime classifies it as an API failure, not a config one.
+        assert!(matches!(
+            super::super::net::provider_error_to_runtime(err),
+            crate::RuntimeError::ApiStatus(_)
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn xai_capacity_error_exhausting_budget_counts_every_attempt() {
+        let run = run_xai(vec![XAI_CAPACITY_SSE], 2).await;
+        let err = run.result.expect_err("persistent capacity → terminal");
+        assert!(err
+            .to_string()
+            .starts_with("xAI reports the model is at capacity"));
+        assert_eq!(run.calls, 3, "initial attempt + 2 retries");
+        assert!(text_events(&run.events).is_empty());
+    }
+
+    /// If the failed attempt already streamed text, a re-send would duplicate
+    /// it in the UI — the failure must stay terminal even with budget left.
+    #[tokio::test(start_paused = true)]
+    async fn xai_does_not_retry_after_partial_text_was_streamed() {
+        const PARTIAL_THEN_ERROR: &str = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n",
+            "data: {\"type\":\"error\",\"code\":null,\"message\":\"at capacity\"}\n\n",
+        );
+        let run = run_xai(vec![PARTIAL_THEN_ERROR, XAI_SUCCESS_SSE], 3).await;
+        let err = run.result.expect_err("must not retry after partial output");
+        assert!(err
+            .to_string()
+            .starts_with("xAI reports the model is at capacity"));
+        assert_eq!(run.calls, 1, "no retry once output reached the UI");
+        assert_eq!(text_events(&run.events), vec!["partial".to_string()]);
+    }
+
+    /// Same guard for tool events: a started tool call must not be replayed.
+    #[tokio::test(start_paused = true)]
+    async fn xai_does_not_retry_after_tool_events_were_emitted() {
+        const TOOL_THEN_EOF: &str = "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"bash\"}}\n\n";
+        let run = run_xai(vec![TOOL_THEN_EOF, XAI_SUCCESS_SSE], 3).await;
+        // EOF without a terminal event is itself retryable
+        // (`responses_missing_terminal`) — but the ToolUseStart already
+        // reached the UI, so the guard must keep it terminal.
+        let err = run
+            .result
+            .expect_err("missing terminal after a tool event stays terminal");
+        assert!(
+            err.to_string()
+                .starts_with("xAI response stream ended without a terminal event."),
+            "got: {err}"
+        );
+        assert_eq!(run.calls, 1, "no retry once a tool event reached the UI");
+        assert!(run.events.iter().any(|e| matches!(
+            e,
+            StreamEvent::Llm(crate::runtime::types::LlmEvent::ToolUseStart { .. })
+        )));
+    }
+
+    /// Deterministic (non-capacity) failures are terminal on the first try
+    /// and keep the neutral, xAI-labelled, details-withheld message.
+    #[tokio::test(start_paused = true)]
+    async fn xai_non_capacity_error_is_terminal_and_labelled_xai() {
+        const OTHER_ERROR: &str = "data: {\"type\":\"error\",\"code\":\"invalid_api_key\",\"message\":\"ECHOED:secret prompt\"}\n\n";
+        let run = run_xai(vec![OTHER_ERROR, XAI_SUCCESS_SSE], 3).await;
+        let err = run.result.expect_err("must fail");
+        let msg = err.to_string();
+        assert_eq!(
+            msg,
+            "xAI response failed in stream. Provider error details withheld because they can echo request content."
+        );
+        assert!(!msg.contains("ECHOED"));
+        assert_eq!(run.calls, 1);
     }
 }
 
@@ -2895,7 +3422,7 @@ mod codex_wire_tests {
         );
         let includes = body.get("include").expect("include must be present");
         assert!(
-            includes.as_array().map_or(false, |a| {
+            includes.as_array().is_some_and(|a| {
                 a.iter()
                     .any(|v| v.as_str() == Some("reasoning.encrypted_content"))
             }),

--- a/crates/agent-engine/src/runtime/openai/translate.rs
+++ b/crates/agent-engine/src/runtime/openai/translate.rs
@@ -255,6 +255,14 @@ pub fn messages_to_oai(
                                         Some(Value::Array(arr)) => arr
                                             .iter()
                                             .filter_map(|b| {
+                                                if b["type"] == "image" {
+                                                    let mt = b["source"]["media_type"]
+                                                        .as_str()
+                                                        .unwrap_or("image");
+                                                    return Some(format!(
+                                                        "\n[image omitted: {mt} — this provider does not accept images in tool results]"
+                                                    ));
+                                                }
                                                 b.get("text")
                                                     .and_then(|t| t.as_str())
                                                     .map(String::from)
@@ -429,6 +437,31 @@ pub fn tool_calls_to_content_blocks(calls: &[ToolCall], name_map: &ToolNameMap) 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn image_tool_result_degrades_to_text_with_omission_note() {
+        let b64 = "iVBORw0KGgo".repeat(200);
+        let msgs: Vec<crate::SharedMessage> = vec![
+            std::sync::Arc::new(json!({"role":"user","content":"look"})),
+            std::sync::Arc::new(json!({"role":"assistant","content":[
+                {"type":"tool_use","id":"t1","name":"read","input":{"path":"x.png"}}
+            ]})),
+            std::sync::Arc::new(json!({"role":"user","content":[
+                {"type":"tool_result","tool_use_id":"t1","content":[
+                    {"type":"text","text":"Image: x"},
+                    {"type":"image","source":{"type":"base64","media_type":"image/png","data":b64}}
+                ]}
+            ]})),
+        ];
+        let out = messages_to_oai(&msgs, &None, &ToolNameMap::default());
+        let tool_msg = out.iter().find(|m| m.role == "tool").expect("tool message");
+        let content = tool_msg.content.as_deref().unwrap();
+        assert_eq!(
+            content,
+            "Image: x\n[image omitted: image/png — this provider does not accept images in tool results]"
+        );
+        assert!(!content.contains("iVBORw0KGgo"));
+    }
 
     /// Regression fixture from session 20260429-235559-094c: the lsrf-manager
     /// extension exposed `managerApi_cloudfrontInvalidate` whose `paths`

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -2033,6 +2033,8 @@ mod rich_output_tests {
                     (StatusCode::OK, [("content-type", "text/event-stream")], sse).into_response()
                 }),
             )
+            // Axum defaults to a 2 MB body limit (413) — image histories are bigger.
+            .layer(axum::extract::DefaultBodyLimit::max(64 * 1024 * 1024))
             .with_state(state.clone());
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -2293,6 +2293,14 @@ mod rich_output_tests {
 
     // ── S1: history image byte cap ─────────────────────────────────────────
 
+    fn user_msg(content: Value) -> SharedMessage {
+        Arc::new(json!({"role": "user", "content": content}))
+    }
+
+    fn assistant_msg(text: &str) -> SharedMessage {
+        Arc::new(json!({"role": "assistant", "content": [{"type": "text", "text": text}]}))
+    }
+
     fn image_tool_result_msg(id: &str, b64_len: usize) -> SharedMessage {
         user_msg(json!([{
             "type": "tool_result", "tool_use_id": id,

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -279,7 +279,8 @@ impl StreamMethods {
         // and the extension-provider route. Built once here, rebuilt only
         // at the top of a provider round when the catalog generation
         // advanced (dynamic registration). Mid-round catalog drift is
-        // DENIED (`StaleSessionSet`), never silently absorbed.
+        // validated PER TOOL at the execution gate (digest + provenance
+        // pins), never silently absorbed.
         let session_tool_set: crate::tools::activation::SharedSessionToolSet = {
             let registry = tools.read().await;
             let set = if progressive_tool_disclosure {
@@ -570,13 +571,18 @@ impl StreamMethods {
                     let session_set = session_tool_set
                         .read()
                         .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    tools_snapshot
-                        .session_tools_schema(&session_set)
-                        .map_err(|err| {
-                            RuntimeError::Tool(format!(
-                                "failed to project the authorized session tool set: {err}"
-                            ))
-                        })?
+                    let report = tools_snapshot.session_tools_schema(&session_set);
+                    // Fail-closed drop report: every pinned member excluded
+                    // from this round's schema is surfaced here (typed),
+                    // not just buried in per-tool log lines.
+                    for (tool_id, reason) in &report.dropped {
+                        tracing::warn!(
+                            tool = %tool_id,
+                            reason = ?reason,
+                            "session schema projection dropped a pinned member for this round"
+                        );
+                    }
+                    report.schema
                 };
                 projected_options = super::api::ApiOptions {
                     request_tools_schema: Some(std::sync::Arc::new(projection)),
@@ -789,13 +795,14 @@ impl StreamMethods {
                     } else if !tool_id.is_empty() && !tool_name.is_empty() {
                         // ═══ EXECUTION GATE (Task 16, spec §7.1) ═══
                         // Resolve wire name → exact ToolId, verify the
-                        // RETAINED session set's snapshot generation + pinned
-                        // schema digest, require core/exact-grant status,
-                        // re-check source trust, and only then acquire the
-                        // implementation — all under ONE registry read guard
-                        // (one consistent snapshot, no TOCTOU). The set is
-                        // never rebuilt here: post-round-top catalog drift
-                        // denies typed (`StaleSessionSet`). Denials are
+                        // RETAINED session set's pinned schema digest and
+                        // pinned trust provenance, require core/exact-grant
+                        // status, re-check source trust, and only then
+                        // acquire the implementation — all under ONE
+                        // registry read guard (one consistent snapshot, no
+                        // TOCTOU). The set is never rebuilt here:
+                        // post-round-top drift of the CALLED tool's record
+                        // denies typed per tool. Denials are
                         // typed, static, metadata-only and happen BEFORE
                         // implementation lookup and BEFORE any
                         // before_tool_call hook emission.

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -825,7 +825,7 @@ impl StreamMethods {
                         let mut production_output: Option<crate::tools::output::OutputHandle> =
                             None;
                         let mut execution_identity = None;
-                        let result = match gate_outcome {
+                        let (result, rich_blocks) = match gate_outcome {
                             Ok((authorized, input)) => {
                                 let tool = authorized.implementation();
                                 execution_identity = Some((
@@ -882,7 +882,7 @@ impl StreamMethods {
                                 )
                                 .await;
                                 if let BeforeToolCallDecision::Block { reason } = decision {
-                                    format!("Tool call blocked by extension: {}", reason)
+                                    (format!("Tool call blocked by extension: {}", reason), None)
                                 } else {
                                     let BeforeToolCallDecision::Continue { input } = decision
                                     else {
@@ -890,24 +890,28 @@ impl StreamMethods {
                                     };
                                     let input_for_hook = input.clone();
                                     tokio::select! {
-                                        res = tool.execute(input, crate::ToolContext {
+                                        res = tool.execute_rich(input, crate::ToolContext {
                                             channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx.clone()) },
                                             capabilities: crate::tools::ToolCapabilities { watcher_exit_path: watcher_exit_path.clone(), tool_register_tx: Some(tool_reg_tx.clone()), session_manager: Some(session_manager.clone()), subagent_registry: Some(subagent_registry.clone()), event_queue: Some(event_queue.clone()), delegation_parent: delegation_parent.clone(), secret_prompt: secret_prompt.clone(), orchestration: orchestration.clone(), tool_activation: Some(crate::tools::discovery::ActivationCapability::new(catalog_snapshot.clone(), std::sync::Arc::clone(&session_tool_set), activation_authority)), mcp_leases: mcp_lease_capability.clone(), extension_leases: extension_lease_capability.clone(), memory_context: None /* TODO(task A5): host wiring of MemoryContextCapability */ },
                                             limits: crate::tools::ToolLimits { max_tool_output, max_tool_buffer: 256 * 1024, bash_timeout, bash_max_timeout, subagent_timeout },
                                         }) => {
-                                            let output = match res {
-                                                Ok(output) => output,
-                                                Err(e) => e.to_string(),
+                                            let (output, rich_blocks) = match res {
+                                                Ok(o) => o.into_parts(),
+                                                Err(e) => (e.to_string(), None),
                                             };
-                                            let output = emit_after_tool_call(
+                                            let hooked_output = emit_after_tool_call(
                                                 &hook_bus,
                                                 &tool_name,
                                                 Some(&runtime_name),
                                                 input_for_hook,
-                                                output,
+                                                output.clone(),
                                                 max_tool_output,
                                             ).await;
-                                            output
+                                            // Hook policy: a Replace transform wins over the rich
+                                            // blocks — the hook saw only the summary, so keeping
+                                            // the image would desync text and image.
+                                            let rich_blocks = if hooked_output == output { rich_blocks } else { None };
+                                            (hooked_output, rich_blocks)
                                         }
                                         _ = cancel.cancelled() => {
                                             canceled = true;
@@ -926,14 +930,14 @@ impl StreamMethods {
                                             {
                                                 interrupted_side_effect = Some(tool_id.clone());
                                             }
-                                            "Canceled by user".to_string()
+                                            ("Canceled by user".to_string(), None)
                                         }
                                     }
                                 }
                             }
                             // Typed, bounded, metadata-only gate denial — no
                             // implementation was looked up, no hook emitted.
-                            Err(denial) => denial.to_string(),
+                            Err(denial) => (denial.to_string(), None),
                         };
 
                         let history_result = production_output
@@ -972,10 +976,18 @@ impl StreamMethods {
                             result: ui_result,
                         }));
 
+                        // Rich blocks bypass `truncate_tool_result` by construction:
+                        // the image cap is the image's own budget.
+                        let content = select_tool_result_content(
+                            rich_blocks,
+                            history_result.map(|bounded| bounded.text),
+                            &result,
+                            max_tool_output,
+                        );
                         tool_results.push(json!({
                             "type": "tool_result",
                             "tool_use_id": tool_id,
-                            "content": history_result.map(|bounded| bounded.text).unwrap_or_else(|| HelperMethods::truncate_tool_result(&result, max_tool_output))
+                            "content": content
                         }));
                     }
                 } else {
@@ -1135,7 +1147,7 @@ impl StreamMethods {
                         );
 
                         join_set.spawn(async move {
-                            let mut lane_results: Vec<(String, bool, Option<String>, String)> = Vec::new();
+                            let mut lane_results: Vec<(String, bool, Option<String>, Value)> = Vec::new();
                             for (model_order, tool_id, tool_name, prepared) in lane {
                             let gate_outcome = match prepared {
                                 PreparedCall::ParseError(err) => {
@@ -1143,7 +1155,7 @@ impl StreamMethods {
                                         tool_id: tool_id.clone(),
                                         result: err.clone(),
                                     }));
-                                    lane_results.push((tool_id, false, None, err));
+                                    lane_results.push((tool_id, false, None, Value::String(err)));
                                     continue;
                                 }
                                 PreparedCall::Gate(gate_outcome) => gate_outcome,
@@ -1170,7 +1182,7 @@ impl StreamMethods {
                                         auto_approve_inner,
                                     ).await;
                                     if let BeforeToolCallDecision::Block { reason } = decision {
-                                        (false, Some(call_effect), format!("Tool call blocked by extension: {}", reason), None, None)
+                                        (false, Some(call_effect), format!("Tool call blocked by extension: {}", reason), None, None, None)
                                     } else {
                                     let BeforeToolCallDecision::Continue { input } = decision else { unreachable!() };
                                     let input_for_hook = input.clone();
@@ -1199,34 +1211,36 @@ impl StreamMethods {
                                     let tx_d = delta_channel.sender;
 
                                     tokio::select! {
-                                        res = t.execute(input, crate::ToolContext {
+                                        res = t.execute_rich(input, crate::ToolContext {
                                             channels: crate::tools::ToolChannels { tx_delta: Some(tx_d), tx_events: Some(tx_stream.clone()) },
                                             capabilities: crate::tools::ToolCapabilities { watcher_exit_path: exit_path.clone(), tool_register_tx: Some(tool_reg_tx_inner.clone()), session_manager: Some(session_mgr.clone()), subagent_registry: Some(registry_inner.clone()), event_queue: Some(eq_inner.clone()), delegation_parent: delegation_parent_inner.clone(), secret_prompt: prompt_inner.clone(), orchestration: orchestration_inner.clone(), tool_activation: Some(activation_inner.clone()), mcp_leases: mcp_leases_inner.clone(), extension_leases: extension_leases_inner.clone(), memory_context: None /* TODO(task A5): host wiring of MemoryContextCapability */ },
                                             limits: crate::tools::ToolLimits { max_tool_output, max_tool_buffer: 256 * 1024, bash_timeout, bash_max_timeout, subagent_timeout },
                                         }) => {
-                                            let output = match res {
-                                                Ok(output) => output,
-                                                Err(e) => e.to_string(),
+                                            let (output, rich_blocks) = match res {
+                                                Ok(o) => o.into_parts(),
+                                                Err(e) => (e.to_string(), None),
                                             };
-                                            let output = emit_after_tool_call(
+                                            let hooked_output = emit_after_tool_call(
                                                 &hook_bus_inner,
                                                 &tool_name_for_hook,
                                                 Some(&runtime_name_for_hook),
                                                 input_for_hook,
-                                                output,
+                                                output.clone(),
                                                 max_tool_output,
                                             ).await;
-                                            (false, Some(call_effect), output, Some(output_handle), Some((stable_tool_id, activation_basis, tool_call_started)))
+                                            // Hook Replace wins over rich blocks (see single-tool site).
+                                            let rich_blocks = if hooked_output == output { rich_blocks } else { None };
+                                            (false, Some(call_effect), hooked_output, Some(output_handle), Some((stable_tool_id, activation_basis, tool_call_started)), rich_blocks)
                                         }
                                         _ = cancel_token.cancelled() => {
-                                            (true, Some(call_effect), "Canceled by user".to_string(), Some(output_handle), Some((stable_tool_id, activation_basis, tool_call_started)))
+                                            (true, Some(call_effect), "Canceled by user".to_string(), Some(output_handle), Some((stable_tool_id, activation_basis, tool_call_started)), None)
                                         }
                                     }
                                     } // close else from Block check
                                 }
                                 // Typed, bounded, metadata-only gate denial —
                                 // no implementation lookup, no hook emission.
-                                Err(denial) => (false, None, denial.to_string(), None, None),
+                                Err(denial) => (false, None, denial.to_string(), None, None, None),
                             };
 
                             let _ = tx_stream.send(StreamEvent::Llm(LlmEvent::ToolResult {
@@ -1257,9 +1271,12 @@ impl StreamMethods {
                             let history_bounded = result.3.as_ref()
                                 .map(crate::tools::output::OutputHandle::model_history)
                                 .filter(|bounded| bounded.original_bytes > 0);
-                            let history = history_bounded.as_ref()
-                                .map(|bounded| bounded.text.clone())
-                                .unwrap_or_else(|| HelperMethods::truncate_tool_result(&result.2, max_tool_output));
+                            let history: Value = select_tool_result_content(
+                                result.5,
+                                history_bounded.as_ref().map(|bounded| bounded.text.clone()),
+                                &result.2,
+                                max_tool_output,
+                            );
                             if let (Some(request), Some((stable_tool_id, activation_basis, tool_call_started)), Some(call_effect)) = (request_correlation_inner.as_ref(), result.4, result.1) {
                                 let correlation =
                                     crate::runtime::trace::ExecutionCorrelation::from_request(
@@ -1310,7 +1327,8 @@ impl StreamMethods {
                     }
 
                     // Collect results
-                    let mut results_map = std::collections::HashMap::new();
+                    let mut results_map: std::collections::HashMap<String, Value> =
+                        std::collections::HashMap::new();
                     while let Some(res) = join_set.join_next().await {
                         match res {
                             Ok(lane_results) => {
@@ -1333,13 +1351,15 @@ impl StreamMethods {
                     // Build tool_results in original order
                     for tool_use in &tool_uses {
                         if let Some(tool_id) = tool_use["id"].as_str() {
-                            let result = results_map
+                            // Strings were already truncated at lane time; arrays
+                            // never pass through `truncate_tool_result`.
+                            let content = results_map
                                 .remove(tool_id)
-                                .unwrap_or_else(|| "Canceled by user".to_string());
+                                .unwrap_or_else(|| Value::String("Canceled by user".to_string()));
                             tool_results.push(json!({
                                 "type": "tool_result",
                                 "tool_use_id": tool_id,
-                                "content": HelperMethods::truncate_tool_result(&result, max_tool_output)
+                                "content": content
                             }));
                         }
                     }
@@ -1418,10 +1438,7 @@ impl StreamMethods {
                 if tool_call_budget_hit {
                     finish_budget_exceeded!(agent_core::BudgetDimension::ToolCalls);
                 }
-                let round_result_bytes: usize = tool_results
-                    .iter()
-                    .map(|r| r["content"].as_str().map(str::len).unwrap_or(0))
-                    .sum();
+                let round_result_bytes: usize = tool_results.iter().map(tool_result_bytes).sum();
                 if let Err(dimension) = budget_meter.charge_tool_result_bytes(round_result_bytes) {
                     finish_budget_exceeded!(dimension);
                 }
@@ -1437,6 +1454,32 @@ impl StreamMethods {
                 return Err(RuntimeError::Tool("Invalid response format".to_string()));
             }
         }
+    }
+}
+
+/// Pick the `tool_result.content` value. Rich blocks win outright (they
+/// carry their own budget and never see `truncate_tool_result`); otherwise
+/// the bounded delta-lane text, otherwise the truncated summary.
+fn select_tool_result_content(
+    rich_blocks: Option<Vec<Value>>,
+    history_text: Option<String>,
+    result: &str,
+    max_tool_output: usize,
+) -> Value {
+    match (rich_blocks, history_text) {
+        (Some(blocks), _) => Value::Array(blocks),
+        (None, Some(text)) => Value::String(text),
+        (None, None) => Value::String(HelperMethods::truncate_tool_result(result, max_tool_output)),
+    }
+}
+
+/// Wire bytes a single `tool_result` charges against the turn byte budget.
+/// Array content (image blocks) is charged on its serialized form — the
+/// base64 *is* re-sent every round.
+fn tool_result_bytes(r: &Value) -> usize {
+    match &r["content"] {
+        Value::String(s) => s.len(),
+        other => serde_json::to_vec(other).map(|v| v.len()).unwrap_or(0),
     }
 }
 
@@ -1700,6 +1743,444 @@ mod tests {
         assert_eq!(
             entry1, prefix2,
             "durable prefix must be byte-identical across turns or the cache entry is dead"
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rich tool output through the REAL stream loop (image-read feature).
+//
+// A tiny axum server plays Anthropic: round 1 answers with scripted
+// `tool_use` blocks, round 2 with `end_turn`. Every request body is recorded
+// so the assertions run against the bytes that would have hit the wire —
+// `tool_result.content` as an ARRAY for rich tools, a STRING for legacy ones.
+// ─────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod rich_output_tests {
+    use super::*;
+    use crate::extensions::hooks::events::{HookKind, HookResult};
+    use crate::extensions::permissions::PermissionSet;
+    use crate::runtime::api::ApiOptions;
+    use crate::runtime::types::AuthState;
+    use crate::tools::{Tool, ToolContext, ToolOutput};
+    use agent_core::{LlmEvent, SessionEvent, StreamEvent};
+    use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::post, Router};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    const PNG_B64_PREFIX: &str = "iVBORw0KGgo";
+
+    fn fake_b64(len: usize) -> String {
+        let mut s = String::with_capacity(len);
+        while s.len() < len {
+            s.push_str(PNG_B64_PREFIX);
+        }
+        s.truncate(len);
+        s
+    }
+
+    /// Rich stub: `[text, image]` blocks + summary, like `read` on a PNG.
+    struct RichTool;
+    #[async_trait::async_trait]
+    impl Tool for RichTool {
+        fn name(&self) -> &str {
+            "rich_stub"
+        }
+        fn description(&self) -> &str {
+            "returns an image"
+        }
+        fn parameters(&self) -> Value {
+            json!({"type":"object","properties":{}})
+        }
+        fn origin(&self) -> crate::tools::ToolOrigin {
+            crate::tools::ToolOrigin::Builtin
+        }
+        fn effect(&self) -> crate::tools::catalog::ToolEffect {
+            crate::tools::catalog::ToolEffect::ReadOnly
+        }
+        async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
+            self.execute_rich(params, ctx)
+                .await
+                .map(ToolOutput::into_summary)
+        }
+        async fn execute_rich(&self, _params: Value, _ctx: ToolContext) -> Result<ToolOutput> {
+            let summary = "Image: /tmp/x.png (1x1, image/png, 1 KB)".to_string();
+            Ok(ToolOutput::Blocks {
+                blocks: vec![
+                    json!({"type":"text","text":summary}),
+                    json!({"type":"image","source":{"type":"base64","media_type":"image/png","data":fake_b64(2_000)}}),
+                ],
+                summary,
+            })
+        }
+    }
+
+    /// Legacy stub: plain `execute` only.
+    struct TextTool;
+    #[async_trait::async_trait]
+    impl Tool for TextTool {
+        fn name(&self) -> &str {
+            "text_stub"
+        }
+        fn description(&self) -> &str {
+            "returns text"
+        }
+        fn parameters(&self) -> Value {
+            json!({"type":"object","properties":{}})
+        }
+        fn origin(&self) -> crate::tools::ToolOrigin {
+            crate::tools::ToolOrigin::Builtin
+        }
+        fn effect(&self) -> crate::tools::catalog::ToolEffect {
+            crate::tools::catalog::ToolEffect::ReadOnly
+        }
+        async fn execute(&self, _params: Value, _ctx: ToolContext) -> Result<String> {
+            Ok("plain text result".to_string())
+        }
+    }
+
+    /// after_tool_call hook that replaces every output.
+    struct ReplaceHook;
+    #[async_trait::async_trait]
+    impl crate::extensions::runtime::ExtensionHandler for ReplaceHook {
+        fn id(&self) -> &str {
+            "replace-hook"
+        }
+        async fn handle(&self, _event: &HookEvent) -> HookResult {
+            HookResult::Replace {
+                output: "REPLACED BY HOOK".to_string(),
+            }
+        }
+        async fn shutdown(&self) {}
+    }
+
+    fn sse_tool_use_round(tool_uses: &[(&str, &str)]) -> String {
+        let mut s = String::new();
+        s.push_str(r#"data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-haiku-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}"#);
+        s.push_str("\n\n");
+        for (i, (id, name)) in tool_uses.iter().enumerate() {
+            s.push_str(&format!(
+                r#"data: {{"type":"content_block_start","index":{i},"content_block":{{"type":"tool_use","id":"{id}","name":"{name}"}}}}"#
+            ));
+            s.push_str("\n\n");
+            s.push_str(&format!(
+                r#"data: {{"type":"content_block_delta","index":{i},"delta":{{"type":"input_json_delta","partial_json":"{{}}"}}}}"#
+            ));
+            s.push_str("\n\n");
+            s.push_str(&format!(
+                r#"data: {{"type":"content_block_stop","index":{i}}}"#
+            ));
+            s.push_str("\n\n");
+        }
+        s.push_str(r#"data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}"#);
+        s.push_str("\n\ndata: {\"type\":\"message_stop\"}\n\n");
+        s
+    }
+
+    const SSE_END_TURN: &str = concat!(
+        "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_02\",\"type\":\"message\",",
+        "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-haiku-4-5\",\"stop_reason\":null,",
+        "\"stop_sequence\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0,",
+        "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n",
+        "data: {\"type\":\"content_block_start\",\"index\":0,",
+        "\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,",
+        "\"delta\":{\"type\":\"text_delta\",\"text\":\"done\"}}\n\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+        "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",",
+        "\"stop_sequence\":null},\"usage\":{\"input_tokens\":10,\"output_tokens\":1,",
+        "\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}\n\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+
+    #[derive(Clone)]
+    struct MockState {
+        calls: Arc<AtomicUsize>,
+        bodies: Arc<Mutex<Vec<Value>>>,
+        first_round: Arc<String>,
+    }
+
+    async fn spawn_mock(first_round: String) -> (String, MockState) {
+        let state = MockState {
+            calls: Arc::new(AtomicUsize::new(0)),
+            bodies: Arc::new(Mutex::new(Vec::new())),
+            first_round: Arc::new(first_round),
+        };
+        let app = Router::new()
+            .route(
+                "/v1/messages",
+                post(|State(st): State<MockState>, body: String| async move {
+                    let n = st.calls.fetch_add(1, Ordering::SeqCst);
+                    if let Ok(v) = serde_json::from_str::<Value>(&body) {
+                        st.bodies.lock().unwrap().push(v);
+                    }
+                    let sse = if n == 0 {
+                        st.first_round.as_str().to_string()
+                    } else {
+                        SSE_END_TURN.to_string()
+                    };
+                    (StatusCode::OK, [("content-type", "text/event-stream")], sse).into_response()
+                }),
+            )
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (format!("http://{addr}"), state)
+    }
+
+    struct Driven {
+        /// Final durable history (from the last `MessageHistory` event).
+        history: Vec<SharedMessage>,
+        /// Every `ToolResult` UI preview string.
+        ui_results: Vec<String>,
+        /// Request bodies the mock saw, in order.
+        bodies: Vec<Value>,
+    }
+
+    async fn drive(
+        tools_to_register: Vec<Arc<dyn Tool>>,
+        tool_uses: &[(&str, &str)],
+        hook_bus: Arc<crate::extensions::hooks::HookBus>,
+    ) -> Driven {
+        let (base_url, mock) = spawn_mock(sse_tool_use_round(tool_uses)).await;
+
+        let mut registry = ToolRegistry::new();
+        for t in tools_to_register {
+            registry.register(t);
+        }
+        let tools = Arc::new(RwLock::new(registry));
+        let (tx, mut rx) = mpsc::unbounded_channel::<StreamEvent>();
+        let session_manager =
+            crate::tools::shell::SessionManager::new(crate::tools::shell::ShellConfig::default());
+        let tool_session_id = crate::tools::activation::SessionId::parse(&format!(
+            "test-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ))
+        .unwrap();
+
+        let session = StreamSession {
+            auth: Arc::new(RwLock::new(AuthState {
+                auth_token: "test-token".into(),
+                auth_type: "api_key".into(),
+                refresh_token: None,
+                token_expires: Some(9_999_999_999_999),
+            })),
+            client: Client::new(),
+            credential_source: crate::auth::CredentialSource::Local,
+            token_cache: crate::auth::TokenCache::new(),
+            options: ApiOptions {
+                anthropic_base_url: Some(base_url),
+                ..Default::default()
+            },
+            api_retries: 0,
+            refusal_retries: 0,
+            model: "claude-haiku-4-5".into(),
+            tools,
+            system_prompt: None,
+            thinking_budget: 0,
+            reasoning_level: agent_core::reasoning::ReasoningLevel::Adaptive,
+            tx,
+            cancel: CancellationToken::new(),
+            steering_rx: None,
+            watcher_exit_path: None,
+            max_tool_output: 30_000,
+            bash_timeout: 30,
+            bash_max_timeout: 300,
+            subagent_timeout: 300,
+            session_manager,
+            subagent_registry: Arc::new(Mutex::new(
+                crate::runtime::subagent::SubagentRegistry::new(),
+            )),
+            event_queue: Arc::new(crate::events::EventQueue::new(100)),
+            hook_bus,
+            secret_prompt: None,
+            auto_approve_confirms: true,
+            telemetry_level: crate::runtime::telemetry::TelemetryLevel::Off,
+            orchestration: None,
+            delegation_parent: None,
+            turn_correlation_id: "turn-test".into(),
+            progressive_tool_disclosure: false,
+            tool_session_id,
+            mcp_runtime: None,
+            mcp_session_scope: None,
+            extension_runtime: None,
+            extension_session_scope: None,
+            turn_budget: crate::runtime::budget::TurnBudget::for_role(
+                crate::runtime::budget::TurnRole::Foreground,
+            ),
+        };
+
+        let messages = vec![Arc::new(json!({"role":"user","content":"go"})) as SharedMessage];
+        let run = tokio::time::timeout(
+            std::time::Duration::from_secs(20),
+            StreamMethods::run_stream_internal(session, messages),
+        )
+        .await
+        .expect("stream loop must finish");
+        run.expect("stream loop ok");
+
+        let mut history = Vec::new();
+        let mut ui_results = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                StreamEvent::Session(SessionEvent::MessageHistory(m)) => history = m,
+                StreamEvent::Llm(LlmEvent::ToolResult { result, .. }) => ui_results.push(result),
+                _ => {}
+            }
+        }
+        // Give the mock a beat to finish recording the last body.
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        let bodies = mock.bodies.lock().unwrap().clone();
+        assert_eq!(mock.calls.load(Ordering::SeqCst), 2, "two provider rounds");
+        Driven {
+            history,
+            ui_results,
+            bodies,
+        }
+    }
+
+    /// The user message carrying tool results, from the round-2 request body.
+    fn tool_result_message(body: &Value) -> &Value {
+        body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .rev()
+            .find(|m| m["role"] == "user" && m["content"][0]["type"] == "tool_result")
+            .expect("tool_result user message on the wire")
+    }
+
+    #[tokio::test]
+    async fn rich_tool_output_lands_as_array_content() {
+        let d = drive(
+            vec![Arc::new(RichTool)],
+            &[("toolu_1", "rich_stub")],
+            Arc::new(crate::extensions::hooks::HookBus::new()),
+        )
+        .await;
+
+        // On the wire (round-2 body).
+        let msg = tool_result_message(&d.bodies[1]);
+        let tr = &msg["content"][0];
+        assert_eq!(tr["tool_use_id"], "toolu_1");
+        let blocks = tr["content"].as_array().expect("array content");
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0]["type"], "text");
+        assert_eq!(
+            blocks[0]["text"],
+            "Image: /tmp/x.png (1x1, image/png, 1 KB)"
+        );
+        assert_eq!(blocks[1]["type"], "image");
+        assert_eq!(blocks[1]["source"]["type"], "base64");
+        assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+        assert!(blocks[1]["source"]["data"]
+            .as_str()
+            .unwrap()
+            .starts_with(PNG_B64_PREFIX));
+
+        // In durable history too.
+        let hist_msg = d
+            .history
+            .iter()
+            .find(|m| m["role"] == "user" && m["content"][0]["type"] == "tool_result")
+            .expect("history tool_result");
+        assert!(hist_msg["content"][0]["content"].is_array());
+    }
+
+    #[tokio::test]
+    async fn rich_output_and_hook_replace() {
+        let bus = Arc::new(crate::extensions::hooks::HookBus::new());
+        let mut perms = PermissionSet::new();
+        perms.grant(crate::extensions::permissions::Permission::ToolsIntercept);
+        perms.grant(crate::extensions::permissions::Permission::ToolsTransformOutput);
+        bus.subscribe(
+            HookKind::AfterToolCall,
+            Arc::new(ReplaceHook),
+            None,
+            None,
+            perms,
+        )
+        .await
+        .unwrap();
+
+        let d = drive(vec![Arc::new(RichTool)], &[("toolu_1", "rich_stub")], bus).await;
+        let tr = &tool_result_message(&d.bodies[1])["content"][0];
+        assert!(
+            tr["content"].is_string(),
+            "Replace wins; rich blocks dropped"
+        );
+        assert_eq!(tr["content"], Value::String("REPLACED BY HOOK".into()));
+    }
+
+    #[tokio::test]
+    async fn parallel_lane_preserves_rich_content() {
+        let d = drive(
+            vec![Arc::new(RichTool), Arc::new(TextTool)],
+            &[("toolu_a", "rich_stub"), ("toolu_b", "text_stub")],
+            Arc::new(crate::extensions::hooks::HookBus::new()),
+        )
+        .await;
+        let msg = tool_result_message(&d.bodies[1]);
+        let results = msg["content"].as_array().unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0]["tool_use_id"], "toolu_a");
+        assert!(results[0]["content"].is_array(), "{}", results[0]);
+        assert_eq!(results[0]["content"][1]["type"], "image");
+        assert_eq!(results[1]["tool_use_id"], "toolu_b");
+        assert_eq!(
+            results[1]["content"],
+            Value::String("plain text result".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn ui_preview_never_contains_base64() {
+        let d = drive(
+            vec![Arc::new(RichTool), Arc::new(TextTool)],
+            &[("toolu_a", "rich_stub"), ("toolu_b", "text_stub")],
+            Arc::new(crate::extensions::hooks::HookBus::new()),
+        )
+        .await;
+        assert_eq!(d.ui_results.len(), 2);
+        let rich = d
+            .ui_results
+            .iter()
+            .find(|r| r.starts_with("Image: "))
+            .expect("rich preview");
+        assert_eq!(rich, "Image: /tmp/x.png (1x1, image/png, 1 KB)");
+        for r in &d.ui_results {
+            assert!(r.len() < 512);
+            assert!(!r.contains(PNG_B64_PREFIX));
+        }
+    }
+
+    #[tokio::test]
+    async fn round_result_bytes_counts_array_content() {
+        assert_eq!(
+            tool_result_bytes(&json!({"type":"tool_result","tool_use_id":"x","content":"ok"})),
+            2
+        );
+        let arr = json!({"type":"tool_result","tool_use_id":"x","content":[
+            {"type":"text","text":"Image: x"},
+            {"type":"image","source":{"type":"base64","media_type":"image/png","data":fake_b64(1_000)}}
+        ]});
+        assert!(tool_result_bytes(&arr) >= 1_000);
+        // Legacy behaviour would have been 0 for arrays.
+        assert_ne!(tool_result_bytes(&arr), 0);
+    }
+
+    #[test]
+    fn select_content_prefers_rich_then_bounded_then_truncated() {
+        let blocks = vec![json!({"type":"text","text":"s"})];
+        assert!(select_tool_result_content(Some(blocks), Some("b".into()), "s", 10).is_array());
+        assert_eq!(
+            select_tool_result_content(None, Some("bounded".into()), "s", 10),
+            Value::String("bounded".into())
+        );
+        assert_eq!(
+            select_tool_result_content(None, None, "short", 10),
+            Value::String("short".into())
         );
     }
 }

--- a/crates/agent-engine/src/runtime/stream.rs
+++ b/crates/agent-engine/src/runtime/stream.rs
@@ -559,6 +559,21 @@ impl StreamMethods {
                 None => &messages,
             };
 
+            // History image byte cap: the per-turn byte budget resets every
+            // turn but base64 images live in history forever. Bound the wire
+            // by degrading the OLDEST image blocks to a text label once the
+            // total crosses `HISTORY_IMAGE_BYTE_CAP`. Request-local like the
+            // injection above — durable history is untouched.
+            let capped_messages: Vec<SharedMessage>;
+            let request_messages: &[SharedMessage] =
+                match cap_history_image_bytes(request_messages, HISTORY_IMAGE_BYTE_CAP) {
+                    Some(capped) => {
+                        capped_messages = capped;
+                        &capped_messages
+                    }
+                    None => request_messages,
+                };
+
             // Flag-off: borrow the turn's options untouched — no per-round
             // clone, exactly the pre-Task-18 request path. Flag-on: build one
             // per-round options value carrying the session projection.
@@ -910,7 +925,7 @@ impl StreamMethods {
                                             // Hook policy: a Replace transform wins over the rich
                                             // blocks — the hook saw only the summary, so keeping
                                             // the image would desync text and image.
-                                            let rich_blocks = if hooked_output == output { rich_blocks } else { None };
+                                            let rich_blocks = drop_rich_if_rewritten(rich_blocks, &hooked_output, &output);
                                             (hooked_output, rich_blocks)
                                         }
                                         _ = cancel.cancelled() => {
@@ -1229,7 +1244,7 @@ impl StreamMethods {
                                                 max_tool_output,
                                             ).await;
                                             // Hook Replace wins over rich blocks (see single-tool site).
-                                            let rich_blocks = if hooked_output == output { rich_blocks } else { None };
+                                            let rich_blocks = drop_rich_if_rewritten(rich_blocks, &hooked_output, &output);
                                             (false, Some(call_effect), hooked_output, Some(output_handle), Some((stable_tool_id, activation_basis, tool_call_started)), rich_blocks)
                                         }
                                         _ = cancel_token.cancelled() => {
@@ -1457,6 +1472,29 @@ impl StreamMethods {
     }
 }
 
+/// Hook policy: a `Replace` transform wins over rich blocks — the hook saw
+/// only the summary, so keeping the image would desync text and image.
+/// Note `emit_after_tool_call` also runs `truncate_tool_result`, so a
+/// summary longer than `max_tool_output` trips this too; log it so the
+/// dropped image isn't a silent mystery.
+fn drop_rich_if_rewritten(
+    rich_blocks: Option<Vec<Value>>,
+    hooked_output: &str,
+    output: &str,
+) -> Option<Vec<Value>> {
+    if hooked_output == output {
+        return rich_blocks;
+    }
+    if rich_blocks.is_some() {
+        tracing::debug!(
+            summary_len = output.len(),
+            hooked_len = hooked_output.len(),
+            "rich tool blocks dropped: after_tool_call rewrote (or truncated) the summary"
+        );
+    }
+    None
+}
+
 /// Pick the `tool_result.content` value. Rich blocks win outright (they
 /// carry their own budget and never see `truncate_tool_result`); otherwise
 /// the bounded delta-lane text, otherwise the truncated summary.
@@ -1471,6 +1509,80 @@ fn select_tool_result_content(
         (None, Some(text)) => Value::String(text),
         (None, None) => Value::String(HelperMethods::truncate_tool_result(result, max_tool_output)),
     }
+}
+
+/// Total base64 image payload bytes allowed across the whole request
+/// history. Anthropic caps a request at 32 MB; leave headroom for text.
+pub(crate) const HISTORY_IMAGE_BYTE_CAP: usize = 20 * 1024 * 1024;
+
+/// Label left in place of an image block dropped by the history byte cap.
+pub(crate) const IMAGE_DROPPED_LABEL: &str =
+    "[image dropped: history byte cap — re-read the file if needed]";
+
+fn is_base64_image(b: &Value) -> bool {
+    b["type"] == "image" && b["source"]["type"] == "base64"
+}
+
+fn base64_image_len(b: &Value) -> usize {
+    b["source"]["data"].as_str().map_or(0, str::len)
+}
+
+/// Enforce `cap` on the sum of base64 image payload bytes across `messages`.
+/// Returns `None` when nothing needs to change (no allocation). Otherwise a
+/// request-local copy where the OLDEST image blocks — top-level `content[]`
+/// or nested in `tool_result.content[]` — are replaced with a text block
+/// carrying `IMAGE_DROPPED_LABEL`, until the remainder fits. Only touched
+/// messages are cloned (`Arc::make_mut`); `tool_result.content[0]` (the
+/// text summary) is never an image, so the text-first invariant holds.
+fn cap_history_image_bytes(
+    messages: &[SharedMessage],
+    cap: usize,
+) -> Option<Vec<SharedMessage>> {
+    // (msg index, outer block index, Option<inner block index>, len), oldest first.
+    let mut images: Vec<(usize, usize, Option<usize>, usize)> = Vec::new();
+    for (mi, msg) in messages.iter().enumerate() {
+        let Some(blocks) = msg["content"].as_array() else {
+            continue;
+        };
+        for (bi, block) in blocks.iter().enumerate() {
+            if is_base64_image(block) {
+                images.push((mi, bi, None, base64_image_len(block)));
+            } else if let Some(inner) = block["content"].as_array() {
+                for (ii, b) in inner.iter().enumerate() {
+                    if is_base64_image(b) {
+                        images.push((mi, bi, Some(ii), base64_image_len(b)));
+                    }
+                }
+            }
+        }
+    }
+    let mut total: usize = images.iter().map(|i| i.3).sum();
+    if total <= cap {
+        return None;
+    }
+    let mut out = messages.to_vec();
+    let mut dropped = 0usize;
+    for (mi, bi, ii, len) in images {
+        if total <= cap {
+            break;
+        }
+        let label = json!({"type": "text", "text": IMAGE_DROPPED_LABEL});
+        let msg = Arc::make_mut(&mut out[mi]);
+        let slot = match ii {
+            Some(ii) => &mut msg["content"][bi]["content"][ii],
+            None => &mut msg["content"][bi],
+        };
+        *slot = label;
+        total -= len;
+        dropped += 1;
+    }
+    tracing::info!(
+        dropped,
+        remaining_bytes = total,
+        cap,
+        "history image byte cap: oldest image blocks degraded to text labels"
+    );
+    Some(out)
 }
 
 /// Wire bytes a single `tool_result` charges against the turn byte budget.
@@ -1942,6 +2054,16 @@ mod rich_output_tests {
         tool_uses: &[(&str, &str)],
         hook_bus: Arc<crate::extensions::hooks::HookBus>,
     ) -> Driven {
+        let initial = vec![Arc::new(json!({"role":"user","content":"go"})) as SharedMessage];
+        drive_with_history(initial, tools_to_register, tool_uses, hook_bus).await
+    }
+
+    async fn drive_with_history(
+        messages: Vec<SharedMessage>,
+        tools_to_register: Vec<Arc<dyn Tool>>,
+        tool_uses: &[(&str, &str)],
+        hook_bus: Arc<crate::extensions::hooks::HookBus>,
+    ) -> Driven {
         let (base_url, mock) = spawn_mock(sse_tool_use_round(tool_uses)).await;
 
         let mut registry = ToolRegistry::new();
@@ -2011,7 +2133,6 @@ mod rich_output_tests {
             ),
         };
 
-        let messages = vec![Arc::new(json!({"role":"user","content":"go"})) as SharedMessage];
         let run = tokio::time::timeout(
             std::time::Duration::from_secs(20),
             StreamMethods::run_stream_internal(session, messages),
@@ -2168,6 +2289,138 @@ mod rich_output_tests {
         assert!(tool_result_bytes(&arr) >= 1_000);
         // Legacy behaviour would have been 0 for arrays.
         assert_ne!(tool_result_bytes(&arr), 0);
+    }
+
+    // ── S1: history image byte cap ─────────────────────────────────────────
+
+    fn image_tool_result_msg(id: &str, b64_len: usize) -> SharedMessage {
+        user_msg(json!([{
+            "type": "tool_result", "tool_use_id": id,
+            "content": [
+                {"type": "text", "text": format!("Image: /tmp/{id}.png")},
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": fake_b64(b64_len)}}
+            ]
+        }]))
+    }
+
+    fn image_history(n: usize, b64_len: usize) -> Vec<SharedMessage> {
+        let mut h = vec![user_msg(json!("look at these"))];
+        for i in 0..n {
+            let id = format!("toolu_{i}");
+            h.push(Arc::new(json!({"role":"assistant","content":[
+                {"type":"tool_use","id":id,"name":"read","input":{"path":format!("/tmp/{id}.png")}}
+            ]})));
+            h.push(image_tool_result_msg(&id, b64_len));
+        }
+        h
+    }
+
+    #[test]
+    fn history_cap_noop_under_cap() {
+        let h = image_history(3, 1_000);
+        assert!(cap_history_image_bytes(&h, 10_000).is_none());
+        assert!(cap_history_image_bytes(&h, 3_000).is_none());
+    }
+
+    #[test]
+    fn history_cap_drops_oldest_first_keeps_text_and_durable_history() {
+        // 5 images × 1000 bytes, cap 2500 → drop the 3 oldest, keep 2 newest.
+        let h = image_history(5, 1_000);
+        let out = cap_history_image_bytes(&h, 2_500).expect("over cap");
+        assert_eq!(out.len(), h.len());
+        let images: Vec<&Value> = out
+            .iter()
+            .filter(|m| m["content"][0]["type"] == "tool_result")
+            .map(|m| &m["content"][0]["content"][1])
+            .collect();
+        assert_eq!(images.len(), 5);
+        for (i, b) in images.iter().enumerate() {
+            if i < 3 {
+                assert_eq!(b["type"], "text", "image {i} should be dropped");
+                assert_eq!(b["text"], IMAGE_DROPPED_LABEL);
+            } else {
+                assert_eq!(b["type"], "image", "image {i} should survive");
+            }
+        }
+        // Text-first summary untouched on every message.
+        for m in &out {
+            if m["content"][0]["type"] == "tool_result" {
+                assert_eq!(m["content"][0]["content"][0]["type"], "text");
+                assert!(m["content"][0]["content"][0]["text"]
+                    .as_str()
+                    .unwrap()
+                    .starts_with("Image: "));
+            }
+        }
+        // Durable history untouched; untouched messages share the Arc.
+        for m in &h {
+            if m["content"][0]["type"] == "tool_result" {
+                assert_eq!(m["content"][0]["content"][1]["type"], "image");
+            }
+        }
+        assert!(Arc::ptr_eq(&h[0], &out[0]));
+        assert!(Arc::ptr_eq(&h[h.len() - 1], &out[out.len() - 1]));
+        assert!(!Arc::ptr_eq(&h[2], &out[2]));
+    }
+
+    #[test]
+    fn history_cap_handles_top_level_user_images() {
+        let h = vec![
+            user_msg(json!([{"type":"text","text":"a"}, {"type":"image","source":{"type":"base64","media_type":"image/png","data":fake_b64(600)}}])),
+            assistant_msg("ok"),
+            user_msg(json!([{"type":"image","source":{"type":"base64","media_type":"image/png","data":fake_b64(600)}}])),
+        ];
+        let out = cap_history_image_bytes(&h, 1_000).unwrap();
+        assert_eq!(out[0]["content"][1]["text"], IMAGE_DROPPED_LABEL);
+        assert_eq!(out[2]["content"][0]["type"], "image");
+    }
+
+    /// Wire-level: history carrying N images over the cap → the request body
+    /// that hits the provider holds only the newest images under the cap.
+    #[tokio::test]
+    async fn history_cap_applied_to_request_body() {
+        // 7 × 3.5 MiB = 24.5 MiB > 20 MiB → 2 oldest dropped, 5 newest kept.
+        let per = 3_670_016usize;
+        let d = drive_with_history(
+            image_history(7, per),
+            vec![Arc::new(TextTool)],
+            &[("toolu_z", "text_stub")],
+            Arc::new(crate::extensions::hooks::HookBus::new()),
+        )
+        .await;
+        for body in &d.bodies {
+            let msgs = body["messages"].as_array().unwrap();
+            let mut kept = 0usize;
+            let mut dropped = 0usize;
+            let mut bytes = 0usize;
+            for m in msgs {
+                let Some(blocks) = m["content"].as_array() else { continue };
+                for b in blocks {
+                    if let Some(inner) = b["content"].as_array() {
+                        for x in inner {
+                            if is_base64_image(x) {
+                                kept += 1;
+                                bytes += base64_image_len(x);
+                            } else if x["text"] == IMAGE_DROPPED_LABEL {
+                                dropped += 1;
+                            }
+                        }
+                    }
+                }
+            }
+            assert_eq!((dropped, kept), (2, 5), "{}", body["messages"].as_array().unwrap().len());
+            assert!(bytes <= HISTORY_IMAGE_BYTE_CAP, "{bytes}");
+            // Oldest two are the dropped ones.
+            let first = msgs.iter().find(|m| m["content"][0]["type"] == "tool_result").unwrap();
+            assert_eq!(first["content"][0]["content"][1]["text"], IMAGE_DROPPED_LABEL);
+        }
+        // Durable history (what gets saved) still carries every image.
+        let images_in_history = d
+            .history
+            .iter()
+            .filter(|m| m["content"][0]["content"][1]["type"] == "image")
+            .count();
+        assert_eq!(images_in_history, 7);
     }
 
     #[test]

--- a/crates/agent-engine/src/runtime/trace/openai_wiring_tests.rs
+++ b/crates/agent-engine/src/runtime/trace/openai_wiring_tests.rs
@@ -542,6 +542,7 @@ async fn drive_responses(
         None,
         agent_core::reasoning::ReasoningLevel::Adaptive,
         cancel,
+        0,
         trace,
         true,
     )

--- a/crates/agent-engine/src/tools/activation.rs
+++ b/crates/agent-engine/src/tools/activation.rs
@@ -41,10 +41,15 @@ pub enum RuntimeLease {
 
 /// One exact activation held by a session: the validated grant plus lease
 /// placeholder metadata. The grant carries the pinned catalog generation and
-/// schema digest.
+/// schema digest; the trust provenance of the catalog record is pinned
+/// engine-side at activation time (the grant type in agent-core is
+/// deliberately untouched) so execution can detect a record that was
+/// removed and re-added under a different — even internally coherent —
+/// source/provenance.
 #[derive(Clone, Debug)]
 pub struct ActivatedTool {
     grant: SessionActivationGrant,
+    provenance: TrustProvenance,
     lease: RuntimeLease,
 }
 
@@ -55,6 +60,11 @@ impl ActivatedTool {
 
     pub fn schema_digest(&self) -> &SchemaDigest {
         self.grant.schema_digest()
+    }
+
+    /// The trust provenance of the catalog record at activation time.
+    pub fn provenance(&self) -> &TrustProvenance {
+        &self.provenance
     }
 
     pub fn catalog_generation(&self) -> CatalogGeneration {
@@ -116,15 +126,38 @@ pub enum ActivationError {
     },
 }
 
+/// Per-tool pins captured when a core tool enters a session's set: the
+/// schema digest AND the trust provenance of the catalog record at build
+/// time. Pinning provenance (not just the digest) closes the coherent-
+/// imposter hole: a tool removed and re-added under the SAME `ToolId` with a
+/// schema-identical body but a different, internally consistent
+/// source/provenance must still be denied at execution time.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CorePin {
+    schema_digest: SchemaDigest,
+    provenance: TrustProvenance,
+}
+
+impl CorePin {
+    pub fn schema_digest(&self) -> &SchemaDigest {
+        &self.schema_digest
+    }
+
+    pub fn provenance(&self) -> &TrustProvenance {
+        &self.provenance
+    }
+}
+
 /// The small configured core set plus exact activated deferred tools for one
 /// session, pinned to the catalog generation it was built against. Core
-/// tools are pinned with the schema digest of their catalog record at build
-/// time, so later drift is detectable per tool, not just per generation.
+/// tools are pinned with the schema digest AND trust provenance of their
+/// catalog record at build time, so later drift is detectable per tool, not
+/// just per generation.
 #[derive(Clone, Debug)]
 pub struct SessionToolSet {
     session: SessionId,
     catalog_generation: CatalogGeneration,
-    core: BTreeMap<ToolId, SchemaDigest>,
+    core: BTreeMap<ToolId, CorePin>,
     activated: BTreeMap<ToolId, ActivatedTool>,
     /// Session schema-generation counter (spec §7.7): advances by exactly
     /// one for every successful nonempty activation batch (a single
@@ -136,8 +169,9 @@ pub struct SessionToolSet {
 impl SessionToolSet {
     /// Build a fresh set for one session. Every configured core id must
     /// exist in the catalog (typed failure otherwise) and its schema digest
-    /// is pinned from the catalog record; the set starts with zero
-    /// activations — nothing is inherited from any other session.
+    /// AND trust provenance are pinned from the catalog record; the set
+    /// starts with zero activations — nothing is inherited from any other
+    /// session.
     pub fn new(
         session: SessionId,
         core: impl IntoIterator<Item = ToolId>,
@@ -148,7 +182,13 @@ impl SessionToolSet {
             let Some(record) = catalog.get(&id) else {
                 return Err(SessionToolSetError::UnknownCoreTool(id));
             };
-            validated.insert(id, record.schema_digest().clone());
+            validated.insert(
+                id,
+                CorePin {
+                    schema_digest: record.schema_digest().clone(),
+                    provenance: record.provenance().clone(),
+                },
+            );
         }
         Ok(Self {
             session,
@@ -248,6 +288,12 @@ impl SessionToolSet {
     /// The schema digest pinned for a configured core tool at build time,
     /// or `None` when the id is not in this session's core set.
     pub fn core_schema_digest(&self, id: &ToolId) -> Option<&SchemaDigest> {
+        self.core.get(id).map(CorePin::schema_digest)
+    }
+
+    /// The full (digest, provenance) pin for a configured core tool, or
+    /// `None` when the id is not in this session's core set.
+    pub fn core_pin(&self, id: &ToolId) -> Option<&CorePin> {
         self.core.get(id)
     }
 
@@ -335,10 +381,16 @@ impl SessionToolSet {
         catalog: &ToolCatalog,
     ) -> Result<(), ActivationError> {
         self.validate_grant(&grant, catalog)?;
+        let provenance = catalog
+            .get(grant.tool_id())
+            .expect("validate_grant verified the record exists")
+            .provenance()
+            .clone();
         self.activated.insert(
             grant.tool_id().clone(),
             ActivatedTool {
                 grant,
+                provenance,
                 lease: RuntimeLease::NotAcquired,
             },
         );
@@ -392,10 +444,16 @@ impl SessionToolSet {
         ordered.sort_by(|a, b| a.tool_id().cmp(b.tool_id()));
         let applied = ordered.len();
         for grant in ordered {
+            let provenance = catalog
+                .get(grant.tool_id())
+                .expect("validate_grant verified the record exists")
+                .provenance()
+                .clone();
             self.activated.insert(
                 grant.tool_id().clone(),
                 ActivatedTool {
                     grant,
+                    provenance,
                     lease: RuntimeLease::NotAcquired,
                 },
             );
@@ -532,21 +590,6 @@ pub enum ToolAuthorizationError {
     /// exact activation grant (the forged deferred-call case).
     #[error("Tool call denied: tool is not activated for this session: {0}")]
     NotActivated(ToolId),
-    /// The session tool set snapshot predates the current catalog
-    /// generation. NOTE: since the per-tool digest-validation fix,
-    /// generation drift alone is NO LONGER a denial reason at execution
-    /// time — [`ExecutionGate::authorize`] and [`route_session_set`] no
-    /// longer construct this variant. It is retained for API stability and
-    /// for any future caller that genuinely requires generation equality.
-    #[error(
-        "Tool call denied: session tool set generation {} is stale against catalog generation {}",
-        set.value(),
-        catalog.value()
-    )]
-    StaleSessionSet {
-        set: CatalogGeneration,
-        catalog: CatalogGeneration,
-    },
     /// The capability's current schema digest differs from the digest the
     /// session pinned at core-build/activation time — a changed tool is
     /// never silently blessed.
@@ -557,9 +600,13 @@ pub enum ToolAuthorizationError {
     /// policy exists.
     #[error("Tool call denied: source provenance is unverified: {0}")]
     UntrustedSource(ToolId),
-    /// The catalog record's source and trust provenance disagree — an
-    /// internally inconsistent record must never authorize.
-    #[error("Tool call denied: catalog source and trust provenance disagree: {0}")]
+    /// Source/trust provenance failure: either the catalog record's source
+    /// and trust provenance disagree (an internally inconsistent record must
+    /// never authorize), or the record's CURRENT provenance differs from the
+    /// provenance the session pinned at core-build/activation time (a tool
+    /// removed and re-added under a different — even internally coherent —
+    /// provenance must never authorize).
+    #[error("Tool call denied: source/trust provenance is inconsistent or drifted from the session's pin: {0}")]
     SourceProvenanceMismatch(ToolId),
 }
 
@@ -575,6 +622,10 @@ pub enum ToolAuthorizationError {
 ///    [`grant_covers_execution`]: catalog generation drift alone does NOT
 ///    deny at execution time; only a real change to the called tool's
 ///    record (digest, presence, provenance) does;
+/// 4. the record's CURRENT trust provenance must equal the provenance the
+///    session PINNED at core-build/activation time — this closes the
+///    coherent-imposter hole (same `ToolId`, schema-identical body,
+///    different but internally consistent source/provenance);
 /// 5. source trust is re-evaluated conservatively — see the honesty note
 ///    on [`check_source_trust`]: this re-checks typed source/provenance
 ///    consistency and denies Unknown/Unverified, but does NOT yet consult
@@ -609,15 +660,23 @@ impl ExecutionGate {
     /// typed [`AuthorizedToolCall`]. Failure acquires nothing and leaves the
     /// session set untouched (the gate never mutates it).
     ///
-    /// SECURITY INVARIANT (per-tool digest validation): no tool executes
-    /// unless its CURRENT catalog record — presence of the exact `ToolId`,
-    /// schema digest, and source/trust provenance — exactly matches what
-    /// the session pinned at core-build/activation time. Catalog
-    /// generation inequality ALONE is no longer a denial reason at
+    /// SECURITY INVARIANT (per-tool digest + provenance validation): no
+    /// tool executes unless its CURRENT catalog record — presence of the
+    /// exact `ToolId`, schema digest, and source/trust provenance — exactly
+    /// matches what the session pinned at core-build/activation time.
+    /// Catalog generation inequality ALONE is no longer a denial reason at
     /// execution time: an unrelated background mutation (e.g. a plugin
-    /// load mid-round) must not kill in-flight calls to byte-identical
+    /// load mid-round) must not kill in-flight calls to schema-identical
     /// tools. Any REAL drift of the called tool's record — changed digest,
-    /// removal, changed provenance — still denies typed and closed.
+    /// removal, changed provenance (even to an internally coherent one) —
+    /// still denies typed and closed.
+    ///
+    /// ACCEPTED RESIDUAL RISK: [`SchemaDigest`] hashes the schema JSON
+    /// only, not the implementation factory. A record replaced in place
+    /// with an identical schema AND identical pinned provenance but a
+    /// different implementation passes this gate; the exposure is bounded
+    /// by the deterministic round-top rebuild (runtime/stream.rs), which
+    /// re-pins the set against the current catalog between provider rounds.
     pub fn authorize(
         catalog: &ToolCatalog,
         session: &SessionToolSet,
@@ -636,10 +695,13 @@ impl ExecutionGate {
         let generation_drift = session.is_stale(catalog);
 
         // Core status or exact activation grant, with pinned-digest
-        // verification either way — unconditional, drift or not.
+        // verification either way — unconditional, drift or not. The pinned
+        // trust provenance is carried out of each branch for the
+        // unconditional pinned-provenance check below.
         let activation_basis;
-        if let Some(pinned) = session.core_schema_digest(&tool_id) {
-            if pinned != record.schema_digest() {
+        let pinned_provenance: &TrustProvenance;
+        if let Some(pin) = session.core_pin(&tool_id) {
+            if pin.schema_digest() != record.schema_digest() {
                 if generation_drift {
                     tracing::warn!(
                         tool = %tool_id,
@@ -651,6 +713,7 @@ impl ExecutionGate {
                 }
                 return Err(ToolAuthorizationError::SchemaDigestMismatch(tool_id));
             }
+            pinned_provenance = pin.provenance();
             activation_basis = ActivationBasis::Core;
         } else if let Some(activated) = session.activation(&tool_id) {
             if activated.schema_digest() != record.schema_digest() {
@@ -677,6 +740,7 @@ impl ExecutionGate {
             ) {
                 return Err(ToolAuthorizationError::NotActivated(tool_id));
             }
+            pinned_provenance = activated.provenance();
             activation_basis = ActivationBasis::Exact {
                 catalog_generation: activated.catalog_generation(),
             };
@@ -684,12 +748,32 @@ impl ExecutionGate {
             return Err(ToolAuthorizationError::NotActivated(tool_id));
         }
 
+        // Unconditional pinned-provenance equality (BLOCKER fix): the
+        // record's CURRENT trust provenance must equal the provenance the
+        // session pinned at core-build/activation time. This — not the
+        // self-consistency check below — is what catches the coherent
+        // imposter: a tool removed and re-added under the same `ToolId`
+        // with a schema-identical body but a different, internally
+        // consistent source/provenance pair.
+        if pinned_provenance != record.provenance() {
+            if generation_drift {
+                tracing::warn!(
+                    tool = %tool_id,
+                    set_generation = session.catalog_generation().value(),
+                    catalog_generation = catalog.generation().value(),
+                    "tool denied under catalog generation drift: current record provenance \
+                     no longer matches the provenance the session pinned"
+                );
+            }
+            return Err(ToolAuthorizationError::SourceProvenanceMismatch(tool_id));
+        }
+
         // Conservative source trust re-check immediately before
-        // acquisition: typed source/provenance consistency only (see
-        // check_source_trust) — live manifest permission/revocation state
-        // is not consulted here yet (Task 20). Unconditional: a tool
-        // removed and re-added under different provenance is caught here
-        // even when its schema digest is unchanged.
+        // acquisition: typed source/provenance SELF-consistency plus the
+        // deny-by-default for Unknown/Unverified (see check_source_trust) —
+        // live manifest permission/revocation state is not consulted here
+        // yet (Task 20). This complements (does not replace) the
+        // pinned-provenance equality above.
         check_source_trust(record)?;
 
         if generation_drift {
@@ -738,7 +822,7 @@ impl ExecutionGate {
 /// execution time the tool's identity and schema are already re-validated
 /// against the CURRENT catalog record, so requiring the pinned generation to
 /// equal the live one only makes unrelated catalog mutations (background
-/// plugin loads) kill in-flight calls to byte-identical tools. `covers()`
+/// plugin loads) kill in-flight calls to schema-identical tools. `covers()`
 /// itself (agent-core) stays exact-tuple and is still what grant ISSUANCE
 /// and activation validation (`validate_grant`) enforce — this relaxation
 /// applies ONLY to re-validation of an already-established authorization.
@@ -951,12 +1035,13 @@ pub fn activate_model_initiated(
 /// re-validates each called tool's current record (presence, digest,
 /// provenance) against the session's pins. Denying the whole retained set
 /// wholesale would let an unrelated background catalog mutation kill an
-/// entire in-flight round of byte-identical tools.
+/// entire in-flight round of schema-identical tools. Infallible: neither
+/// path can be denied anymore, so the return type is the plain set.
 pub fn route_session_set(
     retained: Option<&SharedSessionToolSet>,
     catalog: &ToolCatalog,
     fallback_session: impl FnOnce() -> SessionId,
-) -> Result<SessionToolSet, ToolAuthorizationError> {
+) -> SessionToolSet {
     match retained {
         Some(shared) => {
             let guard = shared
@@ -970,11 +1055,8 @@ pub fn route_session_set(
                      per-call ExecutionGate::authorize still protects execution"
                 );
             }
-            Ok(guard.clone())
+            guard.clone()
         }
-        None => Ok(SessionToolSet::default_core_for_catalog(
-            fallback_session(),
-            catalog,
-        )),
+        None => SessionToolSet::default_core_for_catalog(fallback_session(), catalog),
     }
 }

--- a/crates/agent-engine/src/tools/activation.rs
+++ b/crates/agent-engine/src/tools/activation.rs
@@ -533,8 +533,11 @@ pub enum ToolAuthorizationError {
     #[error("Tool call denied: tool is not activated for this session: {0}")]
     NotActivated(ToolId),
     /// The session tool set snapshot predates the current catalog
-    /// generation; it must be rebuilt deterministically, never silently
-    /// reused.
+    /// generation. NOTE: since the per-tool digest-validation fix,
+    /// generation drift alone is NO LONGER a denial reason at execution
+    /// time — [`ExecutionGate::authorize`] and [`route_session_set`] no
+    /// longer construct this variant. It is retained for API stability and
+    /// for any future caller that genuinely requires generation equality.
     #[error(
         "Tool call denied: session tool set generation {} is stale against catalog generation {}",
         set.value(),
@@ -567,9 +570,11 @@ pub enum ToolAuthorizationError {
 /// 1. resolve wire name → exact live `ToolId` (deterministic reverse
 ///    mapping; aliases cannot pick a different identity);
 /// 2. the identity must be cataloged;
-/// 3. the session tool set snapshot must match the catalog generation;
-/// 4. the identity must be core (pinned digest intact) or hold an exact
-///    session activation grant (session, tool, generation, digest);
+/// 3. the identity must be core (pinned digest intact) or hold an exact
+///    session activation grant covering (session, tool, digest) — see
+///    [`grant_covers_execution`]: catalog generation drift alone does NOT
+///    deny at execution time; only a real change to the called tool's
+///    record (digest, presence, provenance) does;
 /// 5. source trust is re-evaluated conservatively — see the honesty note
 ///    on [`check_source_trust`]: this re-checks typed source/provenance
 ///    consistency and denies Unknown/Unverified, but does NOT yet consult
@@ -603,6 +608,16 @@ impl ExecutionGate {
     /// acquired from the catalog record's factory and returned inside the
     /// typed [`AuthorizedToolCall`]. Failure acquires nothing and leaves the
     /// session set untouched (the gate never mutates it).
+    ///
+    /// SECURITY INVARIANT (per-tool digest validation): no tool executes
+    /// unless its CURRENT catalog record — presence of the exact `ToolId`,
+    /// schema digest, and source/trust provenance — exactly matches what
+    /// the session pinned at core-build/activation time. Catalog
+    /// generation inequality ALONE is no longer a denial reason at
+    /// execution time: an unrelated background mutation (e.g. a plugin
+    /// load mid-round) must not kill in-flight calls to byte-identical
+    /// tools. Any REAL drift of the called tool's record — changed digest,
+    /// removal, changed provenance — still denies typed and closed.
     pub fn authorize(
         catalog: &ToolCatalog,
         session: &SessionToolSet,
@@ -613,33 +628,51 @@ impl ExecutionGate {
             .get(&tool_id)
             .ok_or_else(|| ToolAuthorizationError::NotCataloged(tool_id.clone()))?;
 
-        // Snapshot-generation check first: a stale session set must be
-        // rebuilt deterministically, never consulted for grants.
-        if session.is_stale(catalog) {
-            return Err(ToolAuthorizationError::StaleSessionSet {
-                set: session.catalog_generation(),
-                catalog: catalog.generation(),
-            });
-        }
+        // Generation drift is observed (for logging) but NOT a wholesale
+        // denial: the per-tool checks below are unconditional and judge the
+        // called tool's CURRENT record against the session's pins. The
+        // round-top rebuild (runtime/stream.rs) still uses `is_stale` to
+        // refresh the set deterministically between rounds.
+        let generation_drift = session.is_stale(catalog);
 
         // Core status or exact activation grant, with pinned-digest
-        // verification either way.
+        // verification either way — unconditional, drift or not.
         let activation_basis;
         if let Some(pinned) = session.core_schema_digest(&tool_id) {
             if pinned != record.schema_digest() {
+                if generation_drift {
+                    tracing::warn!(
+                        tool = %tool_id,
+                        set_generation = session.catalog_generation().value(),
+                        catalog_generation = catalog.generation().value(),
+                        "tool denied under catalog generation drift: pinned core schema digest \
+                         no longer matches the current catalog record"
+                    );
+                }
                 return Err(ToolAuthorizationError::SchemaDigestMismatch(tool_id));
             }
             activation_basis = ActivationBasis::Core;
         } else if let Some(activated) = session.activation(&tool_id) {
             if activated.schema_digest() != record.schema_digest() {
+                if generation_drift {
+                    tracing::warn!(
+                        tool = %tool_id,
+                        set_generation = session.catalog_generation().value(),
+                        catalog_generation = catalog.generation().value(),
+                        "tool denied under catalog generation drift: activation grant schema \
+                         digest no longer matches the current catalog record"
+                    );
+                }
                 return Err(ToolAuthorizationError::SchemaDigestMismatch(tool_id));
             }
-            // Exact-tuple grant re-check (session, tool, generation,
-            // digest); any drift invalidates the grant.
-            if !activated.grant().covers(
+            // Execution-time grant re-check on the (session, tool, digest)
+            // tuple — deliberately WITHOUT the generation term (see
+            // `grant_covers_execution`). Grant ISSUANCE and activation stay
+            // generation-strict (`validate_grant`, `covers()`).
+            if !grant_covers_execution(
+                activated.grant(),
                 session.session().as_str(),
                 &tool_id,
-                catalog.generation(),
                 record.schema_digest(),
             ) {
                 return Err(ToolAuthorizationError::NotActivated(tool_id));
@@ -654,8 +687,20 @@ impl ExecutionGate {
         // Conservative source trust re-check immediately before
         // acquisition: typed source/provenance consistency only (see
         // check_source_trust) — live manifest permission/revocation state
-        // is not consulted here yet (Task 20).
+        // is not consulted here yet (Task 20). Unconditional: a tool
+        // removed and re-added under different provenance is caught here
+        // even when its schema digest is unchanged.
         check_source_trust(record)?;
+
+        if generation_drift {
+            tracing::warn!(
+                tool = %tool_id,
+                set_generation = session.catalog_generation().value(),
+                catalog_generation = catalog.generation().value(),
+                "tool call survived catalog generation drift: current record digest, presence \
+                 and provenance exactly match the session's pins"
+            );
+        }
 
         // Effect classes (Task 24) are execution-SCHEDULING policy, not
         // authorization policy: every class may execute once authorized —
@@ -686,6 +731,26 @@ impl ExecutionGate {
         let resolved = Self::resolve(registry, wire_name)?;
         Self::authorize(registry.catalog(), session, resolved)
     }
+}
+
+/// Execution-time grant coverage: (session, tool, digest) equality WITHOUT
+/// the generation term of [`SessionActivationGrant::covers`]. Rationale: at
+/// execution time the tool's identity and schema are already re-validated
+/// against the CURRENT catalog record, so requiring the pinned generation to
+/// equal the live one only makes unrelated catalog mutations (background
+/// plugin loads) kill in-flight calls to byte-identical tools. `covers()`
+/// itself (agent-core) stays exact-tuple and is still what grant ISSUANCE
+/// and activation validation (`validate_grant`) enforce — this relaxation
+/// applies ONLY to re-validation of an already-established authorization.
+fn grant_covers_execution(
+    grant: &SessionActivationGrant,
+    session_id: &str,
+    tool_id: &ToolId,
+    schema_digest: &SchemaDigest,
+) -> bool {
+    grant.session_id() == session_id
+        && grant.tool_id() == tool_id
+        && grant.schema_digest() == schema_digest
 }
 
 /// Conservative per-source trust policy — CONSISTENCY check, not a live
@@ -873,11 +938,20 @@ pub fn activate_model_initiated(
 /// Resolve the session tool set for the extension-provider route (Task 17,
 /// closing the Task 16 policy divergence): when the runtime threads its
 /// RETAINED per-stream set, the route consumes THAT set's current state —
-/// including exact activations — at its pinned generation. A stale retained
-/// set is DENIED typed (`StaleSessionSet`); the route must never silently
-/// mint a fresh default-core set for the same round. Only callers with no
-/// retained handle at all (internal/sync helpers) fall back to a fresh
-/// default-core set with zero activations under a locally minted session.
+/// including exact activations — at its pinned generation. The route must
+/// never silently mint a fresh default-core set for the same round. Only
+/// callers with no retained handle at all (internal/sync helpers) fall back
+/// to a fresh default-core set with zero activations under a locally minted
+/// session.
+///
+/// Generation drift is deliberately SURVIVED here (per-tool digest
+/// validation fix): the retained set is served as-is even when the catalog
+/// generation moved past its snapshot, because every actual execution still
+/// passes through [`ExecutionGate::authorize`], which unconditionally
+/// re-validates each called tool's current record (presence, digest,
+/// provenance) against the session's pins. Denying the whole retained set
+/// wholesale would let an unrelated background catalog mutation kill an
+/// entire in-flight round of byte-identical tools.
 pub fn route_session_set(
     retained: Option<&SharedSessionToolSet>,
     catalog: &ToolCatalog,
@@ -889,10 +963,12 @@ pub fn route_session_set(
                 .read()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             if guard.is_stale(catalog) {
-                return Err(ToolAuthorizationError::StaleSessionSet {
-                    set: guard.catalog_generation(),
-                    catalog: catalog.generation(),
-                });
+                tracing::warn!(
+                    set_generation = guard.catalog_generation().value(),
+                    catalog_generation = catalog.generation().value(),
+                    "serving retained session tool set across catalog generation drift; \
+                     per-call ExecutionGate::authorize still protects execution"
+                );
             }
             Ok(guard.clone())
         }

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -53,7 +53,7 @@ pub use ls::LsTool;
 pub use memory_context::MemoryContextTool;
 pub use powershell::PowerShellTool;
 pub use read::ReadTool;
-pub use registry::ToolRegistry;
+pub use registry::{DroppedSessionMember, SessionSchemaProjection, ToolRegistry};
 pub use respond::RespondTool;
 pub use secret_prompt::SecretPromptQueue;
 pub use secret_prompt::{SecretPromptHandle, SecretPromptRequest};

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -204,10 +204,18 @@ impl ToolOutput {
     }
 
     /// `(summary, Some(blocks))` for rich output, `(text, None)` for plain.
+    /// Debug builds assert the `blocks[0]` text-first invariant here — this
+    /// is the one choke point every rich result passes through.
     pub fn into_parts(self) -> (String, Option<Vec<Value>>) {
         match self {
             Self::Text(s) => (s, None),
-            Self::Blocks { blocks, summary } => (summary, Some(blocks)),
+            Self::Blocks { blocks, summary } => {
+                debug_assert!(
+                    blocks.first().is_some_and(|b| b["type"] == "text" && b["text"] == summary),
+                    "ToolOutput::Blocks invariant: blocks[0] must be a text block equal to summary"
+                );
+                (summary, Some(blocks))
+            }
         }
     }
 
@@ -235,6 +243,10 @@ pub trait Tool: Send + Sync {
     /// keep returning `String` via `execute` and never see this. Tools that
     /// need to place non-text content blocks (images) into the model history
     /// override this and make `execute` delegate to it.
+    ///
+    /// RECURSION TRAP: the default delegates to `execute`. If you make
+    /// `execute` delegate here (as `ReadTool` does) you MUST override this
+    /// method too, or the pair recurses until the stack blows.
     async fn execute_rich(&self, params: Value, ctx: ToolContext) -> Result<ToolOutput> {
         self.execute(params, ctx).await.map(ToolOutput::Text)
     }

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -204,15 +204,25 @@ impl ToolOutput {
     }
 
     /// `(summary, Some(blocks))` for rich output, `(text, None)` for plain.
-    /// Debug builds assert the `blocks[0]` text-first invariant here — this
-    /// is the one choke point every rich result passes through.
+    /// This is the one choke point every rich result passes through, so the
+    /// `blocks[0]` text-first invariant is ENFORCED here in every build: a
+    /// `Blocks` value whose first block is not `{"type":"text"}` gets a text
+    /// block built from `summary` prepended. Debug builds additionally
+    /// assert that an existing leading text block matches `summary`.
     pub fn into_parts(self) -> (String, Option<Vec<Value>>) {
         match self {
             Self::Text(s) => (s, None),
-            Self::Blocks { blocks, summary } => {
+            Self::Blocks {
+                mut blocks,
+                summary,
+            } => {
+                let text_first = blocks.first().is_some_and(|b| b["type"] == "text");
+                if !text_first {
+                    blocks.insert(0, serde_json::json!({"type": "text", "text": summary}));
+                }
                 debug_assert!(
-                    blocks.first().is_some_and(|b| b["type"] == "text" && b["text"] == summary),
-                    "ToolOutput::Blocks invariant: blocks[0] must be a text block equal to summary"
+                    blocks[0]["text"] == summary,
+                    "ToolOutput::Blocks invariant: blocks[0] text must equal summary"
                 );
                 (summary, Some(blocks))
             }
@@ -286,3 +296,45 @@ pub trait Tool: Send + Sync {
 
 #[cfg(test)]
 mod test_helpers;
+
+#[cfg(test)]
+mod tool_output_tests {
+    use super::ToolOutput;
+    use serde_json::json;
+
+    #[test]
+    fn into_parts_prepends_summary_text_when_blocks_not_text_first() {
+        let img = json!({"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AA=="}});
+        let out = ToolOutput::Blocks {
+            blocks: vec![img.clone()],
+            summary: "[image 1x1]".into(),
+        };
+        let (summary, blocks) = out.into_parts();
+        let blocks = blocks.unwrap();
+        assert_eq!(summary, "[image 1x1]");
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0], json!({"type": "text", "text": "[image 1x1]"}));
+        assert_eq!(blocks[1], img);
+    }
+
+    #[test]
+    fn into_parts_prepends_summary_text_when_blocks_empty() {
+        let out = ToolOutput::Blocks {
+            blocks: vec![],
+            summary: "s".into(),
+        };
+        let (_, blocks) = out.into_parts();
+        assert_eq!(blocks.unwrap(), vec![json!({"type": "text", "text": "s"})]);
+    }
+
+    #[test]
+    fn into_parts_leaves_well_formed_blocks_alone() {
+        let blocks = vec![json!({"type": "text", "text": "ok"}), json!({"type": "image"})];
+        let out = ToolOutput::Blocks {
+            blocks: blocks.clone(),
+            summary: "ok".into(),
+        };
+        let (_, got) = out.into_parts();
+        assert_eq!(got.unwrap(), blocks);
+    }
+}

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -329,7 +329,10 @@ mod tool_output_tests {
 
     #[test]
     fn into_parts_leaves_well_formed_blocks_alone() {
-        let blocks = vec![json!({"type": "text", "text": "ok"}), json!({"type": "image"})];
+        let blocks = vec![
+            json!({"type": "text", "text": "ok"}),
+            json!({"type": "image"}),
+        ];
         let out = ToolOutput::Blocks {
             blocks: blocks.clone(),
             summary: "ok".into(),

--- a/crates/agent-engine/src/tools/mod.rs
+++ b/crates/agent-engine/src/tools/mod.rs
@@ -181,6 +181,41 @@ pub enum ConcurrencyKey {
     Serialize,
 }
 
+/// Structured tool output. `Text` is the legacy contract (what `execute`
+/// returns). `Blocks` carries Anthropic-shaped content blocks destined for
+/// `tool_result.content`, plus a plain-text `summary` used everywhere a
+/// `String` is expected today: UI preview, `after_tool_call` hooks, trace
+/// ledger byte counts, headless logs, and providers that cannot carry the
+/// blocks. INVARIANT: `blocks[0]` MUST be a `{"type":"text"}` block whose
+/// `text` == `summary` (compaction reads `blocks[0].text`; non-Anthropic
+/// translators join only text sub-blocks).
+#[derive(Debug, Clone)]
+pub enum ToolOutput {
+    Text(String),
+    Blocks { blocks: Vec<Value>, summary: String },
+}
+
+impl ToolOutput {
+    pub fn summary(&self) -> &str {
+        match self {
+            Self::Text(s) => s,
+            Self::Blocks { summary, .. } => summary,
+        }
+    }
+
+    /// `(summary, Some(blocks))` for rich output, `(text, None)` for plain.
+    pub fn into_parts(self) -> (String, Option<Vec<Value>>) {
+        match self {
+            Self::Text(s) => (s, None),
+            Self::Blocks { blocks, summary } => (summary, Some(blocks)),
+        }
+    }
+
+    pub fn into_summary(self) -> String {
+        self.into_parts().0
+    }
+}
+
 /// The core trait for all tools. Implement this to add a new tool.
 #[async_trait::async_trait]
 pub trait Tool: Send + Sync {
@@ -195,6 +230,14 @@ pub trait Tool: Send + Sync {
 
     /// Execute the tool with the given parameters.
     async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String>;
+
+    /// Structured variant of [`Tool::execute`]. DEFAULTED — existing tools
+    /// keep returning `String` via `execute` and never see this. Tools that
+    /// need to place non-text content blocks (images) into the model history
+    /// override this and make `execute` delegate to it.
+    async fn execute_rich(&self, params: Value, ctx: ToolContext) -> Result<ToolOutput> {
+        self.execute(params, ctx).await.map(ToolOutput::Text)
+    }
 
     /// Owning extension id for tools registered by an extension. Built-in tools return `None`.
     fn extension_id(&self) -> Option<&str> {

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -8,6 +8,10 @@ pub(crate) const MAX_IMAGE_BYTES: usize = 3_670_016;
 const MAX_IMAGE_SIDE_PX: u32 = 8000;
 /// Above this long edge Anthropic downscales server-side (coordinate caveat).
 const PROVIDER_DOWNSCALE_LONG_EDGE: u32 = 1568;
+/// Seatbelt: refuse to load anything larger than this into memory at all.
+/// Checked via `fs::metadata` BEFORE the read, so a 200 MB `.tif` or a
+/// device file never gets pulled in.
+pub(crate) const MAX_READ_BYTES: u64 = 64 * 1024 * 1024;
 
 pub struct ReadTool;
 
@@ -61,6 +65,25 @@ impl Tool for ReadTool {
             .as_str()
             .ok_or_else(|| RuntimeError::Tool("Missing path parameter".to_string()))?;
         let path = expand_path(raw_path);
+
+        // Size guard BEFORE reading: one stat, no bytes loaded.
+        let meta = tokio::fs::metadata(&path).await.map_err(|e| {
+            RuntimeError::Tool(format!("Failed to read file '{}': {}", path.display(), e))
+        })?;
+        if !meta.is_file() {
+            return Err(RuntimeError::Tool(format!(
+                "'{}' is not a regular file. Use `bash` (ls, file, head) to inspect it.",
+                path.display()
+            )));
+        }
+        if meta.len() > MAX_READ_BYTES {
+            return Err(RuntimeError::Tool(format!(
+                "File '{}' is {} KB; the read tool refuses files over {} KB. Use `bash` with `head`, `tail`, `xxd`, or `sed -n` to read a slice, or shrink an image with `convert`.",
+                path.display(),
+                meta.len().div_ceil(1024),
+                MAX_READ_BYTES / 1024
+            )));
+        }
 
         // Read raw bytes first to detect binary files
         let bytes = tokio::fs::read(&path).await.map_err(|e| {
@@ -121,8 +144,8 @@ pub(crate) fn sniff_image_mime(b: &[u8]) -> Option<&'static str> {
     None
 }
 
-/// Header-only dimension parse. Best effort: `None` → label shows `?x?`.
-/// Never a hard failure — dims are for the label and the 8000px guard only.
+/// Header-only dimension parse. `None` → `image_output` rejects the file
+/// (an unsized image bypasses the 8000 px guard → provider 400 → poison pill).
 pub(crate) fn image_dimensions(mime: &str, b: &[u8]) -> Option<(u32, u32)> {
     match mime {
         "image/png" if b.len() >= 24 => Some((be32(&b[16..20]), be32(&b[20..24]))),
@@ -193,6 +216,45 @@ fn le16(b: &[u8]) -> u16 {
 fn le24(b: &[u8]) -> u32 {
     u32::from_le_bytes([b[0], b[1], b[2], 0])
 }
+fn le32(b: &[u8]) -> u32 {
+    u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+}
+
+/// Cheap structural integrity check — trailer/size sanity only, no decode.
+/// A truncated or corrupt image shipped to the provider is a poison pill:
+/// the 400 repeats on every request until the session is cleared, because
+/// a `tool_result` user message always survives history repair. Reject here.
+pub(crate) fn image_integrity_error(mime: &str, b: &[u8]) -> Option<&'static str> {
+    match mime {
+        "image/png" => {
+            if b.len() < 16 || &b[12..16] != b"IHDR" {
+                return Some("first chunk is not IHDR");
+            }
+            if !b.ends_with(b"IEND\xAE\x42\x60\x82") {
+                return Some("missing IEND trailer (truncated?)");
+            }
+        }
+        "image/jpeg" => {
+            if !b.ends_with(&[0xFF, 0xD9]) {
+                return Some("missing EOI marker (truncated?)");
+            }
+        }
+        "image/gif" => {
+            if !b.ends_with(&[0x3B]) {
+                return Some("missing GIF trailer (truncated?)");
+            }
+        }
+        "image/webp" => {
+            let riff = le32(&b[4..8]) as usize;
+            // RIFF size = file length − 8; allow a single pad byte of slack.
+            if riff + 8 != b.len() && riff + 9 != b.len() {
+                return Some("RIFF size does not match file length (truncated?)");
+            }
+        }
+        _ => {}
+    }
+    None
+}
 
 fn image_output(path: &std::path::Path, mime: &'static str, bytes: &[u8]) -> Result<ToolOutput> {
     use base64::Engine as _;
@@ -208,24 +270,33 @@ fn image_output(path: &std::path::Path, mime: &'static str, bytes: &[u8]) -> Res
             cap = MAX_IMAGE_BYTES / 1024
         )));
     }
-    let dims = image_dimensions(mime, bytes);
-    if let Some((w, h)) = dims {
-        if w > MAX_IMAGE_SIDE_PX || h > MAX_IMAGE_SIDE_PX {
-            return Err(RuntimeError::Tool(format!(
-                "Image '{}' is {w}x{h}; the provider rejects images with any side over {MAX_IMAGE_SIDE_PX} px. \
-                 Downscale it with bash (e.g. `convert ... -resize 1568x1568\\>`) and read the new file.",
-                path.display()
-            )));
-        }
+    if let Some(why) = image_integrity_error(mime, bytes) {
+        return Err(RuntimeError::Tool(format!(
+            "Image '{}' ({mime}, {kb} KB) appears truncated or corrupt: {why}. \
+             Not sent to the model. Verify with `file` / `identify`, or re-export it and read the new file.",
+            path.display()
+        )));
     }
-    let dims_label = dims
-        .map(|(w, h)| format!("{w}x{h}"))
-        .unwrap_or_else(|| "?x?".into());
-    let mut summary = format!("Image: {} ({dims_label}, {mime}, {kb} KB)", path.display());
-    if let Some((w, h)) = dims {
-        if w.max(h) > PROVIDER_DOWNSCALE_LONG_EDGE {
-            summary.push_str("\nNote: long edge exceeds 1568 px; the provider downscales before viewing, so pixel coordinates read from the image are approximate.");
-        }
+    // Unknown dims → reject. Shipping an image we cannot size means the
+    // 8000 px guard is bypassed and a provider 400 poisons the session.
+    let Some((w, h)) = image_dimensions(mime, bytes) else {
+        return Err(RuntimeError::Tool(format!(
+            "Image '{}' ({mime}, {kb} KB): could not parse dimensions from the header. \
+             Not sent to the model. Re-export it (e.g. `convert '{}' /tmp/fixed.png`) and read the new file.",
+            path.display(),
+            path.display()
+        )));
+    };
+    if w > MAX_IMAGE_SIDE_PX || h > MAX_IMAGE_SIDE_PX {
+        return Err(RuntimeError::Tool(format!(
+            "Image '{}' is {w}x{h}; the provider rejects images with any side over {MAX_IMAGE_SIDE_PX} px. \
+             Downscale it with bash (e.g. `convert ... -resize 1568x1568\\>`) and read the new file.",
+            path.display()
+        )));
+    }
+    let mut summary = format!("Image: {} ({w}x{h}, {mime}, {kb} KB)", path.display());
+    if w.max(h) > PROVIDER_DOWNSCALE_LONG_EDGE {
+        summary.push_str("\nNote: long edge exceeds 1568 px; the provider downscales before viewing, so pixel coordinates read from the image are approximate.");
     }
     let data = base64::engine::general_purpose::STANDARD.encode(bytes);
     Ok(ToolOutput::Blocks {
@@ -343,12 +414,20 @@ mod tests {
         v
     }
 
-    /// Minimal 1×1 PNG: header + IHDR body tail + (fake) CRC.
-    fn tiny_png() -> Vec<u8> {
-        let mut v = png_header(1, 1);
+    const PNG_IEND: [u8; 12] = [0, 0, 0, 0, b'I', b'E', b'N', b'D', 0xAE, 0x42, 0x60, 0x82];
+
+    /// Structurally complete PNG with the given dims: IHDR + IEND, no IDAT.
+    fn png_with_dims(w: u32, h: u32) -> Vec<u8> {
+        let mut v = png_header(w, h);
         v.extend_from_slice(&[8, 6, 0, 0, 0]); // depth, color, comp, filter, interlace
         v.extend_from_slice(&[0, 0, 0, 0]); // crc (not validated)
+        v.extend_from_slice(&PNG_IEND);
         v
+    }
+
+    /// Minimal 1×1 PNG.
+    fn tiny_png() -> Vec<u8> {
+        png_with_dims(1, 1)
     }
 
     fn tmp(name: &str, bytes: &[u8]) -> std::path::PathBuf {
@@ -528,7 +607,7 @@ mod tests {
 
     #[tokio::test]
     async fn image_over_8000px_rejected() {
-        let p = tmp("wide.png", &png_header(8001, 10));
+        let p = tmp("wide.png", &png_with_dims(8001, 10));
         let err = ReadTool
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
             .await
@@ -562,7 +641,7 @@ mod tests {
         );
         let _ = std::fs::remove_file(p);
 
-        let p = tmp("wide2.png", &png_header(2000, 100));
+        let p = tmp("wide2.png", &png_with_dims(2000, 100));
         let out = ReadTool
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
             .await
@@ -584,7 +663,7 @@ mod tests {
         };
         let p = std::path::PathBuf::from(home).join("Jawz/media/jawz-avatar-v1.png");
         if !p.exists() {
-            eprintln!("skip: {} absent", p.display());
+            eprintln!("SKIPPED real_avatar_png_round_trips_as_image_blocks: {} absent", p.display());
             return;
         }
         let out = ReadTool
@@ -606,10 +685,6 @@ mod tests {
         let data = blocks[1]["source"]["data"].as_str().unwrap();
         assert!(data.starts_with("iVBORw0KGgo"));
         assert!(serde_json::to_vec(&blocks[1]).unwrap().len() < 5_000_000);
-        eprintln!(
-            "INTEGRATION summary={summary:?} base64[..40]={}",
-            &data[..40]
-        );
     }
 
     /// Integration evidence: a real .rs file still reads as numbered text,
@@ -626,18 +701,182 @@ mod tests {
             .unwrap();
         let ToolOutput::Text(text) = out else { panic!("expected Text") };
         assert!(text.starts_with("1\tuse super::"), "{text}");
-        eprintln!("INTEGRATION rs_read_first_line={:?}", text.lines().next().unwrap());
 
-        if let Ok(big) = std::env::var("SYNAPS_TEST_BIG_IMAGE") {
+        let Ok(big) = std::env::var("SYNAPS_TEST_BIG_IMAGE") else {
+            eprintln!("SKIPPED big-image half of real_rs_file_and_optional_big_image: SYNAPS_TEST_BIG_IMAGE unset");
+            return;
+        };
+        let err = ReadTool
+            .execute_rich(json!({"path": big}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("accepts images up to 3584 KB"), "{err}");
+        assert!(err.contains("convert"));
+        assert!(err.len() < 1024);
+    }
+
+    // ── S2: poison-pill integrity checks ────────────────────────────────────
+
+    #[test]
+    fn integrity_check_per_format() {
+        // PNG
+        assert_eq!(image_integrity_error("image/png", &tiny_png()), None);
+        assert!(image_integrity_error("image/png", &png_header(1, 1)).is_some()); // no IEND
+        let mut bad_chunk = tiny_png();
+        bad_chunk[12..16].copy_from_slice(b"iTXt");
+        assert!(image_integrity_error("image/png", &bad_chunk).is_some());
+        assert!(image_integrity_error("image/png", &PNG_SIG).is_some());
+        // JPEG
+        assert_eq!(image_integrity_error("image/jpeg", &[0xFF, 0xD8, 0xFF, 0xD9]), None);
+        assert!(image_integrity_error("image/jpeg", &[0xFF, 0xD8, 0xFF, 0xE0, 0, 0]).is_some());
+        // GIF
+        assert_eq!(image_integrity_error("image/gif", b"GIF89a\x01\x00\x01\x00\x3B"), None);
+        assert!(image_integrity_error("image/gif", b"GIF89a\x01\x00\x01\x00").is_some());
+        // WebP: RIFF size must equal len - 8.
+        let mut webp = b"RIFF\x00\x00\x00\x00WEBPVP8 ".to_vec();
+        webp.extend_from_slice(&[0u8; 20]);
+        assert!(image_integrity_error("image/webp", &webp).is_some());
+        let riff = (webp.len() - 8) as u32;
+        webp[4..8].copy_from_slice(&riff.to_le_bytes());
+        assert_eq!(image_integrity_error("image/webp", &webp), None);
+        webp.pop();
+        assert!(image_integrity_error("image/webp", &webp).is_some());
+    }
+
+    #[tokio::test]
+    async fn truncated_png_rejected_no_image_block() {
+        // Header + 3 KB of zeros, no IEND — the "half-written screenshot" case.
+        let mut bytes = png_header(10, 10);
+        bytes.resize(3_000, 0);
+        let p = tmp("trunc.png", &bytes);
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err();
+        let RuntimeError::Tool(msg) = err else {
+            panic!("expected Tool error, got {err:?}");
+        };
+        assert!(msg.contains("truncated or corrupt"), "{msg}");
+        assert!(msg.contains("IEND"), "{msg}");
+        assert!(!msg.contains("iVBORw0KGgo"), "no base64 in error");
+        assert!(msg.len() < 1024);
+        // Legacy path: same rejection, plain string, no image anywhere.
+        let s = ReadTool
+            .execute(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(s.contains("truncated or corrupt"), "{s}");
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn truncated_jpeg_and_gif_rejected() {
+        let jpeg = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, b'J', b'F', b'I', b'F', 0, 1, 1, 0, 0, 1, 0, 1, 0, 0];
+        let p = tmp("trunc.jpg", &jpeg);
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("EOI"), "{err}");
+        let _ = std::fs::remove_file(p);
+
+        let p = tmp("trunc.gif", b"GIF89a\x01\x00\x01\x00\x00\x00\x00");
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("GIF trailer"), "{err}");
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn unparseable_dims_rejected_not_shipped() {
+        // Structurally complete JPEG (SOI … EOI) but SOS before any SOF →
+        // dims None → must NOT become an image block.
+        let jpeg = [0xFF, 0xD8, 0xFF, 0xDA, 0x00, 0x08, 0, 0, 0, 0, 0, 0, 0xFF, 0xD9];
+        let p = tmp("nodims.jpg", &jpeg);
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("could not parse dimensions"), "{err}");
+        assert!(err.contains("Not sent to the model"), "{err}");
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn complete_gif_and_jpeg_round_trip_through_execute_rich() {
+        let p = tmp("ok.gif", b"GIF89a\x02\x00\x03\x00\x00\x00\x00\x3B");
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        assert!(out.summary().contains("(2x3, image/gif, 1 KB)"), "{}", out.summary());
+        assert!(matches!(out, ToolOutput::Blocks { .. }));
+        let _ = std::fs::remove_file(p);
+
+        let mut j = vec![0xFF, 0xD8, 0xFF, 0xC0, 0x00, 0x11, 0x08];
+        j.extend_from_slice(&480u16.to_be_bytes());
+        j.extend_from_slice(&640u16.to_be_bytes());
+        j.extend_from_slice(&[3, 1, 0x22, 0, 2, 0x11, 1, 3, 0x11, 1, 0xFF, 0xD9]);
+        let p = tmp("ok.jpg", &j);
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        assert!(out.summary().contains("(640x480, image/jpeg, 1 KB)"), "{}", out.summary());
+        let _ = std::fs::remove_file(p);
+    }
+
+    // ── S4: metadata guard before the read ──────────────────────────────────
+
+    #[tokio::test]
+    async fn oversize_file_rejected_by_metadata_without_reading() {
+        // Sparse file: set_len allocates no blocks, so this is instant on
+        // disk but would be a 65 MiB read if the guard ran after the read.
+        let p = std::env::temp_dir().join(format!("read_sparse_{}.bin", std::process::id()));
+        let f = std::fs::File::create(&p).unwrap();
+        f.set_len(MAX_READ_BYTES + 1).unwrap();
+        drop(f);
+        let start = std::time::Instant::now();
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("refuses files over"), "{err}");
+        assert!(err.contains("head"), "{err}");
+        assert!(start.elapsed() < std::time::Duration::from_secs(2));
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn directory_and_device_rejected_as_not_regular_file() {
+        let err = ReadTool
+            .execute_rich(
+                json!({"path": std::env::temp_dir().to_string_lossy()}),
+                create_tool_context(),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not a regular file"), "{err}");
+
+        #[cfg(unix)]
+        if std::path::Path::new("/dev/zero").exists() {
+            let start = std::time::Instant::now();
             let err = ReadTool
-                .execute_rich(json!({"path": big}), create_tool_context())
+                .execute_rich(json!({"path": "/dev/zero"}), create_tool_context())
                 .await
                 .unwrap_err()
                 .to_string();
-            assert!(err.contains("accepts images up to 3584 KB"), "{err}");
-            assert!(err.contains("convert"));
-            assert!(err.len() < 1024);
-            eprintln!("INTEGRATION big_image_rejected={err:?}");
+            assert!(err.contains("not a regular file"), "{err}");
+            assert!(start.elapsed() < std::time::Duration::from_secs(2));
         }
     }
 

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -234,15 +234,11 @@ pub(crate) fn image_integrity_error(mime: &str, b: &[u8]) -> Option<&'static str
                 return Some("missing IEND trailer (truncated?)");
             }
         }
-        "image/jpeg" => {
-            if !b.ends_with(&[0xFF, 0xD9]) {
-                return Some("missing EOI marker (truncated?)");
-            }
+        "image/jpeg" if !b.ends_with(&[0xFF, 0xD9]) => {
+            return Some("missing EOI marker (truncated?)");
         }
-        "image/gif" => {
-            if !b.ends_with(&[0x3B]) {
-                return Some("missing GIF trailer (truncated?)");
-            }
+        "image/gif" if !b.ends_with(&[0x3B]) => {
+            return Some("missing GIF trailer (truncated?)");
         }
         "image/webp" => {
             let riff = le32(&b[4..8]) as usize;

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -612,6 +612,35 @@ mod tests {
         );
     }
 
+    /// Integration evidence: a real .rs file still reads as numbered text,
+    /// and (when `SYNAPS_TEST_BIG_IMAGE` points at a >3.5 MiB image) the
+    /// oversize path rejects in-slot with the shrink hint and no base64.
+    #[tokio::test]
+    async fn real_rs_file_and_optional_big_image() {
+        let out = ReadTool
+            .execute_rich(
+                json!({"path": concat!(env!("CARGO_MANIFEST_DIR"), "/src/tools/read.rs"), "limit": 3}),
+                create_tool_context(),
+            )
+            .await
+            .unwrap();
+        let ToolOutput::Text(text) = out else { panic!("expected Text") };
+        assert!(text.starts_with("1\tuse super::"), "{text}");
+        eprintln!("INTEGRATION rs_read_first_line={:?}", text.lines().next().unwrap());
+
+        if let Ok(big) = std::env::var("SYNAPS_TEST_BIG_IMAGE") {
+            let err = ReadTool
+                .execute_rich(json!({"path": big}), create_tool_context())
+                .await
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("accepts images up to 3584 KB"), "{err}");
+            assert!(err.contains("convert"));
+            assert!(err.len() < 1024);
+            eprintln!("INTEGRATION big_image_rejected={err:?}");
+        }
+    }
+
     #[tokio::test]
     async fn non_image_binary_mentions_image_support() {
         let p = tmp("blob.bin", &[0xFF, 0xFE, 0x00, 0x80, 0x81]);

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -283,6 +283,14 @@ fn image_output(path: &std::path::Path, mime: &'static str, bytes: &[u8]) -> Res
             path.display()
         )));
     };
+    // Zero-sized images are invalid for every supported format and are
+    // rejected by providers — same poison-pill class as unknown dims.
+    if w == 0 || h == 0 {
+        return Err(RuntimeError::Tool(format!(
+            "Image '{}' ({mime}, {kb} KB) declares invalid dimensions {w}x{h} (zero-sized).              Not sent to the model. Re-export it and read the new file.",
+            path.display()
+        )));
+    }
     if w > MAX_IMAGE_SIDE_PX || h > MAX_IMAGE_SIDE_PX {
         return Err(RuntimeError::Tool(format!(
             "Image '{}' is {w}x{h}; the provider rejects images with any side over {MAX_IMAGE_SIDE_PX} px. \
@@ -803,6 +811,22 @@ mod tests {
         assert!(err.contains("could not parse dimensions"), "{err}");
         assert!(err.contains("Not sent to the model"), "{err}");
         let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn zero_dimension_images_rejected_not_shipped() {
+        for (name, w, h) in [("w0.png", 0u32, 7u32), ("h0.png", 7, 0), ("both0.png", 0, 0)] {
+            let p = tmp(name, &png_with_dims(w, h));
+            let err = ReadTool
+                .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+                .await
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("zero-sized"), "{name}: {err}");
+            assert!(err.contains(&format!("{w}x{h}")), "{name}: {err}");
+            assert!(err.contains("Not sent to the model"), "{name}: {err}");
+            let _ = std::fs::remove_file(p);
+        }
     }
 
     #[tokio::test]

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -1,6 +1,13 @@
-use super::{expand_path, Tool, ToolContext};
+use super::{expand_path, Tool, ToolContext, ToolOutput};
 use crate::{Result, RuntimeError};
 use serde_json::{json, Value};
+
+/// Raw-byte cap. 3.5 MiB × 4/3 base64 = 4.89 MB < Anthropic's 5 MB/image.
+pub(crate) const MAX_IMAGE_BYTES: usize = 3_670_016;
+/// Anthropic rejects any side > 8000 px.
+const MAX_IMAGE_SIDE_PX: u32 = 8000;
+/// Above this long edge Anthropic downscales server-side (coordinate caveat).
+const PROVIDER_DOWNSCALE_LONG_EDGE: u32 = 1568;
 
 pub struct ReadTool;
 
@@ -19,7 +26,7 @@ impl Tool for ReadTool {
     }
 
     fn description(&self) -> &str {
-        "Read the contents of a file. Returns lines with line numbers. Reads up to 500 lines by default. For large files, use offset and limit to read in sections."
+        "Read the contents of a file. Returns lines with line numbers. Reads up to 500 lines by default. For large files, use offset and limit to read in sections. Image files (PNG, JPEG, GIF, WebP) are returned as an image the model can see, up to 3.5 MB."
     }
 
     fn parameters(&self) -> Value {
@@ -43,7 +50,13 @@ impl Tool for ReadTool {
         })
     }
 
-    async fn execute(&self, params: Value, _ctx: ToolContext) -> Result<String> {
+    async fn execute(&self, params: Value, ctx: ToolContext) -> Result<String> {
+        self.execute_rich(params, ctx)
+            .await
+            .map(ToolOutput::into_summary)
+    }
+
+    async fn execute_rich(&self, params: Value, _ctx: ToolContext) -> Result<ToolOutput> {
         let raw_path = params["path"]
             .as_str()
             .ok_or_else(|| RuntimeError::Tool("Missing path parameter".to_string()))?;
@@ -54,10 +67,14 @@ impl Tool for ReadTool {
             RuntimeError::Tool(format!("Failed to read file '{}': {}", path.display(), e))
         })?;
 
+        if let Some(mime) = sniff_image_mime(&bytes) {
+            return image_output(&path, mime, &bytes);
+        }
+
         let content = match String::from_utf8(bytes) {
             Ok(s) => s,
             Err(_) => return Err(RuntimeError::Tool(format!(
-                "File '{}' appears to be binary (not valid UTF-8). Use `bash` with `xxd` or `file` to inspect binary files.",
+                "File '{}' appears to be binary (not valid UTF-8). Use `bash` with `xxd` or `file` to inspect binary files. Image files (png/jpg/gif/webp) are returned as images automatically.",
                 path.display()
             ))),
         };
@@ -83,9 +100,144 @@ impl Tool for ReadTool {
             result.push_str(&format!("\n... ({} more lines)", total_lines - end));
         }
 
-        Ok(result)
+        Ok(ToolOutput::Text(result))
     }
 }
+
+/// Magic-byte sniff — content, never extension.
+pub(crate) fn sniff_image_mime(b: &[u8]) -> Option<&'static str> {
+    if b.len() >= 8 && b[..8] == [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A] {
+        return Some("image/png");
+    }
+    if b.len() >= 3 && b[..3] == [0xFF, 0xD8, 0xFF] {
+        return Some("image/jpeg");
+    }
+    if b.len() >= 6 && (&b[..6] == b"GIF87a" || &b[..6] == b"GIF89a") {
+        return Some("image/gif");
+    }
+    if b.len() >= 12 && &b[..4] == b"RIFF" && &b[8..12] == b"WEBP" {
+        return Some("image/webp");
+    }
+    None
+}
+
+/// Header-only dimension parse. Best effort: `None` → label shows `?x?`.
+/// Never a hard failure — dims are for the label and the 8000px guard only.
+pub(crate) fn image_dimensions(mime: &str, b: &[u8]) -> Option<(u32, u32)> {
+    match mime {
+        "image/png" if b.len() >= 24 => Some((be32(&b[16..20]), be32(&b[20..24]))),
+        "image/gif" if b.len() >= 10 => Some((le16(&b[6..8]) as u32, le16(&b[8..10]) as u32)),
+        "image/webp" if b.len() >= 30 => match &b[12..16] {
+            b"VP8 " => Some((
+                (le16(&b[26..28]) & 0x3FFF) as u32,
+                (le16(&b[28..30]) & 0x3FFF) as u32,
+            )),
+            b"VP8L" => {
+                let x = [b[21], b[22], b[23], b[24]];
+                Some((
+                    1 + (((x[1] & 0x3F) as u32) << 8 | x[0] as u32),
+                    1 + (((x[3] & 0x0F) as u32) << 10
+                        | (x[2] as u32) << 2
+                        | ((x[1] & 0xC0) as u32) >> 6),
+                ))
+            }
+            b"VP8X" => Some((1 + le24(&b[24..27]), 1 + le24(&b[27..30]))),
+            _ => None,
+        },
+        "image/jpeg" => jpeg_dimensions(b),
+        _ => None,
+    }
+}
+
+fn jpeg_dimensions(b: &[u8]) -> Option<(u32, u32)> {
+    // Walk segments from offset 2 until a SOFn marker (C0–CF except C4, C8, CC).
+    let mut i = 2usize;
+    while i + 4 <= b.len() {
+        if b[i] != 0xFF {
+            return None;
+        }
+        let m = b[i + 1];
+        if m == 0xFF {
+            i += 1; // fill byte
+            continue;
+        }
+        if m == 0xD8 || m == 0x01 || (0xD0..=0xD7).contains(&m) {
+            i += 2; // standalone marker
+            continue;
+        }
+        if m == 0xD9 || m == 0xDA {
+            return None; // EOI / SOS: no SOF found
+        }
+        let len = be16(&b[i + 2..i + 4]) as usize;
+        if matches!(m, 0xC0..=0xCF) && !matches!(m, 0xC4 | 0xC8 | 0xCC) {
+            if i + 9 > b.len() {
+                return None;
+            }
+            // SOFn payload: Lf(2) P(1) Y(2) X(2) — height then width.
+            return Some((be16(&b[i + 7..i + 9]) as u32, be16(&b[i + 5..i + 7]) as u32));
+        }
+        i += 2 + len;
+    }
+    None
+}
+
+fn be16(b: &[u8]) -> u16 {
+    u16::from_be_bytes([b[0], b[1]])
+}
+fn be32(b: &[u8]) -> u32 {
+    u32::from_be_bytes([b[0], b[1], b[2], b[3]])
+}
+fn le16(b: &[u8]) -> u16 {
+    u16::from_le_bytes([b[0], b[1]])
+}
+fn le24(b: &[u8]) -> u32 {
+    u32::from_le_bytes([b[0], b[1], b[2], 0])
+}
+
+fn image_output(path: &std::path::Path, mime: &'static str, bytes: &[u8]) -> Result<ToolOutput> {
+    use base64::Engine as _;
+    let kb = bytes.len().div_ceil(1024);
+    if bytes.len() > MAX_IMAGE_BYTES {
+        return Err(RuntimeError::Tool(format!(
+            "Image '{p}' is {kb} KB; the read tool accepts images up to {cap} KB. \
+             Shrink it with bash and read the new file, e.g.:\n  \
+             convert '{p}' -resize 1568x1568\\> -quality 85 /tmp/shrunk.jpg   (ImageMagick)\n  \
+             sips -Z 1568 '{p}' --out /tmp/shrunk.png                        (macOS)",
+            p = path.display(),
+            kb = kb,
+            cap = MAX_IMAGE_BYTES / 1024
+        )));
+    }
+    let dims = image_dimensions(mime, bytes);
+    if let Some((w, h)) = dims {
+        if w > MAX_IMAGE_SIDE_PX || h > MAX_IMAGE_SIDE_PX {
+            return Err(RuntimeError::Tool(format!(
+                "Image '{}' is {w}x{h}; the provider rejects images with any side over {MAX_IMAGE_SIDE_PX} px. \
+                 Downscale it with bash (e.g. `convert ... -resize 1568x1568\\>`) and read the new file.",
+                path.display()
+            )));
+        }
+    }
+    let dims_label = dims
+        .map(|(w, h)| format!("{w}x{h}"))
+        .unwrap_or_else(|| "?x?".into());
+    let mut summary = format!("Image: {} ({dims_label}, {mime}, {kb} KB)", path.display());
+    if let Some((w, h)) = dims {
+        if w.max(h) > PROVIDER_DOWNSCALE_LONG_EDGE {
+            summary.push_str("\nNote: long edge exceeds 1568 px; the provider downscales before viewing, so pixel coordinates read from the image are approximate.");
+        }
+    }
+    let data = base64::engine::general_purpose::STANDARD.encode(bytes);
+    Ok(ToolOutput::Blocks {
+        blocks: vec![
+            // FIRST — invariant: blocks[0] is text == summary.
+            json!({ "type": "text", "text": summary }),
+            json!({ "type": "image", "source": { "type": "base64", "media_type": mime, "data": data } }),
+        ],
+        summary,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::test_helpers::create_tool_context;
@@ -175,5 +327,302 @@ mod tests {
 
         // Cleanup
         let _ = std::fs::remove_file(&test_file);
+    }
+
+    // ── image support ───────────────────────────────────────────────────────
+
+    const PNG_SIG: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+
+    /// PNG signature + IHDR chunk header with the given dims (24 bytes total).
+    fn png_header(w: u32, h: u32) -> Vec<u8> {
+        let mut v = PNG_SIG.to_vec();
+        v.extend_from_slice(&13u32.to_be_bytes()); // IHDR length
+        v.extend_from_slice(b"IHDR");
+        v.extend_from_slice(&w.to_be_bytes());
+        v.extend_from_slice(&h.to_be_bytes());
+        v
+    }
+
+    /// Minimal 1×1 PNG: header + IHDR body tail + (fake) CRC.
+    fn tiny_png() -> Vec<u8> {
+        let mut v = png_header(1, 1);
+        v.extend_from_slice(&[8, 6, 0, 0, 0]); // depth, color, comp, filter, interlace
+        v.extend_from_slice(&[0, 0, 0, 0]); // crc (not validated)
+        v
+    }
+
+    fn tmp(name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!("read_img_{}_{name}", std::process::id()));
+        std::fs::write(&p, bytes).unwrap();
+        p
+    }
+
+    #[test]
+    fn sniff_png_jpeg_gif_webp() {
+        assert_eq!(sniff_image_mime(&PNG_SIG), Some("image/png"));
+        assert_eq!(
+            sniff_image_mime(&[0xFF, 0xD8, 0xFF, 0xE0]),
+            Some("image/jpeg")
+        );
+        assert_eq!(
+            sniff_image_mime(b"GIF89a\x01\x00\x01\x00"),
+            Some("image/gif")
+        );
+        assert_eq!(
+            sniff_image_mime(b"GIF87a\x01\x00\x01\x00"),
+            Some("image/gif")
+        );
+        assert_eq!(
+            sniff_image_mime(b"RIFF\x00\x00\x00\x00WEBPVP8 "),
+            Some("image/webp")
+        );
+        assert_eq!(sniff_image_mime(b"hello"), None);
+        assert_eq!(
+            sniff_image_mime(b"BM\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"),
+            None
+        );
+        assert_eq!(sniff_image_mime(b"%PDF-1.4\n%\xE2\xE3\xCF\xD3"), None);
+        assert_eq!(sniff_image_mime(b"RIFF\x00\x00\x00\x00WAVEfmt "), None);
+        assert_eq!(sniff_image_mime(b""), None);
+    }
+
+    #[tokio::test]
+    async fn sniff_ignores_extension() {
+        let text_as_png = tmp("notes.png", b"just text\nline two");
+        let out = ReadTool
+            .execute_rich(
+                json!({"path": text_as_png.to_string_lossy()}),
+                create_tool_context(),
+            )
+            .await
+            .unwrap();
+        match out {
+            ToolOutput::Text(s) => assert!(s.contains("1\tjust text"), "{s}"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+
+        let png_as_txt = tmp("data.txt", &tiny_png());
+        let out = ReadTool
+            .execute_rich(
+                json!({"path": png_as_txt.to_string_lossy()}),
+                create_tool_context(),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(out, ToolOutput::Blocks { .. }), "{out:?}");
+        let _ = std::fs::remove_file(text_as_png);
+        let _ = std::fs::remove_file(png_as_txt);
+    }
+
+    #[test]
+    fn png_dimensions_from_ihdr() {
+        assert_eq!(image_dimensions("image/png", &tiny_png()), Some((1, 1)));
+        assert_eq!(
+            image_dimensions("image/png", &png_header(1024, 1536)),
+            Some((1024, 1536))
+        );
+        assert_eq!(image_dimensions("image/png", &PNG_SIG), None);
+    }
+
+    #[test]
+    fn jpeg_dimensions_from_sof0() {
+        let mut j = vec![0xFF, 0xD8]; // SOI
+        j.extend_from_slice(&[0xFF, 0xE0, 0x00, 0x10]); // APP0, len 16
+        j.extend_from_slice(b"JFIF\0");
+        j.extend_from_slice(&[1, 1, 0, 0, 1, 0, 1, 0, 0]); // 14 payload bytes total
+        j.extend_from_slice(&[0xFF, 0xC0, 0x00, 0x11, 0x08]); // SOF0, len 17, precision
+        j.extend_from_slice(&480u16.to_be_bytes()); // height
+        j.extend_from_slice(&640u16.to_be_bytes()); // width
+        j.extend_from_slice(&[3, 1, 0x22, 0, 2, 0x11, 1, 3, 0x11, 1]);
+        assert_eq!(image_dimensions("image/jpeg", &j), Some((640, 480)));
+
+        // SOI + SOS only → no SOF → None, no panic.
+        let sos_only = [0xFF, 0xD8, 0xFF, 0xDA, 0x00, 0x08, 0, 0, 0, 0, 0, 0];
+        assert_eq!(image_dimensions("image/jpeg", &sos_only), None);
+
+        // Truncated SOF header → None, no panic.
+        let trunc = [0xFF, 0xD8, 0xFF, 0xC0, 0x00, 0x11, 0x08, 0x01];
+        assert_eq!(image_dimensions("image/jpeg", &trunc), None);
+
+        // Garbage after SOI: deterministic pseudo-random bytes, must never panic.
+        let mut seed = 0x9E37_79B9u32;
+        for _ in 0..200 {
+            let mut buf = vec![0xFF, 0xD8, 0xFF];
+            for _ in 0..64 {
+                seed ^= seed << 13;
+                seed ^= seed >> 17;
+                seed ^= seed << 5;
+                buf.push((seed & 0xFF) as u8);
+            }
+            let _ = image_dimensions("image/jpeg", &buf);
+        }
+    }
+
+    #[test]
+    fn webp_dimensions_vp8_vp8l_vp8x() {
+        // VP8 (lossy): frame tag (3) + start code 9D 01 2A + w(2) + h(2)
+        let mut vp8 = b"RIFF\x00\x00\x00\x00WEBPVP8 \x00\x00\x00\x00".to_vec();
+        vp8.extend_from_slice(&[0x00, 0x00, 0x00, 0x9D, 0x01, 0x2A]);
+        vp8.extend_from_slice(&320u16.to_le_bytes());
+        vp8.extend_from_slice(&240u16.to_le_bytes());
+        assert_eq!(image_dimensions("image/webp", &vp8), Some((320, 240)));
+
+        // VP8L (lossless): signature 0x2F then 14-bit w-1, 14-bit h-1.
+        let (w, h) = (100u32, 50u32);
+        let bits: u32 = (w - 1) | ((h - 1) << 14);
+        let mut vp8l = b"RIFF\x00\x00\x00\x00WEBPVP8L\x00\x00\x00\x00\x2F".to_vec();
+        vp8l.extend_from_slice(&bits.to_le_bytes());
+        vp8l.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+        assert_eq!(image_dimensions("image/webp", &vp8l), Some((100, 50)));
+
+        // VP8X (extended): flags(4) + 24-bit w-1 + 24-bit h-1.
+        let mut vp8x = b"RIFF\x00\x00\x00\x00WEBPVP8X\x0A\x00\x00\x00".to_vec();
+        vp8x.extend_from_slice(&[0, 0, 0, 0]);
+        vp8x.extend_from_slice(&(1999u32).to_le_bytes()[..3]);
+        vp8x.extend_from_slice(&(999u32).to_le_bytes()[..3]);
+        assert_eq!(image_dimensions("image/webp", &vp8x), Some((2000, 1000)));
+    }
+
+    #[tokio::test]
+    async fn image_read_block_ordering() {
+        use base64::Engine as _;
+        let bytes = tiny_png();
+        let p = tmp("order.png", &bytes);
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        let ToolOutput::Blocks { blocks, summary } = out else {
+            panic!("expected Blocks");
+        };
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0]["type"], "text");
+        assert_eq!(blocks[0]["text"], summary);
+        assert_eq!(blocks[1]["type"], "image");
+        assert_eq!(blocks[1]["source"]["type"], "base64");
+        assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(blocks[1]["source"]["data"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(decoded, bytes);
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn image_over_cap_rejected() {
+        let mut bytes = png_header(10, 10);
+        bytes.resize(MAX_IMAGE_BYTES + 1, 0);
+        let p = tmp("big.png", &bytes);
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err();
+        let RuntimeError::Tool(msg) = err else {
+            panic!("expected Tool error, got {err:?}");
+        };
+        assert!(msg.contains("convert"), "{msg}");
+        assert!(msg.contains("KB"), "{msg}");
+        assert!(msg.len() < 1024, "{}", msg.len());
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn image_over_8000px_rejected() {
+        let p = tmp("wide.png", &png_header(8001, 10));
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("8000"), "{err}");
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn legacy_execute_returns_summary_for_images() {
+        let p = tmp("legacy.png", &tiny_png());
+        let s = ReadTool
+            .execute(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        assert!(s.starts_with("Image: "), "{s}");
+        assert!(s.len() < 512);
+        let _ = std::fs::remove_file(p);
+    }
+
+    #[tokio::test]
+    async fn label_format() {
+        let p = tmp("label.png", &tiny_png());
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        assert_eq!(
+            out.summary(),
+            format!("Image: {} (1x1, image/png, 1 KB)", p.display())
+        );
+        let _ = std::fs::remove_file(p);
+
+        let p = tmp("wide2.png", &png_header(2000, 100));
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        assert!(out.summary().starts_with(&format!(
+            "Image: {} (2000x100, image/png, 1 KB)",
+            p.display()
+        )));
+        assert!(out.summary().contains("1568 px"), "{}", out.summary());
+        let _ = std::fs::remove_file(p);
+    }
+
+    /// Spec §5.7 scripted integration check against the real test asset.
+    /// Skips (passes) if the asset is absent so CI without ~/Jawz stays green.
+    #[tokio::test]
+    async fn real_avatar_png_round_trips_as_image_blocks() {
+        let Some(home) = std::env::var_os("HOME") else {
+            return;
+        };
+        let p = std::path::PathBuf::from(home).join("Jawz/media/jawz-avatar-v1.png");
+        if !p.exists() {
+            eprintln!("skip: {} absent", p.display());
+            return;
+        }
+        let out = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap();
+        let ToolOutput::Blocks { blocks, summary } = out else {
+            panic!("expected Blocks");
+        };
+        assert!(
+            summary.starts_with(&format!(
+                "Image: {} (1024x1536, image/png, 2292 KB)",
+                p.display()
+            )),
+            "{summary}"
+        );
+        assert_eq!(blocks[0]["text"], summary);
+        assert_eq!(blocks[1]["source"]["media_type"], "image/png");
+        let data = blocks[1]["source"]["data"].as_str().unwrap();
+        assert!(data.starts_with("iVBORw0KGgo"));
+        assert!(serde_json::to_vec(&blocks[1]).unwrap().len() < 5_000_000);
+        eprintln!(
+            "INTEGRATION summary={summary:?} base64[..40]={}",
+            &data[..40]
+        );
+    }
+
+    #[tokio::test]
+    async fn non_image_binary_mentions_image_support() {
+        let p = tmp("blob.bin", &[0xFF, 0xFE, 0x00, 0x80, 0x81]);
+        let err = ReadTool
+            .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("returned as images automatically"),
+            "{err}"
+        );
+        let _ = std::fs::remove_file(p);
     }
 }

--- a/crates/agent-engine/src/tools/read.rs
+++ b/crates/agent-engine/src/tools/read.rs
@@ -667,7 +667,10 @@ mod tests {
         };
         let p = std::path::PathBuf::from(home).join("Jawz/media/jawz-avatar-v1.png");
         if !p.exists() {
-            eprintln!("SKIPPED real_avatar_png_round_trips_as_image_blocks: {} absent", p.display());
+            eprintln!(
+                "SKIPPED real_avatar_png_round_trips_as_image_blocks: {} absent",
+                p.display()
+            );
             return;
         }
         let out = ReadTool
@@ -703,7 +706,9 @@ mod tests {
             )
             .await
             .unwrap();
-        let ToolOutput::Text(text) = out else { panic!("expected Text") };
+        let ToolOutput::Text(text) = out else {
+            panic!("expected Text")
+        };
         assert!(text.starts_with("1\tuse super::"), "{text}");
 
         let Ok(big) = std::env::var("SYNAPS_TEST_BIG_IMAGE") else {
@@ -732,10 +737,16 @@ mod tests {
         assert!(image_integrity_error("image/png", &bad_chunk).is_some());
         assert!(image_integrity_error("image/png", &PNG_SIG).is_some());
         // JPEG
-        assert_eq!(image_integrity_error("image/jpeg", &[0xFF, 0xD8, 0xFF, 0xD9]), None);
+        assert_eq!(
+            image_integrity_error("image/jpeg", &[0xFF, 0xD8, 0xFF, 0xD9]),
+            None
+        );
         assert!(image_integrity_error("image/jpeg", &[0xFF, 0xD8, 0xFF, 0xE0, 0, 0]).is_some());
         // GIF
-        assert_eq!(image_integrity_error("image/gif", b"GIF89a\x01\x00\x01\x00\x3B"), None);
+        assert_eq!(
+            image_integrity_error("image/gif", b"GIF89a\x01\x00\x01\x00\x3B"),
+            None
+        );
         assert!(image_integrity_error("image/gif", b"GIF89a\x01\x00\x01\x00").is_some());
         // WebP: RIFF size must equal len - 8.
         let mut webp = b"RIFF\x00\x00\x00\x00WEBPVP8 ".to_vec();
@@ -777,7 +788,10 @@ mod tests {
 
     #[tokio::test]
     async fn truncated_jpeg_and_gif_rejected() {
-        let jpeg = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, b'J', b'F', b'I', b'F', 0, 1, 1, 0, 0, 1, 0, 1, 0, 0];
+        let jpeg = [
+            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, b'J', b'F', b'I', b'F', 0, 1, 1, 0, 0, 1, 0, 1, 0,
+            0,
+        ];
         let p = tmp("trunc.jpg", &jpeg);
         let err = ReadTool
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
@@ -801,7 +815,9 @@ mod tests {
     async fn unparseable_dims_rejected_not_shipped() {
         // Structurally complete JPEG (SOI … EOI) but SOS before any SOF →
         // dims None → must NOT become an image block.
-        let jpeg = [0xFF, 0xD8, 0xFF, 0xDA, 0x00, 0x08, 0, 0, 0, 0, 0, 0, 0xFF, 0xD9];
+        let jpeg = [
+            0xFF, 0xD8, 0xFF, 0xDA, 0x00, 0x08, 0, 0, 0, 0, 0, 0, 0xFF, 0xD9,
+        ];
         let p = tmp("nodims.jpg", &jpeg);
         let err = ReadTool
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
@@ -815,7 +831,11 @@ mod tests {
 
     #[tokio::test]
     async fn zero_dimension_images_rejected_not_shipped() {
-        for (name, w, h) in [("w0.png", 0u32, 7u32), ("h0.png", 7, 0), ("both0.png", 0, 0)] {
+        for (name, w, h) in [
+            ("w0.png", 0u32, 7u32),
+            ("h0.png", 7, 0),
+            ("both0.png", 0, 0),
+        ] {
             let p = tmp(name, &png_with_dims(w, h));
             let err = ReadTool
                 .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
@@ -836,7 +856,11 @@ mod tests {
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
             .await
             .unwrap();
-        assert!(out.summary().contains("(2x3, image/gif, 1 KB)"), "{}", out.summary());
+        assert!(
+            out.summary().contains("(2x3, image/gif, 1 KB)"),
+            "{}",
+            out.summary()
+        );
         assert!(matches!(out, ToolOutput::Blocks { .. }));
         let _ = std::fs::remove_file(p);
 
@@ -849,7 +873,11 @@ mod tests {
             .execute_rich(json!({"path": p.to_string_lossy()}), create_tool_context())
             .await
             .unwrap();
-        assert!(out.summary().contains("(640x480, image/jpeg, 1 KB)"), "{}", out.summary());
+        assert!(
+            out.summary().contains("(640x480, image/jpeg, 1 KB)"),
+            "{}",
+            out.summary()
+        );
         let _ = std::fs::remove_file(p);
     }
 

--- a/crates/agent-engine/src/tools/registry.rs
+++ b/crates/agent-engine/src/tools/registry.rs
@@ -646,7 +646,8 @@ impl ToolRegistry {
         // `dropped` and the audit signal lost. Walk the session's own
         // core + activated pins and report any id the catalog no longer
         // knows and that the loop did not already account for.
-        let seen: HashSet<&crate::tools::catalog::ToolId> = dropped.iter().map(|(id, _)| id).collect();
+        let seen: HashSet<&crate::tools::catalog::ToolId> =
+            dropped.iter().map(|(id, _)| id).collect();
         let vanished: Vec<crate::tools::catalog::ToolId> = session
             .core_ids()
             .chain(session.activated().map(|a| a.grant().tool_id()))

--- a/crates/agent-engine/src/tools/registry.rs
+++ b/crates/agent-engine/src/tools/registry.rs
@@ -556,20 +556,23 @@ impl ToolRegistry {
     /// capability identity is core or exactly-activated in `session`,
     /// preserving cached byte ordering, API-safe names, and collision
     /// suffixes. Pure read: no catalog insertion, no schema rebuild, no
-    /// factory invocation, no process/network. Catalog generation drift or
-    /// a changed pinned schema digest fails typed instead of serving a
-    /// stale projection. Default runtime exposure (`tools_schema`) is
-    /// unaffected until Task 18 opts in.
+    /// factory invocation, no process/network. Default runtime exposure
+    /// (`tools_schema`) is unaffected until Task 18 opts in.
+    ///
+    /// Drift handling (per-tool digest validation fix): catalog generation
+    /// drift does NOT fail the whole projection — an unrelated background
+    /// mutation must not blank a session's entire tool schema. Instead the
+    /// projection is validated per tool: entries whose CURRENT catalog
+    /// record digest matches the session's pin are included; entries whose
+    /// record drifted (changed digest) or vanished (uncataloged) are
+    /// skipped with a warning — they would be denied by the execution gate
+    /// anyway, so advertising them would be dishonest. The typed
+    /// [`SessionSchemaError`] is retained for genuinely unprojectable
+    /// cases.
     pub fn session_tools_schema(
         &self,
         session: &crate::tools::activation::SessionToolSet,
     ) -> Result<Vec<Value>, SessionSchemaError> {
-        if session.is_stale(&self.catalog) {
-            return Err(SessionSchemaError::StaleSessionSet {
-                set: session.catalog_generation(),
-                catalog: self.catalog.generation(),
-            });
-        }
         let mut projected = Vec::new();
         for entry in self.cached_schema.iter() {
             let Some(api_name) = entry["name"].as_str() else {
@@ -586,12 +589,21 @@ impl ToolRegistry {
             let Some(pinned) = pinned else {
                 continue; // not part of this session's set — absent.
             };
-            let record = self
-                .catalog
-                .get(&id)
-                .ok_or_else(|| SessionSchemaError::NotCataloged(id.clone()))?;
+            let Some(record) = self.catalog.get(&id) else {
+                tracing::warn!(
+                    tool = %id,
+                    "session schema projection skips uncataloged session member \
+                     (removed since the session pinned it)"
+                );
+                continue;
+            };
             if pinned != record.schema_digest() {
-                return Err(SessionSchemaError::SchemaDigestMismatch(id));
+                tracing::warn!(
+                    tool = %id,
+                    "session schema projection skips drifted session member \
+                     (schema digest changed since the session pinned it)"
+                );
+                continue;
             }
             projected.push(entry.clone());
         }
@@ -621,7 +633,10 @@ impl ToolRegistry {
 }
 
 /// Typed failure for [`ToolRegistry::session_tools_schema`]. Metadata-only:
-/// bounded identities and generation counters, never schema bytes.
+/// bounded identities and generation counters, never schema bytes. Since the
+/// per-tool digest-validation fix the projection skips drifted/removed
+/// members instead of failing; these variants are retained for API
+/// stability and genuinely unprojectable future cases.
 #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
 pub enum SessionSchemaError {
     #[error(

--- a/crates/agent-engine/src/tools/registry.rs
+++ b/crates/agent-engine/src/tools/registry.rs
@@ -497,6 +497,22 @@ impl ToolRegistry {
         self.catalog.set_generation_for_tests(generation);
     }
 
+    /// Boundary-test support: upsert one catalog record IN PLACE without
+    /// touching the live tool map — how a hostile/aberrant dynamic source
+    /// could replace a capability record behind a session's back. Doc-hidden
+    /// for the same reason as [`Self::resume_catalog_generation_for_tests`]:
+    /// integration tests run without a `testing` feature.
+    #[doc(hidden)]
+    pub fn upsert_catalog_record_for_tests(
+        &mut self,
+        replaced: Option<&crate::tools::catalog::ToolId>,
+        record: crate::tools::catalog::CapabilityRecord,
+    ) {
+        self.catalog
+            .upsert(replaced, record)
+            .expect("test upsert must be structurally valid");
+    }
+
     pub fn get(&self, name: &str) -> Option<&Arc<dyn Tool>> {
         let runtime_name = self
             .api_to_runtime_names
@@ -559,21 +575,22 @@ impl ToolRegistry {
     /// factory invocation, no process/network. Default runtime exposure
     /// (`tools_schema`) is unaffected until Task 18 opts in.
     ///
-    /// Drift handling (per-tool digest validation fix): catalog generation
-    /// drift does NOT fail the whole projection — an unrelated background
-    /// mutation must not blank a session's entire tool schema. Instead the
-    /// projection is validated per tool: entries whose CURRENT catalog
-    /// record digest matches the session's pin are included; entries whose
-    /// record drifted (changed digest) or vanished (uncataloged) are
-    /// skipped with a warning — they would be denied by the execution gate
-    /// anyway, so advertising them would be dishonest. The typed
-    /// [`SessionSchemaError`] is retained for genuinely unprojectable
-    /// cases.
+    /// Drift handling (per-tool digest + provenance validation fix): catalog
+    /// generation drift does NOT fail the whole projection — an unrelated
+    /// background mutation must not blank a session's entire tool schema.
+    /// Instead the projection is validated per tool: entries whose CURRENT
+    /// catalog record digest AND trust provenance match the session's pins
+    /// are included; entries whose record drifted (changed digest, changed
+    /// provenance — even an internally coherent one) or vanished
+    /// (uncataloged) are dropped fail-closed and REPORTED in the returned
+    /// [`SessionSchemaProjection::dropped`] list — they would be denied by
+    /// the execution gate anyway, so advertising them would be dishonest.
     pub fn session_tools_schema(
         &self,
         session: &crate::tools::activation::SessionToolSet,
-    ) -> Result<Vec<Value>, SessionSchemaError> {
+    ) -> SessionSchemaProjection {
         let mut projected = Vec::new();
+        let mut dropped = Vec::new();
         for entry in self.cached_schema.iter() {
             let Some(api_name) = entry["name"].as_str() else {
                 continue;
@@ -584,30 +601,49 @@ impl ToolRegistry {
             };
             let id = tool_id_for(tool.as_ref());
             let pinned = session
-                .core_schema_digest(&id)
-                .or_else(|| session.activation(&id).map(|a| a.schema_digest()));
-            let Some(pinned) = pinned else {
+                .core_pin(&id)
+                .map(|pin| (pin.schema_digest(), pin.provenance()))
+                .or_else(|| {
+                    session
+                        .activation(&id)
+                        .map(|a| (a.schema_digest(), a.provenance()))
+                });
+            let Some((pinned_digest, pinned_provenance)) = pinned else {
                 continue; // not part of this session's set — absent.
             };
             let Some(record) = self.catalog.get(&id) else {
                 tracing::warn!(
                     tool = %id,
-                    "session schema projection skips uncataloged session member \
+                    "session schema projection drops uncataloged session member \
                      (removed since the session pinned it)"
                 );
+                dropped.push((id, DroppedSessionMember::Uncataloged));
                 continue;
             };
-            if pinned != record.schema_digest() {
+            if pinned_digest != record.schema_digest() {
                 tracing::warn!(
                     tool = %id,
-                    "session schema projection skips drifted session member \
+                    "session schema projection drops drifted session member \
                      (schema digest changed since the session pinned it)"
                 );
+                dropped.push((id, DroppedSessionMember::SchemaDigestMismatch));
+                continue;
+            }
+            if pinned_provenance != record.provenance() {
+                tracing::warn!(
+                    tool = %id,
+                    "session schema projection drops drifted session member \
+                     (trust provenance changed since the session pinned it)"
+                );
+                dropped.push((id, DroppedSessionMember::ProvenanceMismatch));
                 continue;
             }
             projected.push(entry.clone());
         }
-        Ok(projected)
+        SessionSchemaProjection {
+            schema: projected,
+            dropped,
+        }
     }
 
     /// Return runtime names of tools owned by the given extension id, sorted ascending.
@@ -632,26 +668,31 @@ impl ToolRegistry {
     }
 }
 
-/// Typed failure for [`ToolRegistry::session_tools_schema`]. Metadata-only:
-/// bounded identities and generation counters, never schema bytes. Since the
-/// per-tool digest-validation fix the projection skips drifted/removed
-/// members instead of failing; these variants are retained for API
-/// stability and genuinely unprojectable future cases.
-#[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
-pub enum SessionSchemaError {
-    #[error(
-        "session tool set generation {} is stale against catalog generation {}",
-        set.value(),
-        catalog.value()
-    )]
-    StaleSessionSet {
-        set: crate::tools::catalog::CatalogGeneration,
-        catalog: crate::tools::catalog::CatalogGeneration,
-    },
-    #[error("session member is not cataloged: {0}")]
-    NotCataloged(crate::tools::catalog::ToolId),
-    #[error("schema digest changed since the session pinned it: {0}")]
-    SchemaDigestMismatch(crate::tools::catalog::ToolId),
+/// Typed projection report for [`ToolRegistry::session_tools_schema`]: the
+/// projected schema entries PLUS every pinned session member that was
+/// dropped fail-closed, with the typed reason. Metadata-only reasons:
+/// bounded identities, never schema bytes. Callers can surface `dropped`
+/// for audit/telemetry instead of losing the signal to a log line.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SessionSchemaProjection {
+    /// The entries served to the provider, in cached byte order.
+    pub schema: Vec<Value>,
+    /// Pinned session members excluded from the projection and why. A
+    /// dropped member's schema is NEVER served — the execution gate would
+    /// deny it anyway.
+    pub dropped: Vec<(crate::tools::catalog::ToolId, DroppedSessionMember)>,
+}
+
+/// Why a pinned session member was dropped from a schema projection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DroppedSessionMember {
+    /// The member's `ToolId` is no longer in the catalog.
+    Uncataloged,
+    /// The current record's schema digest differs from the session's pin.
+    SchemaDigestMismatch,
+    /// The current record's trust provenance differs from the session's
+    /// pin (the coherent-imposter case).
+    ProvenanceMismatch,
 }
 
 /// Fail-closed message for infallible compatibility wrappers over typed

--- a/crates/agent-engine/src/tools/registry.rs
+++ b/crates/agent-engine/src/tools/registry.rs
@@ -640,6 +640,26 @@ impl ToolRegistry {
             }
             projected.push(entry.clone());
         }
+        // Post-pass: a pinned member that vanished ENTIRELY (extension
+        // unload → `try_disable` rebuilds `cached_schema` without it) never
+        // appears in the loop above, so it would be silently omitted from
+        // `dropped` and the audit signal lost. Walk the session's own
+        // core + activated pins and report any id the catalog no longer
+        // knows and that the loop did not already account for.
+        let seen: HashSet<&crate::tools::catalog::ToolId> = dropped.iter().map(|(id, _)| id).collect();
+        let vanished: Vec<crate::tools::catalog::ToolId> = session
+            .core_ids()
+            .chain(session.activated().map(|a| a.grant().tool_id()))
+            .filter(|id| !seen.contains(id) && self.catalog.get(id).is_none())
+            .cloned()
+            .collect();
+        for id in vanished {
+            tracing::warn!(
+                tool = %id,
+                "session schema projection drops uncataloged session member                  (removed from the registry since the session pinned it)"
+            );
+            dropped.push((id, DroppedSessionMember::Uncataloged));
+        }
         SessionSchemaProjection {
             schema: projected,
             dropped,

--- a/crates/agent-engine/src/tools/subagent/mod.rs
+++ b/crates/agent-engine/src/tools/subagent/mod.rs
@@ -72,6 +72,34 @@ pub(crate) async fn subagent_tools() -> crate::ToolRegistry {
     crate::ToolRegistry::without_subagent()
 }
 
+/// Compose the final system prompt for a subagent spawn.
+///
+/// If `~/.synaps-cli/subagent-preamble.md` exists and is non-empty, its
+/// contents are prepended to `agent_prompt` with a blank-line separator:
+///
+/// ```text
+/// {preamble}
+///
+/// {agent_prompt}
+/// ```
+///
+/// Any IO error (missing file, permission denied, etc.) is silently ignored
+/// and `agent_prompt` is returned unchanged. Never panics.
+pub(crate) fn compose_system_prompt(agent_prompt: String) -> String {
+    let preamble_path = crate::config::base_dir().join("subagent-preamble.md");
+    match std::fs::read_to_string(&preamble_path) {
+        Ok(contents) => {
+            let trimmed = contents.trim();
+            if trimmed.is_empty() {
+                agent_prompt
+            } else {
+                format!("{}\n\n{}", trimmed, agent_prompt)
+            }
+        }
+        Err(_) => agent_prompt,
+    }
+}
+
 #[cfg(test)]
 mod cache_ttl_policy_tests {
     use super::apply_subagent_runtime_policy;
@@ -285,5 +313,32 @@ mod cache_ttl_policy_tests {
             parent.memory_context_status().durable,
             DurableStatus::Active { .. }
         ));
+    }
+}
+
+#[cfg(test)]
+mod preamble_tests {
+    use super::compose_system_prompt;
+
+    #[test]
+    fn no_preamble_file_returns_prompt_unchanged() {
+        // When the preamble file doesn't exist, prompt is unchanged.
+        // We can't easily control base_dir in unit tests, so just verify
+        // the function doesn't panic and returns a non-empty string.
+        let result = compose_system_prompt("hello world".to_string());
+        assert!(result.contains("hello world"));
+    }
+
+    #[test]
+    fn preamble_prepended_with_separator() {
+        // Write a temp preamble file, point base_dir at it, verify output.
+        // Since we can't override base_dir, test the composition logic directly.
+        let preamble = "## Shared context\nUse Sonnet for reads.";
+        let agent = "You are spike.";
+        let composed = format!("{}\n\n{}", preamble, agent);
+        assert!(composed.starts_with("## Shared context"));
+        assert!(composed.contains("You are spike."));
+        let parts: Vec<&str> = composed.splitn(2, "\n\n").collect();
+        assert_eq!(parts.len(), 2);
     }
 }

--- a/crates/agent-engine/src/tools/subagent/oneshot.rs
+++ b/crates/agent-engine/src/tools/subagent/oneshot.rs
@@ -159,7 +159,7 @@ impl Tool for SubagentTool {
                     // one-shots — paying the 1h write premium (~2× input price) on them
                     // is unrecoverable waste (~$0.23 per 10-spawn fan-out). (#110)
                     super::apply_subagent_runtime_policy(&mut runtime, &crate::config::load_config());
-                    runtime.set_system_prompt(system_prompt);
+                    runtime.set_system_prompt(super::compose_system_prompt(system_prompt));
                     runtime.set_model(model);
                     runtime.set_tools(super::subagent_tools().await);
 

--- a/crates/agent-engine/src/tools/subagent/resume.rs
+++ b/crates/agent-engine/src/tools/subagent/resume.rs
@@ -239,7 +239,7 @@ impl Tool for SubagentResumeTool {
                     // one-shots — paying the 1h write premium (~2× input price) on them
                     // is unrecoverable waste (~$0.23 per 10-spawn fan-out). (#110)
                     super::apply_subagent_runtime_policy(&mut runtime, &crate::config::load_config());
-                    runtime.set_system_prompt(system_prompt);
+                    runtime.set_system_prompt(super::compose_system_prompt(system_prompt));
                     runtime.set_model(model_a.clone());
                     runtime.set_tools(super::subagent_tools().await);
 

--- a/crates/agent-engine/src/tools/subagent/start.rs
+++ b/crates/agent-engine/src/tools/subagent/start.rs
@@ -254,7 +254,7 @@ impl Tool for SubagentStartTool {
                     // one-shots — paying the 1h write premium (~2× input price) on them
                     // is unrecoverable waste (~$0.23 per 10-spawn fan-out). (#110)
                     super::apply_subagent_runtime_policy(&mut runtime, &crate::config::load_config());
-                    runtime.set_system_prompt(system_prompt);
+                    runtime.set_system_prompt(super::compose_system_prompt(system_prompt));
                     runtime.set_model(model_a.clone());
                     runtime.set_tools(super::subagent_tools().await);
                     runtime.install_worker_orchestration(Arc::clone(

--- a/crates/agent-engine/tests/discovery_activation_tools.rs
+++ b/crates/agent-engine/tests/discovery_activation_tools.rs
@@ -336,9 +336,7 @@ async fn activate_tools_confirmed_exact_activation_leaves_siblings_denied() {
 
     // The session projection now contains the activated schema; the sibling
     // remains absent (also covered in session_schema_projection.rs).
-    let projection = registry
-        .session_tools_schema(&set.read().unwrap())
-        .expect("projection of fresh set succeeds");
+    let projection = registry.session_tools_schema(&set.read().unwrap()).schema;
     let names: Vec<&str> = projection
         .iter()
         .filter_map(|s| s["name"].as_str())
@@ -799,13 +797,15 @@ fn catalog_generation_drift_keeps_unchanged_tools_but_blocks_new_grants() {
     registry.register(Arc::new(FixtureTool::builtin("late_tool")));
 
     // Per-tool digest validation: the activated tool's current record is
-    // byte-identical, so execution and projection SURVIVE the unrelated
+    // schema-identical, so execution and projection SURVIVE the unrelated
     // drift (wholesale generation denial would kill the in-flight round).
     ExecutionGate::authorize_wire_call(&registry, &set, "beta_tool")
         .expect("unchanged activated tool survives unrelated drift");
-    registry
-        .session_tools_schema(&set)
-        .expect("projection survives drift, serving only digest-matching pins");
+    let report = registry.session_tools_schema(&set);
+    assert!(
+        report.dropped.is_empty(),
+        "projection survives unrelated drift, dropping nothing"
+    );
 
     // Grant issuance/activation stays generation-STRICT: fresh grants
     // against the old snapshot cannot extend a drifted set.
@@ -834,8 +834,7 @@ fn route_session_set_consumes_retained_set_and_survives_drift() {
 
     // Retained + fresh: the route receives the SAME set state/generation,
     // including the exact activation — not a fresh default-core mint.
-    let routed = route_session_set(Some(&set), registry.catalog(), session_id)
-        .expect("fresh retained set is used");
+    let routed = route_session_set(Some(&set), registry.catalog(), session_id);
     assert_eq!(
         routed.catalog_generation(),
         set.read().unwrap().catalog_generation()
@@ -845,10 +844,9 @@ fn route_session_set_consumes_retained_set_and_survives_drift() {
 
     // Retained + drifted: still served (never a fresh mid-round mint, never
     // a wholesale kill) — per-call gate authorization is what protects
-    // execution, and it still passes for the byte-identical tool.
+    // execution, and it still passes for the schema-identical tool.
     registry.register(Arc::new(FixtureTool::builtin("late_tool")));
-    let routed = route_session_set(Some(&set), registry.catalog(), session_id)
-        .expect("drifted retained set is still served");
+    let routed = route_session_set(Some(&set), registry.catalog(), session_id);
     assert!(routed.is_stale(registry.catalog()));
     assert!(routed.activation(&ToolId::builtin("beta_tool")).is_some());
     ExecutionGate::authorize_wire_call(&registry, &routed, "beta_tool")
@@ -856,8 +854,7 @@ fn route_session_set_consumes_retained_set_and_survives_drift() {
 
     // No retained handle (internal callers): fail closed to a fresh
     // default-core set with zero activations, as before.
-    let fallback =
-        route_session_set(None, registry.catalog(), session_id).expect("fallback minted");
+    let fallback = route_session_set(None, registry.catalog(), session_id);
     assert_eq!(fallback.activated().count(), 0);
     assert!(!fallback.is_stale(registry.catalog()));
 }

--- a/crates/agent-engine/tests/discovery_activation_tools.rs
+++ b/crates/agent-engine/tests/discovery_activation_tools.rs
@@ -788,7 +788,7 @@ fn activate_many_rejects_untrusted_source() {
 // ── Drift invalidation through the public surface ───────────────────────────
 
 #[test]
-fn catalog_generation_drift_invalidates_activation_and_projection() {
+fn catalog_generation_drift_keeps_unchanged_tools_but_blocks_new_grants() {
     let mut registry = fixture_registry();
     let mut set = minimal_set(&registry);
     activate_exact_for_user(&mut set, registry.catalog(), &ToolId::builtin("beta_tool"))
@@ -798,17 +798,17 @@ fn catalog_generation_drift_invalidates_activation_and_projection() {
     // Catalog mutation (dynamic registration) advances the generation.
     registry.register(Arc::new(FixtureTool::builtin("late_tool")));
 
-    let denial = ExecutionGate::authorize_wire_call(&registry, &set, "beta_tool")
-        .expect_err("stale set denies");
-    assert!(matches!(
-        denial,
-        ToolAuthorizationError::StaleSessionSet { .. }
-    ));
+    // Per-tool digest validation: the activated tool's current record is
+    // byte-identical, so execution and projection SURVIVE the unrelated
+    // drift (wholesale generation denial would kill the in-flight round).
+    ExecutionGate::authorize_wire_call(&registry, &set, "beta_tool")
+        .expect("unchanged activated tool survives unrelated drift");
     registry
         .session_tools_schema(&set)
-        .expect_err("stale set fails projection");
+        .expect("projection survives drift, serving only digest-matching pins");
 
-    // Fresh grants against the OLD generation cannot rescue a stale set.
+    // Grant issuance/activation stays generation-STRICT: fresh grants
+    // against the old snapshot cannot extend a drifted set.
     let err = activate_exact_for_user(&mut set, registry.catalog(), &ToolId::builtin("gamma_tool"))
         .expect_err("stale snapshot denies further activation");
     assert!(matches!(
@@ -822,7 +822,7 @@ fn catalog_generation_drift_invalidates_activation_and_projection() {
 // ── Extension-provider route threading ──────────────────────────────────────
 
 #[test]
-fn route_session_set_consumes_retained_set_and_denies_stale() {
+fn route_session_set_consumes_retained_set_and_survives_drift() {
     let mut registry = fixture_registry();
     let set = shared(minimal_set(&registry));
     activate_exact_for_user(
@@ -843,14 +843,16 @@ fn route_session_set_consumes_retained_set_and_denies_stale() {
     assert!(routed.activation(&ToolId::builtin("beta_tool")).is_some());
     ExecutionGate::authorize_wire_call(&registry, &routed, "beta_tool").expect("authorized");
 
-    // Retained + stale: DENY — never silently mint a fresh set mid-round.
+    // Retained + drifted: still served (never a fresh mid-round mint, never
+    // a wholesale kill) — per-call gate authorization is what protects
+    // execution, and it still passes for the byte-identical tool.
     registry.register(Arc::new(FixtureTool::builtin("late_tool")));
-    let err = route_session_set(Some(&set), registry.catalog(), session_id)
-        .expect_err("stale retained set denies");
-    assert!(matches!(
-        err,
-        ToolAuthorizationError::StaleSessionSet { .. }
-    ));
+    let routed = route_session_set(Some(&set), registry.catalog(), session_id)
+        .expect("drifted retained set is still served");
+    assert!(routed.is_stale(registry.catalog()));
+    assert!(routed.activation(&ToolId::builtin("beta_tool")).is_some());
+    ExecutionGate::authorize_wire_call(&registry, &routed, "beta_tool")
+        .expect("unchanged tool authorizes across drift");
 
     // No retained handle (internal callers): fail closed to a fresh
     // default-core set with zero activations, as before.

--- a/crates/agent-engine/tests/execution_gate.rs
+++ b/crates/agent-engine/tests/execution_gate.rs
@@ -210,7 +210,7 @@ fn default_session_set_core_is_exactly_verified_registered_tools() {
 /// validation fix): ONE set snapshot judges every sibling call of a model
 /// response; an UNRELATED catalog mutation (background plugin load) no
 /// longer kills the in-flight round — tools whose current record is
-/// byte-identical to the session's pins keep authorizing WITHOUT a rebuild.
+/// schema-identical to the session's pins keep authorizing WITHOUT a rebuild.
 /// Tools the session never pinned (registered after the snapshot) stay
 /// denied until the explicit round-top rebuild, which exposes them as
 /// default core with zero inherited activations.
@@ -442,7 +442,7 @@ fn unchanged_core_digest_survives_generation_drift() {
     assert!(set.is_stale(&catalog));
 
     ExecutionGate::authorize(&catalog, &set, resolved(&id))
-        .expect("byte-identical core tool must survive unrelated drift");
+        .expect("schema-identical core tool must survive unrelated drift");
     assert_eq!(spy.load(Ordering::SeqCst), 1);
 }
 
@@ -468,7 +468,7 @@ fn unchanged_activated_digest_survives_generation_drift() {
     assert!(set.is_stale(&catalog));
 
     ExecutionGate::authorize(&catalog, &set, resolved(&id))
-        .expect("byte-identical activated tool must survive unrelated drift");
+        .expect("schema-identical activated tool must survive unrelated drift");
     assert_eq!(spy.load(Ordering::SeqCst), 1);
 }
 
@@ -583,6 +583,106 @@ fn re_added_tool_with_different_provenance_denies_source_trust_under_drift() {
         .expect_err("provenance drift must deny even with an identical digest");
     assert_eq!(err, ToolAuthorizationError::SourceProvenanceMismatch(id));
     assert_eq!(spy.load(Ordering::SeqCst), 0);
+}
+
+/// A COHERENT imposter: same `ToolId`, byte-identical schema JSON (equal
+/// digest), but source AND provenance both moved to "server-2" — the record
+/// is internally consistent, so `check_source_trust` alone would pass it.
+/// Only the pinned-provenance equality check can deny it.
+fn coherent_imposter_record(id: &ToolId, spy: Arc<AtomicUsize>) -> CapabilityRecord {
+    CapabilityRecord::new(
+        id.clone(),
+        CapabilitySource::Mcp {
+            server_id: "server-2".to_string(),
+            server_tool_name: "deferred".to_string(),
+        },
+        "gate fixture capability",
+        Vec::new(),
+        // Identical schema bytes to the mcp_spy_record fixture → equal digest.
+        SchemaLocator::Inline(serde_json::json!({"type": "object"})),
+        {
+            let spy = Arc::clone(&spy);
+            Arc::new(move || -> Arc<dyn Tool> {
+                spy.fetch_add(1, Ordering::SeqCst);
+                Arc::new(FixtureTool::unknown("spy-implementation"))
+            })
+        },
+        TrustProvenance::McpConfig {
+            server_id: "server-2".to_string(),
+        },
+    )
+}
+
+/// (5, BLOCKER fix) Coherent imposter vs a CORE pin: remove the tool and
+/// re-add the SAME `ToolId` with an identical schema but a different,
+/// internally CONSISTENT source+provenance pair. Presence passes, the digest
+/// passes, self-consistency passes — the pinned-provenance check must be
+/// what denies, with zero factory acquisitions.
+#[test]
+fn coherent_imposter_same_digest_denies_pinned_provenance_core() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let set = SessionToolSet::new(session("s-imposter-core"), vec![id.clone()], &catalog)
+        .expect("core set builds");
+
+    let imposter = coherent_imposter_record(&id, Arc::clone(&spy));
+    assert_eq!(
+        imposter.schema_digest(),
+        catalog.get(&id).expect("present").schema_digest(),
+        "imposter fixture must be schema-identical (equal digest) for the test to bite"
+    );
+    catalog
+        .upsert(Some(&id), imposter)
+        .expect("remove + re-add under the same id");
+
+    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect_err("coherent imposter must be denied on the core path");
+    assert_eq!(err, ToolAuthorizationError::SourceProvenanceMismatch(id));
+    assert_eq!(
+        spy.load(Ordering::SeqCst),
+        0,
+        "denial must never invoke the implementation factory"
+    );
+}
+
+/// (5, BLOCKER fix) Coherent imposter vs an ACTIVATED grant: the grant's
+/// (session, tool, digest) tuple still covers the imposter, so the
+/// engine-side provenance pinned at activation time must be what denies.
+#[test]
+fn coherent_imposter_same_digest_denies_pinned_provenance_activated() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let sid = session("s-imposter-act");
+    let mut set = SessionToolSet::new(sid.clone(), Vec::new(), &catalog).expect("empty core");
+    set.activate(grant_for(&sid, &catalog, &id), &catalog)
+        .expect("exact grant activates");
+
+    let imposter = coherent_imposter_record(&id, Arc::clone(&spy));
+    assert_eq!(
+        imposter.schema_digest(),
+        catalog.get(&id).expect("present").schema_digest(),
+        "imposter fixture must be schema-identical (equal digest) for the test to bite"
+    );
+    catalog
+        .upsert(Some(&id), imposter)
+        .expect("remove + re-add under the same id");
+
+    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect_err("coherent imposter must be denied on the activated path");
+    assert_eq!(err, ToolAuthorizationError::SourceProvenanceMismatch(id));
+    assert_eq!(
+        spy.load(Ordering::SeqCst),
+        0,
+        "denial must never invoke the implementation factory"
+    );
 }
 
 // ── Source/trust re-check ───────────────────────────────────────────────────

--- a/crates/agent-engine/tests/execution_gate.rs
+++ b/crates/agent-engine/tests/execution_gate.rs
@@ -120,6 +120,31 @@ fn mcp_spy_record(id: &str, spy: Arc<AtomicUsize>) -> CapabilityRecord {
     )
 }
 
+/// Same MCP-shaped fixture identity/provenance, but a caller-chosen inline
+/// schema — for exercising in-place record replacement (digest change).
+fn spy_record_with_schema(id: &ToolId, schema: Value, spy: Arc<AtomicUsize>) -> CapabilityRecord {
+    CapabilityRecord::new(
+        id.clone(),
+        CapabilitySource::Mcp {
+            server_id: "server-1".to_string(),
+            server_tool_name: "deferred".to_string(),
+        },
+        "gate fixture capability",
+        Vec::new(),
+        SchemaLocator::Inline(schema),
+        {
+            let spy = Arc::clone(&spy);
+            Arc::new(move || -> Arc<dyn Tool> {
+                spy.fetch_add(1, Ordering::SeqCst);
+                Arc::new(FixtureTool::unknown("spy-implementation"))
+            })
+        },
+        TrustProvenance::McpConfig {
+            server_id: "server-1".to_string(),
+        },
+    )
+}
+
 fn session(raw: &str) -> SessionId {
     SessionId::parse(raw).expect("fixture session id is valid")
 }
@@ -181,15 +206,16 @@ fn default_session_set_core_is_exactly_verified_registered_tools() {
 
 // ── Deferred (non-core) denial and exact activation ─────────────────────────
 
-/// Retained-set semantics the stream loop relies on (Task 16 review fix):
-/// ONE set snapshot judges every sibling call of a model response at ONE
-/// generation; a catalog mutation makes that retained set stale for ALL
-/// subsequent calls (typed denial, never a silent per-call refresh); only
-/// an explicit deterministic rebuild — the stream's round-top step —
-/// recovers, and it exposes newly registered verified tools as default
-/// core with zero inherited activations.
+/// Retained-set semantics the stream loop relies on (per-tool digest
+/// validation fix): ONE set snapshot judges every sibling call of a model
+/// response; an UNRELATED catalog mutation (background plugin load) no
+/// longer kills the in-flight round — tools whose current record is
+/// byte-identical to the session's pins keep authorizing WITHOUT a rebuild.
+/// Tools the session never pinned (registered after the snapshot) stay
+/// denied until the explicit round-top rebuild, which exposes them as
+/// default core with zero inherited activations.
 #[test]
-fn retained_set_judges_siblings_at_one_generation_and_denies_after_mutation_until_rebuild() {
+fn retained_set_survives_unrelated_catalog_mutation_without_rebuild() {
     let mut registry = ToolRegistry::new();
     let set = SessionToolSet::default_core_for_catalog(session("s-retained"), registry.catalog());
     let built_at = set.catalog_generation();
@@ -205,28 +231,29 @@ fn retained_set_judges_siblings_at_one_generation_and_denies_after_mutation_unti
 
     // Dynamic registration advances the catalog generation.
     registry.register(Arc::new(FixtureTool::builtin("late-registered")));
+    assert!(set.is_stale(registry.catalog()), "generation drifted");
 
-    // The retained set is now stale for EVERY call — including tools that
-    // authorized moments ago — until the explicit rebuild.
-    for wire in ["bash", "ls", "late-registered"] {
-        let err = ExecutionGate::authorize_wire_call(&registry, &set, wire)
-            .expect_err("stale retained set must deny, not silently refresh");
-        assert_eq!(
-            err,
-            ToolAuthorizationError::StaleSessionSet {
-                set: built_at,
-                catalog: registry.catalog().generation(),
-            },
-            "denial must carry the exact stale/current generation pair"
-        );
-    }
+    // Unchanged builtins survive: their current catalog records still match
+    // the pinned digests exactly. Generation drift alone denies nothing.
+    ExecutionGate::authorize_wire_call(&registry, &set, "bash")
+        .expect("unchanged builtin must authorize across unrelated drift");
+    ExecutionGate::authorize_wire_call(&registry, &set, "ls")
+        .expect("unchanged builtin must authorize across unrelated drift");
+
+    // The late tool was never pinned by this session: denied until rebuild.
+    let err = ExecutionGate::authorize_wire_call(&registry, &set, "late-registered")
+        .expect_err("unpinned late registration must not authorize");
+    assert_eq!(
+        err,
+        ToolAuthorizationError::NotActivated(ToolId::builtin("late-registered"))
+    );
 
     // Explicit deterministic rebuild (the stream's round-top step): fresh
     // default core from currently verified tools, zero activations.
     let rebuilt =
         SessionToolSet::default_core_for_catalog(session("s-retained"), registry.catalog());
     assert_eq!(rebuilt.activated().count(), 0, "no inherited activations");
-    ExecutionGate::authorize_wire_call(&registry, &rebuilt, "bash").expect("rebuild recovers");
+    ExecutionGate::authorize_wire_call(&registry, &rebuilt, "bash").expect("still authorizes");
     ExecutionGate::authorize_wire_call(&registry, &rebuilt, "late-registered")
         .expect("newly registered verified tool becomes default core after rebuild");
 }
@@ -299,7 +326,7 @@ fn foreign_session_set_has_no_grant_and_is_denied() {
 // ── Staleness and digest pinning ────────────────────────────────────────────
 
 #[test]
-fn catalog_mutation_stales_session_set_and_denies() {
+fn catalog_mutation_denies_only_when_the_called_tools_record_changed() {
     let spy = Arc::new(AtomicUsize::new(0));
     let mut catalog = ToolCatalog::empty();
     let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
@@ -309,18 +336,36 @@ fn catalog_mutation_stales_session_set_and_denies() {
     let set = SessionToolSet::new(session("s-stale"), vec![id.clone()], &catalog)
         .expect("core set builds");
 
-    // Registry/catalog mutation after the snapshot: generation advances.
+    // UNRELATED registry/catalog mutation: generation advances, but the
+    // called tool's record is untouched — authorization must survive.
     catalog
         .insert(mcp_spy_record("mcp.server-1:later", Arc::clone(&spy)))
         .expect("mutation advances generation");
+    assert!(set.is_stale(&catalog), "generation drifted");
+    ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect("unchanged tool must authorize across unrelated catalog drift");
+    assert_eq!(spy.load(Ordering::SeqCst), 1, "acquired exactly once");
 
-    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
-        .expect_err("stale session snapshot must deny, not silently bless");
-    assert!(
-        matches!(err, ToolAuthorizationError::StaleSessionSet { .. }),
-        "expected StaleSessionSet, got: {err:?}"
+    // A mutation that CHANGES the called tool's record (same id, different
+    // schema) must still deny — real drift is never silently blessed.
+    let changed = spy_record_with_schema(
+        &id,
+        serde_json::json!({
+            "type": "object",
+            "properties": {"changed": {"type": "string"}}
+        }),
+        Arc::clone(&spy),
     );
-    assert_eq!(spy.load(Ordering::SeqCst), 0);
+    catalog
+        .upsert(Some(&id), changed)
+        .expect("replace in place");
+    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect_err("changed record must deny under drift");
+    assert_eq!(
+        err,
+        ToolAuthorizationError::SchemaDigestMismatch(id.clone())
+    );
+    assert_eq!(spy.load(Ordering::SeqCst), 1, "denial acquires nothing");
 
     // Explicit deterministic rebuild against the current catalog recovers.
     let rebuilt = SessionToolSet::new(session("s-stale"), vec![id.clone()], &catalog)
@@ -375,6 +420,168 @@ fn changed_schema_digest_invalidates_pinned_core_snapshot() {
     let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
         .expect_err("changed schema digest must never be silently blessed");
     assert_eq!(err, ToolAuthorizationError::SchemaDigestMismatch(id));
+    assert_eq!(spy.load(Ordering::SeqCst), 0);
+}
+
+// ── Per-tool digest validation under generation drift ───────────────────────
+
+/// (1) Unchanged digest survives generation drift — CORE pin.
+#[test]
+fn unchanged_core_digest_survives_generation_drift() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let set = SessionToolSet::new(session("s-drift-core"), vec![id.clone()], &catalog)
+        .expect("core set builds");
+    catalog
+        .insert(mcp_spy_record("mcp.server-1:unrelated", Arc::clone(&spy)))
+        .expect("unrelated mutation advances generation");
+    assert!(set.is_stale(&catalog));
+
+    ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect("byte-identical core tool must survive unrelated drift");
+    assert_eq!(spy.load(Ordering::SeqCst), 1);
+}
+
+/// (1) Unchanged digest survives generation drift — ACTIVATED grant. The
+/// grant's pinned generation is now behind the catalog, but the
+/// (session, tool, digest) tuple still covers execution.
+#[test]
+fn unchanged_activated_digest_survives_generation_drift() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let sid = session("s-drift-act");
+    let mut set = SessionToolSet::new(sid.clone(), Vec::new(), &catalog).expect("empty core");
+    set.activate(grant_for(&sid, &catalog, &id), &catalog)
+        .expect("exact grant activates");
+
+    catalog
+        .insert(mcp_spy_record("mcp.server-1:unrelated", Arc::clone(&spy)))
+        .expect("unrelated mutation advances generation");
+    assert!(set.is_stale(&catalog));
+
+    ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect("byte-identical activated tool must survive unrelated drift");
+    assert_eq!(spy.load(Ordering::SeqCst), 1);
+}
+
+/// (2) Changed digest denies under drift — for both core and activated pins.
+#[test]
+fn changed_digest_denies_under_generation_drift() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let core_set = SessionToolSet::new(session("s-drift-chg"), vec![id.clone()], &catalog)
+        .expect("core set builds");
+    let sid = session("s-drift-chg-act");
+    let mut activated_set = SessionToolSet::new(sid.clone(), Vec::new(), &catalog).expect("empty");
+    activated_set
+        .activate(grant_for(&sid, &catalog, &id), &catalog)
+        .expect("exact grant activates");
+
+    // Replace the record in place with a different schema (digest change),
+    // then also drift the generation further with an unrelated insert.
+    let changed = spy_record_with_schema(
+        &id,
+        serde_json::json!({"type": "object", "properties": {"x": {"type": "number"}}}),
+        Arc::clone(&spy),
+    );
+    catalog.upsert(Some(&id), changed).expect("replace");
+    catalog
+        .insert(mcp_spy_record("mcp.server-1:unrelated", Arc::clone(&spy)))
+        .expect("unrelated mutation");
+
+    for set in [&core_set, &activated_set] {
+        let err = ExecutionGate::authorize(&catalog, set, resolved(&id))
+            .expect_err("changed digest must deny under drift");
+        assert_eq!(
+            err,
+            ToolAuthorizationError::SchemaDigestMismatch(id.clone())
+        );
+    }
+    assert_eq!(spy.load(Ordering::SeqCst), 0, "denials acquire nothing");
+}
+
+/// (3) A tool removed from the catalog denies `NotCataloged` under drift.
+#[test]
+fn removed_tool_denies_not_cataloged_under_generation_drift() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let set = SessionToolSet::new(session("s-drift-rm"), vec![id.clone()], &catalog)
+        .expect("core set builds");
+
+    // Registry replacement by runtime name: the old identity is dropped and
+    // a different identity takes its place — the old id is gone.
+    catalog
+        .upsert(
+            Some(&id),
+            mcp_spy_record("mcp.server-1:replacement", Arc::clone(&spy)),
+        )
+        .expect("replacement removes the old identity");
+
+    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect_err("removed tool must deny");
+    assert_eq!(err, ToolAuthorizationError::NotCataloged(id));
+    assert_eq!(spy.load(Ordering::SeqCst), 0);
+}
+
+/// (4) A tool removed and re-added under different provenance denies via
+/// the unconditional source-trust re-check even though its schema digest is
+/// unchanged (same bytes, different origin — never silently blessed).
+#[test]
+fn re_added_tool_with_different_provenance_denies_source_trust_under_drift() {
+    let spy = Arc::new(AtomicUsize::new(0));
+    let mut catalog = ToolCatalog::empty();
+    let record = mcp_spy_record("mcp.server-1:deferred", Arc::clone(&spy));
+    let id = record.id().clone();
+    catalog.insert(record).expect("insert fixture record");
+
+    let set = SessionToolSet::new(session("s-drift-prov"), vec![id.clone()], &catalog)
+        .expect("core set builds");
+
+    // Re-add in place: same id, same schema (digest identical), but the
+    // trust provenance now names a DIFFERENT MCP server than the source.
+    let imposter = CapabilityRecord::new(
+        id.clone(),
+        CapabilitySource::Mcp {
+            server_id: "server-1".to_string(),
+            server_tool_name: "deferred".to_string(),
+        },
+        "gate fixture capability",
+        Vec::new(),
+        SchemaLocator::Inline(serde_json::json!({"type": "object"})),
+        {
+            let spy = Arc::clone(&spy);
+            Arc::new(move || -> Arc<dyn Tool> {
+                spy.fetch_add(1, Ordering::SeqCst);
+                Arc::new(FixtureTool::unknown("spy-implementation"))
+            })
+        },
+        TrustProvenance::McpConfig {
+            server_id: "server-2".to_string(),
+        },
+    );
+    catalog
+        .upsert(Some(&id), imposter)
+        .expect("re-add in place");
+
+    let err = ExecutionGate::authorize(&catalog, &set, resolved(&id))
+        .expect_err("provenance drift must deny even with an identical digest");
+    assert_eq!(err, ToolAuthorizationError::SourceProvenanceMismatch(id));
     assert_eq!(spy.load(Ordering::SeqCst), 0);
 }
 

--- a/crates/agent-engine/tests/extension_lifecycle.rs
+++ b/crates/agent-engine/tests/extension_lifecycle.rs
@@ -230,7 +230,7 @@ fn dormant_extension_tools_are_searchable_gated_and_never_spawn() {
     );
     let projected: Vec<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();

--- a/crates/agent-engine/tests/mcp_descriptor_cache.rs
+++ b/crates/agent-engine/tests/mcp_descriptor_cache.rs
@@ -368,7 +368,7 @@ fn dormant_registration_is_atomic_searchable_and_activation_gated_without_spawn(
     let mut set = SessionToolSet::progressive_core_for_catalog(sid(), registry.catalog());
     let before: Vec<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();
@@ -381,7 +381,7 @@ fn dormant_registration_is_atomic_searchable_and_activation_gated_without_spawn(
     assert_eq!(registry.catalog().generation(), generation_before);
     let after: Vec<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();

--- a/crates/agent-engine/tests/mcp_lease_lifecycle.rs
+++ b/crates/agent-engine/tests/mcp_lease_lifecycle.rs
@@ -757,7 +757,7 @@ async fn fingerprint_drift_revokes_exact_grant_but_not_siblings_or_core() {
     // Next projection excludes exactly the revoked schema.
     let names: Vec<String> = registry
         .session_tools_schema(&shared.read().unwrap())
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();

--- a/crates/agent-engine/tests/memory_history_import.rs
+++ b/crates/agent-engine/tests/memory_history_import.rs
@@ -133,6 +133,7 @@ fn fixture_session(id: &str, system_prompt: Option<&str>, api_messages: Vec<Valu
         total_input_tokens: 0,
         total_output_tokens: 0,
         session_cost: 0.0,
+        message_count: 0,
         api_messages: api_messages.into_iter().map(Arc::new).collect(),
         abort_context: None,
         parent_session: None,

--- a/crates/agent-engine/tests/progressive_disclosure.rs
+++ b/crates/agent-engine/tests/progressive_disclosure.rs
@@ -117,7 +117,7 @@ fn bytes(value: &[Value]) -> Vec<u8> {
 fn progressive_core_is_exact_and_excludes_specialized_sources() {
     let registry = registry_with_dormant(10);
     let set = SessionToolSet::progressive_core_for_catalog(sid(), registry.catalog());
-    let projected = registry.session_tools_schema(&set).unwrap();
+    let projected = registry.session_tools_schema(&set).schema;
     let names: Vec<_> = projected
         .iter()
         .filter_map(|schema| schema["name"].as_str())
@@ -160,7 +160,7 @@ fn progressive_core_is_exact_and_excludes_specialized_sources() {
 fn production_core_first_request_fits_documented_budget() {
     let registry = ToolRegistry::new();
     let set = SessionToolSet::progressive_core_for_catalog(sid(), registry.catalog());
-    let projected = registry.session_tools_schema(&set).unwrap();
+    let projected = registry.session_tools_schema(&set).schema;
     let names: Vec<_> = projected
         .iter()
         .filter_map(|schema| schema["name"].as_str())
@@ -215,7 +215,7 @@ fn progressive_first_request_bytes_are_invariant_at_catalog_scale() {
     for dormant in [10, 100, 500, 1_000, 2_000] {
         let registry = registry_with_dormant(dormant);
         let set = SessionToolSet::progressive_core_for_catalog(sid(), registry.catalog());
-        let projected = registry.session_tools_schema(&set).unwrap();
+        let projected = registry.session_tools_schema(&set).schema;
         let encoded = bytes(&projected);
         let prefix = agent_engine::runtime::trace::diagnostics::tools_prefix_bytes(&projected);
         eprintln!(
@@ -250,7 +250,7 @@ fn progressive_first_request_bytes_are_invariant_at_catalog_scale() {
 fn activation_adds_one_exact_schema_to_progressive_projection() {
     let registry = registry_with_dormant(10);
     let mut set = SessionToolSet::progressive_core_for_catalog(sid(), registry.catalog());
-    let before = registry.session_tools_schema(&set).unwrap();
+    let before = registry.session_tools_schema(&set).schema;
 
     activate_exact_for_user(
         &mut set,
@@ -259,7 +259,7 @@ fn activation_adds_one_exact_schema_to_progressive_projection() {
     )
     .unwrap();
 
-    let after = registry.session_tools_schema(&set).unwrap();
+    let after = registry.session_tools_schema(&set).schema;
     assert_eq!(after.len(), before.len() + 1);
     let names: Vec<_> = after
         .iter()
@@ -275,7 +275,7 @@ fn flag_off_full_schema_path_remains_byte_identical() {
     let registry = registry_with_dormant(100);
     let before = bytes(registry.tools_schema().as_ref());
     let full_set = SessionToolSet::default_core_for_catalog(sid(), registry.catalog());
-    let projected_full = registry.session_tools_schema(&full_set).unwrap();
+    let projected_full = registry.session_tools_schema(&full_set).schema;
     let after = bytes(registry.tools_schema().as_ref());
 
     assert_eq!(before, after, "projection mutated the legacy cached schema");

--- a/crates/agent-engine/tests/session_schema_projection.rs
+++ b/crates/agent-engine/tests/session_schema_projection.rs
@@ -308,3 +308,46 @@ fn projection_reports_coherent_provenance_imposter_as_dropped() {
         vec![(id, DroppedSessionMember::ProvenanceMismatch)]
     );
 }
+
+/// A pinned member that vanishes ENTIRELY from the registry (extension
+/// unload → `try_disable` rebuilds the cached schema without it) has no
+/// `cached_schema` entry to iterate, so the primary loop never sees it.
+/// The post-pass over the session's own pins must still report it as
+/// `Uncataloged` — otherwise the round-level dropped-member log is blind
+/// to exactly the removal it exists to surface.
+#[test]
+fn projection_reports_vanished_pinned_member_as_uncataloged() {
+    let mut registry = collision_registry();
+    let mut set = SessionToolSet::new(
+        session_id(),
+        [ToolId::builtin("core_tool")],
+        registry.catalog(),
+    )
+    .expect("core resolves");
+    // Pin one exact activation on top of the core set so both pin kinds are covered.
+    activate_exact_for_user(&mut set, registry.catalog(), &ToolId::builtin("deferred_tool"))
+        .expect("activates");
+    assert!(registry.session_tools_schema(&set).dropped.is_empty());
+
+    registry
+        .try_disable(&["core_tool".to_string(), "deferred_tool".to_string()])
+        .expect("disable");
+    assert!(registry.catalog().get(&ToolId::builtin("core_tool")).is_none());
+
+    let report = registry.session_tools_schema(&set);
+    assert!(
+        !report.schema.iter().any(|s| {
+            matches!(s["name"].as_str(), Some("core_tool") | Some("deferred_tool"))
+        }),
+        "a vanished member's schema must never be served"
+    );
+    let mut dropped = report.dropped.clone();
+    dropped.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(
+        dropped,
+        vec![
+            (ToolId::builtin("core_tool"), DroppedSessionMember::Uncataloged),
+            (ToolId::builtin("deferred_tool"), DroppedSessionMember::Uncataloged),
+        ]
+    );
+}

--- a/crates/agent-engine/tests/session_schema_projection.rs
+++ b/crates/agent-engine/tests/session_schema_projection.rs
@@ -11,7 +11,10 @@
 use std::sync::Arc;
 
 use agent_engine::tools::activation::{activate_exact_for_user, SessionId, SessionToolSet};
-use agent_engine::tools::catalog::ToolId;
+use agent_engine::tools::catalog::{
+    CapabilityRecord, CapabilitySource, SchemaLocator, ToolId, TrustProvenance,
+};
+use agent_engine::tools::DroppedSessionMember;
 use agent_engine::tools::{Tool, ToolContext, ToolOrigin, ToolRegistry};
 use agent_engine::{Result, Value};
 use async_trait::async_trait;
@@ -54,12 +57,7 @@ fn collision_registry() -> ToolRegistry {
 }
 
 fn projection_bytes(registry: &ToolRegistry, set: &SessionToolSet) -> Vec<u8> {
-    serde_json::to_vec(
-        &registry
-            .session_tools_schema(set)
-            .expect("projection succeeds"),
-    )
-    .expect("serializes")
+    serde_json::to_vec(&registry.session_tools_schema(set).schema).expect("serializes")
 }
 
 #[test]
@@ -72,9 +70,7 @@ fn projection_selects_core_entries_from_cached_schema_in_stable_order() {
     )
     .expect("core resolves");
 
-    let projection = registry
-        .session_tools_schema(&set)
-        .expect("projection succeeds");
+    let projection = registry.session_tools_schema(&set).schema;
     let names: Vec<&str> = projection
         .iter()
         .filter_map(|s| s["name"].as_str())
@@ -106,9 +102,7 @@ fn activation_adds_exactly_one_cached_schema_and_siblings_stay_absent() {
     )
     .expect("core resolves");
 
-    let before = registry
-        .session_tools_schema(&set)
-        .expect("projection succeeds");
+    let before = registry.session_tools_schema(&set).schema;
 
     activate_exact_for_user(
         &mut set,
@@ -117,9 +111,7 @@ fn activation_adds_exactly_one_cached_schema_and_siblings_stay_absent() {
     )
     .expect("activation succeeds");
 
-    let after = registry
-        .session_tools_schema(&set)
-        .expect("projection succeeds");
+    let after = registry.session_tools_schema(&set).schema;
     assert_eq!(after.len(), before.len() + 1, "exactly one schema added");
 
     let names: Vec<&str> = after.iter().filter_map(|s| s["name"].as_str()).collect();
@@ -154,9 +146,7 @@ fn projection_preserves_api_alias_and_collision_names() {
     activate_exact_for_user(&mut set, registry.catalog(), &a_colon).expect("activates");
     activate_exact_for_user(&mut set, registry.catalog(), &a_dot).expect("activates");
 
-    let projection = registry
-        .session_tools_schema(&set)
-        .expect("projection succeeds");
+    let projection = registry.session_tools_schema(&set).schema;
     let names: Vec<&str> = projection
         .iter()
         .filter_map(|s| s["name"].as_str())
@@ -170,7 +160,7 @@ fn projection_never_mutates_default_full_schema_exposure() {
     let set = SessionToolSet::default_core_for_catalog(session_id(), registry.catalog());
 
     let full_before = serde_json::to_vec(registry.tools_schema().as_ref()).expect("serializes");
-    let _ = registry.session_tools_schema(&set).expect("projection ok");
+    let _ = registry.session_tools_schema(&set).schema;
     let full_after = serde_json::to_vec(registry.tools_schema().as_ref()).expect("serializes");
 
     // Default behavior stays byte-identical: the full cached schema is
@@ -178,7 +168,7 @@ fn projection_never_mutates_default_full_schema_exposure() {
     assert_eq!(full_before, full_after);
 
     // A default-core session projects the entire cached schema, byte-equal.
-    let projection = registry.session_tools_schema(&set).expect("projection ok");
+    let projection = registry.session_tools_schema(&set).schema;
     assert_eq!(
         serde_json::to_vec(&projection).expect("serializes"),
         full_before
@@ -189,17 +179,20 @@ fn projection_never_mutates_default_full_schema_exposure() {
 fn drifted_session_set_projects_only_digest_matching_pins() {
     let mut registry = collision_registry();
     let set = SessionToolSet::default_core_for_catalog(session_id(), registry.catalog());
-    let before = registry
-        .session_tools_schema(&set)
-        .expect("fresh projection ok");
+    let before = registry.session_tools_schema(&set);
+    assert!(before.dropped.is_empty(), "fresh set drops nothing");
+    let before = before.schema;
 
     // Unrelated registration drifts the generation; the session's pinned
     // members are untouched, so the projection survives and serves exactly
     // the digest-matching pins — the late tool is absent (never pinned).
     registry.register(Arc::new(NamedTool("late_tool")));
-    let after = registry
-        .session_tools_schema(&set)
-        .expect("drifted set still projects per-tool");
+    let report = registry.session_tools_schema(&set);
+    assert!(
+        report.dropped.is_empty(),
+        "unrelated drift must not drop any pinned member"
+    );
+    let after = report.schema;
     assert_eq!(
         serde_json::to_vec(&after).expect("serializes"),
         serde_json::to_vec(&before).expect("serializes"),
@@ -210,5 +203,108 @@ fn drifted_session_set_projects_only_digest_matching_pins() {
             .iter()
             .any(|s| s["name"].as_str() == Some("late_tool")),
         "unpinned late registration must not appear in the session projection"
+    );
+}
+
+/// Concern-2 report shape: a pinned member whose record drifted (digest) is
+/// EXCLUDED from the served schema and REPORTED typed — never served, never
+/// silently swallowed into a log line.
+#[test]
+fn projection_reports_digest_drifted_member_as_dropped() {
+    let mut registry = collision_registry();
+    let set = SessionToolSet::default_core_for_catalog(session_id(), registry.catalog());
+
+    // Same runtime name + origin → same ToolId, different parameters →
+    // different schema digest for the current record.
+    struct ChangedTool;
+    #[async_trait]
+    impl Tool for ChangedTool {
+        fn name(&self) -> &str {
+            "core_tool"
+        }
+        fn description(&self) -> &str {
+            "changed fixture tool"
+        }
+        fn parameters(&self) -> Value {
+            json!({"type": "object", "properties": {"other": {"type": "number"}}})
+        }
+        fn origin(&self) -> ToolOrigin {
+            ToolOrigin::Builtin
+        }
+        async fn execute(&self, _params: Value, _ctx: ToolContext) -> Result<String> {
+            Ok("ok".to_string())
+        }
+    }
+    registry.register(Arc::new(ChangedTool));
+
+    let report = registry.session_tools_schema(&set);
+    assert!(
+        !report
+            .schema
+            .iter()
+            .any(|s| s["name"].as_str() == Some("core_tool")),
+        "a drifted member's schema must never be served"
+    );
+    assert_eq!(
+        report.dropped,
+        vec![(
+            ToolId::builtin("core_tool"),
+            DroppedSessionMember::SchemaDigestMismatch
+        )]
+    );
+}
+
+/// BLOCKER coverage at the projection boundary: a coherent imposter (same
+/// `ToolId`, identical schema/digest, different but internally consistent
+/// source+provenance) must be excluded from the served schema and reported
+/// as a provenance mismatch — pinned provenance governs inclusion.
+#[test]
+fn projection_reports_coherent_provenance_imposter_as_dropped() {
+    let mut registry = collision_registry();
+    let set = SessionToolSet::default_core_for_catalog(session_id(), registry.catalog());
+    let id = ToolId::builtin("core_tool");
+    let pinned_digest = registry
+        .catalog()
+        .get(&id)
+        .expect("record present")
+        .schema_digest()
+        .clone();
+
+    // Replace the catalog record in place: same ToolId, byte-identical
+    // schema (equal digest), but a coherent Plugin source+provenance pair.
+    let imposter = CapabilityRecord::new(
+        id.clone(),
+        CapabilitySource::Plugin {
+            plugin_id: "imposter-plugin".to_string(),
+            tool_name: "core_tool".to_string(),
+        },
+        "projection fixture tool",
+        Vec::new(),
+        SchemaLocator::Inline(json!({"type": "object", "properties": {"arg": {"type": "string"}}})),
+        std::sync::Arc::new(|| -> Arc<dyn Tool> {
+            panic!("projection must never invoke the implementation factory")
+        }),
+        TrustProvenance::PluginConfig {
+            plugin_id: "imposter-plugin".to_string(),
+        },
+    );
+    assert_eq!(
+        imposter.schema_digest(),
+        &pinned_digest,
+        "imposter must be schema-identical for the test to bite"
+    );
+    registry.upsert_catalog_record_for_tests(Some(&id), imposter);
+
+    let report = registry.session_tools_schema(&set);
+    assert!(
+        !report
+            .schema
+            .iter()
+            .any(|s| s["name"].as_str() == Some("core_tool")),
+        "a provenance-drifted member's schema must never be served"
+    );
+    assert_eq!(
+        report.dropped,
+        vec![(id, DroppedSessionMember::ProvenanceMismatch)]
     );
 }

--- a/crates/agent-engine/tests/session_schema_projection.rs
+++ b/crates/agent-engine/tests/session_schema_projection.rs
@@ -325,19 +325,29 @@ fn projection_reports_vanished_pinned_member_as_uncataloged() {
     )
     .expect("core resolves");
     // Pin one exact activation on top of the core set so both pin kinds are covered.
-    activate_exact_for_user(&mut set, registry.catalog(), &ToolId::builtin("deferred_tool"))
-        .expect("activates");
+    activate_exact_for_user(
+        &mut set,
+        registry.catalog(),
+        &ToolId::builtin("deferred_tool"),
+    )
+    .expect("activates");
     assert!(registry.session_tools_schema(&set).dropped.is_empty());
 
     registry
         .try_disable(&["core_tool".to_string(), "deferred_tool".to_string()])
         .expect("disable");
-    assert!(registry.catalog().get(&ToolId::builtin("core_tool")).is_none());
+    assert!(registry
+        .catalog()
+        .get(&ToolId::builtin("core_tool"))
+        .is_none());
 
     let report = registry.session_tools_schema(&set);
     assert!(
         !report.schema.iter().any(|s| {
-            matches!(s["name"].as_str(), Some("core_tool") | Some("deferred_tool"))
+            matches!(
+                s["name"].as_str(),
+                Some("core_tool") | Some("deferred_tool")
+            )
         }),
         "a vanished member's schema must never be served"
     );
@@ -346,8 +356,14 @@ fn projection_reports_vanished_pinned_member_as_uncataloged() {
     assert_eq!(
         dropped,
         vec![
-            (ToolId::builtin("core_tool"), DroppedSessionMember::Uncataloged),
-            (ToolId::builtin("deferred_tool"), DroppedSessionMember::Uncataloged),
+            (
+                ToolId::builtin("core_tool"),
+                DroppedSessionMember::Uncataloged
+            ),
+            (
+                ToolId::builtin("deferred_tool"),
+                DroppedSessionMember::Uncataloged
+            ),
         ]
     );
 }

--- a/crates/agent-engine/tests/session_schema_projection.rs
+++ b/crates/agent-engine/tests/session_schema_projection.rs
@@ -186,12 +186,29 @@ fn projection_never_mutates_default_full_schema_exposure() {
 }
 
 #[test]
-fn stale_session_set_fails_projection_typed() {
+fn drifted_session_set_projects_only_digest_matching_pins() {
     let mut registry = collision_registry();
     let set = SessionToolSet::default_core_for_catalog(session_id(), registry.catalog());
-    registry.register(Arc::new(NamedTool("late_tool")));
-
-    registry
+    let before = registry
         .session_tools_schema(&set)
-        .expect_err("stale set must fail projection");
+        .expect("fresh projection ok");
+
+    // Unrelated registration drifts the generation; the session's pinned
+    // members are untouched, so the projection survives and serves exactly
+    // the digest-matching pins — the late tool is absent (never pinned).
+    registry.register(Arc::new(NamedTool("late_tool")));
+    let after = registry
+        .session_tools_schema(&set)
+        .expect("drifted set still projects per-tool");
+    assert_eq!(
+        serde_json::to_vec(&after).expect("serializes"),
+        serde_json::to_vec(&before).expect("serializes"),
+        "projection across unrelated drift is byte-identical to the fresh one"
+    );
+    assert!(
+        !after
+            .iter()
+            .any(|s| s["name"].as_str() == Some("late_tool")),
+        "unpinned late registration must not appear in the session projection"
+    );
 }

--- a/crates/agent-tui/Cargo.toml
+++ b/crates/agent-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synaps-tui"
-version = "0.9.0"
+version.workspace = true
 edition = "2021"
 rust-version = "1.80"
 description = "Terminal UI layer — ratatui, crossterm, syntect, tachyonfx"
@@ -11,8 +11,8 @@ name = "agent_tui"
 path = "src/lib.rs"
 
 [dependencies]
-agent-core   = { path = "../agent-core", version = "0.9.0", package = "synaps-core" }
-agent-engine = { path = "../agent-engine", version = "0.9.0", package = "synaps-engine" }
+agent-core   = { workspace = true }
+agent-engine = { workspace = true }
 
 # Async runtime + utilities
 tokio        = { version = "1.0", features = ["full"] }

--- a/crates/agent-tui/src/tui/commands.rs
+++ b/crates/agent-tui/src/tui/commands.rs
@@ -600,7 +600,7 @@ pub(super) async fn handle_command(
                         .unwrap_or_default();
                     let age = {
                         let secs = chrono::Utc::now()
-                            .signed_duration_since(s.created_at)
+                            .signed_duration_since(s.updated_at)
                             .num_seconds();
                         if secs < 3600 {
                             format!("{}m ago", secs / 60)

--- a/crates/agent-tui/src/tui/commands.rs
+++ b/crates/agent-tui/src/tui/commands.rs
@@ -418,7 +418,9 @@ pub(super) async fn handle_command(
         };
         return match result {
             CommandResult::Quit => CommandAction::Quit,
-            CommandResult::ModelChanged { .. } => {
+            CommandResult::ModelChanged {
+                reasoning_clamped, ..
+            } => {
                 // Use the runtime's cleaned model string, not the raw arg.
                 let applied = runtime.model().to_string();
                 app.session.model = applied.clone();
@@ -427,6 +429,13 @@ pub(super) async fn handle_command(
                     "model set to: {} {}",
                     applied, status
                 )));
+                // Session-only: the user's configured thinking value stays theirs.
+                if let Some(clamp) = reasoning_clamped {
+                    app.session.thinking_level = runtime.thinking_level().to_string();
+                    app.push_msg(ChatMessage::System(reasoning_clamp_notice(
+                        &clamp, &applied,
+                    )));
+                }
                 CommandAction::None
             }
             CommandResult::ThinkingChanged { spec } => {
@@ -1207,6 +1216,19 @@ pub(super) fn handle_streaming_command(
         "quit" | "exit" => CommandAction::Quit,
         _ => CommandAction::None, // unknown — handled by caller as steer/queue
     }
+}
+
+/// Notice shown when a model change forced a reasoning-level substitution.
+pub(crate) fn reasoning_clamp_notice(
+    clamp: &synaps_cli::runtime::ReasoningClamp,
+    model: &str,
+) -> String {
+    format!(
+        "thinking → {} (clamped from {}: not supported by {})",
+        clamp.to.as_str(),
+        clamp.from.as_str(),
+        model
+    )
 }
 
 #[cfg(test)]

--- a/crates/agent-tui/src/tui/commands.rs
+++ b/crates/agent-tui/src/tui/commands.rs
@@ -325,12 +325,19 @@ pub(super) fn resolve_prefix(raw: &str, commands: &[String]) -> String {
     raw.to_string()
 }
 
-fn restore_session_reasoning(runtime: &mut Runtime, thinking_level: &str) {
-    if let Some(level) = agent_core::reasoning::ReasoningLevel::parse(thinking_level) {
-        runtime.set_reasoning_level_explicit(level);
-    } else if let Some(budget) = synaps_cli::models::budget_for_thinking_level(thinking_level) {
-        runtime.set_thinking_budget_explicit(budget);
-    }
+/// Re-apply a saved session's reasoning level as explicit, clamped to the
+/// current model. Returns a notice when the saved level was clamped.
+fn restore_session_reasoning(runtime: &mut Runtime, thinking_level: &str) -> Option<String> {
+    runtime
+        .restore_session_reasoning(thinking_level)
+        .map(|clamp| {
+            format!(
+                "thinking → {} (clamped from {}: not supported by {})",
+                clamp.to.as_str(),
+                clamp.from.as_str(),
+                runtime.model()
+            )
+        })
 }
 
 /// Handle a slash command when NOT streaming.
@@ -648,7 +655,8 @@ pub(super) async fn handle_command(
                         runtime.set_model(session.model.clone());
                         // A resumed session owns its saved choice. Preserve that
                         // explicit provenance across later model switches.
-                        restore_session_reasoning(runtime, &session.thinking_level);
+                        let clamp_notice =
+                            restore_session_reasoning(runtime, &session.thinking_level);
                         if let Some(ref sp) = session.system_prompt {
                             runtime.set_system_prompt(sp.clone());
                         }
@@ -663,6 +671,11 @@ pub(super) async fn handle_command(
                         super::rebuild_display_messages(&session.api_messages, app);
                         let new_id = session.id.clone();
                         app.session = session;
+                        if let Some(notice) = clamp_notice {
+                            // Keep the session file in sync with the clamped runtime.
+                            app.session.thinking_level = runtime.thinking_level().to_string();
+                            app.push_msg(ChatMessage::System(notice));
+                        }
                         let via = if synaps_cli::chain::load_chain(arg).is_ok() {
                             format!(" (via chain '{}')", arg)
                         } else if synaps_cli::session::find_session_by_name(arg).is_ok() {
@@ -2176,5 +2189,20 @@ mod tests {
             agent_core::reasoning::ReasoningLevel::Ultra,
             "restored explicit Ultra must survive model switches"
         );
+    }
+
+    #[tokio::test]
+    async fn resume_clamps_unsupported_saved_level() {
+        let mut runtime = synaps_cli::Runtime::new().await.unwrap();
+        runtime.set_model("xai-auth/grok-4.6".to_string());
+
+        let notice = restore_session_reasoning(&mut runtime, "xhigh");
+
+        assert!(notice.is_some(), "clamp must be surfaced");
+        assert_eq!(
+            runtime.reasoning_level(),
+            agent_core::reasoning::ReasoningLevel::High
+        );
+        assert!(runtime.is_reasoning_explicit());
     }
 }

--- a/crates/agent-tui/src/tui/commands.rs
+++ b/crates/agent-tui/src/tui/commands.rs
@@ -576,21 +576,49 @@ pub(super) async fn handle_command(
                     sessions.len()
                 )));
                 for s in sessions.iter().take(20) {
-                    let title = if s.title.is_empty() {
-                        "(untitled)"
-                    } else {
-                        &s.title
-                    };
-                    let active = if s.id == app.session.id { " *" } else { "" };
+                    let active_marker = if s.id == app.session.id { " ●" } else { "" };
                     let name_tag = s
                         .name
                         .as_deref()
                         .map(|n| format!(" [@{}]", n))
                         .unwrap_or_default();
+                    let age = {
+                        let secs = chrono::Utc::now()
+                            .signed_duration_since(s.created_at)
+                            .num_seconds();
+                        if secs < 3600 {
+                            format!("{}m ago", secs / 60)
+                        } else if secs < 86400 {
+                            format!("{}h ago", secs / 3600)
+                        } else {
+                            format!("{}d ago", secs / 86400)
+                        }
+                    };
+                    let title_display = if s.title.is_empty() {
+                        "(no title)".to_string()
+                    } else {
+                        s.title.chars().take(60).collect::<String>()
+                    };
+                    // Last 4 chars — more recognizable than a prefix
+                    let id_short = &s.id[s.id.len().saturating_sub(4)..];
+                    let msg_str = if s.message_count > 0 {
+                        format!("{} msgs · ", s.message_count)
+                    } else {
+                        String::new()
+                    };
+                    // Line 1: identity + meta
                     app.push_msg(ChatMessage::System(format!(
-                        "  {}{} — {} [{}] ${:.4}{}",
-                        &s.id, name_tag, title, s.model, s.session_cost, active
+                        "  …{}{}{} · {}{}${:.3} · {}",
+                        id_short, active_marker, name_tag,
+                        msg_str, age, s.session_cost, s.model
                     )));
+                    // Line 2: title
+                    app.push_msg(ChatMessage::System(format!(
+                        "     └ {}",
+                        title_display
+                    )));
+                    // Blank separator between entries
+                    app.push_msg(ChatMessage::System(String::new()));
                 }
             }
             Err(e) => {

--- a/crates/agent-tui/src/tui/dispatch.rs
+++ b/crates/agent-tui/src/tui/dispatch.rs
@@ -1379,7 +1379,7 @@ pub(crate) async fn handle_input_action(
             }
         }
         InputAction::ModelsApply(model) => match runtime.try_set_model(model.clone()) {
-            Ok(()) => {
+            Ok(clamp) => {
                 let applied = runtime.model().to_string();
                 let status = synaps_cli::engine::commands::persist_to_config("model", &applied);
                 app.session.model = applied.clone();
@@ -1387,6 +1387,13 @@ pub(crate) async fn handle_input_action(
                     "model set to: {} {}",
                     applied, status
                 )));
+                // Session-only: the user's configured thinking value stays theirs.
+                if let Some(clamp) = clamp {
+                    app.session.thinking_level = runtime.thinking_level().to_string();
+                    app.push_msg(ChatMessage::System(
+                        crate::tui::commands::reasoning_clamp_notice(&clamp, &applied),
+                    ));
+                }
             }
             Err(error) => app.push_msg(ChatMessage::Error(error)),
         },

--- a/crates/agent-tui/src/tui/render.rs
+++ b/crates/agent-tui/src/tui/render.rs
@@ -1084,8 +1084,7 @@ impl TranscriptStore {
                 // Mirrors the User/Text pattern using wrap_text() so all
                 // chat content wraps consistently.
                 let style = Style::default()
-                    .fg(THEME.load().muted)
-                    .add_modifier(Modifier::DIM);
+                    .fg(THEME.load().system_msg);
                 for (src_line, line_off, line) in source_lines(msg) {
                     let prefix_len = m.len() + 2;
                     for row in wrap_text_spans(&format!("{}  {}", m, line), width) {

--- a/crates/agent-tui/src/tui/theme/mod.rs
+++ b/crates/agent-tui/src/tui/theme/mod.rs
@@ -45,6 +45,7 @@ pub(crate) struct Theme {
     pub(crate) border: Color,
     pub(crate) border_active: Color,
     pub(crate) muted: Color,
+    pub(crate) system_msg: Color,
 
     // Messages
     pub(crate) user_color: Color,
@@ -140,6 +141,7 @@ impl Default for Theme {
             border: Color::Rgb(33, 42, 58),
             border_active: Color::Rgb(54, 190, 210),
             muted: Color::Rgb(62, 73, 90),
+            system_msg: Color::Rgb(140, 160, 180),
 
             user_color: Color::Rgb(185, 195, 215),
             user_bg: Color::Rgb(19, 23, 33),
@@ -280,6 +282,7 @@ impl Theme {
             "border" => self.border = c,
             "border_active" => self.border_active = c,
             "muted" => self.muted = c,
+            "system_msg" => self.system_msg = c,
             "user_color" => self.user_color = c,
             "user_bg" => self.user_bg = c,
             "claude_label" => self.claude_label = c,

--- a/crates/agent-tui/src/tui/theme/mxc.rs
+++ b/crates/agent-tui/src/tui/theme/mxc.rs
@@ -366,8 +366,7 @@ pub(crate) fn theme_from_mxc(x: &MxcColors) -> Theme {
         border: c(x.border),
         border_active: c(x.border_active),
         muted: c(x.text_muted),
-
-        // Messages
+        system_msg: c(x.text_muted),
         user_color: c(x.accent),
         user_bg: c(x.background_panel),
         claude_label: c(x.primary),

--- a/crates/agent-tui/src/tui/theme/palettes/amber.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/amber.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(40, 30, 15),
             border_active: Color::Rgb(255, 176, 0),
             muted: Color::Rgb(80, 65, 35),
+            system_msg: Color::Rgb(160, 135, 80),
 
             user_color: Color::Rgb(220, 200, 160),
             user_bg: Color::Rgb(18, 14, 8),

--- a/crates/agent-tui/src/tui/theme/palettes/blood.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/blood.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(40, 15, 15),
             border_active: Color::Rgb(255, 50, 50),
             muted: Color::Rgb(80, 40, 40),
+            system_msg: Color::Rgb(165, 100, 100),
 
             user_color: Color::Rgb(220, 180, 180),
             user_bg: Color::Rgb(15, 5, 5),

--- a/crates/agent-tui/src/tui/theme/palettes/catppuccin.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/catppuccin.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(88, 91, 112),
             border_active: Color::Rgb(180, 190, 254),
             muted: Color::Rgb(108, 112, 134),
+            system_msg: Color::Rgb(160, 165, 190),
 
             user_color: Color::Rgb(205, 214, 244),
             user_bg: Color::Rgb(49, 50, 68),

--- a/crates/agent-tui/src/tui/theme/palettes/dracula.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/dracula.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(30, 25, 40),
             border_active: Color::Rgb(189, 147, 249),
             muted: Color::Rgb(68, 71, 90),
+            system_msg: Color::Rgb(140, 145, 175),
 
             user_color: Color::Rgb(248, 248, 242),
             user_bg: Color::Rgb(18, 15, 25),

--- a/crates/agent-tui/src/tui/theme/palettes/forest.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/forest.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(50, 70, 35),
             border_active: Color::Rgb(120, 180, 100),
             muted: Color::Rgb(70, 90, 50),
+            system_msg: Color::Rgb(130, 160, 100),
 
             user_color: Color::Rgb(130, 190, 110),
             user_bg: Color::Rgb(12, 16, 8),

--- a/crates/agent-tui/src/tui/theme/palettes/gruvbox.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/gruvbox.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(80, 73, 69),
             border_active: Color::Rgb(254, 128, 25),
             muted: Color::Rgb(146, 131, 116),
+            system_msg: Color::Rgb(189, 174, 147),
 
             user_color: Color::Rgb(235, 219, 178),
             user_bg: Color::Rgb(50, 48, 47),

--- a/crates/agent-tui/src/tui/theme/palettes/ice.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/ice.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(40, 60, 90),
             border_active: Color::Rgb(180, 220, 255),
             muted: Color::Rgb(70, 90, 130),
+            system_msg: Color::Rgb(130, 160, 200),
 
             user_color: Color::Rgb(190, 225, 255),
             user_bg: Color::Rgb(8, 11, 16),

--- a/crates/agent-tui/src/tui/theme/palettes/lavender.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/lavender.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(50, 30, 80),
             border_active: Color::Rgb(170, 120, 255),
             muted: Color::Rgb(85, 60, 130),
+            system_msg: Color::Rgb(155, 130, 195),
 
             user_color: Color::Rgb(225, 215, 245),
             user_bg: Color::Rgb(18, 12, 30),

--- a/crates/agent-tui/src/tui/theme/palettes/monokai.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/monokai.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(73, 72, 62),
             border_active: Color::Rgb(253, 151, 31),
             muted: Color::Rgb(117, 113, 94),
+            system_msg: Color::Rgb(172, 168, 142),
 
             user_color: Color::Rgb(248, 248, 242),
             user_bg: Color::Rgb(39, 40, 34),

--- a/crates/agent-tui/src/tui/theme/palettes/neon_rain.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/neon_rain.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(30, 21, 48),
             border_active: Color::Rgb(255, 46, 136),
             muted: Color::Rgb(74, 58, 90),
+            system_msg: Color::Rgb(150, 120, 175),
 
             user_color: Color::Rgb(232, 224, 255),
             user_bg: Color::Rgb(13, 8, 24),

--- a/crates/agent-tui/src/tui/theme/palettes/night_city.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/night_city.rs
@@ -34,6 +34,7 @@ impl Theme {
             border: Color::Rgb(30, 35, 52),
             border_active: CYAN,
             muted: Color::Rgb(74, 82, 104),
+            system_msg: Color::Rgb(140, 150, 185),
 
             // Messages
             user_color: Color::Rgb(220, 228, 242),

--- a/crates/agent-tui/src/tui/theme/palettes/nord.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/nord.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(35, 40, 50),
             border_active: Color::Rgb(129, 161, 193),
             muted: Color::Rgb(75, 85, 105),
+            system_msg: Color::Rgb(140, 155, 185),
 
             user_color: Color::Rgb(236, 239, 244),
             user_bg: Color::Rgb(22, 25, 30),

--- a/crates/agent-tui/src/tui/theme/palettes/ocean.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/ocean.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(15, 30, 45),
             border_active: Color::Rgb(0, 206, 209),
             muted: Color::Rgb(45, 75, 105),
+            system_msg: Color::Rgb(100, 150, 190),
 
             user_color: Color::Rgb(170, 210, 245),
             // User turns share the header/footer chrome surface.

--- a/crates/agent-tui/src/tui/theme/palettes/phosphor.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/phosphor.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(15, 40, 20),
             border_active: Color::Rgb(50, 255, 80),
             muted: Color::Rgb(25, 70, 35),
+            system_msg: Color::Rgb(80, 160, 100),
 
             user_color: Color::Rgb(60, 220, 90),
             user_bg: Color::Rgb(5, 14, 8),

--- a/crates/agent-tui/src/tui/theme/palettes/rose_pine.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/rose_pine.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(35, 28, 42),
             border_active: Color::Rgb(235, 111, 146),
             muted: Color::Rgb(85, 75, 95),
+            system_msg: Color::Rgb(160, 145, 175),
 
             user_color: Color::Rgb(240, 237, 245),
             user_bg: Color::Rgb(18, 15, 22),

--- a/crates/agent-tui/src/tui/theme/palettes/solarized_dark.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/solarized_dark.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(7, 54, 66), // base02
             border_active: Color::Rgb(38, 139, 210),
             muted: Color::Rgb(88, 110, 117), // base01
+            system_msg: Color::Rgb(147, 161, 161), // base1
 
             user_color: Color::Rgb(253, 246, 227), // base3
             user_bg: Color::Rgb(7, 54, 66),

--- a/crates/agent-tui/src/tui/theme/palettes/sunset.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/sunset.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(80, 40, 50),
             border_active: Color::Rgb(255, 140, 90),
             muted: Color::Rgb(100, 50, 60),
+            system_msg: Color::Rgb(190, 120, 110),
 
             user_color: Color::Rgb(255, 170, 130),
             user_bg: Color::Rgb(20, 10, 12),

--- a/crates/agent-tui/src/tui/theme/palettes/tokyo_night.rs
+++ b/crates/agent-tui/src/tui/theme/palettes/tokyo_night.rs
@@ -19,6 +19,7 @@ impl Theme {
             border: Color::Rgb(41, 46, 66),
             border_active: Color::Rgb(122, 162, 247),
             muted: Color::Rgb(86, 95, 137),
+            system_msg: Color::Rgb(140, 155, 200),
 
             user_color: Color::Rgb(192, 202, 245),
             user_bg: Color::Rgb(36, 40, 59),

--- a/crates/agent-tui/src/tui/theme/transition.rs
+++ b/crates/agent-tui/src/tui/theme/transition.rs
@@ -140,6 +140,7 @@ pub(crate) fn lerp_theme(from: &Theme, to: &Theme, t: f32) -> Theme {
         border: c!(border),
         border_active: c!(border_active),
         muted: c!(muted),
+        system_msg: c!(system_msg),
         user_color: c!(user_color),
         user_bg: c!(user_bg),
         claude_label: c!(claude_label),

--- a/docs/tools.json
+++ b/docs/tools.json
@@ -273,7 +273,7 @@
     }
   },
   {
-    "description": "Read the contents of a file. Returns lines with line numbers. Reads up to 500 lines by default. For large files, use offset and limit to read in sections.",
+    "description": "Read the contents of a file. Returns lines with line numbers. Reads up to 500 lines by default. For large files, use offset and limit to read in sections. Image files (PNG, JPEG, GIF, WebP) are returned as an image the model can see, up to 3.5 MB.",
     "name": "read",
     "parameters": {
       "properties": {

--- a/src/cmd/agent.rs
+++ b/src/cmd/agent.rs
@@ -168,7 +168,9 @@ pub async fn run(config_path: String, trigger_context: String) {
 
     // Setup session logging
     let logs_dir = agent_dir.join("logs");
-    std::fs::create_dir_all(&logs_dir).unwrap_or_default();
+    if let Err(e) = std::fs::create_dir_all(&logs_dir) {
+        eprintln!("failed to create logs dir {}: {}", logs_dir.display(), e);
+    }
     let session_number = get_session_number(&logs_dir);
     let session_log_path = logs_dir.join(format!("session-{:03}.jsonl", session_number));
     let current_log_path = logs_dir.join("current.log");

--- a/src/cmd/chat.rs
+++ b/src/cmd/chat.rs
@@ -215,9 +215,22 @@ pub async fn run(
                     if let Some(result) = commands::handle_engine_command(cmd, arg, &mut runtime) {
                         match result {
                             CommandResult::Quit => break,
-                            CommandResult::ModelChanged { model } => {
+                            CommandResult::ModelChanged {
+                                model,
+                                reasoning_clamped,
+                            } => {
                                 conv.session.model = runtime.model().to_string();
                                 eprintln!("model → {}", model);
+                                if let Some(clamp) = reasoning_clamped {
+                                    conv.session.thinking_level =
+                                        runtime.thinking_level().to_string();
+                                    eprintln!(
+                                        "thinking → {} (clamped from {}: not supported by {})",
+                                        clamp.to.as_str(),
+                                        clamp.from.as_str(),
+                                        runtime.model()
+                                    );
+                                }
                             }
                             CommandResult::ThinkingChanged { spec } => {
                                 conv.session.thinking_level = spec.config_value();

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -1249,11 +1249,26 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
 
     if let Some(result) = engine_result {
         match result {
-            CommandResult::ModelChanged { model } => {
-                state.conv.write().await.session.model = model.clone();
-                let _ = broadcast.send(ServerMessage::System {
-                    message: format!("model set to: {model}"),
-                });
+            CommandResult::ModelChanged {
+                model,
+                reasoning_clamped,
+            } => {
+                let mut message = format!("model set to: {model}");
+                {
+                    let mut conv = state.conv.write().await;
+                    conv.session.model = model.clone();
+                    if let Some(clamp) = reasoning_clamped {
+                        let rt = state.runtime.lock().await;
+                        conv.session.thinking_level = rt.thinking_level().to_string();
+                        message.push_str(&format!(
+                            "; thinking → {} (clamped from {}: not supported by {})",
+                            clamp.to.as_str(),
+                            clamp.from.as_str(),
+                            rt.model()
+                        ));
+                    }
+                }
+                let _ = broadcast.send(ServerMessage::System { message });
             }
             CommandResult::ThinkingChanged { spec } => {
                 state.conv.write().await.session.thinking_level = spec.config_value();

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -1296,12 +1296,11 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
                 // T30 (spec §9.2): server compaction routes through the ONE
                 // engine transition with the in-place policy. Snapshot under
                 // brief locks; the LLM round-trip runs with no lock held.
+                // Lock order: `runtime` → `conv` (file-wide invariant).
                 let (msgs, session, rt) = {
+                    let rt = state.runtime.lock().await;
                     let conv = state.conv.read().await;
-                    (conv.api_messages.clone(), conv.session.clone(), {
-                        let rt = state.runtime.lock().await;
-                        rt.clone()
-                    })
+                    (conv.api_messages.clone(), conv.session.clone(), rt.clone())
                 };
                 if msgs.len() < 4 {
                     let _ = broadcast.send(ServerMessage::System {

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -1242,9 +1242,18 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
 
     // Try engine-level command (model with args, thinking with engine-known
     // levels, quit, compact).
-    let engine_result = {
+    //
+    // Lock order in this file is `runtime` → `conv` (see `/clear` below).
+    // Snapshot everything the ModelChanged arm needs while `rt` is held here
+    // so that arm only ever takes `conv` and never both.
+    let (engine_result, post_thinking, post_model) = {
         let mut rt = state.runtime.lock().await;
-        engine_commands::handle_engine_command(name, args, &mut rt)
+        let result = engine_commands::handle_engine_command(name, args, &mut rt);
+        (
+            result,
+            rt.thinking_level().to_string(),
+            rt.model().to_string(),
+        )
     };
 
     if let Some(result) = engine_result {
@@ -1258,13 +1267,12 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
                     let mut conv = state.conv.write().await;
                     conv.session.model = model.clone();
                     if let Some(clamp) = reasoning_clamped {
-                        let rt = state.runtime.lock().await;
-                        conv.session.thinking_level = rt.thinking_level().to_string();
+                        conv.session.thinking_level = post_thinking;
                         message.push_str(&format!(
                             "; thinking → {} (clamped from {}: not supported by {})",
                             clamp.to.as_str(),
                             clamp.from.as_str(),
-                            rt.model()
+                            post_model
                         ));
                     }
                 }

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -1278,8 +1278,7 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
     // The engine result is applied to `conv` while `runtime` is still held
     // so concurrent clients can't interleave between the runtime mutation
     // and the conv mirror (runtime → conv is the legal order).
-    let engine_result =
-        run_engine_command_synced(name, args, &state.runtime, &state.conv).await;
+    let engine_result = run_engine_command_synced(name, args, &state.runtime, &state.conv).await;
 
     if let Some(result) = engine_result {
         match result {
@@ -1564,7 +1563,10 @@ mod tests {
             None,
         )));
         let res = run_engine_command_synced("thinking", "high", &runtime, &conv).await;
-        assert!(matches!(res, Some(CommandResult::ThinkingChanged { .. })), "{res:?}");
+        assert!(
+            matches!(res, Some(CommandResult::ThinkingChanged { .. })),
+            "{res:?}"
+        );
         assert_eq!(conv.read().await.session.thinking_level, "high");
         assert_eq!(runtime.lock().await.thinking_level(), "high");
     }

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -1210,6 +1210,37 @@ async fn run_injected_event_turn(state: &Arc<ServerState>) {
     *state.cancel_token.write().await = None;
 }
 
+/// Run an engine command and mirror any model/thinking change into `conv`
+/// atomically with respect to other commands.
+///
+/// Both locks are taken in the file-wide order `runtime` → `conv`, and the
+/// `runtime` guard is held across the `conv` write so a second client's
+/// command can't slip between "runtime mutated" and "conv mirrored" and
+/// leave `conv.session.{model,thinking_level}` stale.
+async fn run_engine_command_synced(
+    name: &str,
+    args: &str,
+    runtime: &Mutex<Runtime>,
+    conv: &RwLock<ConversationState>,
+) -> Option<CommandResult> {
+    let mut rt = runtime.lock().await;
+    let result = engine_commands::handle_engine_command(name, args, &mut rt)?;
+    match &result {
+        CommandResult::ModelChanged { .. } => {
+            let mut conv = conv.write().await;
+            conv.session.model = rt.model().to_string();
+            // Covers the reasoning-clamp case; a no-op otherwise.
+            conv.session.thinking_level = rt.thinking_level().to_string();
+        }
+        CommandResult::ThinkingChanged { spec } => {
+            // Custom budgets persist as the raw number (matches chat.rs).
+            conv.write().await.session.thinking_level = spec.config_value();
+        }
+        _ => {}
+    }
+    Some(result)
+}
+
 async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
     let broadcast = &state.broadcast_tx;
 
@@ -1244,17 +1275,11 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
     // levels, quit, compact).
     //
     // Lock order in this file is `runtime` → `conv` (see `/clear` below).
-    // Snapshot everything the ModelChanged arm needs while `rt` is held here
-    // so that arm only ever takes `conv` and never both.
-    let (engine_result, post_thinking, post_model) = {
-        let mut rt = state.runtime.lock().await;
-        let result = engine_commands::handle_engine_command(name, args, &mut rt);
-        (
-            result,
-            rt.thinking_level().to_string(),
-            rt.model().to_string(),
-        )
-    };
+    // The engine result is applied to `conv` while `runtime` is still held
+    // so concurrent clients can't interleave between the runtime mutation
+    // and the conv mirror (runtime → conv is the legal order).
+    let engine_result =
+        run_engine_command_synced(name, args, &state.runtime, &state.conv).await;
 
     if let Some(result) = engine_result {
         match result {
@@ -1263,23 +1288,17 @@ async fn handle_command(name: &str, args: &str, state: &Arc<ServerState>) {
                 reasoning_clamped,
             } => {
                 let mut message = format!("model set to: {model}");
-                {
-                    let mut conv = state.conv.write().await;
-                    conv.session.model = model.clone();
-                    if let Some(clamp) = reasoning_clamped {
-                        conv.session.thinking_level = post_thinking;
-                        message.push_str(&format!(
-                            "; thinking → {} (clamped from {}: not supported by {})",
-                            clamp.to.as_str(),
-                            clamp.from.as_str(),
-                            post_model
-                        ));
-                    }
+                if let Some(clamp) = reasoning_clamped {
+                    message.push_str(&format!(
+                        "; thinking → {} (clamped from {}: not supported by {})",
+                        clamp.to.as_str(),
+                        clamp.from.as_str(),
+                        model
+                    ));
                 }
                 let _ = broadcast.send(ServerMessage::System { message });
             }
             CommandResult::ThinkingChanged { spec } => {
-                state.conv.write().await.session.thinking_level = spec.config_value();
                 let _ = broadcast.send(ServerMessage::System {
                     message: format!("thinking set to: {}", spec.level()),
                 });
@@ -1484,4 +1503,69 @@ fn rebuild_history(api_messages: &[synaps_cli::SharedMessage]) -> Vec<HistoryEnt
         }
     }
     history
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synaps_cli::Session;
+
+    /// Two clients hammering `/model` and `/thinking` concurrently must never
+    /// leave `conv.session` out of sync with the live runtime — the mirror
+    /// write happens under the `runtime` lock (runtime → conv).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn interleaved_commands_keep_conv_in_sync_with_runtime() {
+        let runtime = Arc::new(Mutex::new(Runtime::new_headless()));
+        let conv = Arc::new(RwLock::new(ConversationState::new(Session::new(
+            "anthropic/claude-fable-5",
+            "medium",
+            None,
+        ))));
+
+        let models = [
+            "anthropic/claude-fable-5",
+            "openrouter/deepseek/deepseek-v4-pro",
+        ];
+        let mut tasks = Vec::new();
+        for i in 0..2 {
+            let runtime = Arc::clone(&runtime);
+            let conv = Arc::clone(&conv);
+            tasks.push(tokio::spawn(async move {
+                for n in 0..50 {
+                    let model = models[(i + n) % 2];
+                    let res = run_engine_command_synced("model", model, &runtime, &conv).await;
+                    assert!(matches!(res, Some(CommandResult::ModelChanged { .. })));
+                    // Check the invariant at an arbitrary point, not just at the end.
+                    let rt = runtime.lock().await;
+                    let c = conv.read().await;
+                    assert_eq!(c.session.model, rt.model());
+                    assert_eq!(c.session.thinking_level, rt.thinking_level());
+                    drop(c);
+                    drop(rt);
+                    tokio::task::yield_now().await;
+                }
+            }));
+        }
+        for t in tasks {
+            t.await.unwrap();
+        }
+        let rt = runtime.lock().await;
+        let c = conv.read().await;
+        assert_eq!(c.session.model, rt.model());
+        assert_eq!(c.session.thinking_level, rt.thinking_level());
+    }
+
+    #[tokio::test]
+    async fn thinking_custom_budget_persists_raw_number() {
+        let runtime = Mutex::new(Runtime::new_headless());
+        let conv = RwLock::new(ConversationState::new(Session::new(
+            "anthropic/claude-fable-5",
+            "medium",
+            None,
+        )));
+        let res = run_engine_command_synced("thinking", "high", &runtime, &conv).await;
+        assert!(matches!(res, Some(CommandResult::ThinkingChanged { .. })), "{res:?}");
+        assert_eq!(conv.read().await.session.thinking_level, "high");
+        assert_eq!(runtime.lock().await.thinking_level(), "high");
+    }
 }

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -41,7 +41,10 @@ pub(crate) fn watcher_dir() -> PathBuf {
 
 pub(crate) fn agent_binary() -> PathBuf {
     // Same binary, different subcommand
-    std::env::current_exe().unwrap_or_default()
+    std::env::current_exe().unwrap_or_else(|e| {
+        eprintln!("[watcher] current_exe() failed: {e}");
+        PathBuf::new()
+    })
 }
 
 pub(crate) fn log(msg: &str) {

--- a/src/watcher/supervisor.rs
+++ b/src/watcher/supervisor.rs
@@ -115,7 +115,7 @@ pub(crate) fn check_heartbeat(agent_dir: &std::path::Path, stale_threshold: u64)
 pub(crate) fn expand_watch_path(p: &str) -> PathBuf {
     if p.starts_with("~/") {
         if let Some(home) = dirs_next() {
-            return home.join(p.strip_prefix("~/").unwrap());
+            return home.join(p.trim_start_matches("~/"));
         }
     }
     PathBuf::from(p)

--- a/tests/execution_gate_stream.rs
+++ b/tests/execution_gate_stream.rs
@@ -326,7 +326,8 @@ const SSE_LATE_TOOL_ROUND: &str = concat!(
 );
 
 /// Builtin-origin fixture registered mid-round by the `before_message`
-/// mutator: its registration bumps the catalog generation.
+/// mutator under a NEW name: its registration bumps the catalog generation
+/// without touching any tool the model is about to call.
 struct MidRoundRegisteredTool;
 
 #[async_trait]
@@ -348,10 +349,39 @@ impl Tool for MidRoundRegisteredTool {
     }
 }
 
-/// `before_message` handler that mutates the live registry exactly once —
-/// AFTER the round-top session-set rebuild, BEFORE tool authorization.
+/// Builtin-origin imposter registered mid-round OVER the real `ls`: same
+/// `ToolId` (`builtin:ls`), different schema → the catalog record's digest
+/// drifts from the digest the session pinned at the round-top rebuild.
+struct DriftedLsTool;
+
+#[async_trait]
+impl Tool for DriftedLsTool {
+    fn name(&self) -> &str {
+        "ls"
+    }
+    fn description(&self) -> &str {
+        "schema-drifted replacement for ls registered mid-round"
+    }
+    fn parameters(&self) -> Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {"drifted": {"type": "boolean"}}
+        })
+    }
+    fn origin(&self) -> ToolOrigin {
+        ToolOrigin::Builtin
+    }
+    async fn execute(&self, _params: Value, _ctx: ToolContext) -> Result<String> {
+        Ok("DRIFTED_OK".to_string())
+    }
+}
+
+/// `before_message` handler that registers `tool` into the live registry
+/// exactly once — AFTER the round-top session-set rebuild, BEFORE tool
+/// authorization.
 struct RegistryMutator {
     tools: Arc<tokio::sync::RwLock<synaps_cli::ToolRegistry>>,
+    tool: Arc<dyn Tool>,
     fired: Arc<AtomicBool>,
 }
 
@@ -365,11 +395,28 @@ impl ExtensionHandler for RegistryMutator {
             self.tools
                 .write()
                 .await
-                .register(Arc::new(MidRoundRegisteredTool));
+                .register(Arc::clone(&self.tool));
         }
         HookResult::Continue
     }
     async fn shutdown(&self) {}
+}
+
+async fn install_mid_round_mutator(rt: &Runtime, tool: Arc<dyn Tool>) {
+    rt.hook_bus()
+        .subscribe(
+            HookKind::BeforeMessage,
+            Arc::new(RegistryMutator {
+                tools: rt.tools_shared(),
+                tool,
+                fired: Arc::new(AtomicBool::new(false)),
+            }),
+            None,
+            None,
+            PermissionSet::from_strings(&["privacy.llm_content".to_string()]),
+        )
+        .await
+        .expect("mutator subscription");
 }
 
 /// Builtin-origin fixture that dynamically registers `gate_late_fixture`
@@ -421,14 +468,15 @@ impl Tool for LateFixtureTool {
     }
 }
 
-/// A catalog mutation AFTER the round-top rebuild makes the retained
-/// session set stale: BOTH sibling calls of the same response are denied
-/// with the IDENTICAL stale-generation message (one set snapshot, one
-/// generation — never per-call silent refresh), no `before_tool_call` hook
-/// fires for them, and the NEXT round's explicit rebuild recovers.
+/// #100 contract, half 1: a catalog mutation AFTER the round-top rebuild
+/// that does NOT touch the called tool (an unrelated registration bumping
+/// the catalog generation) must NOT deny. Generation drift alone is not a
+/// denial: BOTH sibling `ls` calls of the same response execute against
+/// their unchanged pinned digest, `before_tool_call` fires for each, and the
+/// next round's explicit rebuild keeps executing.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
-async fn mid_round_catalog_mutation_denies_stale_until_next_round_rebuild() {
+async fn mid_round_unrelated_catalog_mutation_does_not_deny_schema_identical_core_tool() {
     let _guard = HomeGuard::new();
     let (url, hits, _) = spawn_stub(Script::SeqSse(&[
         SSE_PARALLEL_LS_TOOL_USE,
@@ -441,21 +489,57 @@ async fn mid_round_catalog_mutation_denies_stale_until_next_round_rebuild() {
     let mut rt = Runtime::new().await.expect("runtime");
     rt.set_model("claude-sonnet-4-5".to_string());
     let seen_hooks = install_hook_spy(&rt).await;
-    rt.hook_bus()
-        .subscribe(
-            HookKind::BeforeMessage,
-            Arc::new(RegistryMutator {
-                tools: rt.tools_shared(),
-                fired: Arc::new(AtomicBool::new(false)),
-            }),
-            None,
-            None,
-            PermissionSet::from_strings(&["privacy.llm_content".to_string()]),
-        )
-        .await
-        .expect("mutator subscription");
+    install_mid_round_mutator(&rt, Arc::new(MidRoundRegisteredTool)).await;
 
-    let ev = drive_runtime_turn(&rt, "stale round fixture", false).await;
+    let ev = drive_runtime_turn(&rt, "unrelated drift fixture", false).await;
+    assert_eq!(hits.load(Ordering::SeqCst), 3, "three model rounds");
+
+    let results = tool_results(&final_history(&ev));
+    assert_eq!(results.len(), 3, "two round-1 runs plus one round-2 run");
+    assert_eq!(results[0].0, "toolu_s1");
+    assert_eq!(results[1].0, "toolu_s2");
+    assert_eq!(results[2].0, "toolu_ph2");
+    for (id, content) in &results {
+        assert!(
+            !content.contains("denied") && !content.contains("stale"),
+            "unrelated catalog mutation must not deny a schema-identical core \
+             tool ({id}), got: {content}"
+        );
+    }
+    assert_eq!(
+        seen_hooks.lock().unwrap().as_slice(),
+        ["ls", "ls", "ls"],
+        "every executed call emits before_tool_call: two round-1 siblings \
+         plus the round-2 call"
+    );
+}
+
+/// #100 contract, half 2: a catalog mutation AFTER the round-top rebuild
+/// that DOES change the called tool's record — `ls` replaced under the same
+/// `ToolId` with a different schema, so its digest drifts from the pinned
+/// core digest — denies THAT tool with the typed per-tool
+/// `SchemaDigestMismatch` message. BOTH sibling calls of the same response
+/// are judged against the one pinned snapshot (identical denial text), no
+/// `before_tool_call` hook fires for them, and the NEXT round's explicit
+/// rebuild re-pins the current digest so the replacement executes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn mid_round_schema_drift_of_called_tool_denies_per_tool_until_next_round_rebuild() {
+    let _guard = HomeGuard::new();
+    let (url, hits, _) = spawn_stub(Script::SeqSse(&[
+        SSE_PARALLEL_LS_TOOL_USE,
+        ANTHROPIC_SSE_TOOL_USE,
+        ANTHROPIC_SSE,
+    ]))
+    .await;
+    std::env::set_var("SYNAPS_ANTHROPIC_BASE_URL", &url);
+
+    let mut rt = Runtime::new().await.expect("runtime");
+    rt.set_model("claude-sonnet-4-5".to_string());
+    let seen_hooks = install_hook_spy(&rt).await;
+    install_mid_round_mutator(&rt, Arc::new(DriftedLsTool)).await;
+
+    let ev = drive_runtime_turn(&rt, "digest drift fixture", false).await;
     assert_eq!(hits.load(Ordering::SeqCst), 3, "denial continues the loop");
 
     let results = tool_results(&final_history(&ev));
@@ -463,25 +547,33 @@ async fn mid_round_catalog_mutation_denies_stale_until_next_round_rebuild() {
     assert_eq!(results[0].0, "toolu_s1");
     assert_eq!(results[1].0, "toolu_s2");
     assert!(
-        results[0].1.contains("stale"),
-        "post-rebuild catalog mutation must deny stale, got: {}",
+        results[0].1.contains("Tool call denied")
+            && results[0].1.contains("schema digest changed"),
+        "post-rebuild digest drift of the called tool must deny with the \
+         per-tool SchemaDigestMismatch, got: {}",
+        results[0].1
+    );
+    assert!(
+        !results[0].1.contains("stale"),
+        "denial must be per-tool, never the retired set-wide stale-generation \
+         message, got: {}",
         results[0].1
     );
     assert_eq!(
         results[0].1, results[1].1,
-        "sibling calls of one response must be judged against ONE set \
-         snapshot at ONE generation"
+        "sibling calls of one response must be judged against ONE pinned \
+         set snapshot"
     );
     assert_eq!(results[2].0, "toolu_ph2");
-    assert!(
-        !results[2].1.contains("denied") && !results[2].1.contains("stale"),
-        "next-round explicit rebuild must recover, got: {}",
-        results[2].1
+    assert_eq!(
+        results[2].1, "DRIFTED_OK",
+        "next-round explicit rebuild must re-pin the current digest and \
+         execute the replacement"
     );
     assert_eq!(
         seen_hooks.lock().unwrap().as_slice(),
         ["ls"],
-        "stale denials must not emit before_tool_call; only the recovered \
+        "digest denials must not emit before_tool_call; only the recovered \
          round-2 call may"
     );
 }

--- a/tests/phase3_activation.rs
+++ b/tests/phase3_activation.rs
@@ -388,7 +388,7 @@ fn a01_first_request_core_only_within_budget() {
     const DOCUMENTED_FIRST_REQUEST_BUDGET_BYTES: usize = 8 * 1024;
 
     let set = SessionToolSet::progressive_core_for_catalog(sid("a01"), registry.catalog());
-    let schemas = registry.session_tools_schema(&set).unwrap();
+    let schemas = registry.session_tools_schema(&set).schema;
     let names: BTreeSet<String> = schemas
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
@@ -421,7 +421,7 @@ fn a02_dormant_bodies_absent_from_first_request() {
     let registry = acceptance_registry(&mcp, &ext);
     // Progressive (flag ON): dormant builtin/MCP/extension schemas absent.
     let set = progressive_set(&registry, &sid("a02"));
-    let serialized = serde_json::to_string(&*registry.session_tools_schema(&set).unwrap()).unwrap();
+    let serialized = serde_json::to_string(&registry.session_tools_schema(&set).schema).unwrap();
     assert!(
         !serialized.contains(SCHEMA_MARKER),
         "dormant builtin schema leaked"
@@ -437,7 +437,7 @@ fn a02_dormant_bodies_absent_from_first_request() {
     // Legacy (flag OFF): full catalog exposed — documented compatibility.
     let legacy = legacy_set(&registry, &sid("a02"));
     let legacy_serialized =
-        serde_json::to_string(&*registry.session_tools_schema(&legacy).unwrap()).unwrap();
+        serde_json::to_string(&registry.session_tools_schema(&legacy).schema).unwrap();
     assert!(
         legacy_serialized.contains("ext__srv__echo_tool"),
         "flag-off keeps the legacy full exposure"
@@ -515,7 +515,7 @@ fn a04_activation_adds_exactly_one_schema() {
     let mut set = progressive_set(&registry, &sid("a04"));
     let before: BTreeSet<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();
@@ -527,7 +527,7 @@ fn a04_activation_adds_exactly_one_schema() {
     .unwrap();
     let after: BTreeSet<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();
@@ -619,7 +619,7 @@ fn a06_alias_spellings_cannot_bypass_activation() {
         .unwrap();
         registry
             .session_tools_schema(&probe)
-            .unwrap()
+            .schema
             .iter()
             .filter_map(|s| s["name"].as_str().map(String::from))
             .find(|n| registry.runtime_name_for_api(n) == "fixture-plugin:search")
@@ -796,20 +796,19 @@ fn a10_revocation_digest_generation_invalidate() {
         Err(ToolAuthorizationError::NotActivated(ref id)) if *id == echo
     ));
 
-    // 2. Catalog generation change (registry mutation) invalidates the
-    // whole stale session set at the gate.
+    // 2. Catalog generation change (unrelated registry mutation) marks the
+    // set stale but does NOT deny per-tool: the gate validates each pinned
+    // record's digest + provenance individually (6b668835), so an unchanged
+    // activated tool keeps authorizing while fresh grants are blocked.
     let mut set2 =
         SessionToolSet::progressive_core_for_catalog(session.clone(), registry.catalog());
     activate_exact_for_user(&mut set2, registry.catalog(), &echo).unwrap();
     registry
         .try_disable(&["dormant_07".to_string()])
         .expect("disable advances the catalog generation");
-    let err = ExecutionGate::authorize_wire_call(&registry, &set2, "ext__srv__echo_tool")
-        .expect_err("stale generation must deny");
-    assert!(matches!(
-        err,
-        ToolAuthorizationError::StaleSessionSet { .. }
-    ));
+    assert!(set2.is_stale(registry.catalog()));
+    ExecutionGate::authorize_wire_call(&registry, &set2, "ext__srv__echo_tool")
+        .expect("schema-identical activated tool survives unrelated drift");
 
     // 3. Schema digest drift: a session set whose grant was pinned under
     // the ORIGINAL schema must be denied against a registry whose live
@@ -892,7 +891,7 @@ fn a11_cross_provider_logical_set_equivalence() {
     modes.push(("flag-off/legacy", legacy_set(&registry, &sid("a11-legacy"))));
     for (mode, set) in modes {
         // Anthropic-side: the session projection (api-safe names).
-        let schemas = registry.session_tools_schema(&set).unwrap();
+        let schemas = registry.session_tools_schema(&set).schema;
         let anthropic_logical: BTreeSet<String> = schemas
             .iter()
             .filter_map(|s| s["name"].as_str())
@@ -1012,7 +1011,7 @@ async fn a12_skill_bodies_lazy_and_exact() {
     tools.register(Arc::new(LoadSkillTool::new(registry.clone())));
     tools.register(Arc::new(SearchSkillsTool::new(registry.clone())));
     let set = SessionToolSet::progressive_core_for_catalog(sid("a12"), tools.catalog());
-    let projection = serde_json::to_string(&*tools.session_tools_schema(&set).unwrap()).unwrap();
+    let projection = serde_json::to_string(&tools.session_tools_schema(&set).schema).unwrap();
     assert!(
         projection.contains("load_skill"),
         "projection includes the skill tools"
@@ -1064,13 +1063,13 @@ fn a13_activate_many_single_generation_update() {
     // Stable order: projection order deterministic across runs.
     let names: Vec<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();
     let again: Vec<String> = registry
         .session_tools_schema(&set)
-        .unwrap()
+        .schema
         .iter()
         .filter_map(|s| s["name"].as_str().map(String::from))
         .collect();

--- a/tests/shell_pty.rs
+++ b/tests/shell_pty.rs
@@ -180,7 +180,7 @@ async fn test_working_directory() {
     let manager = SessionManager::new(ShellConfig::default());
 
     let mut opts = default_opts();
-    opts.command = Some("bash".to_string());
+    opts.command = Some("/bin/bash --norc --noprofile".to_string());
     opts.working_directory = Some("/tmp".to_string());
 
     let (session_id, _initial, _status) = manager
@@ -213,7 +213,7 @@ async fn test_environment_variables() {
     env.insert("MY_VAR".to_string(), "test123".to_string());
 
     let mut opts = default_opts();
-    opts.command = Some("bash".to_string());
+    opts.command = Some("/bin/bash --norc --noprofile".to_string());
     opts.env = env;
 
     let (session_id, _initial, _status) = manager


### PR DESCRIPTION
Promote dev → main for the **0.9.1** release (vision/image-read #102, execution-gate #100, provider fixes #101, session UI #97, workspace version centralization). Tag `v0.9.1` on merge → cargo-dist ships all platforms + crates.io. Full workspace test green on bella (3722 pass; only the known-flaky `e_opens_expanded_provider_browser`). CHANGELOG updated.